### PR TITLE
sql-query-connector: introduce an explicit Context struct

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/direct.rs
@@ -22,8 +22,8 @@ impl RunnerInterface for DirectRunner {
         let schema = psl::parse_schema(datamodel).unwrap();
         let data_source = schema.configuration.datasources.first().unwrap();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
-        let (db_name, executor) = executor::load(data_source, schema.configuration.preview_features(), &url).await?;
-        let internal_data_model = prisma_models::convert(Arc::new(schema), db_name);
+        let executor = executor::load(data_source, schema.configuration.preview_features(), &url).await?;
+        let internal_data_model = prisma_models::convert(Arc::new(schema));
 
         let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(internal_data_model, true));
 

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -129,6 +129,7 @@ impl WriteOperations for MongoDbConnection {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<()> {
         catch(async move { write::m2m_connect(&self.database, &mut self.session, field, parent_id, child_ids).await })
             .await

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -176,6 +176,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        _trace_id: Option<String>,
     ) -> connector_interface::Result<()> {
         catch(async move {
             write::m2m_connect(

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -343,6 +343,7 @@ pub trait WriteOperations {
         field: &RelationFieldRef,
         parent_id: &SelectionResult,
         child_ids: &[SelectionResult],
+        trace_id: Option<String>,
     ) -> crate::Result<()>;
 
     /// Disconnect the children from the parent (m2m relation only).

--- a/query-engine/connectors/sql-query-connector/src/column_metadata.rs
+++ b/query-engine/connectors/sql-query-connector/src/column_metadata.rs
@@ -3,7 +3,7 @@ use psl::dml::FieldArity;
 
 /// Helps dealing with column value conversion and possible error resolution.
 #[derive(Clone, Debug, Copy)]
-pub struct ColumnMetadata<'a> {
+pub(crate) struct ColumnMetadata<'a> {
     identifier: &'a TypeIdentifier,
     name: Option<&'a str>,
     arity: FieldArity,
@@ -42,7 +42,7 @@ impl<'a> ColumnMetadata<'a> {
 
 /// Create a set of metadata objects, combining column names and type
 /// information.
-pub fn create<'a, T>(field_names: &'a [T], idents: &'a [(TypeIdentifier, FieldArity)]) -> Vec<ColumnMetadata<'a>>
+pub(crate) fn create<'a, T>(field_names: &'a [T], idents: &'a [(TypeIdentifier, FieldArity)]) -> Vec<ColumnMetadata<'a>>
 where
     T: AsRef<str>,
 {
@@ -56,7 +56,7 @@ where
 }
 
 /// Create a set of metadata objects.
-pub fn create_anonymous(idents: &[(TypeIdentifier, FieldArity)]) -> Vec<ColumnMetadata<'_>> {
+pub(crate) fn create_anonymous(idents: &[(TypeIdentifier, FieldArity)]) -> Vec<ColumnMetadata<'_>> {
     idents
         .iter()
         .map(|(identifier, arity)| ColumnMetadata::new(identifier, *arity))

--- a/query-engine/connectors/sql-query-connector/src/context.rs
+++ b/query-engine/connectors/sql-query-connector/src/context.rs
@@ -1,0 +1,19 @@
+use quaint::prelude::ConnectionInfo;
+
+pub(super) struct Context<'a> {
+    connection_info: &'a ConnectionInfo,
+    pub(crate) trace_id: Option<&'a str>,
+}
+
+impl<'a> Context<'a> {
+    pub(crate) fn new(connection_info: &'a ConnectionInfo, trace_id: Option<&'a str>) -> Self {
+        Context {
+            connection_info,
+            trace_id,
+        }
+    }
+
+    pub(crate) fn schema_name(&self) -> &str {
+        self.connection_info.schema_name()
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -4,7 +4,7 @@ use crate::{
     query_arguments_ext::QueryArgumentsExt,
     query_builder::{self, read},
     sql_info::SqlInfo,
-    QueryExt, SqlError,
+    Context, QueryExt, SqlError,
 };
 use connector_interface::*;
 use futures::stream::{FuturesUnordered, StreamExt};
@@ -17,9 +17,9 @@ pub(crate) async fn get_single_record(
     filter: &Filter,
     selected_fields: &ModelProjection,
     aggr_selections: &[RelAggregationSelection],
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<Option<SingleRecord>> {
-    let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, filter, trace_id);
+    let query = read::get_records(model, selected_fields.as_columns(ctx), aggr_selections, filter, ctx);
 
     let mut field_names: Vec<_> = selected_fields.db_names().collect();
     let mut aggr_field_names: Vec<_> = aggr_selections.iter().map(|aggr_sel| aggr_sel.db_alias()).collect();
@@ -36,7 +36,7 @@ pub(crate) async fn get_single_record(
 
     let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
 
-    let record = (match conn.find(query, meta.as_slice(), trace_id).await {
+    let record = (match conn.find(query, meta.as_slice(), ctx).await {
         Ok(result) => Ok(Some(result)),
         Err(_e @ SqlError::RecordNotFoundForWhere(_)) => Ok(None),
         Err(_e @ SqlError::RecordDoesNotExist) => Ok(None),
@@ -48,14 +48,14 @@ pub(crate) async fn get_single_record(
     Ok(record)
 }
 
-pub async fn get_many_records(
+pub(crate) async fn get_many_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
     mut query_arguments: QueryArguments,
     selected_fields: &ModelProjection,
     aggr_selections: &[RelAggregationSelection],
     sql_info: SqlInfo,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<ManyRecords> {
     let reversed = query_arguments.needs_reversed_order();
 
@@ -106,9 +106,9 @@ pub async fn get_many_records(
             let mut futures = FuturesUnordered::new();
 
             for args in batches.into_iter() {
-                let query = read::get_records(model, selected_fields.as_columns(), aggr_selections, args, trace_id);
+                let query = read::get_records(model, selected_fields.as_columns(ctx), aggr_selections, args, ctx);
 
-                futures.push(conn.filter(query.into(), meta.as_slice(), trace_id));
+                futures.push(conn.filter(query.into(), meta.as_slice(), ctx));
             }
 
             while let Some(result) = futures.next().await {
@@ -124,13 +124,13 @@ pub async fn get_many_records(
         _ => {
             let query = read::get_records(
                 model,
-                selected_fields.as_columns(),
+                selected_fields.as_columns(ctx),
                 aggr_selections,
                 query_arguments,
-                trace_id,
+                ctx,
             );
 
-            for item in conn.filter(query.into(), meta.as_slice(), trace_id).await?.into_iter() {
+            for item in conn.filter(query.into(), meta.as_slice(), ctx).await?.into_iter() {
                 records.push(Record::from(item))
             }
         }
@@ -143,11 +143,11 @@ pub async fn get_many_records(
     Ok(records)
 }
 
-pub async fn get_related_m2m_record_ids(
+pub(crate) async fn get_related_m2m_record_ids(
     conn: &dyn QueryExt,
     from_field: &RelationFieldRef,
     from_record_ids: &[SelectionResult],
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<Vec<(SelectionResult, SelectionResult)>> {
     let mut idents = vec![];
     idents.extend(ModelProjection::from(from_field.model().primary_identifier()).type_identifiers_with_arities());
@@ -161,10 +161,10 @@ pub async fn get_related_m2m_record_ids(
     let meta = column_metadata::create(&field_names, &idents);
 
     let relation = from_field.relation();
-    let table = relation.as_table();
+    let table = relation.as_table(ctx);
 
-    let from_columns: Vec<_> = from_field.related_field().m2m_columns();
-    let to_columns: Vec<_> = from_field.m2m_columns();
+    let from_columns: Vec<_> = from_field.related_field().m2m_columns(ctx);
+    let to_columns: Vec<_> = from_field.m2m_columns(ctx);
 
     // [DTODO] To verify: We might need chunked fetch here (too many parameters in the query).
     let select = Select::from_table(table)
@@ -184,7 +184,7 @@ pub async fn get_related_m2m_record_ids(
 
     // first parent id, then child id
     Ok(conn
-        .filter(select.into(), meta.as_slice(), trace_id)
+        .filter(select.into(), meta.as_slice(), ctx)
         .await?
         .into_iter()
         .map(|row| {
@@ -212,19 +212,19 @@ pub async fn get_related_m2m_record_ids(
         .collect())
 }
 
-pub async fn aggregate(
+pub(crate) async fn aggregate(
     conn: &dyn QueryExt,
     model: &ModelRef,
     query_arguments: QueryArguments,
     selections: Vec<AggregationSelection>,
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<Vec<AggregationRow>> {
     if !group_by.is_empty() {
-        group_by_aggregate(conn, model, query_arguments, selections, group_by, having, trace_id).await
+        group_by_aggregate(conn, model, query_arguments, selections, group_by, having, ctx).await
     } else {
-        plain_aggregate(conn, model, query_arguments, selections, trace_id)
+        plain_aggregate(conn, model, query_arguments, selections, ctx)
             .await
             .map(|v| vec![v])
     }
@@ -235,9 +235,9 @@ async fn plain_aggregate(
     model: &ModelRef,
     query_arguments: QueryArguments,
     selections: Vec<AggregationSelection>,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<Vec<AggregationResult>> {
-    let query = read::aggregate(model, &selections, query_arguments, trace_id);
+    let query = read::aggregate(model, &selections, query_arguments, ctx);
 
     let idents: Vec<_> = selections
         .iter()
@@ -247,7 +247,7 @@ async fn plain_aggregate(
 
     let meta = column_metadata::create_anonymous(&idents);
 
-    let mut rows = conn.filter(query.into(), meta.as_slice(), trace_id).await?;
+    let mut rows = conn.filter(query.into(), meta.as_slice(), ctx).await?;
     let row = rows
         .pop()
         .expect("Expected exactly one return row for aggregation query.");
@@ -262,9 +262,9 @@ async fn group_by_aggregate(
     selections: Vec<AggregationSelection>,
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<Vec<AggregationRow>> {
-    let query = read::group_by_aggregate(model, query_arguments, &selections, group_by, having, trace_id);
+    let query = read::group_by_aggregate(model, query_arguments, &selections, group_by, having, ctx);
 
     let idents: Vec<_> = selections
         .iter()
@@ -273,7 +273,7 @@ async fn group_by_aggregate(
         .collect();
 
     let meta = column_metadata::create_anonymous(&idents);
-    let rows = conn.filter(query.into(), meta.as_slice(), trace_id).await?;
+    let rows = conn.filter(query.into(), meta.as_slice(), ctx).await?;
 
     Ok(rows
         .into_iter()

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -1,7 +1,9 @@
 use crate::filter_conversion::AliasedCondition;
 use crate::query_builder::write::{build_update_and_set_query, chunk_update_with_ids};
-use crate::sql_trace::SqlTraceComment;
-use crate::{error::SqlError, model_extensions::*, query_builder::write, sql_info::SqlInfo, QueryExt};
+use crate::{
+    error::SqlError, model_extensions::*, query_builder::write, sql_info::SqlInfo, sql_trace::SqlTraceComment, Context,
+    QueryExt,
+};
 use connector_interface::*;
 use itertools::Itertools;
 use prisma_models::*;
@@ -21,8 +23,8 @@ use user_facing_errors::query_engine::DatabaseConstraint;
 async fn generate_id(
     conn: &dyn QueryExt,
     primary_key: &FieldSelection,
-    trace_id: Option<&str>,
     args: &WriteArgs,
+    ctx: &Context<'_>,
 ) -> crate::Result<Option<SelectionResult>> {
     // Go through all the values and generate a select statement with the correct MySQL function
     let (pk_select, need_select) = primary_key
@@ -49,7 +51,7 @@ async fn generate_id(
 
     // db generate values only if needed
     if need_select {
-        let pk_select = pk_select.add_trace_id(trace_id);
+        let pk_select = pk_select.add_trace_id(ctx.trace_id);
         let pk_result = conn.query(pk_select.into()).await?;
         let result = try_convert(&(primary_key.into()), pk_result)?;
 
@@ -61,17 +63,17 @@ async fn generate_id(
 
 /// Create a single record to the database defined in `conn`, resulting into a
 /// `RecordProjection` as an identifier pointing to the just-created record.
-pub async fn create_record(
+pub(crate) async fn create_record(
     conn: &dyn QueryExt,
     sql_family: &SqlFamily,
     model: &ModelRef,
     mut args: WriteArgs,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<SelectionResult> {
     let pk = model.primary_identifier();
 
     let returned_id = if *sql_family == SqlFamily::Mysql {
-        generate_id(conn, &pk, trace_id, &args).await?
+        generate_id(conn, &pk, &args, ctx).await?
     } else {
         args.as_record_projection(pk.clone().into())
     };
@@ -90,7 +92,7 @@ pub async fn create_record(
         _ => args,
     };
 
-    let insert = write::create_record(model, args, trace_id);
+    let insert = write::create_record(model, args, ctx);
 
     let result_set = match conn.insert(insert).await {
         Ok(id) => id,
@@ -152,13 +154,13 @@ pub async fn create_record(
     }
 }
 
-pub async fn create_records(
+pub(crate) async fn create_records(
     conn: &dyn QueryExt,
     sql_info: SqlInfo,
     model: &ModelRef,
     args: Vec<WriteArgs>,
     skip_duplicates: bool,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<usize> {
     if args.is_empty() {
         return Ok(0);
@@ -183,9 +185,9 @@ pub async fn create_records(
 
     if affected_fields.is_empty() {
         // If no fields are to be inserted (everything is DEFAULT) we need to fall back to inserting default rows `args.len()` times.
-        create_many_empty(conn, model, args.len(), skip_duplicates, trace_id).await
+        create_many_empty(conn, model, args.len(), skip_duplicates, ctx).await
     } else {
-        create_many_nonempty(conn, sql_info, model, args, skip_duplicates, affected_fields, trace_id).await
+        create_many_nonempty(conn, sql_info, model, args, skip_duplicates, affected_fields, ctx).await
     }
 }
 
@@ -198,7 +200,7 @@ async fn create_many_nonempty(
     args: Vec<WriteArgs>,
     skip_duplicates: bool,
     affected_fields: HashSet<ScalarFieldRef>,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<usize> {
     let batches = if let Some(max_params) = sql_info.max_bind_values {
         // We need to split inserts if they are above a parameter threshold, as well as split based on number of rows.
@@ -272,7 +274,7 @@ async fn create_many_nonempty(
 
     let mut count = 0;
     for batch in partitioned_batches {
-        let stmt = write::create_records_nonempty(model, batch, skip_duplicates, &affected_fields, trace_id);
+        let stmt = write::create_records_nonempty(model, batch, skip_duplicates, &affected_fields, ctx);
         count += conn.execute(stmt.into()).await?;
     }
 
@@ -285,9 +287,9 @@ async fn create_many_empty(
     model: &ModelRef,
     num_records: usize,
     skip_duplicates: bool,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<usize> {
-    let stmt = write::create_records_empty(model, skip_duplicates, trace_id);
+    let stmt = write::create_records_empty(model, skip_duplicates, ctx);
     let mut count = 0;
 
     for _ in 0..num_records {
@@ -300,24 +302,24 @@ async fn create_many_empty(
 /// Update one record in a database defined in `conn` and the records
 /// defined in `args`, resulting the identifiers that were modified in the
 /// operation.
-pub async fn update_record(
+pub(crate) async fn update_record(
     conn: &dyn QueryExt,
     model: &ModelRef,
     record_filter: RecordFilter,
     args: WriteArgs,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<Vec<SelectionResult>> {
     let id_args = pick_args(&model.primary_identifier().into(), &args);
 
     // This is to match the behaviour expected but it seems a bit strange to me
     // This comes across as if the update happened even if it didn't
     if args.args.is_empty() {
-        let ids: Vec<SelectionResult> = conn.filter_selectors(model, record_filter.clone(), trace_id).await?;
+        let ids: Vec<SelectionResult> = conn.filter_selectors(model, record_filter.clone(), ctx).await?;
 
         return Ok(ids);
     }
 
-    let (_, ids) = update_records_from_ids_and_filter(conn, model, record_filter, args, trace_id).await?;
+    let (_, ids) = update_records_from_ids_and_filter(conn, model, record_filter, args, ctx).await?;
 
     Ok(merge_write_args(ids, id_args))
 }
@@ -329,20 +331,20 @@ async fn update_records_from_ids_and_filter(
     model: &ModelRef,
     record_filter: RecordFilter,
     args: WriteArgs,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<(usize, Vec<SelectionResult>)> {
-    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false);
-    let ids: Vec<SelectionResult> = conn.filter_selectors(model, record_filter, trace_id).await?;
+    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false, ctx);
+    let ids: Vec<SelectionResult> = conn.filter_selectors(model, record_filter, ctx).await?;
 
     if ids.is_empty() {
         return Ok((0, Vec::new()));
     }
 
-    let update = build_update_and_set_query(model, args, trace_id);
+    let update = build_update_and_set_query(model, args, ctx);
 
     let updates = {
         let ids: Vec<&SelectionResult> = ids.iter().collect();
-        chunk_update_with_ids(update, model, &ids, filter_condition)?
+        chunk_update_with_ids(update, model, &ids, filter_condition, ctx)?
     };
 
     let mut count = 0;
@@ -362,10 +364,10 @@ async fn update_records_from_filter(
     model: &ModelRef,
     record_filter: RecordFilter,
     args: WriteArgs,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<usize> {
-    let update = build_update_and_set_query(model, args, trace_id);
-    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false);
+    let update = build_update_and_set_query(model, args, ctx);
+    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false, ctx);
 
     let update = update.so_that(filter_condition);
     let count = conn.execute(update.into()).await?;
@@ -377,22 +379,22 @@ async fn update_records_from_filter(
 /// defined in `args`, and returning the number of updates
 /// This works via two ways, when there are ids in record_filter.selectors, it uses that to update
 /// Otherwise it used the passed down arguments to update.
-pub async fn update_records(
+pub(crate) async fn update_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
     record_filter: RecordFilter,
     args: WriteArgs,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<usize> {
     if args.args.is_empty() {
         return Ok(0);
     }
 
     if record_filter.has_selectors() {
-        let (count, _) = update_records_from_ids_and_filter(conn, model, record_filter, args, trace_id).await?;
+        let (count, _) = update_records_from_ids_and_filter(conn, model, record_filter, args, ctx).await?;
         Ok(count)
     } else {
-        update_records_from_filter(conn, model, record_filter, args, trace_id).await
+        update_records_from_filter(conn, model, record_filter, args, ctx).await
     }
 }
 
@@ -401,10 +403,10 @@ pub(crate) async fn delete_records(
     conn: &dyn QueryExt,
     model: &ModelRef,
     record_filter: RecordFilter,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<usize> {
-    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false);
-    let ids = conn.filter_selectors(model, record_filter, trace_id).await?;
+    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false, ctx);
+    let ids = conn.filter_selectors(model, record_filter, ctx).await?;
     let ids: Vec<&SelectionResult> = ids.iter().collect();
     let count = ids.len();
 
@@ -413,7 +415,7 @@ pub(crate) async fn delete_records(
     }
 
     let mut row_count = 0;
-    for delete in write::delete_many(model, ids.as_slice(), filter_condition, trace_id) {
+    for delete in write::delete_many(model, ids.as_slice(), filter_condition, ctx) {
         row_count += conn.execute(delete).await?;
     }
 
@@ -430,8 +432,9 @@ pub(crate) async fn m2m_connect(
     field: &RelationFieldRef,
     parent_id: &SelectionResult,
     child_ids: &[SelectionResult],
+    ctx: &Context<'_>,
 ) -> crate::Result<()> {
-    let query = write::create_relation_table_records(field, parent_id, child_ids);
+    let query = write::create_relation_table_records(field, parent_id, child_ids, ctx);
     conn.query(query).await?;
 
     Ok(())
@@ -444,9 +447,9 @@ pub(crate) async fn m2m_disconnect(
     field: &RelationFieldRef,
     parent_id: &SelectionResult,
     child_ids: &[SelectionResult],
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> crate::Result<()> {
-    let query = write::delete_relation_table_records(field, parent_id, child_ids, trace_id);
+    let query = write::delete_relation_table_records(field, parent_id, child_ids, ctx);
     conn.delete(query).await?;
 
     Ok(())
@@ -466,7 +469,7 @@ pub(crate) async fn execute_raw(
 
 /// Execute a plain SQL query with the given parameters, returning the answer as
 /// a JSON `Value`.
-pub async fn query_raw(
+pub(crate) async fn query_raw(
     conn: &dyn QueryExt,
     sql_info: SqlInfo,
     features: psl::PreviewFeatures,

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -5,7 +5,7 @@ use std::{any::Any, string::FromUtf8Error};
 use thiserror::Error;
 use user_facing_errors::query_engine::DatabaseConstraint;
 
-pub enum RawError {
+pub(crate) enum RawError {
     IncorrectNumberOfParameters {
         expected: usize,
         actual: usize,

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -1,4 +1,4 @@
-use crate::model_extensions::*;
+use crate::{model_extensions::*, Context};
 use connector_interface::filter::*;
 use prisma_models::prelude::*;
 use quaint::ast::concat;
@@ -22,7 +22,7 @@ impl Default for AliasMode {
 #[derive(Clone, Copy, Debug, Default)]
 /// Aliasing tool to count the nesting level to help with heavily nested
 /// self-related queries.
-pub struct Alias {
+pub(crate) struct Alias {
     counter: usize,
     mode: AliasMode,
 }
@@ -81,19 +81,19 @@ impl ConditionState {
     }
 }
 
-pub trait AliasedCondition {
+pub(crate) trait AliasedCondition {
     /// Conversion to a query condition tree. Columns will point to the given
     /// alias if provided, otherwise using the fully qualified path.
     ///
     /// Alias should be used only when nesting, making the top level queries
     /// more explicit.
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static>;
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static>;
 
-    fn aliased_condition_from(&self, alias: Option<Alias>, reverse: bool) -> ConditionTree<'static>
+    fn aliased_condition_from(&self, alias: Option<Alias>, reverse: bool, ctx: &Context<'_>) -> ConditionTree<'static>
     where
         Self: Sized + Clone,
     {
-        self.clone().aliased_cond(ConditionState::new(alias, reverse))
+        self.clone().aliased_cond(ConditionState::new(alias, reverse), ctx)
     }
 }
 
@@ -103,7 +103,7 @@ trait AliasedSelect {
     ///
     /// Alias should be used only when nesting, making the top level queries
     /// more explicit.
-    fn aliased_sel(self, alias: Option<Alias>) -> Select<'static>;
+    fn aliased_sel(self, alias: Option<Alias>, ctx: &Context<'_>) -> Select<'static>;
 }
 
 trait AliasedColumn {
@@ -111,17 +111,17 @@ trait AliasedColumn {
     ///
     /// Alias should be used only when nesting, making the top level queries
     /// more explicit.
-    fn aliased_col(self, alias: Option<Alias>) -> Column<'static>;
+    fn aliased_col(self, alias: Option<Alias>, ctx: &Context<'_>) -> Column<'static>;
 }
 
 impl AliasedColumn for &ScalarFieldRef {
-    fn aliased_col(self, alias: Option<Alias>) -> Column<'static> {
-        self.as_column().aliased_col(alias)
+    fn aliased_col(self, alias: Option<Alias>, ctx: &Context<'_>) -> Column<'static> {
+        self.as_column(ctx).aliased_col(alias, ctx)
     }
 }
 
 impl AliasedColumn for Column<'static> {
-    fn aliased_col(self, alias: Option<Alias>) -> Column<'static> {
+    fn aliased_col(self, alias: Option<Alias>, _ctx: &Context<'_>) -> Column<'static> {
         match alias {
             Some(alias) => self.table(alias.to_string(None)),
             None => self,
@@ -131,15 +131,15 @@ impl AliasedColumn for Column<'static> {
 
 impl AliasedCondition for Filter {
     /// Conversion from a `Filter` to a query condition tree. Aliased when in a nested `SELECT`.
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static> {
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static> {
         match self {
             Filter::And(mut filters) => match filters.len() {
                 n if n == 0 => ConditionTree::NoCondition,
-                n if n == 1 => filters.pop().unwrap().aliased_cond(state),
+                n if n == 1 => filters.pop().unwrap().aliased_cond(state, ctx),
                 _ => {
                     let exprs = filters
                         .into_iter()
-                        .map(|f| f.aliased_cond(state.clone()))
+                        .map(|f| f.aliased_cond(state.clone(), ctx))
                         .map(Expression::from)
                         .collect();
 
@@ -148,11 +148,11 @@ impl AliasedCondition for Filter {
             },
             Filter::Or(mut filters) => match filters.len() {
                 n if n == 0 => ConditionTree::NegativeCondition,
-                n if n == 1 => filters.pop().unwrap().aliased_cond(state),
+                n if n == 1 => filters.pop().unwrap().aliased_cond(state, ctx),
                 _ => {
                     let exprs = filters
                         .into_iter()
-                        .map(|f| f.aliased_cond(state.clone()))
+                        .map(|f| f.aliased_cond(state.clone(), ctx))
                         .map(Expression::from)
                         .collect();
 
@@ -161,20 +161,20 @@ impl AliasedCondition for Filter {
             },
             Filter::Not(mut filters) => match filters.len() {
                 n if n == 0 => ConditionTree::NoCondition,
-                n if n == 1 => filters.pop().unwrap().aliased_cond(state.invert_reverse()).not(),
+                n if n == 1 => filters.pop().unwrap().aliased_cond(state.invert_reverse(), ctx).not(),
                 _ => {
                     let exprs = filters
                         .into_iter()
-                        .map(|f| f.aliased_cond(state.clone().invert_reverse()).not())
+                        .map(|f| f.aliased_cond(state.clone().invert_reverse(), ctx).not())
                         .map(Expression::from)
                         .collect();
 
                     ConditionTree::And(exprs)
                 }
             },
-            Filter::Scalar(filter) => filter.aliased_cond(state),
-            Filter::OneRelationIsNull(filter) => filter.aliased_cond(state),
-            Filter::Relation(filter) => filter.aliased_cond(state),
+            Filter::Scalar(filter) => filter.aliased_cond(state, ctx),
+            Filter::OneRelationIsNull(filter) => filter.aliased_cond(state, ctx),
+            Filter::Relation(filter) => filter.aliased_cond(state, ctx),
             Filter::BoolFilter(b) => {
                 if b {
                     ConditionTree::NoCondition
@@ -182,8 +182,8 @@ impl AliasedCondition for Filter {
                     ConditionTree::NegativeCondition
                 }
             }
-            Filter::Aggregation(filter) => filter.aliased_cond(state),
-            Filter::ScalarList(filter) => filter.aliased_cond(state),
+            Filter::Aggregation(filter) => filter.aliased_cond(state, ctx),
+            Filter::ScalarList(filter) => filter.aliased_cond(state, ctx),
             Filter::Empty => ConditionTree::NoCondition,
             Filter::Composite(_) => unimplemented!("SQL connectors do not support composites yet."),
         }
@@ -192,7 +192,7 @@ impl AliasedCondition for Filter {
 
 impl AliasedCondition for ScalarFilter {
     /// Conversion from a `ScalarFilter` to a query condition tree. Aliased when in a nested `SELECT`.
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static> {
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static> {
         match self.condition {
             ScalarCondition::Search(_, _) | ScalarCondition::NotSearch(_, _) => {
                 let mut projections = match self.condition.clone() {
@@ -206,7 +206,7 @@ impl AliasedCondition for ScalarFilter {
                 let columns: Vec<Column> = projections
                     .into_iter()
                     .map(|p| match p {
-                        ScalarProjection::Single(field) => field.aliased_col(state.alias()),
+                        ScalarProjection::Single(field) => field.aliased_col(state.alias(), ctx),
                         ScalarProjection::Compound(_) => {
                             unreachable!("Full-text search does not support compound fields")
                         }
@@ -223,25 +223,31 @@ impl AliasedCondition for ScalarFilter {
                     &[],
                     state.alias(),
                     false,
+                    ctx,
                 )
             }
-            _ => scalar_filter_aliased_cond(self, state.alias(), state.reverse()),
+            _ => scalar_filter_aliased_cond(self, state.alias(), state.reverse(), ctx),
         }
     }
 }
 
-fn scalar_filter_aliased_cond(sf: ScalarFilter, alias: Option<Alias>, reverse: bool) -> ConditionTree<'static> {
+fn scalar_filter_aliased_cond(
+    sf: ScalarFilter,
+    alias: Option<Alias>,
+    reverse: bool,
+    ctx: &Context<'_>,
+) -> ConditionTree<'static> {
     match sf.projection {
         ScalarProjection::Single(field) => {
-            let comparable: Expression = field.aliased_col(alias).into();
+            let comparable: Expression = field.aliased_col(alias, ctx).into();
 
-            convert_scalar_filter(comparable, sf.condition, reverse, sf.mode, &[field], alias, false)
+            convert_scalar_filter(comparable, sf.condition, reverse, sf.mode, &[field], alias, false, ctx)
         }
         ScalarProjection::Compound(fields) => {
             let columns: Vec<Column<'static>> = fields
                 .clone()
                 .into_iter()
-                .map(|field| field.aliased_col(alias))
+                .map(|field| field.aliased_col(alias, ctx))
                 .collect();
 
             convert_scalar_filter(
@@ -252,16 +258,17 @@ fn scalar_filter_aliased_cond(sf: ScalarFilter, alias: Option<Alias>, reverse: b
                 &fields,
                 alias,
                 false,
+                ctx,
             )
         }
     }
 }
 
 impl AliasedCondition for ScalarListFilter {
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static> {
-        let comparable: Expression = self.field.aliased_col(state.alias()).into();
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static> {
+        let comparable: Expression = self.field.aliased_col(state.alias(), ctx).into();
 
-        convert_scalar_list_filter(comparable, self.condition, &self.field, state.alias())
+        convert_scalar_list_filter(comparable, self.condition, &self.field, state.alias(), ctx)
     }
 }
 
@@ -270,13 +277,14 @@ fn convert_scalar_list_filter(
     cond: ScalarListCondition,
     field: &ScalarFieldRef,
     alias: Option<Alias>,
+    ctx: &Context<'_>,
 ) -> ConditionTree<'static> {
     let condition = match cond {
         ScalarListCondition::Contains(ConditionValue::Value(val)) => {
             comparable.compare_raw("@>", convert_list_pv(field, vec![val]))
         }
         ScalarListCondition::Contains(ConditionValue::FieldRef(field_ref)) => {
-            let field_ref_expr: Expression = field_ref.aliased_col(alias).into();
+            let field_ref_expr: Expression = field_ref.aliased_col(alias, ctx).into();
 
             // This code path is only reachable for connectors with `ScalarLists` capability
             field_ref_expr.equals(comparable.any())
@@ -285,13 +293,13 @@ fn convert_scalar_list_filter(
             comparable.compare_raw("@>", convert_list_pv(field, vals))
         }
         ScalarListCondition::ContainsEvery(ConditionListValue::FieldRef(field_ref)) => {
-            comparable.compare_raw("@>", field_ref.aliased_col(alias))
+            comparable.compare_raw("@>", field_ref.aliased_col(alias, ctx))
         }
         ScalarListCondition::ContainsSome(ConditionListValue::List(vals)) => {
             comparable.compare_raw("&&", convert_list_pv(field, vals))
         }
         ScalarListCondition::ContainsSome(ConditionListValue::FieldRef(field_ref)) => {
-            comparable.compare_raw("&&", field_ref.aliased_col(alias))
+            comparable.compare_raw("&&", field_ref.aliased_col(alias, ctx))
         }
         ScalarListCondition::IsEmpty(true) => comparable.compare_raw("=", Value::Array(Some(vec![])).raw()),
         ScalarListCondition::IsEmpty(false) => comparable.compare_raw("<>", Value::Array(Some(vec![])).raw()),
@@ -302,12 +310,12 @@ fn convert_scalar_list_filter(
 
 impl AliasedCondition for RelationFilter {
     /// Conversion from a `RelationFilter` to a query condition tree. Aliased when in a nested `SELECT`.
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static> {
-        let ids = ModelProjection::from(self.field.model().primary_identifier()).as_columns();
-        let columns: Vec<Column<'static>> = ids.map(|col| col.aliased_col(state.alias())).collect();
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static> {
+        let ids = ModelProjection::from(self.field.model().primary_identifier()).as_columns(ctx);
+        let columns: Vec<Column<'static>> = ids.map(|col| col.aliased_col(state.alias(), ctx)).collect();
 
         let condition = self.condition;
-        let sub_select = self.aliased_sel(state.alias().map(|a| a.inc(AliasMode::Table)));
+        let sub_select = self.aliased_sel(state.alias().map(|a| a.inc(AliasMode::Table)), ctx);
 
         let comparison = match condition {
             RelationCondition::AtLeastOneRelatedRecord => Row::from(columns).in_selection(sub_select),
@@ -322,28 +330,32 @@ impl AliasedCondition for RelationFilter {
 
 impl AliasedSelect for RelationFilter {
     /// The subselect part of the `RelationFilter` `ConditionTree`.
-    fn aliased_sel<'a>(self, alias: Option<Alias>) -> Select<'static> {
+    fn aliased_sel<'a>(self, alias: Option<Alias>, ctx: &Context<'_>) -> Select<'static> {
         let alias = alias.unwrap_or_default();
         let condition = self.condition;
 
-        let table = self.field.as_table();
+        let table = self.field.as_table(ctx);
         let selected_identifier: Vec<Column> = self
             .field
-            .identifier_columns()
-            .map(|col| col.aliased_col(Some(alias)))
+            .identifier_columns(ctx)
+            .map(|col| col.aliased_col(Some(alias), ctx))
             .collect();
 
-        let join_columns: Vec<Column> = self.field.join_columns().map(|c| c.aliased_col(Some(alias))).collect();
+        let join_columns: Vec<Column> = self
+            .field
+            .join_columns(ctx)
+            .map(|c| c.aliased_col(Some(alias), ctx))
+            .collect();
 
-        let related_table = self.field.related_model().as_table();
+        let related_table = self.field.related_model().as_table(ctx);
         let related_join_columns: Vec<_> = ModelProjection::from(self.field.related_field().linking_fields())
-            .as_columns()
-            .map(|col| col.aliased_col(Some(alias.flip(AliasMode::Join))))
+            .as_columns(ctx)
+            .map(|col| col.aliased_col(Some(alias.flip(AliasMode::Join)), ctx))
             .collect();
 
         let nested_conditions = self
             .nested_filter
-            .aliased_condition_from(Some(alias.flip(AliasMode::Join)), false)
+            .aliased_condition_from(Some(alias.flip(AliasMode::Join)), false, ctx)
             .invert_if(condition.invert_of_subselect());
 
         let conditions = selected_identifier
@@ -364,21 +376,23 @@ impl AliasedSelect for RelationFilter {
 
 impl AliasedCondition for OneRelationIsNullFilter {
     /// Conversion from a `OneRelationIsNullFilter` to a query condition tree. Aliased when in a nested `SELECT`.
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static> {
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static> {
         let alias = state.alias().map(|a| a.to_string(None));
 
         let condition = if self.field.relation_is_inlined_in_parent() {
-            self.field.as_columns().fold(ConditionTree::NoCondition, |acc, column| {
-                let column_is_null = column.opt_table(alias.clone()).is_null();
+            self.field
+                .as_columns(ctx)
+                .fold(ConditionTree::NoCondition, |acc, column| {
+                    let column_is_null = column.opt_table(alias.clone()).is_null();
 
-                match acc {
-                    ConditionTree::NoCondition => column_is_null.into(),
-                    cond => cond.and(column_is_null),
-                }
-            })
+                    match acc {
+                        ConditionTree::NoCondition => column_is_null.into(),
+                        cond => cond.and(column_is_null),
+                    }
+                })
         } else {
             let relation = self.field.relation();
-            let table = relation.as_table();
+            let table = relation.as_table(ctx);
             let relation_table = match alias {
                 Some(ref alias) => table.alias(alias.to_string()),
                 None => table,
@@ -387,7 +401,7 @@ impl AliasedCondition for OneRelationIsNullFilter {
             let columns_not_null =
                 self.field
                     .related_field()
-                    .as_columns()
+                    .as_columns(ctx)
                     .fold(ConditionTree::NoCondition, |acc, column| {
                         let column_is_not_null = column.opt_table(alias.clone()).is_not_null();
 
@@ -404,7 +418,7 @@ impl AliasedCondition for OneRelationIsNullFilter {
                 .related_field()
                 .scalar_fields()
                 .iter()
-                .map(|f| f.as_column().opt_table(alias.clone()))
+                .map(|f| f.as_column(ctx).opt_table(alias.clone()))
                 .collect();
 
             let sub_select = Select::from_table(relation_table)
@@ -412,7 +426,7 @@ impl AliasedCondition for OneRelationIsNullFilter {
                 .and_where(columns_not_null);
 
             let id_columns: Vec<Column<'static>> = ModelProjection::from(self.field.linking_fields())
-                .as_columns()
+                .as_columns(ctx)
                 .map(|c| c.opt_table(alias.clone()))
                 .collect();
 
@@ -425,15 +439,15 @@ impl AliasedCondition for OneRelationIsNullFilter {
 
 impl AliasedCondition for AggregationFilter {
     /// Conversion from an `AggregationFilter` to a query condition tree. Aliased when in a nested `SELECT`.
-    fn aliased_cond(self, state: ConditionState) -> ConditionTree<'static> {
+    fn aliased_cond(self, state: ConditionState, ctx: &Context<'_>) -> ConditionTree<'static> {
         let alias = state.alias();
         let reverse = state.reverse();
         match self {
-            AggregationFilter::Count(filter) => aggregate_conditions(*filter, alias, reverse, |x| count(x).into()),
-            AggregationFilter::Average(filter) => aggregate_conditions(*filter, alias, reverse, |x| avg(x).into()),
-            AggregationFilter::Sum(filter) => aggregate_conditions(*filter, alias, reverse, |x| sum(x).into()),
-            AggregationFilter::Min(filter) => aggregate_conditions(*filter, alias, reverse, |x| min(x).into()),
-            AggregationFilter::Max(filter) => aggregate_conditions(*filter, alias, reverse, |x| max(x).into()),
+            AggregationFilter::Count(filter) => aggregate_conditions(*filter, alias, reverse, |x| count(x).into(), ctx),
+            AggregationFilter::Average(filter) => aggregate_conditions(*filter, alias, reverse, |x| avg(x).into(), ctx),
+            AggregationFilter::Sum(filter) => aggregate_conditions(*filter, alias, reverse, |x| sum(x).into(), ctx),
+            AggregationFilter::Min(filter) => aggregate_conditions(*filter, alias, reverse, |x| min(x).into(), ctx),
+            AggregationFilter::Max(filter) => aggregate_conditions(*filter, alias, reverse, |x| max(x).into(), ctx),
         }
     }
 }
@@ -443,6 +457,7 @@ fn aggregate_conditions<T>(
     alias: Option<Alias>,
     reverse: bool,
     field_transformer: T,
+    ctx: &Context<'_>,
 ) -> ConditionTree<'static>
 where
     T: Fn(Column) -> Expression,
@@ -457,13 +472,14 @@ where
             unimplemented!("Compound aggregate projections are unsupported.")
         }
         ScalarProjection::Single(field) => {
-            let comparable: Expression = field_transformer(field.aliased_col(alias));
+            let comparable: Expression = field_transformer(field.aliased_col(alias, ctx));
 
-            convert_scalar_filter(comparable, sf.condition, reverse, sf.mode, &[field], alias, true)
+            convert_scalar_filter(comparable, sf.condition, reverse, sf.mode, &[field], alias, true, ctx)
         }
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn convert_scalar_filter(
     comparable: Expression<'static>,
     cond: ScalarCondition,
@@ -472,14 +488,23 @@ fn convert_scalar_filter(
     fields: &[ScalarFieldRef],
     alias: Option<Alias>,
     is_parent_aggregation: bool,
+    ctx: &Context<'_>,
 ) -> ConditionTree<'static> {
     match cond {
-        ScalarCondition::JsonCompare(json_compare) => {
-            convert_json_filter(comparable, json_compare, reverse, fields.first().unwrap(), mode, alias)
-        }
+        ScalarCondition::JsonCompare(json_compare) => convert_json_filter(
+            comparable,
+            json_compare,
+            reverse,
+            fields.first().unwrap(),
+            mode,
+            alias,
+            ctx,
+        ),
         _ => match mode {
-            QueryMode::Default => default_scalar_filter(comparable, cond, fields, alias),
-            QueryMode::Insensitive => insensitive_scalar_filter(comparable, cond, fields, alias, is_parent_aggregation),
+            QueryMode::Default => default_scalar_filter(comparable, cond, fields, alias, ctx),
+            QueryMode::Insensitive => {
+                insensitive_scalar_filter(comparable, cond, fields, alias, is_parent_aggregation, ctx)
+            }
         },
     }
 }
@@ -491,6 +516,7 @@ fn convert_json_filter(
     field: &ScalarFieldRef,
     query_mode: QueryMode,
     alias: Option<Alias>,
+    ctx: &Context<'_>,
 ) -> ConditionTree<'static> {
     let JsonCondition {
         path,
@@ -511,39 +537,41 @@ fn convert_json_filter(
 
     let condition: Expression = match *condition {
         ScalarCondition::Contains(value) => {
-            (expr_json, expr_string).json_contains(field, value, target_type.unwrap(), reverse, alias)
+            (expr_json, expr_string).json_contains(field, value, target_type.unwrap(), reverse, alias, ctx)
         }
         ScalarCondition::StartsWith(value) => {
-            (expr_json, expr_string).json_starts_with(field, value, target_type.unwrap(), reverse, alias)
+            (expr_json, expr_string).json_starts_with(field, value, target_type.unwrap(), reverse, alias, ctx)
         }
         ScalarCondition::EndsWith(value) => {
-            (expr_json, expr_string).json_ends_with(field, value, target_type.unwrap(), reverse, alias)
+            (expr_json, expr_string).json_ends_with(field, value, target_type.unwrap(), reverse, alias, ctx)
         }
         ScalarCondition::GreaterThan(value) => {
             let gt = expr_json
                 .clone()
-                .greater_than(convert_value(field, value.clone(), alias));
+                .greater_than(convert_value(field, value.clone(), alias, ctx));
 
-            with_json_type_filter(gt, expr_json, value, alias, reverse)
+            with_json_type_filter(gt, expr_json, value, alias, reverse, ctx)
         }
         ScalarCondition::GreaterThanOrEquals(value) => {
             let gte = expr_json
                 .clone()
-                .greater_than_or_equals(convert_value(field, value.clone(), alias));
+                .greater_than_or_equals(convert_value(field, value.clone(), alias, ctx));
 
-            with_json_type_filter(gte, expr_json, value, alias, reverse)
+            with_json_type_filter(gte, expr_json, value, alias, reverse, ctx)
         }
         ScalarCondition::LessThan(value) => {
-            let lt = expr_json.clone().less_than(convert_value(field, value.clone(), alias));
+            let lt = expr_json
+                .clone()
+                .less_than(convert_value(field, value.clone(), alias, ctx));
 
-            with_json_type_filter(lt, expr_json, value, alias, reverse)
+            with_json_type_filter(lt, expr_json, value, alias, reverse, ctx)
         }
         ScalarCondition::LessThanOrEquals(value) => {
             let lte = expr_json
                 .clone()
-                .less_than_or_equals(convert_value(field, value.clone(), alias));
+                .less_than_or_equals(convert_value(field, value.clone(), alias, ctx));
 
-            with_json_type_filter(lte, expr_json, value, alias, reverse)
+            with_json_type_filter(lte, expr_json, value, alias, reverse, ctx)
         }
         // Those conditions are unreachable because json filters are not accessible via the lowercase `not`.
         // They can only be inverted via the uppercase `NOT`, which doesn't invert filters but adds a Filter::Not().
@@ -551,7 +579,16 @@ fn convert_json_filter(
         ScalarCondition::NotStartsWith(_) => unreachable!(),
         ScalarCondition::NotEndsWith(_) => unreachable!(),
         cond => {
-            return convert_scalar_filter(expr_json, cond, reverse, query_mode, &[field.clone()], alias, false);
+            return convert_scalar_filter(
+                expr_json,
+                cond,
+                reverse,
+                query_mode,
+                &[field.clone()],
+                alias,
+                false,
+                ctx,
+            );
         }
     };
 
@@ -564,6 +601,7 @@ fn with_json_type_filter(
     value: ConditionValue,
     alias: Option<Alias>,
     reverse: bool,
+    ctx: &Context<'_>,
 ) -> Expression<'static> {
     match value {
         ConditionValue::Value(pv) => match pv {
@@ -585,10 +623,10 @@ fn with_json_type_filter(
             _ => unreachable!(),
         },
         ConditionValue::FieldRef(field_ref) if reverse => comparable
-            .or(expr_json.json_type_not_equals(field_ref.aliased_col(alias)))
+            .or(expr_json.json_type_not_equals(field_ref.aliased_col(alias, ctx)))
             .into(),
         ConditionValue::FieldRef(field_ref) => comparable
-            .and(expr_json.json_type_equals(field_ref.aliased_col(alias)))
+            .and(expr_json.json_type_equals(field_ref.aliased_col(alias, ctx)))
             .into(),
     }
 }
@@ -598,17 +636,18 @@ fn default_scalar_filter(
     cond: ScalarCondition,
     fields: &[ScalarFieldRef],
     alias: Option<Alias>,
+    ctx: &Context<'_>,
 ) -> ConditionTree<'static> {
     let condition = match cond {
         ScalarCondition::Equals(ConditionValue::Value(PrismaValue::Null)) => comparable.is_null(),
         ScalarCondition::NotEquals(ConditionValue::Value(PrismaValue::Null)) => comparable.is_not_null(),
-        ScalarCondition::Equals(value) => comparable.equals(convert_first_value(fields, value, alias)),
-        ScalarCondition::NotEquals(value) => comparable.not_equals(convert_first_value(fields, value, alias)),
+        ScalarCondition::Equals(value) => comparable.equals(convert_first_value(fields, value, alias, ctx)),
+        ScalarCondition::NotEquals(value) => comparable.not_equals(convert_first_value(fields, value, alias, ctx)),
         ScalarCondition::Contains(value) => match value {
             ConditionValue::Value(value) => comparable.like(format!("%{}%", value)),
             ConditionValue::FieldRef(field_ref) => comparable.like(quaint::ast::concat::<'_, Expression<'_>>(vec![
                 Value::text("%").raw().into(),
-                field_ref.aliased_col(alias).into(),
+                field_ref.aliased_col(alias, ctx).into(),
                 Value::text("%").raw().into(),
             ])),
         },
@@ -617,7 +656,7 @@ fn default_scalar_filter(
             ConditionValue::FieldRef(field_ref) => {
                 comparable.not_like(quaint::ast::concat::<'_, Expression<'_>>(vec![
                     Value::text("%").raw().into(),
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                     Value::text("%").raw().into(),
                 ]))
             }
@@ -625,7 +664,7 @@ fn default_scalar_filter(
         ScalarCondition::StartsWith(value) => match value {
             ConditionValue::Value(value) => comparable.like(format!("{}%", value)),
             ConditionValue::FieldRef(field_ref) => comparable.like(quaint::ast::concat::<'_, Expression<'_>>(vec![
-                field_ref.aliased_col(alias).into(),
+                field_ref.aliased_col(alias, ctx).into(),
                 Value::text("%").raw().into(),
             ])),
         },
@@ -633,7 +672,7 @@ fn default_scalar_filter(
             ConditionValue::Value(value) => comparable.not_like(format!("{}%", value)),
             ConditionValue::FieldRef(field_ref) => {
                 comparable.not_like(quaint::ast::concat::<'_, Expression<'_>>(vec![
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                     Value::text("%").raw().into(),
                 ]))
             }
@@ -642,7 +681,7 @@ fn default_scalar_filter(
             ConditionValue::Value(value) => comparable.like(format!("%{}", value)),
             ConditionValue::FieldRef(field_ref) => comparable.like(quaint::ast::concat::<'_, Expression<'_>>(vec![
                 Value::text("%").raw().into(),
-                field_ref.aliased_col(alias).into(),
+                field_ref.aliased_col(alias, ctx).into(),
             ])),
         },
         ScalarCondition::NotEndsWith(value) => match value {
@@ -650,17 +689,17 @@ fn default_scalar_filter(
             ConditionValue::FieldRef(field_ref) => {
                 comparable.not_like(quaint::ast::concat::<'_, Expression<'_>>(vec![
                     Value::text("%").raw().into(),
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                 ]))
             }
         },
-        ScalarCondition::LessThan(value) => comparable.less_than(convert_first_value(fields, value, alias)),
+        ScalarCondition::LessThan(value) => comparable.less_than(convert_first_value(fields, value, alias, ctx)),
         ScalarCondition::LessThanOrEquals(value) => {
-            comparable.less_than_or_equals(convert_first_value(fields, value, alias))
+            comparable.less_than_or_equals(convert_first_value(fields, value, alias, ctx))
         }
-        ScalarCondition::GreaterThan(value) => comparable.greater_than(convert_first_value(fields, value, alias)),
+        ScalarCondition::GreaterThan(value) => comparable.greater_than(convert_first_value(fields, value, alias, ctx)),
         ScalarCondition::GreaterThanOrEquals(value) => {
-            comparable.greater_than_or_equals(convert_first_value(fields, value, alias))
+            comparable.greater_than_or_equals(convert_first_value(fields, value, alias, ctx))
         }
         ScalarCondition::In(ConditionListValue::List(values)) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
@@ -677,7 +716,7 @@ fn default_scalar_filter(
         },
         ScalarCondition::In(ConditionListValue::FieldRef(field_ref)) => {
             // This code path is only reachable for connectors with `ScalarLists` capability
-            comparable.equals(Expression::from(field_ref.aliased_col(alias)).any())
+            comparable.equals(Expression::from(field_ref.aliased_col(alias, ctx)).any())
         }
         ScalarCondition::NotIn(ConditionListValue::List(values)) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
@@ -694,7 +733,7 @@ fn default_scalar_filter(
         },
         ScalarCondition::NotIn(ConditionListValue::FieldRef(field_ref)) => {
             // This code path is only reachable for connectors with `ScalarLists` capability
-            comparable.not_equals(Expression::from(field_ref.aliased_col(alias)).all())
+            comparable.not_equals(Expression::from(field_ref.aliased_col(alias, ctx)).all())
         }
         ScalarCondition::Search(value, _) => {
             let query: String = value
@@ -727,6 +766,7 @@ fn insensitive_scalar_filter(
     fields: &[ScalarFieldRef],
     alias: Option<Alias>,
     is_parent_aggregation: bool,
+    ctx: &Context<'_>,
 ) -> ConditionTree<'static> {
     // Current workaround: We assume we can use ILIKE when we see `mode: insensitive`, because postgres is the only DB that has
     // insensitive. We need a connector context for filter building that is unexpectedly complicated to integrate.
@@ -734,12 +774,14 @@ fn insensitive_scalar_filter(
         ScalarCondition::Equals(ConditionValue::Value(PrismaValue::Null)) => comparable.is_null(),
         ScalarCondition::Equals(value) => match value {
             ConditionValue::Value(value) => comparable.compare_raw("ILIKE", format!("{}", value)),
-            ConditionValue::FieldRef(field_ref) => comparable.compare_raw("ILIKE", field_ref.aliased_col(alias)),
+            ConditionValue::FieldRef(field_ref) => comparable.compare_raw("ILIKE", field_ref.aliased_col(alias, ctx)),
         },
         ScalarCondition::NotEquals(ConditionValue::Value(PrismaValue::Null)) => comparable.is_not_null(),
         ScalarCondition::NotEquals(value) => match value {
             ConditionValue::Value(value) => comparable.compare_raw("NOT ILIKE", format!("{}", value)),
-            ConditionValue::FieldRef(field_ref) => comparable.compare_raw("NOT ILIKE", field_ref.aliased_col(alias)),
+            ConditionValue::FieldRef(field_ref) => {
+                comparable.compare_raw("NOT ILIKE", field_ref.aliased_col(alias, ctx))
+            }
         },
         ScalarCondition::Contains(value) => match value {
             ConditionValue::Value(value) => comparable.compare_raw("ILIKE", format!("%{}%", value)),
@@ -747,7 +789,7 @@ fn insensitive_scalar_filter(
                 "ILIKE",
                 concat::<'_, Expression<'_>>(vec![
                     Value::text("%").into(),
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                     Value::text("%").into(),
                 ]),
             ),
@@ -758,7 +800,7 @@ fn insensitive_scalar_filter(
                 "NOT ILIKE",
                 concat::<'_, Expression<'_>>(vec![
                     Value::text("%").into(),
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                     Value::text("%").into(),
                 ]),
             ),
@@ -767,49 +809,49 @@ fn insensitive_scalar_filter(
             ConditionValue::Value(value) => comparable.compare_raw("ILIKE", format!("{}%", value)),
             ConditionValue::FieldRef(field_ref) => comparable.compare_raw(
                 "ILIKE",
-                concat::<'_, Expression<'_>>(vec![field_ref.aliased_col(alias).into(), Value::text("%").into()]),
+                concat::<'_, Expression<'_>>(vec![field_ref.aliased_col(alias, ctx).into(), Value::text("%").into()]),
             ),
         },
         ScalarCondition::NotStartsWith(value) => match value {
             ConditionValue::Value(value) => comparable.compare_raw("NOT ILIKE", format!("{}%", value)),
             ConditionValue::FieldRef(field_ref) => comparable.compare_raw(
                 "NOT ILIKE",
-                concat::<'_, Expression<'_>>(vec![field_ref.aliased_col(alias).into(), Value::text("%").into()]),
+                concat::<'_, Expression<'_>>(vec![field_ref.aliased_col(alias, ctx).into(), Value::text("%").into()]),
             ),
         },
         ScalarCondition::EndsWith(value) => match value {
             ConditionValue::Value(value) => comparable.compare_raw("ILIKE", format!("%{}", value)),
             ConditionValue::FieldRef(field_ref) => comparable.compare_raw(
                 "ILIKE",
-                concat::<'_, Expression<'_>>(vec![Value::text("%").into(), field_ref.aliased_col(alias).into()]),
+                concat::<'_, Expression<'_>>(vec![Value::text("%").into(), field_ref.aliased_col(alias, ctx).into()]),
             ),
         },
         ScalarCondition::NotEndsWith(value) => match value {
             ConditionValue::Value(value) => comparable.compare_raw("NOT ILIKE", format!("%{}", value)),
             ConditionValue::FieldRef(field_ref) => comparable.compare_raw(
                 "NOT ILIKE",
-                concat::<'_, Expression<'_>>(vec![Value::text("%").into(), field_ref.aliased_col(alias).into()]),
+                concat::<'_, Expression<'_>>(vec![Value::text("%").into(), field_ref.aliased_col(alias, ctx).into()]),
             ),
         },
         ScalarCondition::LessThan(value) => {
             let comparable: Expression = lower_if(comparable, !is_parent_aggregation);
 
-            comparable.less_than(lower(convert_first_value(fields, value, alias)))
+            comparable.less_than(lower(convert_first_value(fields, value, alias, ctx)))
         }
         ScalarCondition::LessThanOrEquals(value) => {
             let comparable: Expression = lower_if(comparable, !is_parent_aggregation);
 
-            comparable.less_than_or_equals(lower(convert_first_value(fields, value, alias)))
+            comparable.less_than_or_equals(lower(convert_first_value(fields, value, alias, ctx)))
         }
         ScalarCondition::GreaterThan(value) => {
             let comparable: Expression = lower_if(comparable, !is_parent_aggregation);
 
-            comparable.greater_than(lower(convert_first_value(fields, value, alias)))
+            comparable.greater_than(lower(convert_first_value(fields, value, alias, ctx)))
         }
         ScalarCondition::GreaterThanOrEquals(value) => {
             let comparable: Expression = lower_if(comparable, !is_parent_aggregation);
 
-            comparable.greater_than_or_equals(lower(convert_first_value(fields, value, alias)))
+            comparable.greater_than_or_equals(lower(convert_first_value(fields, value, alias, ctx)))
         }
         ScalarCondition::In(ConditionListValue::List(values)) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
@@ -831,7 +873,7 @@ fn insensitive_scalar_filter(
                     values
                         .into_iter()
                         .map(|value| {
-                            let val: Expression = lower(convert_first_value(fields, value, alias)).into();
+                            let val: Expression = lower(convert_first_value(fields, value, alias, ctx)).into();
                             val
                         })
                         .collect::<Vec<_>>(),
@@ -840,7 +882,7 @@ fn insensitive_scalar_filter(
         },
         ScalarCondition::In(ConditionListValue::FieldRef(field_ref)) => {
             // This code path is only reachable for connectors with `ScalarLists` capability
-            comparable.compare_raw("ILIKE", Expression::from(field_ref.aliased_col(alias)).any())
+            comparable.compare_raw("ILIKE", Expression::from(field_ref.aliased_col(alias, ctx)).any())
         }
         ScalarCondition::NotIn(ConditionListValue::List(values)) => match values.split_first() {
             Some((PrismaValue::List(_), _)) => {
@@ -862,7 +904,7 @@ fn insensitive_scalar_filter(
                     values
                         .into_iter()
                         .map(|value| {
-                            let val: Expression = lower(convert_first_value(fields, value, alias)).into();
+                            let val: Expression = lower(convert_first_value(fields, value, alias, ctx)).into();
                             val
                         })
                         .collect::<Vec<_>>(),
@@ -871,7 +913,7 @@ fn insensitive_scalar_filter(
         },
         ScalarCondition::NotIn(ConditionListValue::FieldRef(field_ref)) => {
             // This code path is only reachable for connectors with `ScalarLists` capability
-            comparable.compare_raw("NOT ILIKE", Expression::from(field_ref.aliased_col(alias)).all())
+            comparable.compare_raw("NOT ILIKE", Expression::from(field_ref.aliased_col(alias, ctx)).all())
         }
         ScalarCondition::Search(value, _) => {
             let query: String = value
@@ -906,10 +948,15 @@ fn lower_if(expr: Expression<'_>, cond: bool) -> Expression<'_> {
     }
 }
 
-fn convert_value<'a>(field: &ScalarFieldRef, value: impl Into<ConditionValue>, alias: Option<Alias>) -> Expression<'a> {
+fn convert_value<'a>(
+    field: &ScalarFieldRef,
+    value: impl Into<ConditionValue>,
+    alias: Option<Alias>,
+    ctx: &Context<'_>,
+) -> Expression<'a> {
     match value.into() {
         ConditionValue::Value(pv) => convert_pv(field, pv),
-        ConditionValue::FieldRef(field_ref) => field_ref.aliased_col(alias).into(),
+        ConditionValue::FieldRef(field_ref) => field_ref.aliased_col(alias, ctx).into(),
     }
 }
 
@@ -917,10 +964,11 @@ fn convert_first_value<'a>(
     fields: &[ScalarFieldRef],
     value: impl Into<ConditionValue>,
     alias: Option<Alias>,
+    ctx: &Context<'_>,
 ) -> Expression<'a> {
     match value.into() {
         ConditionValue::Value(pv) => convert_pv(fields.first().unwrap(), pv),
-        ConditionValue::FieldRef(field_ref) => field_ref.aliased_col(alias).into(),
+        ConditionValue::FieldRef(field_ref) => field_ref.aliased_col(alias, ctx).into(),
     }
 }
 
@@ -953,6 +1001,7 @@ trait JsonFilterExt {
         target_type: JsonTargetType,
         reverse: bool,
         alias: Option<Alias>,
+        ctx: &Context<'_>,
     ) -> Expression<'static>;
 
     fn json_starts_with(
@@ -962,6 +1011,7 @@ trait JsonFilterExt {
         target_type: JsonTargetType,
         reverse: bool,
         alias: Option<Alias>,
+        ctx: &Context<'_>,
     ) -> Expression<'static>;
 
     fn json_ends_with(
@@ -971,6 +1021,7 @@ trait JsonFilterExt {
         target_type: JsonTargetType,
         reverse: bool,
         alias: Option<Alias>,
+        ctx: &Context<'_>,
     ) -> Expression<'static>;
 }
 
@@ -982,6 +1033,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
         target_type: JsonTargetType,
         reverse: bool,
         alias: Option<Alias>,
+        ctx: &Context<'_>,
     ) -> Expression<'static> {
         let (expr_json, expr_string) = self;
 
@@ -1010,7 +1062,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
             (ConditionValue::FieldRef(field_ref), JsonTargetType::String) => {
                 let contains = expr_string.like(quaint::ast::concat::<'_, Expression<'_>>(vec![
                     Value::text("%").raw().into(),
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                     Value::text("%").raw().into(),
                 ]));
 
@@ -1022,7 +1074,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
             }
             // array_contains (ref)
             (ConditionValue::FieldRef(field_ref), JsonTargetType::Array) => {
-                let contains = expr_json.clone().json_array_contains(field_ref.aliased_col(alias));
+                let contains = expr_json.clone().json_array_contains(field_ref.aliased_col(alias, ctx));
 
                 if reverse {
                     contains.or(expr_json.json_type_not_equals(JsonType::Array)).into()
@@ -1040,6 +1092,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
         target_type: JsonTargetType,
         reverse: bool,
         alias: Option<Alias>,
+        ctx: &Context<'_>,
     ) -> Expression<'static> {
         let (expr_json, expr_string) = self;
         match (value, target_type) {
@@ -1066,7 +1119,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
             // string_starts_with (ref)
             (ConditionValue::FieldRef(field_ref), JsonTargetType::String) => {
                 let starts_with = expr_string.like(quaint::ast::concat::<'_, Expression<'_>>(vec![
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                     Value::text("%").raw().into(),
                 ]));
 
@@ -1078,7 +1131,9 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
             }
             // array_starts_with (ref)
             (ConditionValue::FieldRef(field_ref), JsonTargetType::Array) => {
-                let starts_with = expr_json.clone().json_array_begins_with(field_ref.aliased_col(alias));
+                let starts_with = expr_json
+                    .clone()
+                    .json_array_begins_with(field_ref.aliased_col(alias, ctx));
 
                 if reverse {
                     starts_with.or(expr_json.json_type_not_equals(JsonType::Array)).into()
@@ -1096,6 +1151,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
         target_type: JsonTargetType,
         reverse: bool,
         alias: Option<Alias>,
+        ctx: &Context<'_>,
     ) -> Expression<'static> {
         let (expr_json, expr_string) = self;
 
@@ -1124,7 +1180,7 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
             (ConditionValue::FieldRef(field_ref), JsonTargetType::String) => {
                 let ends_with = expr_string.like(quaint::ast::concat::<'_, Expression<'_>>(vec![
                     Value::text("%").raw().into(),
-                    field_ref.aliased_col(alias).into(),
+                    field_ref.aliased_col(alias, ctx).into(),
                 ]));
 
                 if reverse {
@@ -1135,7 +1191,9 @@ impl JsonFilterExt for (Expression<'static>, Expression<'static>) {
             }
             // array_ends_with (ref)
             (ConditionValue::FieldRef(field_ref), JsonTargetType::Array) => {
-                let ends_with = expr_json.clone().json_array_ends_into(field_ref.aliased_col(alias));
+                let ends_with = expr_json
+                    .clone()
+                    .json_array_ends_into(field_ref.aliased_col(alias, ctx));
 
                 if reverse {
                     ends_with.or(expr_json.json_type_not_equals(JsonType::Array)).into()

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 
 mod column_metadata;
+mod context;
 mod cursor_condition;
 mod database;
 mod error;
@@ -26,6 +27,7 @@ mod sql_trace;
 mod value;
 mod value_ext;
 
+use self::context::Context;
 use column_metadata::*;
 use filter_conversion::*;
 use query_ext::QueryExt;

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/column.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/column.rs
@@ -1,8 +1,7 @@
-use crate::model_extensions::ScalarFieldExt;
+use crate::{model_extensions::ScalarFieldExt, Context};
 use itertools::Itertools;
 use prisma_models::{Field, ModelProjection, RelationField, ScalarField};
 use quaint::ast::{Column, Row};
-use std::convert::AsRef;
 
 pub struct ColumnIterator {
     inner: Box<dyn Iterator<Item = Column<'static>> + 'static>,
@@ -24,19 +23,19 @@ impl From<Vec<Column<'static>>> for ColumnIterator {
     }
 }
 
-pub trait AsRow {
-    fn as_row(&self) -> Row<'static>;
+pub(crate) trait AsRow {
+    fn as_row(&self, ctx: &Context<'_>) -> Row<'static>;
 }
 
-pub trait AsColumns {
-    fn as_columns(&self) -> ColumnIterator;
+pub(crate) trait AsColumns {
+    fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator;
 }
 
 impl AsColumns for ModelProjection {
-    fn as_columns(&self) -> ColumnIterator {
+    fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
         let cols: Vec<Column<'static>> = self
             .fields()
-            .flat_map(|f| f.as_columns())
+            .flat_map(|f| f.as_columns(ctx))
             .unique_by(|c| c.name.clone())
             .collect();
 
@@ -45,29 +44,29 @@ impl AsColumns for ModelProjection {
 }
 
 impl AsRow for ModelProjection {
-    fn as_row(&self) -> Row<'static> {
-        let cols: Vec<Column<'static>> = self.as_columns().collect();
+    fn as_row(&self, ctx: &Context<'_>) -> Row<'static> {
+        let cols: Vec<Column<'static>> = self.as_columns(ctx).collect();
         Row::from(cols)
     }
 }
 
-pub trait AsColumn {
-    fn as_column(&self) -> Column<'static>;
+pub(crate) trait AsColumn {
+    fn as_column(&self, ctx: &Context<'_>) -> Column<'static>;
 }
 
 impl AsColumns for Field {
-    fn as_columns(&self) -> ColumnIterator {
+    fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
         match self {
-            Field::Scalar(ref sf) => ColumnIterator::from(vec![sf.as_column()]),
-            Field::Relation(ref rf) => rf.as_columns(),
+            Field::Scalar(ref sf) => ColumnIterator::from(vec![sf.as_column(ctx)]),
+            Field::Relation(ref rf) => rf.as_columns(ctx),
             Field::Composite(_) => unimplemented!(),
         }
     }
 }
 
 impl AsColumns for RelationField {
-    fn as_columns(&self) -> ColumnIterator {
-        self.scalar_fields().as_columns()
+    fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
+        self.scalar_fields().as_columns(ctx)
     }
 }
 
@@ -75,8 +74,8 @@ impl<T> AsColumns for &[T]
 where
     T: AsColumn,
 {
-    fn as_columns(&self) -> ColumnIterator {
-        let inner: Vec<_> = self.iter().map(|x| x.as_column()).collect();
+    fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
+        let inner: Vec<_> = self.iter().map(|x| x.as_column(ctx)).collect();
         ColumnIterator::from(inner)
     }
 }
@@ -85,8 +84,8 @@ impl<T> AsColumns for Vec<T>
 where
     T: AsColumn,
 {
-    fn as_columns(&self) -> ColumnIterator {
-        let inner: Vec<_> = self.iter().map(|x| x.as_column()).collect();
+    fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
+        let inner: Vec<_> = self.iter().map(|x| x.as_column(ctx)).collect();
         ColumnIterator::from(inner)
     }
 }
@@ -95,11 +94,11 @@ impl<T> AsColumn for T
 where
     T: AsRef<ScalarField>,
 {
-    fn as_column(&self) -> Column<'static> {
+    fn as_column(&self, ctx: &Context<'_>) -> Column<'static> {
         let sf = self.as_ref();
 
         // Unwrap is safe: SQL connectors do not anything other than models as field containers.
-        let full_table_name = sf.container().as_model().unwrap().db_name_with_schema();
+        let full_table_name = super::table::db_name_with_schema(&sf.container().as_model().unwrap(), ctx);
         let col = sf.db_name().to_string();
 
         let column = Column::from((full_table_name, col)).type_family(sf.type_family());

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/mod.rs
@@ -5,9 +5,4 @@ mod scalar_field;
 mod selection_result;
 mod table;
 
-pub use column::*;
-pub use record::*;
-pub use relation::*;
-pub use scalar_field::*;
-pub use selection_result::*;
-pub use table::*;
+pub(crate) use self::{column::*, record::*, relation::*, scalar_field::*, selection_result::*, table::*};

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/relation.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/relation.rs
@@ -1,18 +1,20 @@
-use super::{AsTable, ColumnIterator};
-use crate::model_extensions::AsColumns;
+use crate::{
+    model_extensions::{AsColumns, AsTable, ColumnIterator},
+    Context,
+};
 use prisma_models::{ModelProjection, Relation, RelationField, RelationLinkManifestation, RelationSide};
 use quaint::{ast::Table, prelude::Column};
 use RelationLinkManifestation::*;
 
-pub trait RelationFieldExt {
-    fn m2m_columns(&self) -> Vec<Column<'static>>;
-    fn join_columns(&self) -> ColumnIterator;
-    fn identifier_columns(&self) -> ColumnIterator;
-    fn as_table(&self) -> Table<'static>;
+pub(crate) trait RelationFieldExt {
+    fn m2m_columns(&self, ctx: &Context<'_>) -> Vec<Column<'static>>;
+    fn join_columns(&self, ctx: &Context<'_>) -> ColumnIterator;
+    fn identifier_columns(&self, ctx: &Context<'_>) -> ColumnIterator;
+    fn as_table(&self, ctx: &Context<'_>) -> Table<'static>;
 }
 
 impl RelationFieldExt for RelationField {
-    fn m2m_columns(&self) -> Vec<Column<'static>> {
+    fn m2m_columns(&self, ctx: &Context<'_>) -> Vec<Column<'static>> {
         let references = &self.relation_info().references;
         let prefix = if self.relation_side.is_a() { "B" } else { "A" };
 
@@ -20,34 +22,34 @@ impl RelationFieldExt for RelationField {
             references
                 .iter()
                 .map(|to_field| format!("{}_{}", prefix, to_field))
-                .map(|name| Column::from(name).table(self.as_table()))
+                .map(|name| Column::from(name).table(self.as_table(ctx)))
                 .collect()
         } else {
-            vec![Column::from(prefix).table(self.as_table())]
+            vec![Column::from(prefix).table(self.as_table(ctx))]
         }
     }
 
-    fn join_columns(&self) -> ColumnIterator {
-        match (self.relation().manifestation(), &self.relation_side) {
+    fn join_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
+        match (&self.relation().manifestation(), &self.relation_side) {
             (RelationTable(ref m), RelationSide::A) => ColumnIterator::from(vec![m.model_b_column.clone().into()]),
             (RelationTable(ref m), RelationSide::B) => ColumnIterator::from(vec![m.model_a_column.clone().into()]),
-            _ => ModelProjection::from(self.linking_fields()).as_columns(),
+            _ => ModelProjection::from(self.linking_fields()).as_columns(ctx),
         }
     }
 
-    fn identifier_columns(&self) -> ColumnIterator {
-        match (self.relation().manifestation(), &self.relation_side) {
+    fn identifier_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
+        match (&self.relation().manifestation(), &self.relation_side) {
             (RelationTable(ref m), RelationSide::A) => ColumnIterator::from(vec![m.model_a_column.clone().into()]),
             (RelationTable(ref m), RelationSide::B) => ColumnIterator::from(vec![m.model_b_column.clone().into()]),
-            _ => ModelProjection::from(self.model().primary_identifier()).as_columns(),
+            _ => ModelProjection::from(self.model().primary_identifier()).as_columns(ctx),
         }
     }
 
-    fn as_table(&self) -> Table<'static> {
+    fn as_table(&self, ctx: &Context<'_>) -> Table<'static> {
         if self.relation().is_many_to_many() {
-            self.related_field().relation().as_table()
+            self.related_field().relation().as_table(ctx)
         } else {
-            self.model().as_table()
+            self.model().as_table(ctx)
         }
     }
 }
@@ -59,16 +61,14 @@ impl AsTable for Relation {
     /// - One of the model tables for one-to-many or one-to-one relations.
     /// - A separate relation table for all relations, if using the deprecated
     ///   data model syntax.
-    fn as_table(&self) -> Table<'static> {
+    fn as_table(&self, ctx: &Context<'_>) -> Table<'static> {
         match self.manifestation() {
             // In this case we must define our unique indices for the relation
             // table, so MSSQL can convert the `INSERT .. ON CONFLICT IGNORE` into
             // a `MERGE` statement.
             RelationLinkManifestation::RelationTable(ref m) => {
                 let model_a = self.model_a();
-                let prefix = model_a
-                    .schema_name()
-                    .unwrap_or_else(|| model_a.internal_data_model().db_name.clone());
+                let prefix = model_a.schema_name().unwrap_or_else(|| ctx.schema_name().to_owned());
                 let table: Table = (prefix, m.table.clone()).into();
 
                 table.add_unique_index(vec![Column::from("A"), Column::from("B")])
@@ -77,7 +77,7 @@ impl AsTable for Relation {
                 .internal_data_model()
                 .find_model(&m.in_table_of_model_name)
                 .unwrap()
-                .as_table(),
+                .as_table(ctx),
         }
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/table.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/table.rs
@@ -1,26 +1,32 @@
-use super::AsColumns;
+use crate::{model_extensions::AsColumns, Context};
 use prisma_models::Model;
 use quaint::ast::{Column, Table};
 
-pub trait AsTable {
-    fn as_table(&self) -> Table<'static>;
+pub(crate) fn db_name_with_schema(model: &Model, ctx: &Context<'_>) -> Table<'static> {
+    let schema_prefix = model.schema_name().unwrap_or_else(|| ctx.schema_name().to_owned());
+    let model_db_name = model.db_name().to_string();
+    (schema_prefix, model_db_name).into()
+}
+
+pub(crate) trait AsTable {
+    fn as_table(&self, ctx: &Context<'_>) -> Table<'static>;
 }
 
 impl AsTable for Model {
-    fn as_table(&self) -> Table<'static> {
-        let table: Table<'static> = self.db_name_with_schema().into();
+    fn as_table(&self, ctx: &Context<'_>) -> Table<'static> {
+        let table: Table<'static> = db_name_with_schema(self, ctx);
 
         let id_cols: Vec<Column<'static>> = self
             .primary_identifier()
             .as_scalar_fields()
             .expect("Primary identifier has non-scalar fields.")
-            .as_columns()
+            .as_columns(ctx)
             .collect();
 
         let table = table.add_unique_index(id_cols);
 
         self.unique_indexes().into_iter().fold(table, |table, index| {
-            let index: Vec<Column<'static>> = index.fields().as_columns().collect();
+            let index: Vec<Column<'static>> = index.fields().as_columns(ctx).collect();
             table.add_unique_index(index)
         })
     }

--- a/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
+++ b/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
@@ -1,16 +1,19 @@
-use crate::join_utils::{compute_aggr_join, AggregationType, AliasedJoin};
+use crate::{
+    join_utils::{compute_aggr_join, AggregationType, AliasedJoin},
+    Context,
+};
 use connector_interface::RelAggregationSelection;
 use quaint::prelude::*;
 
 #[derive(Debug)]
-pub struct RelAggregationJoins {
+pub(crate) struct RelAggregationJoins {
     // Joins necessary to perform the relation aggregations
     pub(crate) joins: Vec<AliasedJoin>,
     // Aggregator columns
     pub(crate) columns: Vec<Expression<'static>>,
 }
 
-pub fn build(aggr_selections: &[RelAggregationSelection]) -> RelAggregationJoins {
+pub(crate) fn build(aggr_selections: &[RelAggregationSelection], ctx: &Context<'_>) -> RelAggregationJoins {
     let mut joins = vec![];
     let mut columns: Vec<Expression<'static>> = vec![];
 
@@ -26,6 +29,7 @@ pub fn build(aggr_selections: &[RelAggregationSelection]) -> RelAggregationJoins
                     aggregator_alias.as_str(),
                     join_alias.as_str(),
                     None,
+                    ctx,
                 );
 
                 columns.push(Column::from((join.alias.clone(), aggregator_alias)).into());

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -1,4 +1,4 @@
-use crate::{join_utils::*, model_extensions::*, query_arguments_ext::QueryArgumentsExt};
+use crate::{join_utils::*, model_extensions::*, query_arguments_ext::QueryArgumentsExt, Context};
 use connector_interface::QueryArguments;
 use itertools::Itertools;
 use prisma_models::*;
@@ -25,7 +25,7 @@ pub(crate) struct OrderByBuilder {
 
 impl OrderByBuilder {
     /// Builds all expressions for an `ORDER BY` clause based on the query arguments.
-    pub(crate) fn build(&mut self, query_arguments: &QueryArguments) -> Vec<OrderByDefinition> {
+    pub(crate) fn build(&mut self, query_arguments: &QueryArguments, ctx: &Context<'_>) -> Vec<OrderByDefinition> {
         let needs_reversed_order = query_arguments.needs_reversed_order();
 
         // The index is used to differentiate potentially separate relations to the same model.
@@ -33,16 +33,23 @@ impl OrderByBuilder {
             .order_by
             .iter()
             .map(|order_by| match order_by {
-                OrderBy::Scalar(order_by) => self.build_order_scalar(order_by, needs_reversed_order),
-                OrderBy::ScalarAggregation(order_by) => self.build_order_aggr_scalar(order_by, needs_reversed_order),
-                OrderBy::ToManyAggregation(order_by) => self.build_order_aggr_rel(order_by, needs_reversed_order),
-                OrderBy::Relevance(order_by) => self.build_order_relevance(order_by, needs_reversed_order),
+                OrderBy::Scalar(order_by) => self.build_order_scalar(order_by, needs_reversed_order, ctx),
+                OrderBy::ScalarAggregation(order_by) => {
+                    self.build_order_aggr_scalar(order_by, needs_reversed_order, ctx)
+                }
+                OrderBy::ToManyAggregation(order_by) => self.build_order_aggr_rel(order_by, needs_reversed_order, ctx),
+                OrderBy::Relevance(order_by) => self.build_order_relevance(order_by, needs_reversed_order, ctx),
             })
             .collect_vec()
     }
 
-    fn build_order_scalar(&mut self, order_by: &OrderByScalar, needs_reversed_order: bool) -> OrderByDefinition {
-        let (joins, order_column) = self.compute_joins_scalar(order_by);
+    fn build_order_scalar(
+        &mut self,
+        order_by: &OrderByScalar,
+        needs_reversed_order: bool,
+        ctx: &Context<'_>,
+    ) -> OrderByDefinition {
+        let (joins, order_column) = self.compute_joins_scalar(order_by, ctx);
         let order: Option<Order> = Some(into_order(
             &order_by.sort_order,
             order_by.nulls_order.as_ref(),
@@ -57,8 +64,13 @@ impl OrderByBuilder {
         }
     }
 
-    fn build_order_relevance(&mut self, order_by: &OrderByRelevance, needs_reversed_order: bool) -> OrderByDefinition {
-        let columns: Vec<Expression> = order_by.fields.iter().map(|sf| sf.as_column().into()).collect();
+    fn build_order_relevance(
+        &mut self,
+        order_by: &OrderByRelevance,
+        needs_reversed_order: bool,
+        ctx: &Context<'_>,
+    ) -> OrderByDefinition {
+        let columns: Vec<Expression> = order_by.fields.iter().map(|sf| sf.as_column(ctx).into()).collect();
         let order_column: Expression = text_search_relevance(&columns, order_by.search.clone()).into();
         let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
         let order_definition: OrderDefinition = (order_column.clone(), order);
@@ -74,9 +86,10 @@ impl OrderByBuilder {
         &mut self,
         order_by: &OrderByScalarAggregation,
         needs_reversed_order: bool,
+        ctx: &Context<'_>,
     ) -> OrderByDefinition {
         let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
-        let order_column = order_by.field.as_column();
+        let order_column = order_by.field.as_column(ctx);
         let order_definition: OrderDefinition = match order_by.sort_aggregation {
             SortAggregation::Count => (count(order_column.clone()).into(), order),
             SortAggregation::Avg => (avg(order_column.clone()).into(), order),
@@ -96,9 +109,10 @@ impl OrderByBuilder {
         &mut self,
         order_by: &OrderByToManyAggregation,
         needs_reversed_order: bool,
+        ctx: &Context<'_>,
     ) -> OrderByDefinition {
         let order: Option<Order> = Some(into_order(&order_by.sort_order, None, needs_reversed_order));
-        let (joins, order_column) = self.compute_joins_aggregation(order_by);
+        let (joins, order_column) = self.compute_joins_aggregation(order_by, ctx);
         let order_definition: OrderDefinition = match order_by.sort_aggregation {
             SortAggregation::Count => {
                 let exprs: Vec<Expression> = vec![order_column.clone().into(), Value::integer(0).into()];
@@ -120,6 +134,7 @@ impl OrderByBuilder {
     fn compute_joins_aggregation(
         &mut self,
         order_by: &OrderByToManyAggregation,
+        ctx: &Context<'_>,
     ) -> (Vec<AliasedJoin>, Column<'static>) {
         let (last_hop, rest_hops) = order_by
             .path
@@ -131,7 +146,12 @@ impl OrderByBuilder {
         for (i, hop) in rest_hops.iter().enumerate() {
             let previous_join = if i > 0 { joins.get(i - 1) } else { None };
 
-            let join = compute_one2m_join(hop.into_relation_hop().unwrap(), &self.join_prefix(), previous_join);
+            let join = compute_one2m_join(
+                hop.into_relation_hop().unwrap(),
+                &self.join_prefix(),
+                previous_join,
+                ctx,
+            );
 
             joins.push(join);
         }
@@ -149,6 +169,7 @@ impl OrderByBuilder {
             ORDER_AGGREGATOR_ALIAS,
             &self.join_prefix(),
             joins.last(),
+            ctx,
         );
 
         // This is the final column identifier to be used for the scalar field to order by.
@@ -160,12 +181,21 @@ impl OrderByBuilder {
         (joins, order_by_column)
     }
 
-    pub fn compute_joins_scalar(&mut self, order_by: &OrderByScalar) -> (Vec<AliasedJoin>, Column<'static>) {
+    pub(crate) fn compute_joins_scalar(
+        &mut self,
+        order_by: &OrderByScalar,
+        ctx: &Context<'_>,
+    ) -> (Vec<AliasedJoin>, Column<'static>) {
         let mut joins = vec![];
 
         for (i, hop) in order_by.path.iter().enumerate() {
             let previous_join = if i > 0 { joins.get(i - 1) } else { None };
-            let join = compute_one2m_join(hop.into_relation_hop().unwrap(), &self.join_prefix(), previous_join);
+            let join = compute_one2m_join(
+                hop.into_relation_hop().unwrap(),
+                &self.join_prefix(),
+                previous_join,
+                ctx,
+            );
 
             joins.push(join);
         }
@@ -178,7 +208,7 @@ impl OrderByBuilder {
         let order_by_column = if let Some(last_join) = joins.last() {
             Column::from((last_join.alias.to_owned(), order_by.field.db_name().to_owned()))
         } else {
-            order_by.field.as_column()
+            order_by.field.as_column(ctx)
         };
 
         (joins, order_by_column)

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -1,6 +1,6 @@
 use crate::{
     cursor_condition, filter_conversion::AliasedCondition, model_extensions::*, nested_aggregations,
-    ordering::OrderByBuilder, sql_trace::SqlTraceComment,
+    ordering::OrderByBuilder, sql_trace::SqlTraceComment, Context,
 };
 use connector_interface::{filter::Filter, AggregationSelection, QueryArguments, RelAggregationSelection};
 use itertools::Itertools;
@@ -13,7 +13,7 @@ pub(crate) trait SelectDefinition {
         self,
         _: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> (Select<'static>, Vec<Expression<'static>>);
 }
 
@@ -22,10 +22,10 @@ impl SelectDefinition for Filter {
         self,
         model: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
         let args = QueryArguments::from((model.clone(), self));
-        args.into_select(model, aggr_selections, trace_id)
+        args.into_select(model, aggr_selections, ctx)
     }
 }
 
@@ -34,9 +34,9 @@ impl SelectDefinition for &Filter {
         self,
         model: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
-        self.clone().into_select(model, aggr_selections, trace_id)
+        self.clone().into_select(model, aggr_selections, ctx)
     }
 }
 
@@ -45,7 +45,7 @@ impl SelectDefinition for Select<'static> {
         self,
         _: &ModelRef,
         _: &[RelAggregationSelection],
-        _trace_id: Option<&str>,
+        _ctx: &Context<'_>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
         (self, vec![])
     }
@@ -56,18 +56,18 @@ impl SelectDefinition for QueryArguments {
         self,
         model: &ModelRef,
         aggr_selections: &[RelAggregationSelection],
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
-        let order_by_definitions = OrderByBuilder::default().build(&self);
-        let (table_opt, cursor_condition) = cursor_condition::build(&self, &model, &order_by_definitions);
-        let aggregation_joins = nested_aggregations::build(aggr_selections);
+        let order_by_definitions = OrderByBuilder::default().build(&self, ctx);
+        let (table_opt, cursor_condition) = cursor_condition::build(&self, &model, &order_by_definitions, ctx);
+        let aggregation_joins = nested_aggregations::build(aggr_selections, ctx);
 
         let limit = if self.ignore_take { None } else { self.take_abs() };
         let skip = if self.ignore_skip { 0 } else { self.skip.unwrap_or(0) };
 
         let filter: ConditionTree = self
             .filter
-            .map(|f| f.aliased_condition_from(None, false))
+            .map(|f| f.aliased_condition_from(None, false, ctx))
             .unwrap_or(ConditionTree::NoCondition);
 
         let conditions = match (filter, cursor_condition) {
@@ -80,7 +80,7 @@ impl SelectDefinition for QueryArguments {
         let joined_table = order_by_definitions
             .iter()
             .flat_map(|j| &j.joins)
-            .fold(model.as_table(), |acc, join| acc.left_join(join.clone().data));
+            .fold(model.as_table(ctx), |acc, join| acc.left_join(join.clone().data));
 
         // Add joins necessary to the nested aggregations
         let joined_table = aggregation_joins
@@ -92,7 +92,7 @@ impl SelectDefinition for QueryArguments {
             .so_that(conditions)
             .offset(skip as usize)
             .append_trace(&Span::current())
-            .add_trace_id(trace_id);
+            .add_trace_id(ctx.trace_id);
 
         let select_ast = if let Some(table) = table_opt {
             select_ast.and_from(table)
@@ -116,15 +116,15 @@ pub(crate) fn get_records<T>(
     columns: impl Iterator<Item = Column<'static>>,
     aggr_selections: &[RelAggregationSelection],
     query: T,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> Select<'static>
 where
     T: SelectDefinition,
 {
-    let (select, additional_selection_set) = query.into_select(model, aggr_selections, trace_id);
+    let (select, additional_selection_set) = query.into_select(model, aggr_selections, ctx);
     let select = columns.fold(select, |acc, col| acc.column(col));
 
-    let select = select.append_trace(&Span::current()).add_trace_id(trace_id);
+    let select = select.append_trace(&Span::current()).add_trace_id(ctx.trace_id);
 
     additional_selection_set
         .into_iter()
@@ -161,16 +161,16 @@ pub(crate) fn aggregate(
     model: &ModelRef,
     selections: &[AggregationSelection],
     args: QueryArguments,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> Select<'static> {
-    let columns = extract_columns(model, &selections);
-    let sub_query = get_records(model, columns.into_iter(), &[], args, trace_id);
+    let columns = extract_columns(model, &selections, ctx);
+    let sub_query = get_records(model, columns.into_iter(), &[], args, ctx);
     let sub_table = Table::from(sub_query).alias("sub");
 
     selections.iter().fold(
         Select::from_table(sub_table)
             .append_trace(&Span::current())
-            .add_trace_id(trace_id),
+            .add_trace_id(ctx.trace_id),
         |select, next_op| match next_op {
             AggregationSelection::Field(field) => select.column(Column::from(field.db_name().to_owned())),
 
@@ -211,17 +211,17 @@ pub(crate) fn group_by_aggregate(
     selections: &[AggregationSelection],
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
-    trace_id: Option<&str>,
+    ctx: &Context<'_>,
 ) -> Select<'static> {
-    let (base_query, _) = args.into_select(model, &[], trace_id);
+    let (base_query, _) = args.into_select(model, &[], ctx);
 
     let select_query = selections.iter().fold(base_query, |select, next_op| match next_op {
-        AggregationSelection::Field(field) => select.column(field.as_column()),
+        AggregationSelection::Field(field) => select.column(field.as_column(ctx)),
 
         AggregationSelection::Count { all, fields } => {
-            let select = fields
-                .iter()
-                .fold(select, |select, next_field| select.value(count(next_field.as_column())));
+            let select = fields.iter().fold(select, |select, next_field| {
+                select.value(count(next_field.as_column(ctx)))
+            });
 
             if *all {
                 select.value(count(asterisk()))
@@ -230,35 +230,35 @@ pub(crate) fn group_by_aggregate(
             }
         }
 
-        AggregationSelection::Average(fields) => fields
-            .iter()
-            .fold(select, |select, next_field| select.value(avg(next_field.as_column()))),
+        AggregationSelection::Average(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(avg(next_field.as_column(ctx)))
+        }),
 
-        AggregationSelection::Sum(fields) => fields
-            .iter()
-            .fold(select, |select, next_field| select.value(sum(next_field.as_column()))),
+        AggregationSelection::Sum(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(sum(next_field.as_column(ctx)))
+        }),
 
-        AggregationSelection::Min(fields) => fields
-            .iter()
-            .fold(select, |select, next_field| select.value(min(next_field.as_column()))),
+        AggregationSelection::Min(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(min(next_field.as_column(ctx)))
+        }),
 
-        AggregationSelection::Max(fields) => fields
-            .iter()
-            .fold(select, |select, next_field| select.value(max(next_field.as_column()))),
+        AggregationSelection::Max(fields) => fields.iter().fold(select, |select, next_field| {
+            select.value(max(next_field.as_column(ctx)))
+        }),
     });
 
     let grouped = group_by.into_iter().fold(
-        select_query.append_trace(&Span::current()).add_trace_id(trace_id),
-        |query, field| query.group_by(field.as_column()),
+        select_query.append_trace(&Span::current()).add_trace_id(ctx.trace_id),
+        |query, field| query.group_by(field.as_column(ctx)),
     );
 
     match having {
-        Some(filter) => grouped.having(filter.aliased_condition_from(None, false)),
+        Some(filter) => grouped.having(filter.aliased_condition_from(None, false, ctx)),
         None => grouped,
     }
 }
 
-fn extract_columns(model: &ModelRef, selections: &[AggregationSelection]) -> Vec<Column<'static>> {
+fn extract_columns(model: &ModelRef, selections: &[AggregationSelection], ctx: &Context<'_>) -> Vec<Column<'static>> {
     let fields: Vec<_> = selections
         .iter()
         .flat_map(|selection| match selection {
@@ -281,5 +281,5 @@ fn extract_columns(model: &ModelRef, selections: &[AggregationSelection]) -> Vec
         .unique_by(|field| field.db_name().to_owned())
         .collect();
 
-    fields.as_columns().collect()
+    fields.as_columns(ctx).collect()
 }

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -1,6 +1,7 @@
 use crate::{
-    column_metadata, error::*, model_extensions::*, sql_info::SqlInfo, sql_trace::SqlTraceComment,
-    value_ext::IntoTypedJsonExtension, AliasedCondition, ColumnMetadata, SqlRow, ToSqlRow,
+    column_metadata, error::*, model_extensions::*, sql_info::SqlInfo, sql_trace::trace_parent_to_string,
+    sql_trace::SqlTraceComment, value_ext::IntoTypedJsonExtension, AliasedCondition, ColumnMetadata, Context, SqlRow,
+    ToSqlRow,
 };
 use async_trait::async_trait;
 use connector_interface::{filter::Filter, RecordFilter};
@@ -15,12 +16,9 @@ use quaint::{
 };
 use tracing_futures::Instrument;
 
+use opentelemetry::trace::TraceContextExt;
 use serde_json::{Map, Value};
 use std::{collections::HashMap, panic::AssertUnwindSafe};
-
-use crate::sql_trace::trace_parent_to_string;
-
-use opentelemetry::trace::TraceContextExt;
 use tracing::{info_span, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
@@ -30,13 +28,13 @@ impl QueryExt for PooledConnection {}
 /// An extension trait for Quaint's `Queryable`, offering certain Prisma-centric
 /// database operations on top of `Queryable`.
 #[async_trait]
-pub trait QueryExt: Queryable + Send + Sync {
+pub(crate) trait QueryExt: Queryable + Send + Sync {
     /// Filter and map the resulting types with the given identifiers.
     async fn filter(
         &self,
         q: Query<'_>,
         idents: &[ColumnMetadata<'_>],
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> crate::Result<Vec<SqlRow>> {
         let span = info_span!("filter read query");
 
@@ -44,7 +42,7 @@ pub trait QueryExt: Queryable + Send + Sync {
         let span_ref = otel_ctx.span();
         let span_ctx = span_ref.span_context();
 
-        let q = match (q, trace_id) {
+        let q = match (q, ctx.trace_id) {
             (Query::Select(x), _) if span_ctx.trace_flags() == TraceFlags::SAMPLED => {
                 Query::Select(Box::from(x.comment(trace_parent_to_string(span_ctx))))
             }
@@ -118,8 +116,8 @@ pub trait QueryExt: Queryable + Send + Sync {
     }
 
     /// Select one row from the database.
-    async fn find(&self, q: Select<'_>, meta: &[ColumnMetadata<'_>], trace_id: Option<&str>) -> crate::Result<SqlRow> {
-        self.filter(q.limit(1).into(), meta, trace_id)
+    async fn find(&self, q: Select<'_>, meta: &[ColumnMetadata<'_>], ctx: &Context<'_>) -> crate::Result<SqlRow> {
+        self.filter(q.limit(1).into(), meta, ctx)
             .await?
             .into_iter()
             .next()
@@ -132,12 +130,12 @@ pub trait QueryExt: Queryable + Send + Sync {
         &self,
         model: &ModelRef,
         record_filter: RecordFilter,
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> crate::Result<Vec<SelectionResult>> {
         if let Some(selectors) = record_filter.selectors {
             Ok(selectors)
         } else {
-            self.filter_ids(model, record_filter.filter, trace_id).await
+            self.filter_ids(model, record_filter.filter, ctx).await
         }
     }
 
@@ -146,25 +144,25 @@ pub trait QueryExt: Queryable + Send + Sync {
         &self,
         model: &ModelRef,
         filter: Filter,
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> crate::Result<Vec<SelectionResult>> {
         let model_id: ModelProjection = model.primary_identifier().into();
-        let id_cols: Vec<Column<'static>> = model_id.as_columns().collect();
+        let id_cols: Vec<Column<'static>> = model_id.as_columns(ctx).collect();
 
-        let select = Select::from_table(model.as_table())
+        let select = Select::from_table(model.as_table(ctx))
             .columns(id_cols)
             .append_trace(&Span::current())
-            .add_trace_id(trace_id)
-            .so_that(filter.aliased_condition_from(None, false));
+            .add_trace_id(ctx.trace_id)
+            .so_that(filter.aliased_condition_from(None, false, ctx));
 
-        self.select_ids(select, model_id, trace_id).await
+        self.select_ids(select, model_id, ctx).await
     }
 
     async fn select_ids(
         &self,
         select: Select<'_>,
         model_id: ModelProjection,
-        trace_id: Option<&str>,
+        ctx: &Context<'_>,
     ) -> crate::Result<Vec<SelectionResult>> {
         let idents: Vec<_> = model_id
             .fields()
@@ -179,7 +177,7 @@ pub trait QueryExt: Queryable + Send + Sync {
         let meta = column_metadata::create(field_names.as_slice(), &idents);
 
         // TODO: Add tracing
-        let mut rows = self.filter(select.into(), &meta, trace_id).await?;
+        let mut rows = self.filter(select.into(), &meta, ctx).await?;
         let mut result = Vec::new();
 
         for row in rows.drain(0..) {

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -80,7 +80,7 @@ impl From<SqlRow> for Record {
     }
 }
 
-pub trait ToSqlRow {
+pub(crate) trait ToSqlRow {
     /// Conversion from a database specific row to an allocated `SqlRow`. To
     /// help deciding the right types, the provided `ColumnMetadata`s should map
     /// to the returned columns in the right order.

--- a/query-engine/core/src/executor/loader.rs
+++ b/query-engine/core/src/executor/loader.rs
@@ -1,25 +1,20 @@
 use super::{interpreting_executor::InterpretingExecutor, QueryExecutor};
 use crate::CoreError;
-use connection_string::JdbcString;
 use connector::Connector;
-use mongodb_client::MongoConnectionString;
 use psl::{builtin_connectors::*, Datasource, PreviewFeatures};
 use sql_connector::*;
 use std::collections::HashMap;
-use std::str::FromStr;
 use url::Url;
 
 #[cfg(feature = "mongodb")]
 use mongodb_connector::MongoDb;
-
-const DEFAULT_SQLITE_DB_NAME: &str = "main";
 
 /// Loads a query executor based on the parsed Prisma schema (datasource).
 pub async fn load(
     source: &Datasource,
     features: PreviewFeatures,
     url: &str,
-) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
+) -> crate::Result<Box<dyn QueryExecutor + Send + Sync>> {
     match source.active_provider {
         p if SQLITE.is_provider(p) => sqlite(source, url, features).await,
         p if MYSQL.is_provider(p) => mysql(source, url, features).await,
@@ -37,82 +32,22 @@ pub async fn load(
     }
 }
 
-pub fn db_name(source: &Datasource, url: &str) -> crate::Result<String> {
-    match source.active_provider {
-        p if SQLITE.is_provider(p) => Ok(DEFAULT_SQLITE_DB_NAME.to_string()),
-        p if MYSQL.is_provider(p) => {
-            let url = Url::parse(url)?;
-            let err_str = "No database found in connection string";
-
-            let mut db_name = url
-                .path_segments()
-                .ok_or_else(|| CoreError::ConfigurationError(err_str.into()))?;
-
-            let db_name = db_name.next().expect(err_str).to_owned();
-
-            Ok(db_name)
-        }
-        p if POSTGRES.is_provider(p) | COCKROACH.is_provider(p) => {
-            let url = Url::parse(url)?;
-            let params: HashMap<String, String> = url.query_pairs().into_owned().collect();
-
-            let db_name = params
-                .get("schema")
-                .map(ToString::to_string)
-                .unwrap_or_else(|| String::from("public"));
-
-            Ok(db_name)
-        }
-        p if MSSQL.is_provider(p) => {
-            let mut conn = JdbcString::from_str(&format!("jdbc:{}", url))?;
-            let db_name = conn
-                .properties_mut()
-                .remove("schema")
-                .unwrap_or_else(|| String::from("dbo"));
-
-            Ok(db_name)
-        }
-        #[cfg(feature = "mongodb")]
-        p if MONGODB.is_provider(p) => {
-            let url: MongoConnectionString = url.parse().map_err(|e: mongodb_client::Error| match &e.kind {
-                mongodb_client::ErrorKind::InvalidArgument { message } => {
-                    CoreError::ConfigurationError(format!("Error parsing connection string: {}", message))
-                }
-                _ => {
-                    let kind = connector::error::ErrorKind::ConnectionError(e.into());
-                    CoreError::ConnectorError(connector::error::ConnectorError::from_kind(kind))
-                }
-            })?;
-
-            Ok(url.database)
-        }
-        x => Err(CoreError::ConfigurationError(format!(
-            "Unsupported connector type: {}",
-            x
-        ))),
-    }
-}
-
 async fn sqlite(
     source: &Datasource,
     url: &str,
     features: PreviewFeatures,
-) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
+) -> crate::Result<Box<dyn QueryExecutor + Send + Sync>> {
     trace!("Loading SQLite query connector...");
-
     let sqlite = Sqlite::from_source(source, url, features).await?;
-
-    let db_name = db_name(source, url)?;
-
     trace!("Loaded SQLite query connector.");
-    Ok((db_name, sql_executor(sqlite, false)))
+    Ok(sql_executor(sqlite, false))
 }
 
 async fn postgres(
     source: &Datasource,
     url: &str,
     features: PreviewFeatures,
-) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
+) -> crate::Result<Box<dyn QueryExecutor + Send + Sync>> {
     trace!("Loading Postgres query connector...");
 
     let database_str = url;
@@ -126,40 +61,30 @@ async fn postgres(
         .and_then(|flag| flag.parse().ok())
         .unwrap_or(false);
 
-    let db_name = db_name(source, database_str)?;
-
     trace!("Loaded Postgres query connector.");
-    Ok((db_name, sql_executor(psql, force_transactions)))
+    Ok(sql_executor(psql, force_transactions))
 }
 
 async fn mysql(
     source: &Datasource,
     url: &str,
     features: PreviewFeatures,
-) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
+) -> crate::Result<Box<dyn QueryExecutor + Send + Sync>> {
     trace!("Loading MySQL query connector...");
-
     let mysql = Mysql::from_source(source, url, features).await?;
-
-    let db_name = db_name(source, url)?;
-
     trace!("Loaded MySQL query connector.");
-    Ok((db_name, sql_executor(mysql, false)))
+    Ok(sql_executor(mysql, false))
 }
 
 async fn mssql(
     source: &Datasource,
     url: &str,
     features: PreviewFeatures,
-) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
+) -> crate::Result<Box<dyn QueryExecutor + Send + Sync>> {
     trace!("Loading SQL Server query connector...");
-
     let mssql = Mssql::from_source(source, url, features).await?;
-
-    let db_name = db_name(source, url)?;
-
     trace!("Loaded SQL Server query connector.");
-    Ok((db_name, sql_executor(mssql, false)))
+    Ok(sql_executor(mssql, false))
 }
 
 fn sql_executor<T>(connector: T, force_transactions: bool) -> Box<dyn QueryExecutor + Send + Sync>
@@ -174,12 +99,9 @@ async fn mongodb(
     source: &Datasource,
     url: &str,
     _features: PreviewFeatures,
-) -> crate::Result<(String, Box<dyn QueryExecutor + Send + Sync>)> {
+) -> crate::Result<Box<dyn QueryExecutor + Send + Sync>> {
     trace!("Loading MongoDB query connector...");
-
     let mongo = MongoDb::new(source, url).await?;
-    let db_name = db_name(source, url)?;
-
     trace!("Loaded MongoDB query connector.");
-    Ok((db_name.to_owned(), Box::new(InterpretingExecutor::new(mongo, false))))
+    Ok(Box::new(InterpretingExecutor::new(mongo, false)))
 }

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -17,7 +17,7 @@ pub async fn execute(
         WriteQuery::DeleteRecord(q) => delete_one(tx, q, trace_id).await,
         WriteQuery::UpdateManyRecords(q) => update_many(tx, q, trace_id).await,
         WriteQuery::DeleteManyRecords(q) => delete_many(tx, q, trace_id).await,
-        WriteQuery::ConnectRecords(q) => connect(tx, q).await,
+        WriteQuery::ConnectRecords(q) => connect(tx, q, trace_id).await,
         WriteQuery::DisconnectRecords(q) => disconnect(tx, q, trace_id).await,
         WriteQuery::ExecuteRaw(q) => execute_raw(tx, q).await,
         WriteQuery::QueryRaw(q) => query_raw(tx, q).await,
@@ -126,11 +126,16 @@ async fn delete_many(
     Ok(QueryResult::Count(res))
 }
 
-async fn connect(tx: &mut dyn ConnectionLike, q: ConnectRecords) -> InterpretationResult<QueryResult> {
+async fn connect(
+    tx: &mut dyn ConnectionLike,
+    q: ConnectRecords,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
     tx.m2m_connect(
         &q.relation_field,
         &q.parent_id.expect("Expected parent record ID to be set for connect"),
         &q.child_ids,
+        trace_id,
     )
     .await?;
 

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -15,7 +15,7 @@ pub fn dmmf_json_from_schema(schema: &str) -> String {
 // enable raw param?
 pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
     let schema = Arc::new(psl::parse_schema(schema).unwrap());
-    let internal_data_model = prisma_models::convert(schema, "dummy".to_owned());
+    let internal_data_model = prisma_models::convert(schema);
     from_precomputed_parts(Arc::new(schema_builder::build(internal_data_model, true)))
 }
 

--- a/query-engine/prisma-models/src/convert.rs
+++ b/query-engine/prisma-models/src/convert.rs
@@ -2,7 +2,7 @@ use crate::{builders, InternalDataModel, InternalDataModelRef};
 use once_cell::sync::OnceCell;
 use std::sync::Arc;
 
-pub fn convert(schema: Arc<psl::ValidatedSchema>, db_name: String) -> InternalDataModelRef {
+pub fn convert(schema: Arc<psl::ValidatedSchema>) -> InternalDataModelRef {
     let datamodel = psl::lift(&schema);
     let relation_mode = schema.relation_mode();
 
@@ -20,7 +20,6 @@ pub fn convert(schema: Arc<psl::ValidatedSchema>, db_name: String) -> InternalDa
         composite_types: OnceCell::new(),
         relations: OnceCell::new(),
         relation_fields: OnceCell::new(),
-        db_name,
         enums: enums.into_iter().map(Arc::new).collect(),
         schema,
     });

--- a/query-engine/prisma-models/src/internal_data_model.rs
+++ b/query-engine/prisma-models/src/internal_data_model.rs
@@ -12,12 +12,6 @@ pub struct InternalDataModel {
     pub(crate) relations: OnceCell<Vec<RelationRef>>,
     pub(crate) relation_fields: OnceCell<Vec<RelationFieldRef>>,
 
-    /// Todo clarify / rename.
-    /// The db name influences how data is queried from the database.
-    /// E.g. this influences the schema part of a postgres query: `database`.`schema`.`table`.
-    /// Other connectors do not use `schema`, like postgres does, and this variable would
-    /// influence the `database` part instead.
-    pub db_name: String,
     pub enums: Vec<InternalEnumRef>,
     pub schema: Arc<psl::ValidatedSchema>,
 }

--- a/query-engine/prisma-models/src/model.rs
+++ b/query-engine/prisma-models/src/model.rs
@@ -32,16 +32,6 @@ impl Model {
         self.dml_model.schema.clone()
     }
 
-    pub fn db_name_with_schema(&self) -> (String, String) {
-        let schema_prefix = self
-            .schema_name()
-            .unwrap_or_else(|| self.internal_data_model().db_name.clone());
-
-        let model_db_name = self.db_name().to_string();
-
-        (schema_prefix, model_db_name)
-    }
-
     pub(crate) fn finalize(&self) {
         self.fields.get().unwrap().finalize();
     }

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -561,7 +561,7 @@ fn implicit_many_to_many_relation() {
 
 fn convert(datamodel: &str) -> Arc<InternalDataModel> {
     let schema = psl::parse_schema(datamodel).unwrap();
-    prisma_models::convert(Arc::new(schema), "not_important".to_string())
+    prisma_models::convert(Arc::new(schema))
 }
 
 trait DatamodelAssertions {

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -225,12 +225,12 @@ impl QueryEngine {
                     .load_url_with_config_dir(&builder.config_dir, |key| builder.env.get(key).map(ToString::to_string))
                     .map_err(|err| crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned()))?;
 
-                let (db_name, executor) = executor::load(data_source, preview_features, &url).await?;
+                let executor = executor::load(data_source, preview_features, &url).await?;
                 let connector = executor.primary_connector();
                 connector.get_connection().await?;
 
                 // Build internal data model
-                let internal_data_model = prisma_models::convert(Arc::clone(&builder.schema), db_name);
+                let internal_data_model = prisma_models::convert(Arc::clone(&builder.schema));
 
                 let enable_raw_queries = true;
                 let query_schema = schema_builder::build(internal_data_model, enable_raw_queries);

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -32,7 +32,7 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
         .to_result()
         .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
 
-    let internal_data_model = prisma_models::convert(Arc::new(schema), "".into());
+    let internal_data_model = prisma_models::convert(Arc::new(schema));
     let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(internal_data_model, true));
     let dmmf = dmmf::render_dmmf(query_schema);
 

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -81,7 +81,7 @@ impl CliCommand {
     }
 
     async fn dmmf(request: DmmfRequest) -> PrismaResult<()> {
-        let internal_data_model = prisma_models::convert(Arc::new(request.schema), "".into());
+        let internal_data_model = prisma_models::convert(Arc::new(request.schema));
         let query_schema: QuerySchemaRef =
             Arc::new(schema_builder::build(internal_data_model, request.enable_raw_queries));
         let dmmf = dmmf::render_dmmf(query_schema);

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -58,10 +58,10 @@ impl PrismaContext {
         let url = data_source.load_url(|key| env::var(key).ok())?;
 
         // Load executor
-        let (db_name, executor) = executor::load(data_source, config.preview_features(), &url).await?;
+        let executor = executor::load(data_source, config.preview_features(), &url).await?;
 
         // Build internal data model
-        let internal_data_model = prisma_models::convert(Arc::new(schema), db_name);
+        let internal_data_model = prisma_models::convert(Arc::new(schema));
 
         // Construct query schema
         let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(internal_data_model, enable_raw_queries));

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 pub fn get_query_schema(datamodel_string: &str) -> QuerySchema {
     let dm = psl::parse_schema(datamodel_string).unwrap();
-    let internal_ref = prisma_models::convert(Arc::new(dm), "db".to_owned());
+    let internal_ref = prisma_models::convert(Arc::new(dm));
     schema_builder::build(internal_ref, false)
 }
 

--- a/query-engine/schema-builder/benches/schema_builder_bench.rs
+++ b/query-engine/schema-builder/benches/schema_builder_bench.rs
@@ -15,10 +15,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let validated_schema = std::sync::Arc::new(psl::validate(source_file));
 
         c.bench_function(&format!("prisma_models::convert ({name})"), |b| {
-            b.iter(|| black_box(prisma_models::convert(validated_schema.clone(), "".into())))
+            b.iter(|| black_box(prisma_models::convert(validated_schema.clone())))
         });
 
-        let idm = prisma_models::convert(validated_schema, "".into());
+        let idm = prisma_models::convert(validated_schema);
 
         c.bench_function(&format!("schema_builder::build ({name})"), |b| {
             b.iter(|| black_box(schema_builder::build(idm.clone(), true)));


### PR DESCRIPTION
In this PR, it is used for the current request's trace ID and the
connection info.

We then pass that context everywhere. This is a pattern that we have
used with success in other places. PSL validation comes to mind. The
connection info is then used to render qualified table names in SQL,
which takes over that responsibility from `prisma_models`.

From a lifecycle perspective, this decouples prisma_models from having a
schema with parsed URLs, resolved env vars, etc. Coupling to a concrete
database happens later, when actually executing queries.

This already simplifies initialization of a query engine (no need for
connector-specific logic to extract the db_name to feed to
`prisma_models::convert()`).

This change will make it much easier to base the `prisma_models` API on
`psl::ValidatedSchema` only. The relevant issue this works towards
tackling is https://github.com/prisma/client-planning/issues/204

closes https://github.com/prisma/client-planning/issues/183