### PR TITLE
nix: make the flake work on darwin

### DIFF
--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -5,6 +5,7 @@ let
   src = pkgs.lib.cleanSourceWith { filter = enginesSourceFilter; src = srcPath; };
   craneLib = inputs.crane.mkLib pkgs;
   deps = craneLib.vendorCargoDeps { inherit src; };
+  libSuffix = if pkgs.stdenv.isDarwin then "dylib" else "so";
 
   enginesSourceFilter = path: type: (builtins.match "\\.pest$" path != null) ||
     (builtins.match "\\.README.md$" path != null) ||
@@ -25,6 +26,9 @@ in
       protobuf # for tonic
       openssl.dev
       pkg-config
+    ] ++ lib.optionals stdenv.isDarwin [
+      perl # required to build openssl
+      darwin.apple_sdk.frameworks.Security
     ];
 
     buildPhase = ''
@@ -40,7 +44,7 @@ in
       cp target/release/migration-engine $out/bin/
       cp target/release/introspection-engine $out/bin/
       cp target/release/prisma-fmt $out/bin/
-      cp target/release/libquery_engine.so $out/lib/libquery_engine.node
+      cp target/release/libquery_engine.${libSuffix} $out/lib/libquery_engine.node
     '';
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,7 +5,9 @@ let
 in
 {
   devShells.default = pkgs.mkShell {
-    packages = [ devToolchain pkgs.llvmPackages.bintools ];
+    packages = with pkgs;
+      [ devToolchain llvmPackages_latest.bintools ]
+      ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
     inputsFrom = [ self'.packages.prisma-engines ];
     shellHook = "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";
   };


### PR DESCRIPTION
This commit fixes the errors encountered when trying to run build the engines
with `cargo build` under Nix shell or when running the `nix build .#prisma-engines`
and `nix develop .#cli-shell` commands on macOS

1. Use lld from LLVM 14 instead of LLVM 11 in the dev shell by switching from
   `llvmPackages.bintools` package to `llvmPackages_latest.bintools`. Darwin and
   Mach-O support was still broken in lld from LLVM 11 except maybe for simplest
   programs, but it is now functional in recent LLVM versions.

   This fixes errors like this:

   ```
   ld64.lld: warning: ignoring unknown argument: -platform_version
   ld64.lld: warning: ignoring unknown argument: -no_uuid
   ld64.lld: warning: -sdk_version is required when emitting min version load command.  Setting sdk version to match provided min version
   Cannot open macos: No such file or directory
   clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
   ```

2. Add `darwin.apple_sdk.frameworks.Security` to `packages` in the dev shell and to
   `nativeBuildInputs` of the `prisma-engines` package on Darwin. This fixes errors
   like this:

   ```
   ld: framework not found Security
   clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
   ```

3. Add `perl` to `nativeBuildInputs` to fix the `openssl-sys` build error when running `nix build .#prisma-engines`:

   ```
   error: failed to run custom build command for `openssl-sys v0.9.79`

   Caused by:
     process didn't exit successfully: `/private/tmp/nix-build-prisma-engines.drv-0/source/target/release/build/openssl-sys-d1fb436332932c79/build-script-main` (exit status: 101)
     --- stdout
     cargo:rustc-cfg=const_fn
     cargo:rustc-cfg=openssl
     cargo:rerun-if-env-changed=AARCH64_APPLE_DARWIN_OPENSSL_NO_VENDOR
     AARCH64_APPLE_DARWIN_OPENSSL_NO_VENDOR unset
     cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
     OPENSSL_NO_VENDOR unset
     CC_aarch64-apple-darwin = None
     CC_aarch64_apple_darwin = None
     HOST_CC = None
     CC = Some("clang")
     CFLAGS_aarch64-apple-darwin = None
     CFLAGS_aarch64_apple_darwin = None
     HOST_CFLAGS = None
     CFLAGS = None
     CRATE_CC_NO_DEFAULTS = None
     DEBUG = Some("false")
     running "perl" "./Configure" "--prefix=/private/tmp/nix-build-prisma-engines.drv-0/source/target/release/build/openssl-sys-dd647f0766556427/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-s>

     --- stderr
     thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /nix/store/lkbbbyc00zbh0p6d9ylqvpvl015b1jsd-vendor-cargo-deps/c19b7c>
     note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
   ```

4. Use platform-specific library suffix and fix the following error:

   ```
   cp: cannot stat 'target/release/libquery_engine.so': No such file or directory
   ```
