### PR TITLE
Load all table names for persistence without sql-schema-describer

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/flavour.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour.rs
@@ -152,6 +152,10 @@ pub(crate) trait SqlFlavour:
     /// Drop the migrations table
     fn drop_migrations_table(&mut self) -> BoxFuture<'_, ConnectorResult<()>>;
 
+    /// List all visible tables in the given namespaces,
+    /// including the search path.
+    fn table_names(&mut self, namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<Vec<String>>>;
+
     /// Return an empty database schema. This happens in the flavour, because we need
     /// SqlSchema::connector_data to be set.
     fn empty_database_schema(&self) -> SqlSchema {

--- a/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_migration_persistence.rs
@@ -11,21 +11,16 @@ impl MigrationPersistence for SqlMigrationConnector {
         self.flavour.create_migrations_table()
     }
 
+    #[tracing::instrument(skip(self))]
     fn initialize(&mut self, namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<()>> {
         Box::pin(async move {
-            let schema = self.flavour.describe_schema(namespaces).await?;
+            let table_names = self.flavour.table_names(namespaces).await?;
 
-            if schema
-                .table_walkers()
-                .any(|table| table.name() == crate::MIGRATIONS_TABLE_NAME)
-            {
+            if table_names.iter().any(|name| name == crate::MIGRATIONS_TABLE_NAME) {
                 return Ok(());
             }
 
-            if schema
-                .table_walkers()
-                .any(|t| !self.flavour().table_should_be_ignored(t.name()))
-            {
+            if table_names.iter().any(|t| !self.flavour().table_should_be_ignored(t)) {
                 return Err(ConnectorError::user_facing(
                     user_facing_errors::migration_engine::DatabaseSchemaNotEmpty,
                 ));

--- a/migration-engine/core/src/state.rs
+++ b/migration-engine/core/src/state.rs
@@ -193,6 +193,7 @@ impl GenericApi for EngineState {
 
     async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput> {
         let namespaces = self.namespaces();
+
         self.with_default_connector(Box::new(move |connector| {
             Box::pin(
                 commands::apply_migrations(input, connector, namespaces)

--- a/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/schema_push/mod.rs
@@ -493,6 +493,6 @@ model m1 {
     let expected = expect_test::expect![[r#"
         The `mysql` database is a system database, it should not be altered with prisma migrate. Please connect to another database.
            0: migration_core::state::SchemaPush
-                     at migration-engine/core/src/state.rs:430"#]];
+                     at migration-engine/core/src/state.rs:431"#]];
     expected.assert_eq(&err.to_string());
 }


### PR DESCRIPTION
It just causes problems with relations in the search path, and we don't need all that machinery to figure out is the database dirty and do we already have the migrations table.

Closes: https://github.com/prisma/prisma/issues/17220