### PR TITLE
Better error for foreign keys pointing to a schema not in schemas property

### DIFF
--- a/libs/sql-schema-describer/src/error.rs
+++ b/libs/sql-schema-describer/src/error.rs
@@ -55,6 +55,8 @@ pub enum DescriberErrorKind {
         to: String,
         /// Name of the constraint.
         constraint: String,
+        /// This must be added to the schemas property.
+        missing_namespace: String,
     },
 }
 
@@ -74,11 +76,15 @@ impl Display for DescriberErrorKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::QuaintError(err) => err.fmt(f),
-            Self::CrossSchemaReference { from, to, constraint } => {
+            Self::CrossSchemaReference {
+                from,
+                to,
+                constraint,
+                missing_namespace,
+            } => {
                 write!(
                     f,
-                    "Illegal cross schema reference from `{}` to `{}` in constraint `{}`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175",
-                    from, to, constraint
+                    "The schema of the introspected database was inconsistent: Cross schema references are only allowed when the target schema is listed in the schemas property of your datasource. `{from}` points to `{to}` in constraint `{constraint}`. Please add `{missing_namespace}` to your `schemas` property and run this command again.",
                 )
             }
         }

--- a/libs/sql-schema-describer/src/mssql.rs
+++ b/libs/sql-schema-describer/src/mssql.rs
@@ -701,6 +701,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                     from: format!("{namespace}.{table_name}"),
                     to: format!("{referenced_schema_name}.{referenced_table}"),
                     constraint: constraint_name,
+                    missing_namespace: referenced_schema_name,
                 }));
             }
 

--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -957,9 +957,10 @@ impl<'a> SqlSchemaDescriber<'a> {
             let referenced_schema_name = row.get_expect_string("referenced_schema_name");
             if !sql_schema.namespaces.contains(&referenced_schema_name) {
                 return Err(DescriberError::from(DescriberErrorKind::CrossSchemaReference {
-                    from: format!("{}.{}", sql_schema.namespaces[0], table_name), //TODO(matthias)
+                    from: format!("{}.{}", sql_schema.namespaces[0], table_name),
                     to: format!("{}.{}", referenced_schema_name, referenced_table),
                     constraint: constraint_name,
+                    missing_namespace: referenced_schema_name,
                 }));
             }
 

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -721,10 +721,9 @@ fn mssql_cross_schema_references_are_not_allowed(api: TestApi) {
     api.raw_cmd(&sql);
     let err = api.describe_error();
 
-    assert_eq!(
-        "Illegal cross schema reference from `dbo.User` to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175",
-        err.to_string(),
-    );
+    let expected = expect!["The schema of the introspected database was inconsistent: Cross schema references are only allowed when the target schema is listed in the schemas property of your datasource. `dbo.User` points to `mssql_foreign_key_on_delete_must_be_handled_B.City` in constraint `FK__city`. Please add `mssql_foreign_key_on_delete_must_be_handled_B` to your `schemas` property and run this command again."];
+
+    expected.assert_eq(&err.to_string());
 }
 
 #[test_connector(tags(Mssql))]

--- a/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1117,12 +1117,10 @@ fn cross_schema_references_are_not_allowed(api: TestApi) {
     api.raw_cmd(&sql);
 
     let err = api.describe_error();
-    let fk_name = "User_city_fkey";
 
-    assert_eq!(
-        format!("Illegal cross schema reference from `prisma-tests.User` to `prisma-tests_2.City` in constraint `{}`. Foreign keys between database schemas are not supported in Prisma. Please follow the GitHub ticket: https://github.com/prisma/prisma/issues/1175", fk_name),
-        err.to_string()
-    );
+    let expected = expect!["The schema of the introspected database was inconsistent: Cross schema references are only allowed when the target schema is listed in the schemas property of your datasource. `prisma-tests.User` points to `prisma-tests_2.City` in constraint `User_city_fkey`. Please add `prisma-tests_2` to your `schemas` property and run this command again."];
+
+    expected.assert_eq(&err.to_string());
 }
 
 #[test_connector(tags(Postgres))]


### PR DESCRIPTION
Closes: https://github.com/prisma/prisma/issues/16615