### PR TITLE
nix: upgrade to rust 1.61.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670900067,
-        "narHash": "sha256-VXVa+KBfukhmWizaiGiHRVX/fuk66P8dgSFfkVN4/MY=",
+        "lastModified": 1673405853,
+        "narHash": "sha256-6Nq9DuOo+gE2I8z5UZaKuumykz2xxZ9JGYmUthOuwSA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "59b31b41a589c0a65e4a1f86b0e5eac68081468b",
+        "rev": "b13963c8c18026aa694acd98d14f66d24666f70b",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670441596,
-        "narHash": "sha256-+T487QnluBT5F9tVk0chG/zzv+9zzTrx3o7rlOBK7ps=",
+        "lastModified": 1673362319,
+        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8d0e2444ab05f79df93b70e5e497f8c708eb6b9b",
+        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1670929434,
-        "narHash": "sha256-n5UBO6XBV4h3TB7FYu2yAuNQMEYOrQyKeODUwKe06ow=",
+        "lastModified": 1673226411,
+        "narHash": "sha256-b6cGb5Ln7Zy80YO66+cbTyGdjZKtkoqB/iIIhDX9gRA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1710ed1f6f8ceb75cf7d1cf55ee0cc21760e1c7a",
+        "rev": "aa1d74709f5dac623adb4d48fdfb27cc2c92a4d4",
         "type": "github"
       },
       "original": {
@@ -112,11 +112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1670985057,
-        "narHash": "sha256-QfLKTSQUc82HXeIipukznInr5IXXgK1YKm5dplm1Q+A=",
+        "lastModified": 1673404037,
+        "narHash": "sha256-9yhRzFiqzVQaJN5jsAIwApDolkORRQ3EJi7D4yu58ig=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "da99b6227d450438d53ba4b0cf64e43ad2e93e58",
+        "rev": "a979c85ed4691bf996af88504522b32e9611ccfe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -20,10 +20,10 @@
   };
 
   outputs = inputs@{ self, nixpkgs, rust-overlay, flake-parts, flake-utils, crane, ... }:
-    flake-parts.lib.mkFlake { inherit self; } {
+    flake-parts.lib.mkFlake { inherit inputs; } {
       systems = flake-utils.lib.defaultSystems;
       perSystem = { config, system, pkgs, craneLib, ... }: {
-        config._module.args.inputs = inputs;
+        config._module.args.flakeInputs = inputs;
         imports = [
           ./nix/all-engines.nix
           ./nix/args.nix

--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -1,9 +1,9 @@
-{ craneLib, pkgs, inputs, ... }:
+{ craneLib, pkgs, flakeInputs, ... }:
 
 let
   srcPath = builtins.path { path = ../.; name = "prisma-engines-workspace-root-path"; };
   src = pkgs.lib.cleanSourceWith { filter = enginesSourceFilter; src = srcPath; };
-  craneLib = inputs.crane.mkLib pkgs;
+  craneLib = flakeInputs.crane.mkLib pkgs;
   deps = craneLib.vendorCargoDeps { inherit src; };
   libSuffix = if pkgs.stdenv.isDarwin then "dylib" else "so";
 

--- a/nix/args.nix
+++ b/nix/args.nix
@@ -1,13 +1,13 @@
-{ inputs, system, ... }:
+{ flakeInputs, system, ... }:
 {
   config._module.args =
     let
       overlays = [
-        inputs.rust-overlay.overlays.default
+        flakeInputs.rust-overlay.overlays.default
         (self: super:
           let toolchain = super.rust-bin.stable.latest; in
           { cargo = toolchain.minimal; rustc = toolchain.minimal; rustToolchain = toolchain; })
       ];
     in
-    { pkgs = import inputs.nixpkgs { inherit system overlays; }; };
+    { pkgs = import flakeInputs.nixpkgs { inherit system overlays; }; };
 }


### PR DESCRIPTION
There's a CVE: https://blog.rust-lang.org/2023/01/10/Rust-1.66.1.html

This commit also updates flake-parts and follows the recommended upgrade path.