### PR TITLE
psl: extend public API for prisma-models takeover

### DIFF
--- a/libs/dml/src/composite_type.rs
+++ b/libs/dml/src/composite_type.rs
@@ -1,8 +1,8 @@
 //! Composite types defined with the `type` keyword.
 
 use crate::{
-    default_value::DefaultValue, field::FieldArity, native_type_instance::NativeTypeInstance, scalars::ScalarType,
-    Field, FieldType, ScalarField,
+    default_value::DefaultValue, native_type_instance::NativeTypeInstance, scalars::ScalarType, Field, FieldArity,
+    FieldType, ScalarField,
 };
 
 #[derive(Debug, PartialEq, Clone)]

--- a/libs/dml/src/field.rs
+++ b/libs/dml/src/field.rs
@@ -1,37 +1,12 @@
 //! A field in a model.
 
+use crate::default_value::{DefaultKind, DefaultValue, ValueGenerator};
 use crate::native_type_instance::NativeTypeInstance;
 use crate::relation_info::RelationInfo;
 use crate::scalars::ScalarType;
 use crate::traits::{Ignorable, WithDatabaseName, WithName};
-use crate::CompositeTypeFieldType;
-use crate::{
-    default_value::{DefaultKind, DefaultValue, ValueGenerator},
-    relation_info::ReferentialAction,
-};
-use std::hash::Hash;
-
-/// Arity of a Field in a Model.
-#[derive(Debug, PartialEq, Copy, Clone, Eq, Hash)]
-pub enum FieldArity {
-    Required,
-    Optional,
-    List,
-}
-
-impl FieldArity {
-    pub fn is_list(&self) -> bool {
-        self == &Self::List
-    }
-
-    pub fn is_required(&self) -> bool {
-        self == &Self::Required
-    }
-
-    pub fn is_optional(&self) -> bool {
-        self == &Self::Optional
-    }
-}
+use crate::{CompositeTypeFieldType, FieldArity};
+use psl_core::parser_database::ReferentialAction;
 
 /// Datamodel field type.
 #[derive(Debug, PartialEq, Clone)]
@@ -563,15 +538,5 @@ impl WithDatabaseName for CompositeField {
     }
     fn set_database_name(&mut self, database_name: Option<String>) {
         self.database_name = database_name;
-    }
-}
-
-impl From<psl_core::parser_database::ast::FieldArity> for FieldArity {
-    fn from(arity: psl_core::parser_database::ast::FieldArity) -> Self {
-        match arity {
-            schema_ast::ast::FieldArity::Required => FieldArity::Required,
-            schema_ast::ast::FieldArity::Optional => FieldArity::Optional,
-            schema_ast::ast::FieldArity::List => FieldArity::List,
-        }
     }
 }

--- a/libs/dml/src/lib.rs
+++ b/libs/dml/src/lib.rs
@@ -21,7 +21,7 @@ pub use self::{
     relation_info::*, scalars::*, traits::*,
 };
 pub use prisma_value::{self, PrismaValue};
-pub use psl_core::parser_database::IndexType;
+pub use psl_core::parser_database::{ast::FieldArity, IndexType, ReferentialAction};
 
 use psl_core::ValidatedSchema;
 

--- a/libs/dml/src/lift.rs
+++ b/libs/dml/src/lift.rs
@@ -128,8 +128,8 @@ impl<'a> LiftAstToDml<'a> {
 
                         let forward_field_walker = relation.forward_relation_field().unwrap();
                         // Construct a relation field in the DML for an existing relation field in the source.
-                        let arity = forward_field_walker.ast_field().arity.into();
-                        let referential_arity = forward_field_walker.referential_arity().into();
+                        let arity = forward_field_walker.ast_field().arity;
+                        let referential_arity = forward_field_walker.referential_arity();
                         let mut relation_field =
                             RelationField::new(forward_field_walker.name(), arity, referential_arity, relation_info);
 
@@ -185,8 +185,8 @@ impl<'a> LiftAstToDml<'a> {
 
                         let mut field = if let Some(relation_field) = relation.back_relation_field() {
                             let ast_field = relation_field.ast_field();
-                            let arity = ast_field.arity.into();
-                            let referential_arity = relation_field.referential_arity().into();
+                            let arity = ast_field.arity;
+                            let referential_arity = relation_field.referential_arity();
                             let mut field =
                                 RelationField::new(relation_field.name(), arity, referential_arity, relation_info);
 
@@ -219,9 +219,9 @@ impl<'a> LiftAstToDml<'a> {
                 RefinedRelationWalker::ImplicitManyToMany(relation) => {
                     for relation_field in [relation.field_a(), relation.field_b()] {
                         let ast_field = relation_field.ast_field();
-                        let arity = ast_field.arity.into();
+                        let arity = ast_field.arity;
                         let relation_info = RelationInfo::new(relation_field.related_model().name());
-                        let referential_arity = relation_field.referential_arity().into();
+                        let referential_arity = relation_field.referential_arity();
                         let mut field =
                             RelationField::new(relation_field.name(), arity, referential_arity, relation_info);
 
@@ -249,9 +249,9 @@ impl<'a> LiftAstToDml<'a> {
                 RefinedRelationWalker::TwoWayEmbeddedManyToMany(relation) => {
                     for relation_field in [relation.field_a(), relation.field_b()] {
                         let ast_field = relation_field.ast_field();
-                        let arity = ast_field.arity.into();
+                        let arity = ast_field.arity;
                         let relation_info = RelationInfo::new(relation_field.related_model().name());
-                        let referential_arity = relation_field.referential_arity().into();
+                        let referential_arity = relation_field.referential_arity();
 
                         let mut field =
                             RelationField::new(relation_field.name(), arity, referential_arity, relation_info);
@@ -291,7 +291,7 @@ impl<'a> LiftAstToDml<'a> {
             let field = CompositeTypeField {
                 name: field.name().to_owned(),
                 r#type: self.lift_composite_type_field_type(field, field.r#type()),
-                arity: field.arity().into(),
+                arity: field.arity(),
                 database_name: field.mapped_name().map(String::from),
                 documentation: field.documentation().map(ToString::to_string),
                 default_value: field.default_value().map(|value| DefaultValue {
@@ -407,7 +407,7 @@ impl<'a> LiftAstToDml<'a> {
                     field.documentation = ast_field.documentation().map(String::from);
                     field.is_ignored = scalar_field.is_ignored();
                     field.database_name = scalar_field.mapped_name().map(String::from);
-                    field.arity = ast_field.arity.into();
+                    field.arity = ast_field.arity;
 
                     model.add_field(Field::CompositeField(field));
                     continue;
@@ -415,7 +415,7 @@ impl<'a> LiftAstToDml<'a> {
                 _ => self.lift_scalar_field_type(ast_field, &scalar_field.scalar_field_type(), scalar_field),
             };
 
-            let mut field = ScalarField::new(ast_field.name(), ast_field.arity.into(), field_type);
+            let mut field = ScalarField::new(ast_field.name(), ast_field.arity, field_type);
 
             field.documentation = ast_field.documentation().map(String::from);
             field.is_ignored = scalar_field.is_ignored();

--- a/libs/dml/src/relation_info.rs
+++ b/libs/dml/src/relation_info.rs
@@ -1,6 +1,4 @@
-use enumflags2::bitflags;
 use psl_core::parser_database as db;
-use std::fmt;
 
 /// Holds information about a relation field.
 #[derive(Debug, PartialEq, Clone)]
@@ -17,10 +15,10 @@ pub struct RelationInfo {
     pub fk_name: Option<String>,
     /// A strategy indicating what happens when
     /// a related node is deleted.
-    pub on_delete: Option<ReferentialAction>,
+    pub on_delete: Option<db::ReferentialAction>,
     /// A strategy indicating what happens when
     /// a related node is updated.
-    pub on_update: Option<ReferentialAction>,
+    pub on_update: Option<db::ReferentialAction>,
 }
 
 impl RelationInfo {
@@ -36,67 +34,5 @@ impl RelationInfo {
             on_delete: None,
             on_update: None,
         }
-    }
-}
-
-/// Describes what happens when related nodes are deleted.
-#[repr(u8)]
-#[bitflags]
-#[derive(Debug, Copy, PartialEq, Clone)]
-pub enum ReferentialAction {
-    /// Deletes record if dependent record is deleted. Updates relation scalar
-    /// fields if referenced scalar fields of the dependent record are updated.
-    /// Prevents operation (both updates and deletes) from succeeding if any
-    /// records are connected.
-    Cascade,
-    /// Prevents operation (both updates and deletes) from succeeding if any
-    /// records are connected. This behavior will always result in a runtime
-    /// error for required relations.
-    Restrict,
-    /// Behavior is database specific. Either defers throwing an integrity check
-    /// error until the end of the transaction or errors immediately. If
-    /// deferred, this makes it possible to temporarily violate integrity in a
-    /// transaction while making sure that subsequent operations in the
-    /// transaction restore integrity.
-    /// When using relationMode = "prisma", NoAction becomes an alias of
-    /// the emulated Restrict (when supported).
-    NoAction,
-    /// Sets relation scalar fields to null if the relation is deleted or
-    /// updated. This will always result in a runtime error if one or more of the
-    /// relation scalar fields are required.
-    SetNull,
-    /// Sets relation scalar fields to their default values on update or delete
-    /// of relation. Will always result in a runtime error if no defaults are
-    /// provided for any relation scalar fields.
-    SetDefault,
-}
-
-impl From<db::ReferentialAction> for ReferentialAction {
-    fn from(ra: db::ReferentialAction) -> Self {
-        match ra {
-            db::ReferentialAction::Cascade => ReferentialAction::Cascade,
-            db::ReferentialAction::SetNull => ReferentialAction::SetNull,
-            db::ReferentialAction::SetDefault => ReferentialAction::SetDefault,
-            db::ReferentialAction::Restrict => ReferentialAction::Restrict,
-            db::ReferentialAction::NoAction => ReferentialAction::NoAction,
-        }
-    }
-}
-
-impl AsRef<str> for ReferentialAction {
-    fn as_ref(&self) -> &'static str {
-        match self {
-            ReferentialAction::Cascade => "Cascade",
-            ReferentialAction::Restrict => "Restrict",
-            ReferentialAction::NoAction => "NoAction",
-            ReferentialAction::SetNull => "SetNull",
-            ReferentialAction::SetDefault => "SetDefault",
-        }
-    }
-}
-
-impl fmt::Display for ReferentialAction {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_ref())
     }
 }

--- a/psl/parser-database/src/lib.rs
+++ b/psl/parser-database/src/lib.rs
@@ -69,7 +69,7 @@ pub struct ParserDatabase {
     ast: ast::SchemaAst,
     file: schema_ast::SourceFile,
     interner: interner::StringInterner,
-    _names: Names,
+    names: Names,
     types: Types,
     relations: Relations,
 }
@@ -94,7 +94,7 @@ impl ParserDatabase {
                 ast,
                 file,
                 interner,
-                _names: names,
+                names,
                 types,
                 relations,
             };
@@ -109,7 +109,7 @@ impl ParserDatabase {
                 ast,
                 file,
                 interner,
-                _names: names,
+                names,
                 types,
                 relations,
             };
@@ -127,7 +127,7 @@ impl ParserDatabase {
             ast,
             file,
             interner,
-            _names: names,
+            names,
             types,
             relations,
         }

--- a/psl/parser-database/src/relations.rs
+++ b/psl/parser-database/src/relations.rs
@@ -5,7 +5,7 @@ use crate::{
     {context::Context, types::RelationField},
 };
 use enumflags2::bitflags;
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, fmt};
 
 /// Detect relation types and construct relation objects to the database.
 pub(super) fn infer_relations(ctx: &mut Context<'_>) {
@@ -86,7 +86,7 @@ impl std::ops::Index<RelationId> for Relations {
 
 impl Relations {
     /// Iterate over all relations in the schema.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = RelationId> {
+    pub(crate) fn iter(&self) -> impl ExactSizeIterator<Item = RelationId> + Clone {
         (0..self.relations_storage.len()).map(|idx| RelationId(idx as u32))
     }
 
@@ -417,6 +417,9 @@ pub(super) fn ingest_relation<'db>(evidence: RelationEvidence<'db>, relations: &
 pub enum ReferentialAction {
     /// Deletes record if dependent record is deleted. Updates relation scalar
     /// fields if referenced scalar fields of the dependent record are updated.
+    ///
+    /// Prevents operation (both updates and deletes) from succeeding if any
+    /// records are connected.
     Cascade,
     /// Prevents operation (both updates and deletes) from succeeding if any
     /// records are connected. This behavior will always result in a runtime
@@ -427,6 +430,9 @@ pub enum ReferentialAction {
     /// deferred, this makes it possible to temporarily violate integrity in a
     /// transaction while making sure that subsequent operations in the
     /// transaction restore integrity.
+    ///
+    /// When using relationMode = "prisma", NoAction becomes an alias of
+    /// the emulated Restrict (when supported).
     NoAction,
     /// Sets relation scalar fields to null if the relation is deleted or
     /// updated. This will always result in a runtime error if one or more of the
@@ -488,5 +494,23 @@ impl ReferentialAction {
                 None
             }
         }
+    }
+}
+
+impl AsRef<str> for ReferentialAction {
+    fn as_ref(&self) -> &'static str {
+        match self {
+            ReferentialAction::Cascade => "Cascade",
+            ReferentialAction::Restrict => "Restrict",
+            ReferentialAction::NoAction => "NoAction",
+            ReferentialAction::SetNull => "SetNull",
+            ReferentialAction::SetDefault => "SetDefault",
+        }
+    }
+}
+
+impl fmt::Display for ReferentialAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_ref())
     }
 }

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -50,6 +50,15 @@ where
 }
 
 impl crate::ParserDatabase {
+    /// Find an enum by name.
+    pub fn find_enum<'db>(&'db self, name: &str) -> Option<EnumWalker<'db>> {
+        self.interner
+            .lookup(name)
+            .and_then(|name_id| self.names.tops.get(&name_id))
+            .and_then(|top_id| top_id.as_enum_id())
+            .map(|enum_id| self.walk(enum_id))
+    }
+
     /// Traverse a schema element by id.
     pub fn walk<I>(&self, id: I) -> Walker<'_, I> {
         Walker { db: self, id }
@@ -107,7 +116,7 @@ impl crate::ParserDatabase {
 
     /// Walk all the relations in the schema. A relation may be defined by one or two fields; in
     /// both cases, it is still a single relation.
-    pub fn walk_relations(&self) -> impl Iterator<Item = RelationWalker<'_>> + '_ {
+    pub fn walk_relations(&self) -> impl ExactSizeIterator<Item = RelationWalker<'_>> + Clone + '_ {
         self.relations.iter().map(move |relation_id| Walker {
             db: self,
             id: relation_id,

--- a/psl/parser-database/src/walkers/composite_type.rs
+++ b/psl/parser-database/src/walkers/composite_type.rs
@@ -39,7 +39,7 @@ impl<'db> CompositeTypeWalker<'db> {
     }
 
     /// Iterator over all the fields of the composite type.
-    pub fn fields(self) -> impl Iterator<Item = CompositeTypeFieldWalker<'db>> {
+    pub fn fields(self) -> impl ExactSizeIterator<Item = CompositeTypeFieldWalker<'db>> + Clone {
         self.ast_composite_type()
             .iter_fields()
             .map(move |(id, _)| self.walk((self.id, id)))
@@ -142,7 +142,7 @@ impl<'db> CompositeTypeFieldWalker<'db> {
     }
 
     /// The final database name of the field. See crate docs for explanations on database names.
-    pub(crate) fn database_name(self) -> &'db str {
+    pub fn database_name(self) -> &'db str {
         self.field()
             .mapped_name
             .map(|id| &self.db[id])

--- a/psl/parser-database/src/walkers/index.rs
+++ b/psl/parser-database/src/walkers/index.rs
@@ -193,19 +193,13 @@ impl<'db> IndexWalker<'db> {
     }
 }
 
-#[derive(Copy, Clone, PartialEq)]
-pub(super) enum InnerIndexFieldWalker<'db> {
-    Scalar(ScalarFieldWalker<'db>),
-    Composite(CompositeTypeFieldWalker<'db>),
-}
-
-impl<'db> From<ScalarFieldWalker<'db>> for InnerIndexFieldWalker<'db> {
+impl<'db> From<ScalarFieldWalker<'db>> for IndexFieldWalker<'db> {
     fn from(sf: ScalarFieldWalker<'db>) -> Self {
         Self::Scalar(sf)
     }
 }
 
-impl<'db> From<CompositeTypeFieldWalker<'db>> for InnerIndexFieldWalker<'db> {
+impl<'db> From<CompositeTypeFieldWalker<'db>> for IndexFieldWalker<'db> {
     fn from(cf: CompositeTypeFieldWalker<'db>) -> Self {
         Self::Composite(cf)
     }
@@ -214,104 +208,107 @@ impl<'db> From<CompositeTypeFieldWalker<'db>> for InnerIndexFieldWalker<'db> {
 /// A field in an index definition. It can point to a scalar field in the
 /// current model, or through embedding a field in a composite type.
 #[derive(Copy, Clone, PartialEq)]
-pub struct IndexFieldWalker<'db> {
-    inner: InnerIndexFieldWalker<'db>,
+pub enum IndexFieldWalker<'db> {
+    /// A field on a model.
+    Scalar(ScalarFieldWalker<'db>),
+    /// The path to a field in a composite type.
+    Composite(CompositeTypeFieldWalker<'db>),
 }
 
 impl<'db> IndexFieldWalker<'db> {
-    pub(super) fn new(inner: impl Into<InnerIndexFieldWalker<'db>>) -> Self {
-        Self { inner: inner.into() }
+    pub(super) fn new(inner: impl Into<IndexFieldWalker<'db>>) -> Self {
+        inner.into()
     }
 
     /// Is the field optional / nullable?
     pub fn is_optional(self) -> bool {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.is_optional(),
-            InnerIndexFieldWalker::Composite(cf) => cf.arity().is_optional(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.is_optional(),
+            IndexFieldWalker::Composite(cf) => cf.arity().is_optional(),
         }
     }
 
     /// Is the field a list?
     pub fn is_list(self) -> bool {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.is_list(),
-            InnerIndexFieldWalker::Composite(cf) => cf.arity().is_list(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.is_list(),
+            IndexFieldWalker::Composite(cf) => cf.arity().is_list(),
         }
     }
 
     /// Is the type of the field `Unsupported("...")`?
     pub fn is_unsupported(self) -> bool {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.is_unsupported(),
-            InnerIndexFieldWalker::Composite(cf) => cf.r#type().is_unsupported(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.is_unsupported(),
+            IndexFieldWalker::Composite(cf) => cf.r#type().is_unsupported(),
         }
     }
 
     /// The ID of the field node in the AST.
     pub fn field_id(self) -> ast::FieldId {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.field_id(),
-            InnerIndexFieldWalker::Composite(cf) => cf.field_id(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.field_id(),
+            IndexFieldWalker::Composite(cf) => cf.field_id(),
         }
     }
 
     /// The name of the field.
     pub fn name(self) -> &'db str {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.name(),
-            InnerIndexFieldWalker::Composite(cf) => cf.name(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.name(),
+            IndexFieldWalker::Composite(cf) => cf.name(),
         }
     }
 
     /// The final database name of the field. See crate docs for explanations on database names.
     pub fn database_name(self) -> &'db str {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.database_name(),
-            InnerIndexFieldWalker::Composite(cf) => cf.database_name(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.database_name(),
+            IndexFieldWalker::Composite(cf) => cf.database_name(),
         }
     }
 
     /// The type of the field.
     pub fn scalar_field_type(self) -> ScalarFieldType {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.scalar_field_type(),
-            InnerIndexFieldWalker::Composite(cf) => *cf.r#type(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.scalar_field_type(),
+            IndexFieldWalker::Composite(cf) => *cf.r#type(),
         }
     }
 
     /// Convert the walker to a scalar field, if the underlying field is in a
     /// model.
     pub fn as_scalar_field(self) -> Option<ScalarFieldWalker<'db>> {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => Some(sf),
-            InnerIndexFieldWalker::Composite(_) => None,
+        match self {
+            IndexFieldWalker::Scalar(sf) => Some(sf),
+            IndexFieldWalker::Composite(_) => None,
         }
     }
 
     /// Convert the walker to a composite field, if the underlying field is in a
     /// composite type.
     pub fn as_composite_field(self) -> Option<CompositeTypeFieldWalker<'db>> {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(_) => None,
-            InnerIndexFieldWalker::Composite(cf) => Some(cf),
+        match self {
+            IndexFieldWalker::Scalar(_) => None,
+            IndexFieldWalker::Composite(cf) => Some(cf),
         }
     }
 
     /// True if the index field is a scalar field.
     pub fn is_scalar_field(self) -> bool {
-        matches!(self.inner, InnerIndexFieldWalker::Scalar(_))
+        matches!(self, IndexFieldWalker::Scalar(_))
     }
 
     /// True if the index field is a composite field.
     pub fn is_composite_field(self) -> bool {
-        matches!(self.inner, InnerIndexFieldWalker::Composite(_))
+        matches!(self, IndexFieldWalker::Composite(_))
     }
 
     /// Does the field define a primary key by its own.
     pub fn is_single_pk(self) -> bool {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.is_single_pk(),
-            InnerIndexFieldWalker::Composite(_) => false,
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.is_single_pk(),
+            IndexFieldWalker::Composite(_) => false,
         }
     }
 
@@ -319,17 +316,17 @@ impl<'db> IndexFieldWalker<'db> {
     ///
     /// For example: `@db.Text` would translate to ("db", "Text", &[], <the span>)
     pub fn raw_native_type(self) -> Option<(&'db str, &'db str, &'db [String], ast::Span)> {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.raw_native_type(),
-            InnerIndexFieldWalker::Composite(cf) => cf.raw_native_type(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.raw_native_type(),
+            IndexFieldWalker::Composite(cf) => cf.raw_native_type(),
         }
     }
 
     /// The field node in the AST.
     pub fn ast_field(self) -> &'db ast::Field {
-        match self.inner {
-            InnerIndexFieldWalker::Scalar(sf) => sf.ast_field(),
-            InnerIndexFieldWalker::Composite(cf) => cf.ast_field(),
+        match self {
+            IndexFieldWalker::Scalar(sf) => sf.ast_field(),
+            IndexFieldWalker::Composite(cf) => cf.ast_field(),
         }
     }
 }

--- a/psl/parser-database/src/walkers/relation.rs
+++ b/psl/parser-database/src/walkers/relation.rs
@@ -13,6 +13,12 @@ use crate::{ast, relations::*, walkers::*};
 pub type RelationWalker<'db> = Walker<'db, RelationId>;
 
 impl<'db> RelationWalker<'db> {
+    /// Is this a relation where both ends are the same model?
+    pub fn is_self_relation(self) -> bool {
+        let r = self.get();
+        r.model_a == r.model_b
+    }
+
     /// Converts the walker to either an implicit many to many, or a inline relation walker
     /// gathering 1:1 and 1:n relations.
     pub fn refine(self) -> RefinedRelationWalker<'db> {

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -3,7 +3,7 @@ mod cycle_detection;
 use crate::common::*;
 use psl::{
     datamodel_connector::RelationMode,
-    dml::ReferentialAction::{self, *},
+    parser_database::ReferentialAction::{self, *},
 };
 
 #[test]

--- a/psl/schema-ast/src/ast/composite_type.rs
+++ b/psl/schema-ast/src/ast/composite_type.rs
@@ -44,7 +44,7 @@ impl CompositeType {
         false
     }
 
-    pub fn iter_fields(&self) -> impl Iterator<Item = (FieldId, &Field)> {
+    pub fn iter_fields(&self) -> impl ExactSizeIterator<Item = (FieldId, &Field)> + Clone {
         self.fields
             .iter()
             .enumerate()

--- a/psl/schema-ast/src/ast/field.rs
+++ b/psl/schema-ast/src/ast/field.rs
@@ -92,7 +92,7 @@ impl WithDocumentation for Field {
 }
 
 /// An arity of a data model field.
-#[derive(Copy, Debug, Clone)]
+#[derive(Copy, Debug, Clone, PartialEq, Eq, Hash)]
 pub enum FieldArity {
     /// The field either must be in an insert statement, or the field must have
     /// a default value for the insert to succeed.


### PR DESCRIPTION
We are going to need some more public API for the parser database for the upcoming dml-free prisma-models.