### PR TITLE
fix indoc::formatdoc error

### DIFF
--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -133,7 +133,7 @@ impl Datasource {
                     To use a URL with protocol `prisma://` the Data Proxy must be enabled via `prisma generate --data-proxy`.
 
                     More information about Data Proxy: https://pris.ly/d/data-proxy
-                "};
+                ", err_str=err_str};
 
                 Cow::from(s)
             } else {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs
@@ -186,7 +186,12 @@ pub fn schema_with_relation(
 
                                     @@unique([c_1, c_2])
                                 }}
-                            "};
+                            ", 
+                                    parent_field=parent_field,
+                                    parent_id=parent_id,
+                                    child_field=child_field,
+                                    child_id=child_id
+                            };
 
                             let mut required_capabilities_for_dm = vec![];
 


### PR DESCRIPTION
This PR fixes two compile errors, by passing values to indoc::formatdoc! explicitly
```
error: there is no argument named `err_str`
   --> psl/psl-core/src/configuration/datasource.rs:130:44
    |
130 |                   let s = indoc::formatdoc! {"
    |  ____________________________________________^
131 | |                     {err_str}
132 | |
133 | |                     To use a URL with protocol `prisma://` the Data Proxy must be enabled via `prisma generate --data-proxy`.
134 | |
135 | |                     More information about Data Proxy: https://pris.ly/d/data-proxy
136 | |                 "};
    | |_________________^
    |
    = note: did you intend to capture a variable `err_str` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
```
and
```
    error: there is no argument named `child_id`
   --> query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs:167:64
    |
167 |   ...                   let datamodel = indoc::formatdoc! {"
    |  __________________________________________________________^
168 | | ...                       model Parent {{
169 | | ...                           p             String    @unique
170 | | ...                           p_1           String
...   |
188 | | ...                       }}
189 | | ...                   "};
    | |_______________________^
    |
    = note: did you intend to capture a variable `child_id` from the surrounding scope?
    = note: to avoid ambiguity, `format_args!` cannot capture variables when the format string is expanded from a macro
    ```