### PR TITLE
query-tests-setup: delete ConnectorTag::requires_teardown()

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/cockroachdb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/cockroachdb.rs
@@ -42,10 +42,6 @@ impl ConnectorTagInterface for CockroachDbConnectorTag {
     fn is_versioned(&self) -> bool {
         false
     }
-
-    fn requires_teardown(&self) -> bool {
-        true
-    }
 }
 
 impl CockroachDbConnectorTag {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -51,11 +51,6 @@ pub trait ConnectorTagInterface {
     /// Must return `true` if the connector family is versioned (e.g. Postgres9, Postgres10, ...), false otherwise.
     fn is_versioned(&self) -> bool;
 
-    /// Indicates whether or not the test setup needs to explicitly tear down test databases (via `qe_teardown`).
-    fn requires_teardown(&self) -> bool {
-        false
-    }
-
     /// Defines where relational constraints are handled:
     ///   - "prisma" is handled in the Query Engine core
     ///   - "foreignKeys" lets the database handle them

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -78,10 +78,6 @@ impl ConnectorTagInterface for PostgresConnectorTag {
     fn is_versioned(&self) -> bool {
         true
     }
-
-    fn requires_teardown(&self) -> bool {
-        false
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -155,7 +155,6 @@ fn run_relation_link_test_impl(
     if ConnectorTag::should_run(config, enabled_connectors, capabilities, test_name) {
         let datamodel = render_test_datamodel(config, test_database, template, &[], None, Default::default(), None);
         let connector = config.test_connector_tag().unwrap();
-        let requires_teardown = connector.requires_teardown();
         let metrics = setup_metrics();
         let metrics_for_subscriber = metrics.clone();
         let (log_capture, log_tx) = TestLogCapture::new();
@@ -171,9 +170,7 @@ fn run_relation_link_test_impl(
 
                 test_fn(&runner, &dm_with_params_json).await.unwrap();
 
-                if requires_teardown {
-                    teardown_project(&datamodel, Default::default()).await.unwrap();
-                }
+                teardown_project(&datamodel, Default::default()).await.unwrap();
             }
             .with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, metrics_for_subscriber, log_tx)),
         );
@@ -270,7 +267,6 @@ pub fn run_connector_test_impl(
         async {
             crate::setup_project(&datamodel, db_schemas).await.unwrap();
 
-            let requires_teardown = connector.requires_teardown();
             let runner = Runner::load(
                 crate::CONFIG.runner(),
                 datamodel.clone(),
@@ -283,9 +279,7 @@ pub fn run_connector_test_impl(
 
             test_fn(runner).await.unwrap();
 
-            if requires_teardown {
-                crate::teardown_project(&datamodel, db_schemas).await.unwrap();
-            }
+            crate::teardown_project(&datamodel, db_schemas).await.unwrap();
         }
         .with_subscriber(test_tracing_subscriber(&ENV_LOG_LEVEL, metrics_for_subscriber, log_tx)),
     );


### PR DESCRIPTION
The implementors of ConnectorTag already have no-op implementations of `teardown()`, so `requires_teardown()` is redundant.