### PR TITLE
fix: onDelete: SetNull shouldn't recursively delete child models

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
@@ -44,7 +44,7 @@ mod one2one_req {
     }
 }
 
-#[test_suite(suite = "cascade_onD_1to1_opt", schema(optional))]
+#[test_suite(suite = "cascade_onD_1to1_opt", schema(optional), relation_mode = "prisma")]
 mod one2one_opt {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -128,7 +128,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "cascade_onD_1toM_req", schema(required))]
+#[test_suite(suite = "cascade_onD_1toM_req", schema(required), relation_mode = "prisma")]
 mod one2many_req {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -172,7 +172,7 @@ mod one2many_req {
     }
 }
 
-#[test_suite(suite = "cascade_onD_1toM_opt", schema(optional))]
+#[test_suite(suite = "cascade_onD_1toM_opt", schema(optional), relation_mode = "prisma")]
 mod one2many_opt {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -216,7 +216,7 @@ mod one2many_opt {
     }
 }
 
-#[test_suite(schema(schema), exclude(SqlServer))]
+#[test_suite(schema(schema), exclude(SqlServer), relation_mode = "prisma")]
 mod multiple_cascading_paths {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(suite = "cascade_onD_1to1_req", schema(required))]
+#[test_suite(suite = "cascade_onD_1to1_req", schema(required), relation_mode = "prisma")]
 mod one2one_req {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/no_action.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/no_action.rs
@@ -54,7 +54,8 @@ mod one2one_req {
 #[test_suite(
     suite = "noaction_onD_1to1_opt",
     schema(optional),
-    exclude(Postgres, Sqlite, MongoDb)
+    exclude(Postgres, Sqlite),
+    relation_mode = "prisma"
 )]
 mod one2one_opt {
     fn optional() -> String {
@@ -85,15 +86,15 @@ mod one2one_opt {
         assert_error!(
             runner,
             "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-            2003,
-            "Foreign key constraint failed on the field"
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
         );
 
         assert_error!(
             runner,
             "mutation { deleteManyParent(where: { id: 1 }) { count }}",
-            2003,
-            "Foreign key constraint failed on the field"
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
         );
 
         Ok(())
@@ -251,7 +252,7 @@ mod one2many_req {
 #[test_suite(
     suite = "noaction_onD_1toM_opt",
     schema(optional),
-    exclude(Postgres, Sqlite, MongoDb),
+    exclude(Postgres, Sqlite),
     relation_mode = "prisma"
 )]
 mod one2many_opt {
@@ -283,15 +284,15 @@ mod one2many_opt {
         assert_error!(
             runner,
             "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-            2003,
-            "Foreign key constraint failed on the field"
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
         );
 
         assert_error!(
             runner,
             "mutation { deleteManyParent(where: { id: 1 }) { count }}",
-            2003,
-            "Foreign key constraint failed on the field"
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/no_action.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/no_action.rs
@@ -251,7 +251,8 @@ mod one2many_req {
 #[test_suite(
     suite = "noaction_onD_1toM_opt",
     schema(optional),
-    exclude(Postgres, Sqlite, MongoDb)
+    exclude(Postgres, Sqlite, MongoDb),
+    relation_mode = "prisma"
 )]
 mod one2many_opt {
     fn optional() -> String {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
@@ -46,7 +46,12 @@ mod one2one_req {
     }
 }
 
-#[test_suite(suite = "restrict_onD_1to1_opt", schema(optional), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onD_1to1_opt",
+    schema(optional),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2one_opt {
     fn optional() -> String {
         let schema = indoc! {
@@ -145,7 +150,12 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "restrict_onD_1toM_req", schema(required), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onD_1toM_req",
+    schema(required),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2many_req {
     fn required() -> String {
         let schema = indoc! {
@@ -209,7 +219,12 @@ mod one2many_req {
     }
 }
 
-#[test_suite(suite = "restrict_onD_1toM_opt", schema(optional), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onD_1toM_opt",
+    schema(optional),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2many_opt {
     fn optional() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
@@ -3,7 +3,12 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "restrict_onD_1to1_req", schema(required), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onD_1to1_req",
+    schema(required),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2one_req {
     fn required() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
@@ -35,20 +35,12 @@ mod one2one_req {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            "mutation { deleteOneParent(where: { id: 1 }) { id }}",
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -81,20 +73,12 @@ mod one2one_opt {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            "mutation { deleteOneParent(where: { id: 1 }) { id }}",
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -188,20 +172,12 @@ mod one2many_req {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            "mutation { deleteOneParent(where: { id: 1 }) { id }}",
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -260,20 +236,12 @@ mod one2many_opt {
           @r###"{"data":{"createOneParent":{"id":1}}}"###
         );
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                "mutation { deleteOneParent(where: { id: 1 }) { id }}",
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            "mutation { deleteOneParent(where: { id: 1 }) { id }}",
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
@@ -293,7 +293,12 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "setnull_onD_1toM_opt", schema(optional), exclude(MongoDb))]
+#[test_suite(
+    suite = "setnull_onD_1toM_opt",
+    schema(optional),
+    exclude(MongoDb),
+    relation_mode = "prisma"
+)]
 mod one2many_opt {
     fn optional() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
@@ -3,8 +3,10 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "setnull_onD_1to1_opt", schema(optional), exclude(MongoDb))]
+#[test_suite(suite = "setnull_onD_1to1_opt", schema(optional), relation_mode = "prisma")]
 mod one2one_opt {
+    use query_engine_tests::run_query;
+
     fn optional() -> String {
         let schema = indoc! {
             r#"model Parent {
@@ -82,6 +84,213 @@ mod one2one_opt {
 
         Ok(())
     }
+
+    fn one2one2one_opt_set_null() -> String {
+        let schema = indoc! {
+          r#"model A {
+            #id(id, Int, @id)
+            b_id Int? @unique
+            b B?
+          }
+          
+          model B {
+            #id(id, Int, @id)
+            a_id Int? @unique
+            a A? @relation(fields: [a_id], references: [b_id], onDelete: SetNull)
+
+            c C?
+          }
+          
+          model C {
+            #id(id, Int, @id)
+            b_id Int? @unique
+            b B? @relation(fields: [b_id], references: [a_id], onUpdate: SetNull)
+          }
+          "#
+        };
+
+        schema.to_owned()
+    }
+
+    // SET_NULL should also apply to child relations sharing a common fk
+    #[connector_test(schema(one2one2one_opt_set_null))]
+    async fn delete_parent_recurse_set_null(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+            createOneA(data: {
+              id: 1,
+              b_id: 1,
+              b: {
+                create: {
+                  id: 1,
+                  c: {
+                    create: {
+                      id: 1
+                    }
+                  }
+                }
+              }
+            }) {
+              id
+            }
+          }"#),
+          @r###"{"data":{"createOneA":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation { deleteOneA(where: { id: 1 }) { id } }"#),
+          @r###"{"data":{"deleteOneA":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{ findManyB { id a_id } }"#),
+          @r###"{"data":{"findManyB":[{"id":1,"a_id":null}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{ findManyC { id b_id } }"#),
+          @r###"{"data":{"findManyC":[{"id":1,"b_id":null}]}}"###
+        );
+
+        Ok(())
+    }
+
+    fn one2one2one_opt_set_null_restrict() -> String {
+        let schema = indoc! {
+            r#"model A {
+                #id(id, Int, @id)
+                b_id Int? @unique
+                b B?
+              }
+              
+              model B {
+                #id(id, Int, @id)
+                a_id Int? @unique
+                a A? @relation(fields: [a_id], references: [b_id], onDelete: SetNull)
+
+                c C?
+              }
+              
+              model C {
+                #id(id, Int, @id)
+                b_id Int? @unique
+                b B? @relation(fields: [b_id], references: [a_id], onDelete: SetNull, onUpdate: Restrict)
+              }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    // SET_NULL should also apply to child relations sharing a common fk
+    #[connector_test(schema(one2one2one_opt_set_null_restrict))]
+    async fn delete_parent_set_null_restrict(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+          createOneA(data: {
+              id: 1,
+              b_id: 1,
+              b: {
+                create: {
+                  id: 1,
+                  c: {
+                    create: {
+                      id: 1
+                    }
+                  }
+                }
+              }
+            }) {
+              id
+            }
+          }"#),
+          @r###"{"data":{"createOneA":{"id":1}}}"###
+        );
+
+        // Deletion of A fails because it updates B which in turns update C, except that C.b has an onUpdate: Restrict that's set.
+        // So the entire operation cannot be performed.
+        // Note that the `onDelete` referential action set on `C.b` is not taken into account here.
+        assert_error!(
+            runner,
+            r#"mutation { deleteOneA(where: { id: 1 }) { id } }"#,
+            2014,
+            "The change you are trying to make would violate the required relation 'BToC' between the `B` and `C` models."
+        );
+
+        Ok(())
+    }
+
+    fn one2one2one_opt_set_null_cascade() -> String {
+        let schema = indoc! {
+            r#"model A {
+              #id(id, Int, @id)
+              b_id Int? @unique
+              b B?
+            }
+            
+            model B {
+              #id(id, Int, @id)
+              a_id Int? @unique
+              a A? @relation(fields: [a_id], references: [b_id], onDelete: SetNull)
+
+              c C?
+            }
+            
+            model C {
+              #id(id, Int, @id)
+              b_id Int? @unique
+              b B? @relation(fields: [b_id], references: [a_id], onDelete: Restrict, onUpdate: Cascade)
+            }
+          "#
+        };
+
+        schema.to_owned()
+    }
+
+    // SET_NULL should also apply to child relations sharing a common fk
+    #[connector_test(schema(one2one2one_opt_set_null_cascade))]
+    async fn delete_parent_set_null_cascade(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation {
+          createOneA(data: {
+              id: 1,
+              b_id: 1,
+              b: {
+                create: {
+                  id: 1,
+                  c: {
+                    create: {
+                      id: 1
+                    }
+                  }
+                }
+              }
+            }) {
+              id
+            }
+          }"#),
+          @r###"{"data":{"createOneA":{"id":1}}}"###
+        );
+
+        // Note that the `onDelete: Restrict` referential action set on field `C.b` is not taken into account here,
+        // because B is never deleted but only updated based on the onDelete: SetNull referential action set on field `B.a`.
+        insta::assert_snapshot!(
+          run_query!(runner, r#"mutation { deleteOneA(where: { id: 1 }) { id } }"#),
+          @r###"{"data":{"deleteOneA":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{ findManyB { id a_id } }"#),
+          @r###"{"data":{"findManyB":[{"id":1,"a_id":null}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{ findManyC { id b_id } }"#),
+          @r###"{"data":{"findManyC":[{"id":1,"b_id":null}]}}"###
+        );
+
+        Ok(())
+    }
 }
 
 #[test_suite(suite = "setnull_onD_1toM_opt", schema(optional), exclude(MongoDb))]
@@ -119,6 +328,78 @@ mod one2many_opt {
         insta::assert_snapshot!(
           run_query!(&runner, r#"query { findManyChild { id parent_id }}"#),
           @r###"{"data":{"findManyChild":[{"id":1,"parent_id":null}]}}"###
+        );
+
+        Ok(())
+    }
+
+    fn prisma_17255_schema() -> String {
+        let schema = indoc! {
+            r#"model Main {
+            #id(id, Int, @id)
+          
+            alice   Alice?  @relation(fields: [aliceId], references: [id], onDelete: SetNull, onUpdate: Cascade)
+            aliceId Int?
+          
+            bob Bob?
+          }
+          
+          model Alice {
+            #id(id, Int, @id)
+            manyMains Main[]
+          }
+          
+          model Bob {
+            #id(id, Int, @id)
+          
+            main   Main   @relation(fields: [mainId], references: [id], onDelete: Cascade, onUpdate: Cascade)
+            mainId Int @unique
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // Do not recurse when relations have no fks in common
+    #[connector_test(schema(prisma_17255_schema))]
+    async fn prisma_17255(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation {
+          createOneMain(data: {
+            id: 1,
+            alice: { create: { id: 1 } },
+            bob: { create: { id: 1 } }
+          }) {
+            id
+          }
+        }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            updateOneMain(where: { id: 1 }, data: {
+              alice: { delete: true }
+            }) {
+              id
+            }
+          }"#),
+          @r###"{"data":{"updateOneMain":{"id":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{ findManyMain { id alice { id } bob { id } } }"#),
+          @r###"{"data":{"findManyMain":[{"id":1,"alice":null,"bob":{"id":1}}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyAlice { id } }"#),
+          @r###"{"data":{"findManyAlice":[]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyBob { id } }"#),
+          @r###"{"data":{"findManyBob":[{"id":1}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(suite = "cascade_onU_1to1_req", schema(required))]
+#[test_suite(suite = "cascade_onU_1to1_req", schema(required), relation_mode = "prisma")]
 mod one2one_req {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -138,7 +138,7 @@ mod one2one_req {
     }
 }
 
-#[test_suite(suite = "cascade_onU_1to1_opt", schema(optional))]
+#[test_suite(suite = "cascade_onU_1to1_opt", schema(optional), relation_mode = "prisma")]
 mod one2one_opt {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -317,7 +317,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "cascade_onU_1toM_req", schema(required))]
+#[test_suite(suite = "cascade_onU_1toM_req", schema(required), relation_mode = "prisma")]
 mod one2many_req {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -362,7 +362,7 @@ mod one2many_req {
     }
 }
 
-#[test_suite(suite = "cascade_onU_1toM_opt", schema(optional))]
+#[test_suite(suite = "cascade_onU_1toM_opt", schema(optional), relation_mode = "prisma")]
 mod one2many_opt {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -455,7 +455,7 @@ mod one2many_opt {
     }
 }
 
-#[test_suite(schema(schema), exclude(SqlServer))]
+#[test_suite(schema(schema), exclude(SqlServer), relation_mode = "prisma")]
 mod multiple_cascading_paths {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
@@ -3,7 +3,12 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "restrict_onU_1to1_req", schema(required), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onU_1to1_req",
+    schema(required),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2one_req {
     fn required() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
@@ -36,20 +36,12 @@ mod one2one_req {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -61,20 +53,12 @@ mod one2one_req {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -86,20 +70,12 @@ mod one2one_req {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -114,7 +90,12 @@ mod one2one_req {
     }
 }
 
-#[test_suite(suite = "restrict_onU_1to1_opt", schema(optional), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onU_1to1_opt",
+    schema(optional),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2one_opt {
     fn optional() -> String {
         let schema = indoc! {
@@ -142,20 +123,12 @@ mod one2one_opt {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -167,20 +140,12 @@ mod one2one_opt {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -192,20 +157,12 @@ mod one2one_opt {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", child: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -220,7 +177,12 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "restrict_onU_1toM_req", schema(required), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onU_1toM_req",
+    schema(required),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2many_req {
     fn required() -> String {
         let schema = indoc! {
@@ -248,20 +210,12 @@ mod one2many_req {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -273,20 +227,12 @@ mod one2many_req {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -298,20 +244,12 @@ mod one2many_req {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -362,7 +300,12 @@ mod one2many_req {
     }
 }
 
-#[test_suite(suite = "restrict_onU_1toM_opt", schema(optional), exclude(SqlServer))]
+#[test_suite(
+    suite = "restrict_onU_1toM_opt",
+    schema(optional),
+    exclude(SqlServer),
+    relation_mode = "prisma"
+)]
 mod one2many_opt {
     fn optional() -> String {
         let schema = indoc! {
@@ -390,20 +333,12 @@ mod one2many_opt {
 
         let query = r#"mutation { updateOneParent(where: { id: 1 }, data: { uniq: "u1" }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -415,20 +350,12 @@ mod one2many_opt {
 
         let query = r#"mutation { updateManyParent(where: { id: 1 }, data: { uniq: "u1" }) { count }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }
@@ -440,20 +367,12 @@ mod one2many_opt {
 
         let query = r#"mutation { upsertOneParent(where: { id: 1 }, update: { uniq: "u1" }, create: { id: 1, name: "Bob", uniq: "1", children: { create: { id: 1 }} }) { id }}"#;
 
-        match runner.connector_version() {
-            ConnectorVersion::MongoDb(_) => assert_error!(
-                runner,
-                query,
-                2014,
-                "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
-            ),
-            _ => assert_error!(
-                runner,
-                query,
-                2003,
-                "Foreign key constraint failed on the field"
-            ),
-        };
+        assert_error!(
+            runner,
+            query,
+            2014,
+            "The change you are trying to make would violate the required relation 'ChildToParent' between the `Child` and `Parent` models."
+        );
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
@@ -3,7 +3,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "setnull_onU_1to1_opt", schema(optional))]
+#[test_suite(suite = "setnull_onU_1to1_opt", schema(optional), relation_mode = "prisma")]
 mod one2one_opt {
     fn optional() -> String {
         let schema = indoc! {
@@ -206,20 +206,12 @@ mod one2one_opt {
 
         let query = r#"mutation { updateOneA(where: { id: 1 }, data: { b_id: 2 }) { id } }"#;
 
-        match runner.connector_version() {
-          ConnectorVersion::MongoDb(_) => assert_error!(
-              runner,
-              query,
-              2014,
-              "The change you are trying to make would violate the required relation 'BToC' between the `B` and `C` models."
-          ),
-          _ => assert_error!(
-              runner,
-              query,
-              2003,
-              "Foreign key constraint failed on the field"
-          ),
-        };
+        assert_error!(
+          runner,
+          query,
+          2014,
+          "The change you are trying to make would violate the required relation 'BToC' between the `B` and `C` models."
+        );
 
         insta::assert_snapshot!(
           run_query!(runner, r#"{ findManyA { id b_id b { id a_id c { id b_id } } } }"#),
@@ -351,7 +343,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "setnull_onU_1toM_opt", schema(optional))]
+#[test_suite(suite = "setnull_onU_1toM_opt", schema(optional), relation_mode = "prisma")]
 mod one2many_opt {
     fn optional() -> String {
         let schema = indoc! {
@@ -654,20 +646,12 @@ mod one2many_opt {
 
         let query = r#"mutation { updateOneA(where: { id: 1 }, data: { b_id: 2 }) { id } }"#;
 
-        match runner.connector_version() {
-        ConnectorVersion::MongoDb(_) => assert_error!(
-            runner,
-            query,
-            2014,
-            "The change you are trying to make would violate the required relation 'BToC' between the `B` and `C` models."
-        ),
-        _ => assert_error!(
-            runner,
-            query,
-            2003,
-            "Foreign key constraint failed on the field"
-        ),
-      };
+        assert_error!(
+          runner,
+          query,
+          2014,
+          "The change you are trying to make would violate the required relation 'BToC' between the `B` and `C` models."
+        );
 
         insta::assert_snapshot!(
           run_query!(runner, r#"{ findManyA { id b_id bs { id a_id cs { id b_id } } } }"#),
@@ -676,6 +660,7 @@ mod one2many_opt {
 
         Ok(())
     }
+
     fn one2m2m_no_shared_fk() -> String {
         let schema = indoc! {
             r#"model A {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -265,6 +265,7 @@ pub fn run_connector_test_impl(
 
     crate::run_with_tokio(
         async {
+            println!("Used datamodel:\n {}", datamodel.clone().yellow());
             crate::setup_project(&datamodel, db_schemas).await.unwrap();
 
             let runner = Runner::load(

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -81,6 +81,7 @@ pub fn upsert_record(
 
             create_write_args.add_datetimes(&model);
             update_write_args.add_datetimes(&model);
+
             graph.create_node(WriteQuery::native_upsert(
                 field.name,
                 model,
@@ -89,6 +90,7 @@ pub fn upsert_record(
                 update_write_args,
                 read,
             ));
+
             return Ok(());
         }
     }
@@ -238,6 +240,7 @@ fn can_use_connector_native_upsert(
         && !empty_update
         && !has_nested_selects
         && where_values_same_as_create
+        && !connector_ctx.relation_mode.is_prisma()
 }
 
 fn is_unique_field(field_name: &String, model: &ModelRef) -> bool {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/17255

- `onDelete: SetNull` used to recurse over dependent models, potentially chain deleting everything 💀
- We're still recursing, but:
	- Only for relation fields that share a common foreign key with the relation field that is set to null.
	- We apply `onUpdate` emulation from then on, as we _update_ (and not delete) models based on the set_null
- The test suites related to referential actions were running with `relationMode = "foreignKeys"`. They're now set to run with `relationMode = "prisma`. Note: Ideally, we should have a test setup that allows us to assert that our emulated behaviour matches the database behavior. But it's painful.
- Switching those test suites to use `relationMode = "prisma"` made me uncover a small bug where we weren't emulating referential actions anymore when using postgres because it can now use a native upsert in some case. This native upsert makes it hard for us to emulate referential action. I decided to avoid using a native upsert when the `relationMode` is set to `prisma`.

## Run through

Consider this datamodel:

```prisma
model A {
  id   Int  @id
  b_id Int? @unique
  b    B?
}

model B {
  id   Int  @id
  a_id Int? @unique
  a    A?   @relation(fields: [a_id], references: [b_id], onDelete: SetNull)

  c C?
}

model C {
  id   Int  @id
  b_id Int? @unique
  b    B?   @relation(fields: [b_id], references: [a_id], onUpdate: Restrict)
}
```

Notice how `A`, `B` and `C` have foreign keys pointing to each other. `A.b_id` points to `B.a_id` which points to `C.b_id`.

Now say you run the following query:

```ts
await prisma.A.delete({ where { id: 1 } });
```

1. This triggers `B.a`'s `onDelete: SetNull` referential action. So it sets `B.a_id` to `NULL`.
2. The issue is, `C.b` _also_ points to `B.a_id`. So we also need to maintain the referential integrity between `B` and `C`.
3. This is what `collect_overlapping_relation_fields` gather. In this specific example, after emulating `B.a`'s `onDelete` referential action, it finds other relation fields in that same model that shares the foreign key(s) that were just updated. In this case, it finds `B.c` and returns `C.b` because that's where the relation is inlined.
4. So we go over model `C`, and we apply the `onUpdate` referential action of the relation field `C.b`. Why the `onUpdate` RA ? Because we just _updated_ model `B` by setting `B.id = NULL`.
5. In this example, the `C.b`'s `onUpdate` referential action is set to `Restrict`. So the entire operation fails. As it does when relying on the database's referential integrity.
6. If the `onUpdate` RA was set to `SetNull`, it would also set `C.b_id` to NULL. If it was set to `onUpdate: Cascade`, it would also set `C.b_id` to `NULL`.