### PR TITLE
tests(cockroach): fix a flaky cockroach test

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -92,3 +92,29 @@ macro_rules! assert_error {
         $runner.query($q).await?.assert_failure($code, Some($msg.to_string()));
     };
 }
+
+#[macro_export]
+macro_rules! retry {
+    ($body:block, $times:expr) => {{
+        use std::time::Duration;
+        use tokio::time::sleep;
+
+        let mut retries = $times;
+
+        loop {
+            let res = $body.await?;
+
+            if !res.failed() {
+                break res;
+            }
+
+            if retries > 0 {
+                retries -= 1;
+                sleep(Duration::from_millis(5)).await;
+                continue;
+            }
+
+            break res;
+        }
+    }};
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
@@ -38,6 +38,8 @@ mod create {
     // "A Create Mutation" should "create and return item"
     #[connector_test]
     async fn create_should_work(runner: Runner) -> TestResult<()> {
+        // This test is flaky on CockroachDB because of a TX write conflict.
+        // We mitigate this issue by retrying multiple times.
         let res = retry!(
             {
                 runner.query(format!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
@@ -38,26 +38,30 @@ mod create {
     // "A Create Mutation" should "create and return item"
     #[connector_test]
     async fn create_should_work(runner: Runner) -> TestResult<()> {
+        let res = retry!(
+            {
+                runner.query(format!(
+                    r#"mutation {{
+                      createOneScalarModel(data: {{
+                        id: "1",
+                        optString: "lala{}",
+                        optInt: 1337,
+                        optFloat: 1.234,
+                        optBoolean: true,
+                        optEnum: A,
+                        optDateTime: "2016-07-31T23:59:01.000Z"
+                      }}) {{
+                        id, optString, optInt, optFloat, optBoolean, optEnum, optDateTime
+                      }}
+                    }}"#,
+                    TROUBLE_CHARS
+                ))
+            },
+            5
+        );
+
         insta::assert_snapshot!(
-          run_query!(
-            runner,
-            format!(
-                r#"mutation {{
-                  createOneScalarModel(data: {{
-                    id: "1",
-                    optString: "lala{}",
-                    optInt: 1337,
-                    optFloat: 1.234,
-                    optBoolean: true,
-                    optEnum: A,
-                    optDateTime: "2016-07-31T23:59:01.000Z"
-                  }}) {{
-                    id, optString, optInt, optFloat, optBoolean, optEnum, optDateTime
-                  }}
-                }}"#,
-                TROUBLE_CHARS
-            )
-        ),
+          res.to_string(),
           @r###"{"data":{"createOneScalarModel":{"id":"1","optString":"lala¥฿😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮😯😰😱😲😳😴😵😶😷😸😹😺😻😼😽😾😿🙀🙁🙂🙃🙄🙅🙆🙇🙈🙉🙊🙋🙌🙍🙎🙏ऀँंःऄअआइईउऊऋऌऍऎएऐऑऒओऔकखगघङचछजझञटठडढणतथदधनऩपफबभमयर€₭₮₯₰₱₲₳₴₵₶₷₸₹₺₻₼₽₾₿⃀","optInt":1337,"optFloat":1.234,"optBoolean":true,"optEnum":"A","optDateTime":"2016-07-31T23:59:01.000Z"}}}"###
         );
 


### PR DESCRIPTION
## Overview

Attempt retrying a flaky cockroach test that fails because of tx write conflict. The PR adds a `retry!` macro so that we can easily retry tests in the future if needed.