### PR TITLE
macos: build binaries for 10.15+ again

### DIFF
--- a/.github/workflows/build-apple-intel.yml
+++ b/.github/workflows/build-apple-intel.yml
@@ -12,6 +12,7 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
+      MACOSX_DEPLOYMENT_TARGET: 10.15
     runs-on: macos-11
 
     steps:

--- a/.github/workflows/build-apple-intel.yml
+++ b/.github/workflows/build-apple-intel.yml
@@ -12,6 +12,8 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
+
+      # minimum supported version of macOS
       MACOSX_DEPLOYMENT_TARGET: 10.15
     runs-on: macos-11
 


### PR DESCRIPTION
Starting with Prisma 4.2.0, the minimum supported macOS version in our
x86_64 binaries indicates 11.0 instead of the previous 10.15. The reason is
we started building on Big Sur with newer SDK without specifying the
target version.

Before 012c7a59ecf4851fa09ef606cb8d549fdaa917db:

```
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 10.15
      sdk 10.15.6
   ntools 1
     tool 3
  version 609.8
```

After 012c7a59ecf4851fa09ef606cb8d549fdaa917db:

```
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 11.0
      sdk 12.1
   ntools 1
     tool 3
  version 711.0
```

After this PR:

```
      cmd LC_BUILD_VERSION
  cmdsize 32
 platform 1
    minos 10.15
      sdk 12.1
   ntools 1
     tool 3
  version 711.0
```

(`$ otool -l query-engine`).

This commit tells clang and the linker to target Catalina via the
`MACOS_DEPLOYMENT_TARGET` env var. Another alternative could be
something like

```toml
[target.x86_64-apple-darwin]
rustflags=["-C", "link-arg=-mmacosx-version-min=10.15"]
```

in `.cargo/config` but that could still pose problems since that
wouldn't be passed to the C compiler some `-sys` crates might be
invoking when building them.

Ref: https://github.com/prisma/prisma-engines/pull/3095
