### PR TITLE
sql-query-connector: more clippy, delete dead code

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -1,7 +1,5 @@
 use super::{catch, transaction::SqlConnectorTransaction};
-use crate::{
-    database::operations::*, operations::upsert::native_upsert, sql_info::SqlInfo, Context, QueryExt, SqlError,
-};
+use crate::{database::operations::*, sql_info::SqlInfo, Context, QueryExt, SqlError};
 use async_trait::async_trait;
 use connector::{ConnectionLike, RelAggregationSelection};
 use connector_interface::{
@@ -248,7 +246,7 @@ where
     ) -> connector::Result<SingleRecord> {
         catch(self.connection_info.clone(), async move {
             let ctx = Context::new(&self.connection_info, trace_id.as_deref());
-            native_upsert(&self.inner, upsert, &ctx).await
+            upsert::native_upsert(&self.inner, upsert, &ctx).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,5 +1,5 @@
 use super::catch;
-use crate::{database::operations::*, operations::upsert::native_upsert, sql_info::SqlInfo, Context, SqlError};
+use crate::{database::operations::*, sql_info::SqlInfo, Context, SqlError};
 use async_trait::async_trait;
 use connector::{ConnectionLike, RelAggregationSelection};
 use connector_interface::{
@@ -39,7 +39,7 @@ impl<'tx> ConnectionLike for SqlConnectorTransaction<'tx> {}
 impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
     async fn commit(&mut self) -> connector::Result<()> {
         catch(self.connection_info.clone(), async move {
-            Ok(self.inner.commit().await.map_err(SqlError::from)?)
+            self.inner.commit().await.map_err(SqlError::from)
         })
         .await
     }
@@ -226,7 +226,7 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
     ) -> connector::Result<SingleRecord> {
         catch(self.connection_info.clone(), async move {
             let ctx = Context::new(&self.connection_info, trace_id.as_deref());
-            native_upsert(&self.inner, upsert, &ctx).await
+            upsert::native_upsert(&self.inner, upsert, &ctx).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -1,12 +1,10 @@
 #![allow(
     clippy::wrong_self_convention,
-    clippy::upper_case_acronyms,
-    clippy::needless_question_mark,
     clippy::branches_sharing_code,
-    clippy::mem_replace_with_default,
     clippy::needless_borrow,
     clippy::needless_collect
 )]
+#![deny(unsafe_code)]
 
 mod column_metadata;
 mod context;
@@ -27,13 +25,9 @@ mod sql_trace;
 mod value;
 mod value_ext;
 
-use self::context::Context;
-use column_metadata::*;
-use filter_conversion::*;
-use query_ext::QueryExt;
-use row::*;
+use self::{column_metadata::*, context::Context, filter_conversion::*, query_ext::QueryExt, row::*};
 
-pub use database::*;
+pub use database::{FromSource, Mssql, Mysql, PostgreSql, Sqlite};
 pub use error::SqlError;
 
 type Result<T> = std::result::Result<T, error::SqlError>;

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -4,16 +4,13 @@ use chrono::{DateTime, NaiveDate, Utc};
 use connector_interface::{coerce_null_to_zero_value, AggregationResult, AggregationSelection};
 use prisma_models::{PrismaValue, Record, TypeIdentifier};
 use psl::dml::FieldArity;
-use quaint::{
-    ast::{Expression, Value},
-    connector::ResultRow,
-};
+use quaint::{ast::Value, connector::ResultRow};
 use std::{io, str::FromStr};
 use uuid::Uuid;
 
 /// An allocated representation of a `Row` returned from the database.
 #[derive(Debug, Clone, Default)]
-pub struct SqlRow {
+pub(crate) struct SqlRow {
     pub values: Vec<PrismaValue>,
 }
 
@@ -264,29 +261,6 @@ fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result
         },
         TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),
     })
-}
-
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub enum SqlId {
-    String(String),
-    Int(usize),
-    UUID(Uuid),
-}
-
-impl From<SqlId> for Expression<'static> {
-    fn from(id: SqlId) -> Self {
-        match id {
-            SqlId::String(s) => s.into(),
-            SqlId::Int(i) => (i as i64).into(),
-            SqlId::UUID(u) => u.into(),
-        }
-    }
-}
-
-impl From<&SqlId> for Expression<'static> {
-    fn from(id: &SqlId) -> Self {
-        id.clone().into()
-    }
 }
 
 // We assume the bytes are stored as a big endian signed integer, because that is what

--- a/query-engine/connectors/sql-query-connector/src/sql_info.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_info.rs
@@ -1,4 +1,3 @@
-use psl::datamodel_connector::{ConnectorCapabilities, ConnectorCapability};
 use quaint::prelude::ConnectionInfo;
 use std::env;
 
@@ -24,18 +23,8 @@ fn get_batch_size(_: usize) -> Option<usize> {
     env::var("QUERY_BATCH_SIZE").ok().and_then(|size| size.parse().ok())
 }
 
-pub enum SqlFamily {
-    SQLite,
-    Postgres,
-    MySQL,
-    MSSQL,
-}
-
 /// Contains meta information about the loaded connector.
-pub struct SqlInfo {
-    /// SQL family the connector belongs to.
-    pub family: SqlFamily,
-
+pub(crate) struct SqlInfo {
     /// Maximum rows allowed at once for an insert query.
     /// None is unlimited.
     pub max_rows: Option<usize>,
@@ -43,51 +32,35 @@ pub struct SqlInfo {
     /// Maximum number of bind parameters allowed for a single query.
     /// None is unlimited.
     pub max_bind_values: Option<usize>,
-
-    /// Capabilities of the connector
-    pub capabilities: ConnectorCapabilities,
 }
 
 impl SqlInfo {
-    #[allow(dead_code)]
-    pub fn has_capability(&self, capability: ConnectorCapability) -> bool {
-        self.capabilities.contains(capability)
-    }
-
     fn sqlite() -> Self {
         Self {
-            family: SqlFamily::SQLite,
             max_rows: Some(999),
             max_bind_values: get_batch_size(999),
-            capabilities: ConnectorCapabilities::new(psl::builtin_connectors::SQLITE.capabilities().to_owned()),
         }
     }
 
     fn mysql() -> Self {
         Self {
-            family: SqlFamily::MySQL,
             max_rows: None,
             // See https://stackoverflow.com/a/11131824/788562
             max_bind_values: get_batch_size(65535),
-            capabilities: ConnectorCapabilities::new(psl::builtin_connectors::MYSQL.capabilities().to_owned()),
         }
     }
 
     fn postgres() -> Self {
         Self {
-            family: SqlFamily::Postgres,
             max_rows: None,
             max_bind_values: get_batch_size(32766),
-            capabilities: ConnectorCapabilities::new(psl::builtin_connectors::POSTGRES.capabilities().to_owned()),
         }
     }
 
     fn mssql() -> Self {
         Self {
-            family: SqlFamily::MSSQL,
             max_rows: Some(1000),
             max_bind_values: get_batch_size(2099),
-            capabilities: ConnectorCapabilities::new(psl::builtin_connectors::MSSQL.capabilities().to_owned()),
         }
     }
 }


### PR DESCRIPTION
And slightly shrink the public API. And add deny(unsafe_code) at the crate level. Delete dead code.