### PR TITLE
directUrl: always resolve directUrl in getConfig

### DIFF
--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -153,4 +153,121 @@ mod tests {
         let response = get_config(&request.to_string()).unwrap();
         expected.assert_eq(&response);
     }
+
+    #[test]
+    fn get_config_direct_url_value() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = "postgresql://example.com/direct"
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+            "env": {
+                "DBURL": "postgresql://example.com/mydb"
+            }
+        });
+        let expected = expect![[
+            r#"{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"directUrl":{"fromEnvVar":null,"value":"postgresql://example.com/direct"},"schemas":[]}],"warnings":[]}"#
+        ]];
+        let response = get_config(&request.to_string()).unwrap();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_config_direct_url_env() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = env("DBDIRURL")
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+            "env": {
+                "DBURL": "postgresql://example.com/mydb",
+                "DBDIRURL": "postgresql://example.com/direct"
+            }
+        });
+        let expected = expect![[
+            r#"{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"directUrl":{"fromEnvVar":"DBDIRURL","value":"postgresql://example.com/direct"},"schemas":[]}],"warnings":[]}"#
+        ]];
+        let response = get_config(&request.to_string()).unwrap();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_config_direct_url_direct_empty() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = ""
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+            "env": {
+                "DBURL": "postgresql://example.com/mydb",
+            }
+        });
+        let expected = expect![[
+            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+        ]];
+        let response = get_config(&request.to_string()).unwrap_err();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_config_direct_url_env_not_found() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = env("DOES_NOT_EXIST")
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+            "env": {
+                "DBURL": "postgresql://example.com/mydb",
+            }
+        });
+        let expected = expect![[
+            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+        ]];
+        let response = get_config(&request.to_string()).unwrap_err();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_config_direct_url_env_is_empty() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = env("DOES_NOT_EXIST")
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+            "env": {
+                "DBURL": "postgresql://example.com/mydb",
+                "DOES_NOT_EXIST": "",
+            }
+        });
+        let expected = expect![[
+            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+        ]];
+        let response = get_config(&request.to_string()).unwrap_err();
+        expected.assert_eq(&response);
+    }
 }

--- a/psl/psl-core/src/configuration/configuration_struct.rs
+++ b/psl/psl-core/src/configuration/configuration_struct.rs
@@ -60,6 +60,43 @@ impl Configuration {
             if datasource.url.from_env_var.is_some() && datasource.url.value.is_none() {
                 datasource.url.value = Some(datasource.load_url(env)?);
             }
+
+            if let (Some(direct_url), Some(span)) = (&datasource.direct_url, &datasource.direct_url_span) {
+                let result = match super::from_url(direct_url, env) {
+                        Err(err) => {
+                            match err {
+                        super::UrlValidationError::EmptyUrlValue => {
+                            let msg = "You must provide a nonempty direct URL";
+                            Err(DatamodelError::new_source_validation_error(msg, &datasource.name, *span))
+                        }
+                        super::UrlValidationError::EmptyEnvValue(env_var) => {
+                            Err(DatamodelError::new_source_validation_error(
+                                &format!(
+                        "You must provide a nonempty direct URL. The environment variable `{}` resolved to an empty string.",
+                        env_var
+                    ),
+                                &datasource.name,
+                                *span,
+                            ))
+                        },
+                        super::UrlValidationError::NoEnvValue(env_var) => {
+                            Err(DatamodelError::new_environment_functional_evaluation_error(
+                                env_var,
+                                *span,
+                            ))
+                        },
+                        super::UrlValidationError::NoUrlOrEnv => {
+                          Ok(None)
+                        },
+                    }
+                        },
+                        Ok(res) => Ok(Some(res)),
+                    }?;
+                datasource.direct_url = Some(crate::StringFromEnvVar {
+                    from_env_var: direct_url.from_env_var.clone(),
+                    value: result,
+                });
+            }
         }
 
         Ok(())

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -244,7 +244,7 @@ impl Datasource {
     }
 }
 
-fn from_url<F>(url: &StringFromEnvVar, env: F) -> Result<String, UrlValidationError>
+pub(crate) fn from_url<F>(url: &StringFromEnvVar, env: F) -> Result<String, UrlValidationError>
 where
     F: Fn(&str) -> Option<String>,
 {


### PR DESCRIPTION
This should fix the issue with `directUrl` not getting resolved for `getConfig`. Hopefully the tests cover all cases.

I'm not a huge fan of this solution, especially not the duplication of the error mapping, but I don't see much choice. We have one more place that's incredibly similar, but in the case of `directUrl` being empty, it would automagically fallback to `url`, which is not what we want in this particular piece of code.