### PR TITLE
query-engine-tests: make TestConfig::load() private

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
@@ -3,18 +3,14 @@
 //! transaction progresses, the test uses separate engines inside
 //! actors to allow test to continue even if one query is blocking.
 
-use std::future::Future;
-
 use indoc::indoc;
-use once_cell::sync::Lazy;
 use query_engine_tests::{
     query_core::TxId, render_test_datamodel, setup_metrics, setup_project, test_tracing_subscriber, ConnectorTag,
-    LogEmit, QueryResult, Runner, TestConfig, TestError, TestLogCapture, TestResult, TryFrom, WithSubscriber,
+    LogEmit, QueryResult, Runner, TestError, TestLogCapture, TestResult, TryFrom, WithSubscriber, CONFIG,
     ENV_LOG_LEVEL,
 };
+use std::future::Future;
 use tokio::sync::mpsc;
-
-static CONFIG: Lazy<TestConfig> = Lazy::new(|| TestConfig::load().unwrap());
 
 const SCHEMA: &str = indoc! {r#"
     model Country {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -29,7 +29,7 @@ pub struct TestConfig {
 
 impl TestConfig {
     /// Loads a configuration. File-based config has precedence over env config.
-    pub fn load() -> TestResult<Self> {
+    pub(crate) fn load() -> TestResult<Self> {
         let config = Self::from_file().or_else(Self::from_env);
 
         match config {


### PR DESCRIPTION
Since the test configuration depends from the environment or a static file, `load()` should always produce the same result within a test run. That makes the API of TestConfig clearer and simplifies one existing test.