### PR TITLE
Revert "query-engine-node-api: delete getConfig() (#3608)"

### DIFF
--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -1,8 +1,12 @@
 use crate::error::ApiError;
+use napi::{bindgen_prelude::*, JsUnknown};
 use napi_derive::napi;
 use query_core::{schema::QuerySchemaRef, schema_builder};
 use request_handlers::dmmf;
-use std::sync::Arc;
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 #[derive(serde::Serialize, Clone, Copy)]
 #[napi(object)]
@@ -33,6 +37,43 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
     let dmmf = dmmf::render_dmmf(query_schema);
 
     Ok(serde_json::to_string(&dmmf)?)
+}
+
+#[napi]
+pub fn get_config(js_env: Env, options: JsUnknown) -> napi::Result<JsUnknown> {
+    #[derive(serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct GetConfigOptions {
+        datamodel: String,
+        #[serde(default)]
+        ignore_env_var_errors: bool,
+        #[serde(default)]
+        datasource_overrides: BTreeMap<String, String>,
+        #[serde(default)]
+        env: HashMap<String, String>,
+    }
+
+    let options: GetConfigOptions = js_env.from_js_value(options)?;
+
+    let GetConfigOptions {
+        datamodel,
+        ignore_env_var_errors,
+        datasource_overrides,
+        env,
+    } = options;
+
+    let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();
+    let mut config = psl::parse_configuration(&datamodel).map_err(|errors| ApiError::conversion(errors, &datamodel))?;
+
+    if !ignore_env_var_errors {
+        config
+            .resolve_datasource_urls_from_env(&overrides, |key| env.get(key).map(ToString::to_string))
+            .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
+    }
+
+    let serialized = psl::get_config::config_to_mcf_json_value(&config);
+
+    js_env.to_js_value(&serialized)
 }
 
 #[napi]


### PR DESCRIPTION
We deleted getConfig from the node api builds of the query-engine for a 30kb gain with the assumption that it wasn't used at all anymore in the CLI. It is not the case.

This reverts commit 7e6991a472f700dcea04ffab5800ea589abcf097.