### PR TITLE
refactor: inline all raw query tags

### DIFF
--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -83,7 +83,11 @@ impl QueryGraphBuilder {
             (QueryTag::DeleteOne, Some(m)) => QueryGraph::root(|g| write::delete_record(g, connector_ctx, m, parsed_field)),
             (QueryTag::DeleteMany, Some(m)) => QueryGraph::root(|g| write::delete_many_records(g, connector_ctx, m, parsed_field)),
             (QueryTag::ExecuteRaw, _) => QueryGraph::root(|g| write::execute_raw(g, parsed_field)),
-            (QueryTag::QueryRaw { query_type }, m) => QueryGraph::root(|g| write::query_raw(g, m, query_type, parsed_field)),
+            (QueryTag::QueryRaw, m) => QueryGraph::root(|g| write::query_raw(g, m, None, parsed_field)),
+            // MongoDB specific raw operations
+            (QueryTag::FindRaw, m) => QueryGraph::root(|g| write::query_raw(g, m, Some(QueryTag::FindRaw.to_string()), parsed_field)),
+            (QueryTag::AggregateRaw, m) => QueryGraph::root(|g| write::query_raw(g, m, Some(QueryTag::AggregateRaw.to_string()), parsed_field)),
+            (QueryTag::RunCommandRaw, m) => QueryGraph::root(|g| write::query_raw(g, m, Some(QueryTag::RunCommandRaw.to_string()), parsed_field)),
             _ => unreachable!("Query builder dispatching failed."),
         }?;
 

--- a/query-engine/core/src/query_graph_builder/write/raw.rs
+++ b/query-engine/core/src/query_graph_builder/write/raw.rs
@@ -14,10 +14,10 @@ pub fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuil
 pub fn query_raw(
     graph: &mut QueryGraph,
     model: Option<ModelRef>,
-    query_type: &Option<String>,
+    query_type: Option<String>,
     field: ParsedField,
 ) -> QueryGraphBuilderResult<()> {
-    let raw_query = Query::Write(WriteQuery::QueryRaw(raw_query(model, query_type.to_owned(), field)?));
+    let raw_query = Query::Write(WriteQuery::QueryRaw(raw_query(model, query_type, field)?));
 
     graph.create_node(raw_query);
     Ok(())

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
@@ -122,14 +122,7 @@ impl RenderContext {
         if let Some(info) = operation {
             if let Some(ref model) = info.model {
                 let model_name = model.name();
-                let tag_str = match &info.tag {
-                    // If it's a QueryRaw with a query_type, then use this query_type as operation name
-                    // eg: findRaw, aggregateRaw..
-                    QueryTag::QueryRaw { query_type } if query_type.is_some() => {
-                        query_type.as_ref().unwrap().to_owned()
-                    }
-                    tag => format!("{}", tag),
-                };
+                let tag_str = format!("{}", &info.tag);
                 let model_op = self
                     .mappings
                     .model_operations
@@ -147,15 +140,7 @@ impl RenderContext {
                 };
             } else {
                 match &info.tag {
-                    // If it's a QueryRaw with a query_type, then use this query_type as operation name
-                    // eg: runCommandRaw
-                    QueryTag::QueryRaw { query_type } if query_type.is_some() => {
-                        self.mappings
-                            .other_operations
-                            .write
-                            .push(query_type.as_ref().unwrap().to_owned());
-                    }
-                    QueryTag::ExecuteRaw | QueryTag::QueryRaw { query_type: _ } => {
+                    QueryTag::ExecuteRaw | QueryTag::QueryRaw | QueryTag::RunCommandRaw => {
                         self.mappings.other_operations.write.push(info.tag.to_string());
                     }
                     _ => unreachable!("Invalid operations mapping."),

--- a/query-engine/schema-builder/src/output_types/mutation_type.rs
+++ b/query-engine/schema-builder/src/output_types/mutation_type.rs
@@ -131,7 +131,7 @@ fn create_query_raw_field() -> OutputField {
         ],
         OutputType::json(),
         Some(QueryInfo {
-            tag: QueryTag::QueryRaw { query_type: None },
+            tag: QueryTag::QueryRaw,
             model: None,
         }),
     )
@@ -143,9 +143,7 @@ fn create_mongodb_run_command_raw() -> OutputField {
         vec![input_field("command", InputType::json(), None)],
         OutputType::json(),
         Some(QueryInfo {
-            tag: QueryTag::QueryRaw {
-                query_type: Some("runCommandRaw".to_string()),
-            },
+            tag: QueryTag::RunCommandRaw,
             model: None,
         }),
     )

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -162,9 +162,7 @@ fn mongo_aggregate_raw_field(model: &ModelRef) -> OutputField {
         ],
         OutputType::json(),
         Some(QueryInfo {
-            tag: QueryTag::QueryRaw {
-                query_type: Some("aggregateRaw".to_owned()),
-            },
+            tag: QueryTag::AggregateRaw,
             model: Some(model.clone()),
         }),
     )
@@ -181,9 +179,7 @@ fn mongo_find_raw_field(model: &ModelRef) -> OutputField {
         ],
         OutputType::json(),
         Some(QueryInfo {
-            tag: QueryTag::QueryRaw {
-                query_type: Some("findRaw".to_owned()),
-            },
+            tag: QueryTag::FindRaw,
             model: Some(model.clone()),
         }),
     )

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -159,7 +159,10 @@ pub enum QueryTag {
     Aggregate,
     GroupBy,
     ExecuteRaw,
-    QueryRaw { query_type: Option<String> },
+    QueryRaw,
+    RunCommandRaw,
+    FindRaw,
+    AggregateRaw,
 }
 
 impl fmt::Display for QueryTag {
@@ -180,7 +183,10 @@ impl fmt::Display for QueryTag {
             Self::Aggregate => "aggregate",
             Self::GroupBy => "groupBy",
             Self::ExecuteRaw => "executeRaw",
-            Self::QueryRaw { query_type: _ } => "queryRaw",
+            Self::QueryRaw => "queryRaw",
+            Self::RunCommandRaw => "runCommandRaw",
+            Self::FindRaw => "findRaw",
+            Self::AggregateRaw => "aggregateRaw",
         };
 
         write!(f, "{}", s)


### PR DESCRIPTION
## Overview

closes https://github.com/prisma/client-planning/issues/252

This PR is a second step towards implemeting the JSON protocol.
Since the new protocol relies on "action"s instead of sending the actual schema field name (eg: `model: "User", "action": "updateOne"` instead of `updateOneUser), we need to inline all query tags so that raw operations can keep working.

This is all internal and shouldn't affect clients.