### PR TITLE
Finish removing authors fields from Cargo.toml's

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
+++ b/introspection-engine/connectors/sql-introspection-connector/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Marcus Böhm <boehm@prisma.io>"]
 edition = "2021"
 name = "sql-introspection-connector"
 version = "0.1.0"

--- a/introspection-engine/introspection-engine-tests/Cargo.toml
+++ b/introspection-engine/introspection-engine-tests/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "introspection-engine-tests"
 version = "0.1.0"
-authors = ["Julius de Bruijn <julius+github@nauk.io>"]
 edition = "2021"
 
 [dependencies]

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Marcus Böhm <boehm@prisma.io>"]
 edition = "2021"
 name = "prisma-value"
 version = "0.1.0"

--- a/libs/sql-ddl/Cargo.toml
+++ b/libs/sql-ddl/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "sql-ddl"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [features]

--- a/libs/test-macros/Cargo.toml
+++ b/libs/test-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-macros"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [lib]

--- a/libs/test-setup/Cargo.toml
+++ b/libs/test-setup/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "test-setup"
 version = "0.1.0"
-authors = ["Tom Houlé <tom@tomhoule.com>"]
 edition = "2021"
 
 [dependencies]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dominic Petrick <dompetrick@gmail.com>"]
 edition = "2018"
 name = "query-engine-tests"
 version = "0.1.0"

--- a/query-engine/connector-test-kit-rs/query-test-macros/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-test-macros/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "query-test-macros"
 version = "0.1.0"
-authors = ["Dominic Petrick <dompetrick@gmail.com>"]
 edition = "2021"
 
 [lib]

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "query-tests-setup"
 version = "0.1.0"
-authors = ["Dominic Petrick <dompetrick@gmail.com>"]
 edition = "2021"
 
 [dependencies]

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dominic Petrick <dompetrick@gmail.com>", "Katharina Fey <kookie@spacekookie.de>"]
 edition = "2021"
 name = "query-core"
 version = "0.1.0"

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "query-engine-node-api"
 version = "0.1.0"
-authors = ["Julius de Bruijn <bruijn@prisma.io>"]
 edition = "2021"
 
 [lib]

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Dominic Petrick <dompetrick@gmail.com>", "Katharina Fey <kookie@spacekookie.de>"]
 edition = "2021"
 name = "query-engine"
 version = "0.1.0"

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "request-handlers"
 version = "0.1.0"
-authors = ["Julius de Bruijn <julius+github@nauk.io>"]
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
- This is not best practice anymore (cargo new doesn't add an authors key anymore, among other things)
- This is not up to date at all
- We've done it for many crates in the workspace already