### PR TITLE
refactor: lift some coercions from serializer to connectors

### DIFF
--- a/libs/prisma-value/src/error.rs
+++ b/libs/prisma-value/src/error.rs
@@ -1,10 +1,11 @@
+use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::Display;
 
 #[derive(Debug)]
 pub struct ConversionFailure {
-    pub from: &'static str,
-    pub to: &'static str,
+    pub from: Cow<'static, str>,
+    pub to: Cow<'static, str>,
 }
 
 impl Error for ConversionFailure {}
@@ -16,7 +17,14 @@ impl Display for ConversionFailure {
 }
 
 impl ConversionFailure {
-    pub fn new(from: &'static str, to: &'static str) -> ConversionFailure {
-        ConversionFailure { from, to }
+    pub fn new<A, B>(from: A, to: B) -> ConversionFailure
+    where
+        A: Into<Cow<'static, str>>,
+        B: Into<Cow<'static, str>>,
+    {
+        ConversionFailure {
+            from: from.into(),
+            to: to.into(),
+        }
     }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/value.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/value.rs
@@ -333,10 +333,12 @@ fn read_scalar_value(bson: Bson, meta: &ScalarOutputMeta) -> crate::Result<Prism
         (TypeIdentifier::Int, Bson::Int64(i)) => PrismaValue::Int(i),
         (TypeIdentifier::Int, Bson::Int32(i)) => PrismaValue::Int(i as i64),
         (TypeIdentifier::Int, Bson::Double(i)) => PrismaValue::Int(i as i64),
+        (TypeIdentifier::Int, Bson::Boolean(bool)) => PrismaValue::Int(bool as i64),
 
         // BigInt
         (TypeIdentifier::BigInt, Bson::Int64(i)) => PrismaValue::BigInt(i),
         (TypeIdentifier::BigInt, Bson::Int32(i)) => PrismaValue::BigInt(i as i64),
+        (TypeIdentifier::BigInt, Bson::Boolean(bool)) => PrismaValue::BigInt(bool as i64),
 
         // Floats
         (TypeIdentifier::Float, Bson::Double(f)) => {

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -2,7 +2,7 @@ use crate::{column_metadata::ColumnMetadata, error::SqlError, value::to_prisma_v
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use chrono::{DateTime, NaiveDate, Utc};
 use connector_interface::{coerce_null_to_zero_value, AggregationResult, AggregationSelection};
-use prisma_models::{ConversionFailure, dml::FieldArity, PrismaValue, Record, TypeIdentifier};
+use prisma_models::{dml::FieldArity, ConversionFailure, PrismaValue, Record, TypeIdentifier};
 use quaint::{ast::Value, connector::ResultRow};
 use std::{io, str::FromStr};
 use uuid::Uuid;

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -230,12 +230,21 @@ fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result
             }
             _ => return Err(create_error(&p_value)),
         },
-        TypeIdentifier::Int | TypeIdentifier::BigInt => match p_value {
+        TypeIdentifier::Int => match p_value {
             Value::Int32(Some(i)) => PrismaValue::Int(i as i64),
             Value::Int64(Some(i)) => PrismaValue::Int(i),
             Value::Bytes(Some(bytes)) => PrismaValue::Int(interpret_bytes_as_i64(&bytes)),
             Value::Text(Some(ref txt)) => {
                 PrismaValue::Int(i64::from_str(txt.trim_start_matches('\0')).map_err(|_| create_error(&p_value))?)
+            }
+            other => to_prisma_value(other)?,
+        },
+        TypeIdentifier::BigInt => match p_value {
+            Value::Int32(Some(i)) => PrismaValue::BigInt(i as i64),
+            Value::Int64(Some(i)) => PrismaValue::BigInt(i),
+            Value::Bytes(Some(bytes)) => PrismaValue::BigInt(interpret_bytes_as_i64(&bytes)),
+            Value::Text(Some(ref txt)) => {
+                PrismaValue::BigInt(i64::from_str(txt.trim_start_matches('\0')).map_err(|_| create_error(&p_value))?)
             }
             other => to_prisma_value(other)?,
         },

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -322,7 +322,7 @@ fn interpret_bytes_as_i64(bytes: &[u8]) -> i64 {
     }
 }
 
-pub fn sanitize_f32(n: f32, to: &'static str) -> crate::Result<()> {
+pub(crate) fn sanitize_f32(n: f32, to: &'static str) -> crate::Result<()> {
     if n.is_nan() {
         return Err(ConversionFailure::new("NaN", to).into());
     }
@@ -334,7 +334,7 @@ pub fn sanitize_f32(n: f32, to: &'static str) -> crate::Result<()> {
     Ok(())
 }
 
-pub fn sanitize_f64(n: f64, to: &'static str) -> crate::Result<()> {
+pub(crate) fn sanitize_f64(n: f64, to: &'static str) -> crate::Result<()> {
     if n.is_nan() {
         return Err(ConversionFailure::new("NaN", to).into());
     }
@@ -346,7 +346,7 @@ pub fn sanitize_f64(n: f64, to: &'static str) -> crate::Result<()> {
     Ok(())
 }
 
-pub fn big_decimal_to_i64(dec: BigDecimal, to: &'static str) -> Result<i64, SqlError> {
+pub(crate) fn big_decimal_to_i64(dec: BigDecimal, to: &'static str) -> Result<i64, SqlError> {
     dec.normalized()
         .to_i64()
         .ok_or_else(|| SqlError::from(ConversionFailure::new(format!("BigDecimal({dec})"), to)))

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -249,6 +249,7 @@ fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result
                 PrismaValue::Int(big_decimal_to_i64(BigDecimal::from_f64(f).unwrap(), "Int")?)
             }
             Value::Numeric(Some(dec)) => PrismaValue::Int(big_decimal_to_i64(dec, "Int")?),
+            Value::Boolean(Some(bool)) => PrismaValue::Int(bool as i64),
             other => to_prisma_value(other)?,
         },
         TypeIdentifier::BigInt => match p_value {
@@ -270,6 +271,7 @@ fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result
                 PrismaValue::BigInt(big_decimal_to_i64(BigDecimal::from_f64(f).unwrap(), "BigInt")?)
             }
             Value::Numeric(Some(dec)) => PrismaValue::BigInt(big_decimal_to_i64(dec, "BigInt")?),
+            Value::Boolean(Some(bool)) => PrismaValue::BigInt(bool as i64),
             other => to_prisma_value(other)?,
         },
         TypeIdentifier::String => match p_value {

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -546,10 +546,6 @@ fn convert_prisma_value(field: &OutputFieldRef, value: PrismaValue, st: &ScalarT
         (ScalarType::Json, PrismaValue::String(s)) => PrismaValue::Json(s),
         (ScalarType::Json, PrismaValue::Json(s)) => PrismaValue::Json(s),
 
-        (ScalarType::Int, PrismaValue::Float(f)) => PrismaValue::Int(
-            f.to_i64()
-                .ok_or_else(|| CoreError::decimal_conversion_error(&f, "i64"))?,
-        ),
         (ScalarType::Int, PrismaValue::Int(i)) => PrismaValue::Int(i),
 
         (ScalarType::Float, PrismaValue::Float(f)) => PrismaValue::Float(f),

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -559,7 +559,6 @@ fn convert_prisma_value(field: &OutputFieldRef, value: PrismaValue, st: &ScalarT
         (ScalarType::Decimal, PrismaValue::Float(f)) => PrismaValue::String(f.to_string()),
 
         (ScalarType::BigInt, PrismaValue::BigInt(i)) => PrismaValue::BigInt(i),
-        (ScalarType::BigInt, PrismaValue::Int(i)) => PrismaValue::BigInt(i),
         (ScalarType::BigInt, PrismaValue::Float(f)) => PrismaValue::BigInt(
             f.to_i64()
                 .ok_or_else(|| CoreError::decimal_conversion_error(&f, "i64"))?,

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -559,10 +559,6 @@ fn convert_prisma_value(field: &OutputFieldRef, value: PrismaValue, st: &ScalarT
         (ScalarType::Decimal, PrismaValue::Float(f)) => PrismaValue::String(f.to_string()),
 
         (ScalarType::BigInt, PrismaValue::BigInt(i)) => PrismaValue::BigInt(i),
-        (ScalarType::BigInt, PrismaValue::Float(f)) => PrismaValue::BigInt(
-            f.to_i64()
-                .ok_or_else(|| CoreError::decimal_conversion_error(&f, "i64"))?,
-        ),
 
         (ScalarType::Boolean, PrismaValue::Boolean(b)) => PrismaValue::Boolean(b),
         (ScalarType::Int, PrismaValue::Boolean(b)) => PrismaValue::Int(b as i64),

--- a/query-engine/prisma-models/src/error.rs
+++ b/query-engine/prisma-models/src/error.rs
@@ -41,6 +41,6 @@ pub enum DomainError {
 
 impl From<super::ConversionFailure> for DomainError {
     fn from(err: ConversionFailure) -> Self {
-        Self::ConversionFailure(err.from.to_owned(), err.to.to_owned())
+        Self::ConversionFailure(err.from.into_owned(), err.to.into_owned())
     }
 }


### PR DESCRIPTION
## Overview

This PR lifts some coercions from the serializer to connectors. The goals are:
- Reduced indirections
- Useful for the JSON protocol new response format as we'll deal with streamlined values that don't undergo last-minute coercions