### PR TITLE
qe: start threading typed identifiers through dml

### DIFF
--- a/psl/psl/tests/parsing/literals.rs
+++ b/psl/psl/tests/parsing/literals.rs
@@ -15,8 +15,8 @@ fn strings_with_quotes_are_unescaped() {
         }"#
     );
 
-    let mut dml = parse(input);
-    let cat = dml.models_mut().find(|m| m.name == "Category").unwrap();
+    let dml = parse(input);
+    let cat = dml.models().find(|m| m.name == "Category").unwrap();
     let name = cat.scalar_fields().find(|f| f.name == "name").unwrap();
 
     assert_eq!(
@@ -41,8 +41,8 @@ fn strings_with_newlines_are_unescaped() {
         }"#
     );
 
-    let mut dml = parse(input);
-    let cat = dml.models_mut().find(|m| m.name == "Category").unwrap();
+    let dml = parse(input);
+    let cat = dml.models().find(|m| m.name == "Category").unwrap();
     let name = cat.scalar_fields().find(|f| f.name == "name").unwrap();
 
     assert_eq!(
@@ -69,8 +69,8 @@ fn strings_with_escaped_unicode_codepoints_are_unescaped() {
         }"#
     );
 
-    let mut dml = parse(input);
-    let cat = dml.models_mut().find(|m| m.name == "Category").unwrap();
+    let dml = parse(input);
+    let cat = dml.models().find(|m| m.name == "Category").unwrap();
     let name = cat.scalar_fields().find(|f| f.name == "name").unwrap();
 
     assert_eq!(

--- a/query-engine/dml/src/enum.rs
+++ b/query-engine/dml/src/enum.rs
@@ -1,8 +1,10 @@
 use crate::traits::{WithDatabaseName, WithName};
+use psl_core::schema_ast::ast;
 
 /// Represents an enum in the datamodel.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Enum {
+    pub id: ast::EnumId,
     /// Name of the enum.
     pub name: String,
     /// Values of the enum.
@@ -17,13 +19,14 @@ pub struct Enum {
 
 impl Enum {
     /// Creates a new enum with the given schema, name and values.
-    pub fn new(name: &str, values: Vec<EnumValue>, schema: Option<String>) -> Enum {
+    pub fn new(id: ast::EnumId, name: &str) -> Enum {
         Enum {
+            id,
             name: String::from(name),
-            values,
+            values: Vec::new(),
             documentation: None,
             database_name: None,
-            schema,
+            schema: None,
         }
     }
 

--- a/query-engine/dml/src/field.rs
+++ b/query-engine/dml/src/field.rs
@@ -67,10 +67,6 @@ impl FieldType {
         matches!(self, Self::CompositeType(_))
     }
 
-    pub fn is_enum(&self, name: &str) -> bool {
-        matches!(self, Self::Enum(this) if this == name)
-    }
-
     pub fn is_unsupported(&self) -> bool {
         matches!(self, Self::Unsupported(_))
     }

--- a/query-engine/dml/src/lift.rs
+++ b/query-engine/dml/src/lift.rs
@@ -47,7 +47,7 @@ impl<'a> LiftAstToDml<'a> {
     }
 
     pub(crate) fn lift(&self) -> Datamodel {
-        let mut schema = Datamodel::new();
+        let mut schema = Datamodel::default();
 
         // We iterate over scalar fields, then relations, but we want the
         // order of fields in the Model to match the order of the fields in
@@ -70,7 +70,7 @@ impl<'a> LiftAstToDml<'a> {
 
         self.lift_relations(&mut schema, &mut field_ids_for_sorting);
 
-        for model in schema.models_mut() {
+        for model in &mut schema.models {
             let model_name = model.name.as_str();
             model
                 .fields
@@ -317,7 +317,7 @@ impl<'a> LiftAstToDml<'a> {
         field_ids_for_sorting: &mut HashMap<(&'a str, &'a str), ast::FieldId>,
     ) -> Model {
         let ast_model = walker.ast_model();
-        let mut model = Model::new(ast_model.name().to_owned(), None);
+        let mut model = Model::new(walker.id, ast_model.name().to_owned(), None);
 
         model.documentation = ast_model.documentation().map(String::from);
         model.database_name = walker.mapped_name().map(String::from);
@@ -435,7 +435,7 @@ impl<'a> LiftAstToDml<'a> {
 
     /// Internal: Validates an enum AST node.
     fn lift_enum(&self, r#enum: EnumWalker<'_>) -> Enum {
-        let mut en = Enum::new(r#enum.name(), vec![], None);
+        let mut en = Enum::new(r#enum.id, r#enum.name());
 
         for value in r#enum.values() {
             en.add_value(self.lift_enum_value(value));

--- a/query-engine/dml/src/model.rs
+++ b/query-engine/dml/src/model.rs
@@ -3,12 +3,13 @@ use crate::field::{Field, FieldType, RelationField, ScalarField};
 use crate::scalars::ScalarType;
 use crate::traits::{Ignorable, WithDatabaseName, WithName};
 use indoc::formatdoc;
-use psl_core::parser_database::IndexType;
+use psl_core::parser_database::{ast, IndexType};
 use std::{borrow::Cow, fmt};
 
 /// Represents a model in a prisma schema.
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Model {
+    pub id: ast::ModelId,
     /// Name of the model.
     pub name: String,
     /// Fields of the model.
@@ -341,8 +342,9 @@ impl<'a> UniqueCriterion<'a> {
 
 impl Model {
     /// Creates a new model with the given name.
-    pub fn new(name: String, database_name: Option<String>) -> Model {
+    pub fn new(id: ast::ModelId, name: String, database_name: Option<String>) -> Model {
         Model {
+            id,
             name,
             fields: vec![],
             indices: vec![],

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -4,7 +4,6 @@ mod serialization_ast;
 pub use serialization_ast::DataModelMetaFormat;
 
 use ast_builders::{schema_to_dmmf, DmmfQuerySchemaRenderer};
-use prisma_models::dml;
 use schema::{QuerySchemaRef, QuerySchemaRenderer};
 use std::sync::Arc;
 
@@ -21,7 +20,7 @@ pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
 }
 
 pub fn from_precomputed_parts(query_schema: QuerySchemaRef) -> DataModelMetaFormat {
-    let data_model = schema_to_dmmf(&dml::lift(&query_schema.internal_data_model.schema));
+    let data_model = schema_to_dmmf(&query_schema.internal_data_model.schema);
     let (schema, mappings) = DmmfQuerySchemaRenderer::render(query_schema);
 
     DataModelMetaFormat {


### PR DESCRIPTION
This will progressively make dml, then the prisma_model builders obsolete. We can already remove some dead code in this commit.

This is part of https://github.com/prisma/client-planning/issues/265