### PR TITLE
query-engine-tests: upgrade to edition = "2021"

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2018"
+edition = "2021"
 name = "query-engine-tests"
 version = "0.1.0"
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/querying.rs
@@ -8,7 +8,7 @@ macro_rules! assert_query {
 
 #[macro_export]
 macro_rules! match_connector_result {
-    ($runner:expr, $q:expr, $( $($matcher:pat)|+ $( if $pred:expr )? => $result:expr ),*) => {
+    ($runner:expr, $q:expr, $( $($matcher:pat_param)|+ $( if $pred:expr )? => $result:expr ),*) => {
         use query_tests_setup::*;
         use query_tests_setup::ConnectorVersion::*;
 
@@ -23,16 +23,13 @@ macro_rules! match_connector_result {
         let query_result = $runner.query($q).await?.to_string();
 
         if results.len() == 0 {
-            panic!(format!("No results defined for connector {}. Query result: {}", connector, query_result));
+            panic!("No results defined for connector {connector}. Query result: {query_result}");
         }
 
         assert_eq!(
             results.contains(&query_result.as_str()),
             true,
-            "Query result: {} is not part of the expected results: {:?} for connector {}",
-            query_result,
-            results,
-            connector
+            "Query result: {query_result} is not part of the expected results: {results:?} for connector {connector}",
         );
     };
 }


### PR DESCRIPTION
- This is the last crate still on 2018 in the workspace.
- Fixes an assertion format string using punning — it never got expanded, and that started triggering a warning with the new release.