### PR TITLE
CI: fix the github action that publishes the cargo docs

### DIFF
--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -15,42 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Generate docs
-        run: cargo doc --workspace
-
-      - name: Move docs to gh-pages branch
-        run: |
-          mkdir -p /tmp/cargo-doc-output
-          mv target/doc /tmp/cargo-doc-output/doc
-
-      - uses: actions/checkout@v3
-        with:
-          ref: gh-pages
-
-      - name: Replace old docs with new docs
-        run: |
-          rm -rf ./doc
-          mv /tmp/cargo-doc-output/doc doc
-
-      - name: Commit and push new docs
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: cargo docs for ${{ env.GITHUB_SHA }}
-          branch: gh-pages
-          commit_user_name: prisma-bot
-          commit_user_email: prismabots@gmail.com
-          commit_author: prisma-bot <prismabots@gmail.com>
-
+      - uses: cachix/install-nix-action@v18
+      - run: |
+          git config user.email "prismabots@gmail.com"
+          git config user.name "prisma-bot"
+      - run: nix run .#publish-cargo-docs

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
         imports = [
           ./nix/all-engines.nix
           ./nix/args.nix
+          ./nix/cargo-doc.nix
           ./nix/cli-shell.nix
           ./nix/dev-vm.nix
           ./nix/prisma-fmt-wasm.nix

--- a/nix/cargo-doc.nix
+++ b/nix/cargo-doc.nix
@@ -1,0 +1,50 @@
+{ pkgs, self', ... }:
+
+{
+  packages.cargo-docs = pkgs.clangStdenv.mkDerivation {
+    name = "prisma-engines-cargo-docs";
+    inherit (self'.packages.prisma-engines) buildInputs nativeBuildInputs src;
+
+    buildPhase = ''
+      mkdir .cargo
+      ln -s ${self'.packages.prisma-engines-deps}/config.toml .cargo/config.toml
+      cargo doc --workspace
+    '';
+
+    installPhase = ''
+      mkdir -p $out/share
+      mv target/doc/ $out/share/docs
+    '';
+  };
+
+  packages.publish-cargo-docs = pkgs.writeShellApplication {
+    name = "publish-cargo-docs";
+    text = ''
+      set -euxo pipefail
+
+      if ! git diff --exit-code 1> /dev/null; then
+        : "The workspace is not clean. Please commit or reset, then try again".
+        exit 1
+      fi
+
+      CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+      CURRENT_COMMIT=$(git rev-parse --short HEAD)
+      REPO_ROOT=$(git rev-parse --show-toplevel)
+
+      pushd "$REPO_ROOT"
+      git fetch --depth=1 origin gh-pages
+      git checkout origin/gh-pages
+      rm -rf ./doc
+      cp \
+        --recursive \
+        --no-preserve=mode,ownership \
+        ${self'.packages.cargo-docs}/share/docs \
+        ./doc
+      git add doc
+      git commit --quiet -m "cargo docs for $CURRENT_COMMIT"
+      git push origin '+HEAD:gh-pages'
+      git checkout "$CURRENT_BRANCH"
+      popd
+    '';
+  };
+}


### PR DESCRIPTION
The builds started hanging weeks ago. There is very little output to debug with. The docs haven't been built for
https://prisma.github.io/prisma-engines/ since.

This commit replaces the logic in YAML inside the github action with a script we can test, run and debug locally.