### PR TITLE
dmmf: dml-free composite type conversion

### DIFF
--- a/query-engine/dml/src/lib.rs
+++ b/query-engine/dml/src/lib.rs
@@ -17,8 +17,8 @@ pub mod scalars;
 pub mod traits;
 
 pub use self::{
-    composite_type::*, datamodel::*, default_value::*, field::*, model::*, native_type_instance::*, r#enum::*,
-    relation_info::*, scalars::*, traits::*,
+    composite_type::*, datamodel::*, default_value::*, field::*, lift::dml_default_kind, model::*,
+    native_type_instance::*, r#enum::*, relation_info::*, scalars::*, traits::*,
 };
 pub use prisma_value::{self, PrismaValue};
 pub use psl_core::parser_database::{ast::FieldArity, IndexType, ReferentialAction};

--- a/query-engine/dml/src/lift.rs
+++ b/query-engine/dml/src/lift.rs
@@ -549,7 +549,7 @@ fn parser_database_scalar_type_to_dml_scalar_type(st: db::ScalarType) -> dml::Sc
     st.as_str().parse().unwrap()
 }
 
-fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<ScalarType>) -> DefaultKind {
+pub fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<ScalarType>) -> DefaultKind {
     // This has all been validated in parser-database, so unwrapping is always safe.
     match default_value {
         ast::Expression::Function(funcname, args, _) if funcname == "dbgenerated" => {


### PR DESCRIPTION
Slowly continue making dml disappear until it's only used in prisma-models anymore.

part of https://github.com/prisma/client-planning/issues/265