### PR TITLE
feat(wasm): throw formatted errors when the Wasm'd `get_dmmf` is given an invalid schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2954,6 +2954,7 @@ dependencies = [
 name = "prisma-fmt"
 version = "0.1.0"
 dependencies = [
+ "colored",
  "dissimilar",
  "dmmf",
  "enumflags2",

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -12,7 +12,7 @@ pub fn get_config(params: String) -> Result<String, JsError> {
 }
 
 #[wasm_bindgen]
-pub fn get_dmmf(params: String) -> String {
+pub fn get_dmmf(params: String) -> Result<String, String> {
     prisma_fmt::get_dmmf(params)
 }
 

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -12,8 +12,8 @@ pub fn get_config(params: String) -> Result<String, JsError> {
 }
 
 #[wasm_bindgen]
-pub fn get_dmmf(params: String) -> Result<String, String> {
-    prisma_fmt::get_dmmf(params)
+pub fn get_dmmf(params: String) -> Result<String, JsError> {
+    prisma_fmt::get_dmmf(params).map_err(|e| JsError::new(&e))
 }
 
 #[wasm_bindgen]

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -22,6 +22,11 @@ pub fn lint(input: String) -> String {
 }
 
 #[wasm_bindgen]
+pub fn validate(schema: String) -> Result<(), String> {
+    prisma_fmt::validate(schema)
+}
+
+#[wasm_bindgen]
 pub fn native_types(input: String) -> String {
     prisma_fmt::native_types(input)
 }

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -11,6 +11,7 @@ pub fn get_config(params: String) -> Result<String, JsError> {
     prisma_fmt::get_config(params).map_err(|e| JsError::new(&e))
 }
 
+/// Docs: https://prisma.github.io/prisma-engines/doc/prisma_fmt/fn.get_dmmf.html
 #[wasm_bindgen]
 pub fn get_dmmf(params: String) -> Result<String, JsError> {
     prisma_fmt::get_dmmf(params).map_err(|e| JsError::new(&e))

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+colored = "2"
 dmmf = { path = "../query-engine/dmmf"}
 psl.workspace = true
 serde_json.workspace = true

--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -3,6 +3,8 @@ use serde::Deserialize;
 use serde_json::json;
 use std::collections::HashMap;
 
+use crate::validate::SCHEMA_PARSER_ERROR_CODE;
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct GetConfigParams {
@@ -17,7 +19,7 @@ struct GetConfigParams {
 
 #[derive(Debug)]
 struct GetConfigError {
-    error_code: Option<String>,
+    error_code: Option<&'static str>,
     message: String,
 }
 
@@ -49,7 +51,7 @@ fn get_config_impl(params: GetConfigParams) -> Result<serde_json::Value, GetConf
 
         GetConfigError {
             // this mirrors user_facing_errors::common::SchemaParserError
-            error_code: Some(String::from("P1012")),
+            error_code: Some(SCHEMA_PARSER_ERROR_CODE),
             message: full_error,
         }
     };

--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -39,7 +39,9 @@ mod tests {
             "prismaSchema": schema,
         });
 
-        let expected = expect![[r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 3"}"#]];
+        let expected = expect![[
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 3"}"#
+        ]];
 
         let response = get_dmmf(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
@@ -101,7 +103,9 @@ mod tests {
             "prismaSchema": schema,
         });
 
-        let expected = expect![[r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m 7 | \u001b[0m          }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#]];
+        let expected = expect![[
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m 7 | \u001b[0m          }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
+        ]];
         let response = get_dmmf(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }

--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -39,30 +39,7 @@ mod tests {
             "prismaSchema": schema,
         });
 
-        let expected = expect![[r#"
-            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
-              [1;94m-->[0m  [4mschema.prisma:5[0m
-            [1;94m   | [0m
-            [1;94m 4 | [0m
-            [1;94m 5 | [0m            [1;91mdatasøurce yolo {[0m
-            [1;94m 6 | [0m            }
-            [1;94m   | [0m
-            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
-              [1;94m-->[0m  [4mschema.prisma:6[0m
-            [1;94m   | [0m
-            [1;94m 5 | [0m            datasøurce yolo {
-            [1;94m 6 | [0m            [1;91m}[0m
-            [1;94m 7 | [0m        
-            [1;94m   | [0m
-            [1;91merror[0m: [1mArgument "provider" is missing in generator block "js".[0m
-              [1;94m-->[0m  [4mschema.prisma:2[0m
-            [1;94m   | [0m
-            [1;94m 1 | [0m
-            [1;94m 2 | [0m            [1;91mgenerator js {[0m
-            [1;94m 3 | [0m            }
-            [1;94m   | [0m
-
-            Validation Error Count: 3"#]];
+        let expected = expect![[r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 3"}"#]];
 
         let response = get_dmmf(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
@@ -124,16 +101,7 @@ mod tests {
             "prismaSchema": schema,
         });
 
-        let expected = expect![[r#"
-            [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
-              [1;94m-->[0m  [4mschema.prisma:6[0m
-            [1;94m   | [0m
-            [1;94m 5 | [0m              relationMode = "prisma"
-            [1;94m 6 | [0m              [1;91mreferentialIntegrity = "foreignKeys"[0m
-            [1;94m 7 | [0m          }
-            [1;94m   | [0m
-
-            Validation Error Count: 1"#]];
+        let expected = expect![[r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m 7 | \u001b[0m          }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#]];
         let response = get_dmmf(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }

--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -1,12 +1,14 @@
 use serde::Deserialize;
 
+use crate::validate;
+
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 struct GetDmmfParams {
     prisma_schema: String,
 }
 
-pub(crate) fn get_dmmf(params: &str) -> String {
+pub(crate) fn get_dmmf(params: &str) -> Result<String, String> {
     let params: GetDmmfParams = match serde_json::from_str(params) {
         Ok(params) => params,
         Err(serde_err) => {
@@ -14,6 +16,125 @@ pub(crate) fn get_dmmf(params: &str) -> String {
         }
     };
 
-    // if the Prisma schema is not valid, this panics
-    dmmf::dmmf_json_from_schema(&params.prisma_schema)
+    validate::run(&params.prisma_schema).map(|_| dmmf::dmmf_json_from_schema(&params.prisma_schema))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+    use serde_json::json;
+
+    #[test]
+    fn get_dmmf_invalid_schema() {
+        let schema = r#"
+            generator js {
+            }
+
+            datasøurce yolo {
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[r#"
+            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
+              [1;94m-->[0m  [4mschema.prisma:5[0m
+            [1;94m   | [0m
+            [1;94m 4 | [0m
+            [1;94m 5 | [0m            [1;91mdatasøurce yolo {[0m
+            [1;94m 6 | [0m            }
+            [1;94m   | [0m
+            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
+              [1;94m-->[0m  [4mschema.prisma:6[0m
+            [1;94m   | [0m
+            [1;94m 5 | [0m            datasøurce yolo {
+            [1;94m 6 | [0m            [1;91m}[0m
+            [1;94m 7 | [0m        
+            [1;94m   | [0m
+            [1;91merror[0m: [1mArgument "provider" is missing in generator block "js".[0m
+              [1;94m-->[0m  [4mschema.prisma:2[0m
+            [1;94m   | [0m
+            [1;94m 1 | [0m
+            [1;94m 2 | [0m            [1;91mgenerator js {[0m
+            [1;94m 3 | [0m            }
+            [1;94m   | [0m
+
+            Validation Error Count: 3"#]];
+
+        let response = get_dmmf(&request.to_string()).unwrap_err();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_dmmf_missing_env_var() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST")
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[
+            r#"{"datamodel":{"enums":[],"models":[],"types":[]},"schema":{"inputObjectTypes":{},"outputObjectTypes":{"prisma":[{"name":"Query","fields":[]},{"name":"Mutation","fields":[{"name":"executeRaw","args":[{"name":"query","isRequired":true,"isNullable":false,"inputTypes":[{"type":"String","location":"scalar","isList":false}]},{"name":"parameters","isRequired":false,"isNullable":false,"inputTypes":[{"type":"Json","location":"scalar","isList":false}]}],"isNullable":false,"outputType":{"type":"Json","location":"scalar","isList":false}},{"name":"queryRaw","args":[{"name":"query","isRequired":true,"isNullable":false,"inputTypes":[{"type":"String","location":"scalar","isList":false}]},{"name":"parameters","isRequired":false,"isNullable":false,"inputTypes":[{"type":"Json","location":"scalar","isList":false}]}],"isNullable":false,"outputType":{"type":"Json","location":"scalar","isList":false}}]}]},"enumTypes":{"prisma":[{"name":"TransactionIsolationLevel","values":["ReadUncommitted","ReadCommitted","RepeatableRead","Serializable"]}]},"fieldRefTypes":{}},"mappings":{"modelOperations":[],"otherOperations":{"read":[],"write":["executeRaw","queryRaw"]}}}"#
+        ]];
+        let response = get_dmmf(&request.to_string()).unwrap();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_dmmf_direct_url_direct_empty() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = ""
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[
+            r#"{"datamodel":{"enums":[],"models":[],"types":[]},"schema":{"inputObjectTypes":{},"outputObjectTypes":{"prisma":[{"name":"Query","fields":[]},{"name":"Mutation","fields":[{"name":"executeRaw","args":[{"name":"query","isRequired":true,"isNullable":false,"inputTypes":[{"type":"String","location":"scalar","isList":false}]},{"name":"parameters","isRequired":false,"isNullable":false,"inputTypes":[{"type":"Json","location":"scalar","isList":false}]}],"isNullable":false,"outputType":{"type":"Json","location":"scalar","isList":false}},{"name":"queryRaw","args":[{"name":"query","isRequired":true,"isNullable":false,"inputTypes":[{"type":"String","location":"scalar","isList":false}]},{"name":"parameters","isRequired":false,"isNullable":false,"inputTypes":[{"type":"Json","location":"scalar","isList":false}]}],"isNullable":false,"outputType":{"type":"Json","location":"scalar","isList":false}}]}]},"enumTypes":{"prisma":[{"name":"TransactionIsolationLevel","values":["ReadUncommitted","ReadCommitted","RepeatableRead","Serializable"]}]},"fieldRefTypes":{}},"mappings":{"modelOperations":[],"otherOperations":{"read":[],"write":["executeRaw","queryRaw"]}}}"#
+        ]];
+        let response = get_dmmf(&request.to_string()).unwrap();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn get_dmmf_using_both_relation_mode_and_referential_integrity() {
+        let schema = r#"
+          datasource db {
+              provider = "sqlite"
+              url = "sqlite"
+              relationMode = "prisma"
+              referentialIntegrity = "foreignKeys"
+          }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[r#"
+            [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
+              [1;94m-->[0m  [4mschema.prisma:6[0m
+            [1;94m   | [0m
+            [1;94m 5 | [0m              relationMode = "prisma"
+            [1;94m 6 | [0m              [1;91mreferentialIntegrity = "foreignKeys"[0m
+            [1;94m 7 | [0m          }
+            [1;94m   | [0m
+
+            Validation Error Count: 1"#]];
+        let response = get_dmmf(&request.to_string()).unwrap_err();
+        expected.assert_eq(&response);
+    }
 }

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -142,6 +142,38 @@ pub fn get_config(get_config_params: String) -> Result<String, String> {
     get_config::get_config(&get_config_params)
 }
 
+/// This is the same command as get_config()
+///
+/// Params is a JSON string with the following shape:
+///
+/// ```ignore
+/// interface GetDmmfParams {
+///   prismaSchema: string
+/// }
+/// ```
+/// Params example:
+///
+/// ```ignore
+/// {
+///   "prismaSchema": <the prisma schema>,
+/// }
+/// ```
+///
+/// The response is a JSON string with the following shape:
+///
+/// ```ignore
+/// type GetDmmfSuccessResponse = any // same as QE getDmmf
+///
+/// interface GetDmmfErrorResponse {
+///   error: {
+///     error_code?: string
+///     message: string
+///   }
+/// }
+///
+/// type GetDmmfResponse = GetDmmfErrorResponse | GetDmmfSuccessResponse
+///
+/// ```
 pub fn get_dmmf(get_dmmf_params: String) -> Result<String, String> {
     get_dmmf::get_dmmf(&get_dmmf_params)
 }

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -66,7 +66,8 @@ pub fn lint(schema: String) -> String {
     lint::run(&schema)
 }
 
-/// Function that emulates what happened when improperly calling the `getDmmf` query engine RPC on invalid schemas.
+/// Function that throws a human-friendly error message when the schema is invalid, following the JSON formatting
+/// historically used by the Query Engine's `user_facing_errors::common::SchemaParserError`.
 /// When the schema is valid, nothing happens.
 /// When the schema is invalid, the function displays a human-friendly error message indicating the schema lines
 /// where the errors lie and the total error count, e.g.:
@@ -83,7 +84,7 @@ pub fn lint(schema: String) -> String {
 /// Validation Error Count: 1
 /// ```
 ///
-/// This function doesn't panic.
+/// This function isn't supposed to panic.
 pub fn validate(schema: String) -> Result<(), String> {
     validate::run(&schema)
 }
@@ -142,7 +143,7 @@ pub fn get_config(get_config_params: String) -> Result<String, String> {
     get_config::get_config(&get_config_params)
 }
 
-/// This is the same command as get_config()
+/// This is the same command as get_dmmf()
 ///
 /// Params is a JSON string with the following shape:
 ///

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -6,6 +6,7 @@ mod lint;
 mod native;
 mod preview;
 mod text_document_completion;
+mod validate;
 
 use log::*;
 use lsp_types::{Position, Range};
@@ -63,6 +64,28 @@ pub fn format(schema: &str, params: &str) -> String {
 
 pub fn lint(schema: String) -> String {
     lint::run(&schema)
+}
+
+/// Function that emulates what happened when improperly calling the `getDmmf` query engine RPC on invalid schemas.
+/// When the schema is valid, nothing happens.
+/// When the schema is invalid, the function displays a human-friendly error message indicating the schema lines
+/// where the errors lie and the total error count, e.g.:
+///
+/// ```sh
+/// The `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.
+///   -->  schema.prisma:5
+///   |
+/// 4 |   relationMode         = "prisma"
+/// 5 |   referentialIntegrity = "foreignKeys"
+/// 6 | }
+///   |
+///
+/// Validation Error Count: 1
+/// ```
+///
+/// This function doesn't panic.
+pub fn validate(schema: String) -> Result<(), String> {
+    validate::run(&schema)
 }
 
 pub fn native_types(schema: String) -> String {

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -142,7 +142,7 @@ pub fn get_config(get_config_params: String) -> Result<String, String> {
     get_config::get_config(&get_config_params)
 }
 
-pub fn get_dmmf(get_dmmf_params: String) -> String {
+pub fn get_dmmf(get_dmmf_params: String) -> Result<String, String> {
     get_dmmf::get_dmmf(&get_dmmf_params)
 }
 

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -11,6 +11,9 @@ pub(crate) fn run(input_schema: &str) -> Result<(), String> {
         return Ok(());
     }
 
+    // always colorise output regardless of the environment
+    colored::control::set_override(true);
+
     use std::fmt::Write as _;
     let mut formatted_error = diagnostics.to_pretty_string("schema.prisma", input_schema);
     write!(

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -1,7 +1,8 @@
 use serde_json::json;
+use std::fmt::Write as _;
 
 // this mirrors user_facing_errors::common::SchemaParserError
-pub static SCHEMA_PARSER_ERROR_CODE: &str = "P1012";
+pub(crate) static SCHEMA_PARSER_ERROR_CODE: &str = "P1012";
 
 pub(crate) fn run(input_schema: &str) -> Result<(), String> {
     let validate_schema = psl::validate(input_schema.into());
@@ -11,10 +12,9 @@ pub(crate) fn run(input_schema: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    // always colorise output regardless of the environment
+    // always colorise output regardless of the environment, which is important for Wasm
     colored::control::set_override(true);
 
-    use std::fmt::Write as _;
     let mut formatted_error = diagnostics.to_pretty_string("schema.prisma", input_schema);
     write!(
         formatted_error,

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -7,14 +7,14 @@ pub(crate) fn run(input_schema: &str) -> Result<(), String> {
     }
 
     use std::fmt::Write as _;
-    let mut formatted_error = diagnostics.to_pretty_string("schema.prisma", &input_schema);
+    let mut formatted_error = diagnostics.to_pretty_string("schema.prisma", input_schema);
     write!(
         formatted_error,
         "\nValidation Error Count: {}",
         diagnostics.errors().len(),
     )
     .unwrap();
-    return Err(formatted_error);
+    Err(formatted_error)
 }
 
 #[cfg(test)]
@@ -57,7 +57,7 @@ mod tests {
 
             Validation Error Count: 3"#]];
 
-        let response = run(&schema).unwrap_err();
+        let response = run(schema).unwrap_err();
         expected.assert_eq(&response);
     }
 
@@ -70,7 +70,7 @@ mod tests {
             }
         "#;
 
-        run(&schema).unwrap();
+        run(schema).unwrap();
     }
 
     #[test]
@@ -83,7 +83,7 @@ mod tests {
             }
         "#;
 
-        run(&schema).unwrap();
+        run(schema).unwrap();
     }
 
     #[test]
@@ -107,7 +107,7 @@ mod tests {
             [1;94m   | [0m
 
             Validation Error Count: 1"#]];
-        let response = run(&schema).unwrap_err();
+        let response = run(schema).unwrap_err();
         expected.assert_eq(&response);
     }
 }

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -1,0 +1,113 @@
+pub(crate) fn run(input_schema: &str) -> Result<(), String> {
+    let validate_schema = psl::validate(input_schema.into());
+    let diagnostics = &validate_schema.diagnostics;
+
+    if !diagnostics.has_errors() {
+        return Ok(());
+    }
+
+    use std::fmt::Write as _;
+    let mut formatted_error = diagnostics.to_pretty_string("schema.prisma", &input_schema);
+    write!(
+        formatted_error,
+        "\nValidation Error Count: {}",
+        diagnostics.errors().len(),
+    )
+    .unwrap();
+    return Err(formatted_error);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+
+    #[test]
+    fn validate_invalid_schema() {
+        let schema = r#"
+            generator js {
+            }
+
+            datasøurce yolo {
+            }
+        "#;
+
+        let expected = expect![[r#"
+            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
+              [1;94m-->[0m  [4mschema.prisma:5[0m
+            [1;94m   | [0m
+            [1;94m 4 | [0m
+            [1;94m 5 | [0m            [1;91mdatasøurce yolo {[0m
+            [1;94m 6 | [0m            }
+            [1;94m   | [0m
+            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
+              [1;94m-->[0m  [4mschema.prisma:6[0m
+            [1;94m   | [0m
+            [1;94m 5 | [0m            datasøurce yolo {
+            [1;94m 6 | [0m            [1;91m}[0m
+            [1;94m 7 | [0m        
+            [1;94m   | [0m
+            [1;91merror[0m: [1mArgument "provider" is missing in generator block "js".[0m
+              [1;94m-->[0m  [4mschema.prisma:2[0m
+            [1;94m   | [0m
+            [1;94m 1 | [0m
+            [1;94m 2 | [0m            [1;91mgenerator js {[0m
+            [1;94m 3 | [0m            }
+            [1;94m   | [0m
+
+            Validation Error Count: 3"#]];
+
+        let response = run(&schema).unwrap_err();
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn validate_missing_env_var() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST")
+            }
+        "#;
+
+        run(&schema).unwrap();
+    }
+
+    #[test]
+    fn validate_direct_url_direct_empty() {
+        let schema = r#"
+            datasource thedb {
+                provider = "postgresql"
+                url = env("DBURL")
+                directUrl = ""
+            }
+        "#;
+
+        run(&schema).unwrap();
+    }
+
+    #[test]
+    fn validate_using_both_relation_mode_and_referential_integrity() {
+        let schema = r#"
+          datasource db {
+              provider = "sqlite"
+              url = "sqlite"
+              relationMode = "prisma"
+              referentialIntegrity = "foreignKeys"
+          }
+        "#;
+
+        let expected = expect![[r#"
+            [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
+              [1;94m-->[0m  [4mschema.prisma:6[0m
+            [1;94m   | [0m
+            [1;94m 5 | [0m              relationMode = "prisma"
+            [1;94m 6 | [0m              [1;91mreferentialIntegrity = "foreignKeys"[0m
+            [1;94m 7 | [0m          }
+            [1;94m   | [0m
+
+            Validation Error Count: 1"#]];
+        let response = run(&schema).unwrap_err();
+        expected.assert_eq(&response);
+    }
+}

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -1,3 +1,8 @@
+use serde_json::json;
+
+// this mirrors user_facing_errors::common::SchemaParserError
+pub static SCHEMA_PARSER_ERROR_CODE: &str = "P1012";
+
 pub(crate) fn run(input_schema: &str) -> Result<(), String> {
     let validate_schema = psl::validate(input_schema.into());
     let diagnostics = &validate_schema.diagnostics;
@@ -14,7 +19,11 @@ pub(crate) fn run(input_schema: &str) -> Result<(), String> {
         diagnostics.errors().len(),
     )
     .unwrap();
-    Err(formatted_error)
+    Err(json!({
+        "error_code": SCHEMA_PARSER_ERROR_CODE,
+        "message": formatted_error,
+    })
+    .to_string())
 }
 
 #[cfg(test)]
@@ -32,30 +41,9 @@ mod tests {
             }
         "#;
 
-        let expected = expect![[r#"
-            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
-              [1;94m-->[0m  [4mschema.prisma:5[0m
-            [1;94m   | [0m
-            [1;94m 4 | [0m
-            [1;94m 5 | [0m            [1;91mdatasøurce yolo {[0m
-            [1;94m 6 | [0m            }
-            [1;94m   | [0m
-            [1;91merror[0m: [1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.[0m
-              [1;94m-->[0m  [4mschema.prisma:6[0m
-            [1;94m   | [0m
-            [1;94m 5 | [0m            datasøurce yolo {
-            [1;94m 6 | [0m            [1;91m}[0m
-            [1;94m 7 | [0m        
-            [1;94m   | [0m
-            [1;91merror[0m: [1mArgument "provider" is missing in generator block "js".[0m
-              [1;94m-->[0m  [4mschema.prisma:2[0m
-            [1;94m   | [0m
-            [1;94m 1 | [0m
-            [1;94m 2 | [0m            [1;91mgenerator js {[0m
-            [1;94m 3 | [0m            }
-            [1;94m   | [0m
-
-            Validation Error Count: 3"#]];
+        let expected = expect![[
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 3"}"#
+        ]];
 
         let response = run(schema).unwrap_err();
         expected.assert_eq(&response);
@@ -97,16 +85,9 @@ mod tests {
           }
         "#;
 
-        let expected = expect![[r#"
-            [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
-              [1;94m-->[0m  [4mschema.prisma:6[0m
-            [1;94m   | [0m
-            [1;94m 5 | [0m              relationMode = "prisma"
-            [1;94m 6 | [0m              [1;91mreferentialIntegrity = "foreignKeys"[0m
-            [1;94m 7 | [0m          }
-            [1;94m   | [0m
-
-            Validation Error Count: 1"#]];
+        let expected = expect![[
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m 7 | \u001b[0m          }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
+        ]];
         let response = run(schema).unwrap_err();
         expected.assert_eq(&response);
     }


### PR DESCRIPTION
Before this PR, the Wasm'd `get_dmmf` method panicked on invalid schemas.
With this PR, it returns a formatted `Err(String)` suitable for human consumption, just like the `get_dmmf` method from the query-engine does.

The validation logic is also exposed into a new `validate(schema: String) -> Result<(), String>` method available to Wasm, which will later be used in TypeScript in place of `getDmmf()` where `getDmmf()` was improperly used as a "schema validator" utility.

**Context**: see [Slack thread](https://prisma-company.slack.com/archives/C02A1646TBR/p1675096718467069).

~~**Note**: apparently, the colors of the formatted output aren't visible in the TS land~~