### PR TITLE
query-engine: simplify PrismaError

### DIFF
--- a/query-engine/query-engine/src/error.rs
+++ b/query-engine/query-engine/src/error.rs
@@ -1,46 +1,31 @@
 use connector::error::ConnectorError;
-use graphql_parser::query::ParseError as GqlParseError;
 use psl::diagnostics::Diagnostics;
 use query_core::CoreError;
-
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 #[allow(clippy::enum_variant_names)]
 pub enum PrismaError {
-    #[error("{}", _0)]
-    SerializationError(String),
-
-    #[error("{}", _0)]
+    #[error(transparent)]
     CoreError(Box<CoreError>),
 
-    #[error("{}", _0)]
+    #[error(transparent)]
     JsonDecodeError(anyhow::Error),
 
     #[error("{}", _0)]
     ConfigurationError(String),
 
-    #[error("{}", _0)]
+    #[error(transparent)]
     ConnectorError(Box<ConnectorError>),
 
     #[error("{:?}", _0)]
     ConversionError(Diagnostics, String),
 
-    #[error("{}", _0)]
+    #[error(transparent)]
     IOError(anyhow::Error),
-
-    #[error("{}", _0)]
-    InvocationError(String),
-
-    /// (Feature name, additional error text)
-    #[error("Unsupported feature: {}. {}", _0, _1)]
-    UnsupportedFeatureError(&'static str, String),
 
     #[error("Error in data model: {:?}", _0)]
     DatamodelError(Diagnostics),
-
-    #[error("{}", _0)]
-    QueryConversionError(String),
 }
 
 impl From<PrismaError> for user_facing_errors::Error {
@@ -138,12 +123,6 @@ impl From<std::string::FromUtf8Error> for PrismaError {
 impl From<base64::DecodeError> for PrismaError {
     fn from(e: base64::DecodeError) -> PrismaError {
         PrismaError::ConfigurationError(format!("Invalid base64: {e}"))
-    }
-}
-
-impl From<GqlParseError> for PrismaError {
-    fn from(e: GqlParseError) -> PrismaError {
-        PrismaError::QueryConversionError(format!("Error parsing GraphQL query: {e}"))
     }
 }
 


### PR DESCRIPTION
- Delete unused variants
- Use #[error(transparent)] for variants where it is possible. Compared to the situation before this commit, it is more readable, and more importantly it doesn't lose track of the error source (the impl Error for PrismaError will forward tot he source).