### PR TITLE
test: showcase validation test failures for `mysql`, `postgres`, `sqlite` when `relationMode = "prisma"` in https://github.com/prisma/prisma/issues/17649

### DIFF
--- a/psl/psl/tests/validation/relations/mongodb/cascading_on_delete_self_relations.prisma
+++ b/psl/psl/tests/validation/relations/mongodb/cascading_on_delete_self_relations.prisma
@@ -1,0 +1,18 @@
+datasource db {
+  provider = "mongodb"
+  url = "mongodb://"
+}
+
+model A {
+  id     String  @id @default(auto()) @map("_id") @db.ObjectId
+  child  A?      @relation(name: "a_self_relation")
+  parent A?      @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    String? @unique @db.ObjectId
+}
+// [1;91merror[0m: [1mError validating: A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. (Implicit default `onUpdate`: `Cascade`) Read more at https://pris.ly/d/cyclic-referential-actions[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  child  A?      @relation(name: "a_self_relation")
+// [1;94m 9 | [0m  [1;91mparent A?      @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+// [1;94m10 | [0m  aId    String? @unique @db.ObjectId
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/mysql/cascading_on_delete_self_relations_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/relations/mysql/cascading_on_delete_self_relations_mode_foreignkeys.prisma
@@ -1,0 +1,11 @@
+datasource db {
+  provider = "mysql"
+  url = "mysql://"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}

--- a/psl/psl/tests/validation/relations/mysql/cascading_on_delete_self_relations_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/mysql/cascading_on_delete_self_relations_mode_prisma.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "mysql"
+  url = "mysql://"
+  relationMode = "prisma"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}
+// [1;91merror[0m: [1mError validating: A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. (Implicit default `onUpdate`: `Cascade`) Read more at https://pris.ly/d/cyclic-referential-actions[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
+// [1;94m   | [0m
+// [1;94m 9 | [0m  child  A?   @relation(name: "a_self_relation")
+// [1;94m10 | [0m  [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+// [1;94m11 | [0m  aId    Int? @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/cascading_on_delete_self_relations_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/relations/postgres/cascading_on_delete_self_relations_mode_foreignkeys.prisma
@@ -1,0 +1,11 @@
+datasource db {
+  provider = "postgres"
+  url = "postgres://"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}

--- a/psl/psl/tests/validation/relations/postgres/cascading_on_delete_self_relations_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/postgres/cascading_on_delete_self_relations_mode_prisma.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "postgres"
+  url = "postgres://"
+  relationMode = "prisma"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}
+// [1;91merror[0m: [1mError validating: A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. (Implicit default `onUpdate`: `Cascade`) Read more at https://pris.ly/d/cyclic-referential-actions[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
+// [1;94m   | [0m
+// [1;94m 9 | [0m  child  A?   @relation(name: "a_self_relation")
+// [1;94m10 | [0m  [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+// [1;94m11 | [0m  aId    Int? @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/sqlite/cascading_on_delete_self_relations_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/relations/sqlite/cascading_on_delete_self_relations_mode_foreignkeys.prisma
@@ -1,0 +1,11 @@
+datasource db {
+  provider = "sqlite"
+  url = "sqlite://"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}

--- a/psl/psl/tests/validation/relations/sqlite/cascading_on_delete_self_relations_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/sqlite/cascading_on_delete_self_relations_mode_prisma.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "sqlite"
+  url = "sqlite://"
+  relationMode = "prisma"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}
+// [1;91merror[0m: [1mError validating: A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. (Implicit default `onUpdate`: `Cascade`) Read more at https://pris.ly/d/cyclic-referential-actions[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
+// [1;94m   | [0m
+// [1;94m 9 | [0m  child  A?   @relation(name: "a_self_relation")
+// [1;94m10 | [0m  [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+// [1;94m11 | [0m  aId    Int? @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/sqlserver/cascading_on_delete_self_relations_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/relations/sqlserver/cascading_on_delete_self_relations_mode_foreignkeys.prisma
@@ -1,0 +1,18 @@
+datasource db {
+  provider = "sqlserver"
+  url = "mssql://"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}
+// [1;91merror[0m: [1mError validating: A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. (Implicit default `onUpdate`: `Cascade`) Read more at https://pris.ly/d/cyclic-referential-actions[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
+// [1;94m   | [0m
+// [1;94m 8 | [0m  child  A?   @relation(name: "a_self_relation")
+// [1;94m 9 | [0m  [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+// [1;94m10 | [0m  aId    Int? @unique
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/sqlserver/cascading_on_delete_self_relations_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/sqlserver/cascading_on_delete_self_relations_mode_prisma.prisma
@@ -1,0 +1,19 @@
+datasource db {
+  provider = "sqlserver"
+  url = "mssql://"
+  relationMode = "prisma"
+}
+
+model A {
+  id     Int  @id @default(autoincrement())
+  child  A?   @relation(name: "a_self_relation")
+  parent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)
+  aId    Int? @unique
+}
+// [1;91merror[0m: [1mError validating: A self-relation must have `onDelete` and `onUpdate` referential actions set to `NoAction` in one of the @relation attributes. (Implicit default `onUpdate`: `Cascade`) Read more at https://pris.ly/d/cyclic-referential-actions[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
+// [1;94m   | [0m
+// [1;94m 9 | [0m  child  A?   @relation(name: "a_self_relation")
+// [1;94m10 | [0m  [1;91mparent A?   @relation(name: "a_self_relation", fields: [aId], references: [id], onDelete: Cascade)[0m
+// [1;94m11 | [0m  aId    Int? @unique
+// [1;94m   | [0m


### PR DESCRIPTION
Reproduce https://github.com/prisma/prisma/issues/17649.
The behavior is expected, as described in https://github.com/prisma/prisma-engines/pull/2415, but apparently the docs were never updated to reflect the change in the code logic.