### PR TITLE
Improve cursor performance

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
+++ b/query-engine/connectors/sql-query-connector/src/cursor_condition.rs
@@ -10,8 +10,6 @@ use itertools::Itertools;
 use prisma_models::*;
 use quaint::ast::*;
 
-static ORDER_TABLE_ALIAS: &str = "order_cmp";
-
 #[derive(Debug)]
 struct CursorOrderDefinition {
     /// Direction of the sort
@@ -20,10 +18,6 @@ struct CursorOrderDefinition {
     pub(crate) order_column: Expression<'static>,
     /// Foreign keys of the relations on which the order is performed
     pub(crate) order_fks: Option<Vec<CursorOrderForeignKey>>,
-    /// Column selected from the ORDER_TABLE_ALIAS cmp table and compared against the order_column
-    pub(crate) cmp_column: Expression<'static>,
-    /// Alias of the cmp_column
-    pub(crate) cmp_column_alias: String,
     /// Indicates whether the ordering is performed on nullable field(s)
     pub(crate) on_nullable_fields: bool,
 }
@@ -39,53 +33,102 @@ struct CursorOrderForeignKey {
 /// An example query for 4 order-by fields (where the last field is one2m relation) is:
 ///
 /// ```sql
-/// SELECT
-///   `ModelA`.`id`
-/// FROM
-///   `ModelA`
+/// SELECT `ModelA`.`id`
+/// FROM `ModelA`
 ///   LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
 ///     `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
-///   ),
-///   -- >>> Begin Part #1
-///   (
-///     SELECT
-///       `ModelA`.`fieldA` AS `ModelA_fieldA_0`,
-///       `ModelA`.`fieldB` AS `ModelA_fieldB_1`,
-///       `ModelA`.`fieldC` AS `ModelA_fieldC_2`,
-///       `orderby_3_ModelB`.`fieldD` AS `ModelB_fieldD_3`
-///     FROM
-///       `ModelA`
-///       LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
-///         `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
-///       )
-///     WHERE
-///       (`ModelA`.`id`) = (?)
-///   ) AS `order_cmp` -- <<< End Part #1
-/// WHERE
-///   -- >>> Begin Part #2
-///   (
+///   )
+/// WHERE (
 ///     (
-///       `ModelA`.`fieldA` = `order_cmp`.`ModelA_fieldA_0`
-///       AND `ModelA`.`fieldB` = `order_cmp`.`ModelA_fieldB_1`
-///       AND `ModelA`.`fieldC` = `order_cmp`.`ModelA_fieldC_2`
-///       AND `orderby_3_ModelB`.`fieldD` <= `order_cmp`.`ModelB_fieldD_3`
+///       `ModelA`.`fieldA` = (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       AND `ModelA`.`fieldB` = (
+///         SELECT `ModelA`.`fieldB`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       AND `ModelA`.`fieldC` = (
+///         SELECT `ModelA`.`fieldC`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       AND `orderby_3_ModelB`.`fieldD` <= (
+///         SELECT `orderby_3_ModelB`.`fieldD`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
 ///     )
 ///     OR (
-///       `ModelA`.`fieldA` = `order_cmp`.`ModelA_fieldA_0`
-///       AND `ModelA`.`fieldB` = `order_cmp`.`ModelA_fieldB_1`
-///       AND `ModelA`.`fieldC` > `order_cmp`.`ModelA_fieldC_2`
+///       `ModelA`.`fieldA` = (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       AND `ModelA`.`fieldB` = (
+///         SELECT `ModelA`.`fieldB`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       AND `ModelA`.`fieldC` > (
+///         SELECT `ModelA`.`fieldC`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
 ///     )
 ///     OR (
-///       `ModelA`.`fieldA` = `order_cmp`.`ModelA_fieldA_0`
-///       AND `ModelA`.`fieldB` > `order_cmp`.`ModelA_fieldB_1`
+///       `ModelA`.`fieldA` = (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       AND `ModelA`.`fieldB` > (
+///         SELECT `ModelA`.`fieldB`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
 ///     )
 ///     OR (
-///       `ModelA`.`fieldA` < `order_cmp`.`ModelA_fieldA_0`
+///       `ModelA`.`fieldA` < (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
 ///     )
 ///   )
-///   -- <<< End Part #2
-/// ORDER BY
-///   `ModelA`.`fieldA` DESC,
+/// ORDER BY `ModelA`.`fieldA` DESC,
 ///   `ModelA`.`fieldB` ASC,
 ///   `ModelA`.`fieldC` ASC,
 ///   `orderby_3_ModelB`.`fieldD` DESC
@@ -96,16 +139,44 @@ struct CursorOrderForeignKey {
 ///   -- ... The first (4 - condition) block:
 ///   (
 ///     (
-///       `TestModel`.`fieldA` = `order_cmp`.`fieldA`
-///       OR `order_cmp`.`fieldA` IS NULL
+///       `TestModel`.`fieldA` = (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///       OR (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       ) IS NULL
 ///       OR `TestModel`.`fieldA` IS NULL
 ///     )
 ///     AND -- ...
 ///   )
 ///   -- ...The other blocks (3, 2) in between, then the single condition block:
 ///   OR (
-///     `TestModel`.`fieldA` < `order_cmp`.`fieldA`
-///     OR `order_cmp`.`fieldA` IS NULL
+///     `TestModel`.`fieldA` < (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       )
+///     OR (
+///         SELECT `ModelA`.`fieldA`
+///         FROM `ModelA`
+///           LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///             `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///           )
+///         WHERE (`ModelA`.`id`) = (?)
+///       ) IS NULL
 ///     OR `TestModel`.`fieldA` IS NULL
 ///   )
 ///   -- ...
@@ -115,7 +186,14 @@ struct CursorOrderForeignKey {
 /// ```sql
 ///   -- ... The first (4 - condition) block:
 ///   AND (
-///     `orderby_3_ModelB`.`id` <= `order_cmp`.`ModelB_fieldD_3`
+///     `orderby_3_ModelB`.`id` <= (
+///       SELECT `orderby_3_ModelB`.`fieldD`
+///       FROM `ModelA`
+///         LEFT JOIN `ModelB` AS `orderby_3_ModelB` ON (
+///           `ModelA`.`modelB_id` = `orderby_3_ModelB`.`fieldD`
+///         )
+///       WHERE (`ModelA`.`id`) = (?)
+///     )
 ///     OR `ModelA`.`modelB_id` IS NULL -- >>> Additional check for the nullable foreign key
 ///   )
 /// ```
@@ -124,9 +202,9 @@ pub(crate) fn build(
     model: &ModelRef,
     order_by_defs: &[OrderByDefinition],
     ctx: &Context<'_>,
-) -> (Option<Table<'static>>, ConditionTree<'static>) {
+) -> ConditionTree<'static> {
     match query_arguments.cursor {
-        None => (None, ConditionTree::NoCondition),
+        None => ConditionTree::NoCondition,
         Some(ref cursor) => {
             let cursor_fields: Vec<_> = cursor.as_scalar_fields().expect("Cursor fields contain non-scalars.");
             let cursor_values: Vec<_> = cursor.db_values();
@@ -142,35 +220,34 @@ pub(crate) fn build(
             // Orderings for this query. Influences which fields we need to fetch for comparing order fields.
             let mut definitions = order_definitions(query_arguments, model, &order_by_defs, ctx);
 
-            // Subquery to find the value of the order field(s) that we need for comparison. Builds part #1 of the query example in the docs.
-            let order_subquery = definitions
-                .iter()
-                .fold(Select::from_table(model.as_table(ctx)), |select, definition| {
-                    select.value(definition.cmp_column.clone())
-                })
-                .so_that(cursor_condition);
+            // Subquery to find the value of the order field(s) that we need for comparison.
+            let order_subquery = Select::from_table(model.as_table(ctx)).so_that(cursor_condition);
 
             let order_subquery = order_by_defs
                 .iter()
                 .flat_map(|j| &j.joins)
                 .fold(order_subquery, |acc, join| acc.left_join(join.data.clone()));
 
-            let subquery_table = Table::from(order_subquery).alias(ORDER_TABLE_ALIAS);
             let len = definitions.len();
             let reverse = query_arguments.needs_reversed_order();
 
-            // Builds part #2 of the example query.
             // If we only have one ordering, we only want a single, slightly different, condition of (orderField [<= / >=] cmp_field).
             let condition_tree = if len == 1 {
                 let order_definition = definitions.pop().unwrap();
-                ConditionTree::Single(Box::new(map_orderby_condition(&order_definition, reverse, true, ctx)))
+                ConditionTree::Single(Box::new(map_orderby_condition(
+                    &order_subquery,
+                    &order_definition,
+                    reverse,
+                    true,
+                    ctx,
+                )))
             } else {
                 let or_conditions = (0..len).fold(Vec::with_capacity(len), |mut conditions_acc, n| {
                     let (head, tail) = definitions.split_at(len - n - 1);
                     let mut and_conditions = Vec::with_capacity(head.len() + 1);
 
                     for order_definition in head {
-                        and_conditions.push(map_equality_condition(&order_definition));
+                        and_conditions.push(map_equality_condition(&order_subquery, &order_definition));
                     }
 
                     let order_definition = tail.first().unwrap();
@@ -200,9 +277,21 @@ pub(crate) fn build(
                         //
                         // Said differently, we handle all the cases in which the prefixes are equal to len - 1 to account for possible identical comparators,
                         // but everything else must come strictly "after" the cursor.
-                        and_conditions.push(map_orderby_condition(order_definition, reverse, true, ctx));
+                        and_conditions.push(map_orderby_condition(
+                            &order_subquery,
+                            &order_definition,
+                            reverse,
+                            true,
+                            ctx,
+                        ));
                     } else {
-                        and_conditions.push(map_orderby_condition(order_definition, reverse, false, ctx));
+                        and_conditions.push(map_orderby_condition(
+                            &order_subquery,
+                            &order_definition,
+                            reverse,
+                            false,
+                            ctx,
+                        ));
                     }
 
                     conditions_acc.push(ConditionTree::And(and_conditions));
@@ -212,7 +301,7 @@ pub(crate) fn build(
                 ConditionTree::Or(or_conditions.into_iter().map(Into::into).collect())
             };
 
-            (Some(subquery_table), condition_tree)
+            condition_tree
         }
     }
 }
@@ -220,12 +309,13 @@ pub(crate) fn build(
 // A negative `take` value signifies that values should be taken before the cursor,
 // requiring the correct comparison operator to be used to fit the reversed order.
 fn map_orderby_condition(
+    order_subquery: &Select<'static>,
     order_definition: &CursorOrderDefinition,
     reverse: bool,
     include_eq: bool,
     ctx: &Context<'_>,
 ) -> Expression<'static> {
-    let cmp_column = Column::from((ORDER_TABLE_ALIAS, order_definition.cmp_column_alias.to_owned()));
+    let cmp_column = order_subquery.clone().value(order_definition.order_column.clone());
     let cloned_cmp_column = cmp_column.clone();
     let order_column = order_definition.order_column.clone();
     let cloned_order_column = order_column.clone();
@@ -272,7 +362,7 @@ fn map_orderby_condition(
     let order_expr = if order_definition.on_nullable_fields {
         order_expr
             .or(cloned_order_column.is_null())
-            .or(cloned_cmp_column.is_null())
+            .or(Expression::from(cloned_cmp_column).is_null())
             .into()
     } else {
         order_expr
@@ -299,8 +389,11 @@ fn map_orderby_condition(
     order_expr
 }
 
-fn map_equality_condition(order_definition: &CursorOrderDefinition) -> Expression<'static> {
-    let cmp_column = Column::from((ORDER_TABLE_ALIAS, order_definition.cmp_column_alias.to_owned()));
+fn map_equality_condition(
+    order_subquery: &Select<'static>,
+    order_definition: &CursorOrderDefinition,
+) -> Expression<'static> {
+    let cmp_column = order_subquery.clone().value(order_definition.order_column.clone());
     let order_column = order_definition.order_column.to_owned();
 
     // If we have null values in the ordering or comparison row, those are automatically included because we can't make a
@@ -309,7 +402,7 @@ fn map_equality_condition(order_definition: &CursorOrderDefinition) -> Expressio
         order_column
             .clone()
             .equals(cmp_column.clone())
-            .or(cmp_column.is_null())
+            .or(Expression::from(cmp_column).is_null())
             .or(order_column.is_null())
             .into()
     } else {
@@ -337,8 +430,6 @@ fn order_definitions(
                 sort_order: SortOrder::Ascending,
                 order_column: f.as_column(ctx).into(),
                 order_fks: None,
-                cmp_column: f.as_column(ctx).into(),
-                cmp_column_alias: f.db_name().to_string(),
                 on_nullable_fields: !f.is_required(),
             })
             .collect();
@@ -349,43 +440,26 @@ fn order_definitions(
         .iter()
         .enumerate()
         .zip(order_by_defs.iter())
-        .map(|((index, order_by), order_by_def)| match order_by {
-            OrderBy::Scalar(order_by) => cursor_order_def_scalar(order_by, order_by_def, index),
-            OrderBy::ScalarAggregation(order_by) => cursor_order_def_aggregation_scalar(order_by, order_by_def, index),
-            OrderBy::ToManyAggregation(order_by) => cursor_order_def_aggregation_rel(order_by, order_by_def, index),
-            OrderBy::Relevance(order_by) => cursor_order_def_relevance(order_by, order_by_def, index),
+        .map(|((_, order_by), order_by_def)| match order_by {
+            OrderBy::Scalar(order_by) => cursor_order_def_scalar(order_by, order_by_def),
+            OrderBy::ScalarAggregation(order_by) => cursor_order_def_aggregation_scalar(order_by, order_by_def),
+            OrderBy::ToManyAggregation(order_by) => cursor_order_def_aggregation_rel(order_by, order_by_def),
+            OrderBy::Relevance(order_by) => cursor_order_def_relevance(order_by, order_by_def),
         })
         .collect_vec()
 }
 
 /// Build a CursorOrderDefinition for an order by scalar
-fn cursor_order_def_scalar(
-    order_by: &OrderByScalar,
-    order_by_def: &OrderByDefinition,
-    index: usize,
-) -> CursorOrderDefinition {
+fn cursor_order_def_scalar(order_by: &OrderByScalar, order_by_def: &OrderByDefinition) -> CursorOrderDefinition {
     // If there are any ordering hops, this finds the foreign key fields for the _last_ hop (we look for the last one because the ordering is done the last one).
     // These fk fields are needed to check whether they are nullable
     // cf: part #2 of the SQL query above, when a field is nullable.
     let fks = foreign_keys_from_order_path(&order_by.path, &order_by_def.joins);
 
-    // Selected fields needs to be aliased in case there are two order bys on two different tables, pointing to a field of the same name.
-    // eg: orderBy: [{ id: asc }, { b: { id: asc } }]
-    // Without these aliases, selecting from the <ORDER_TABLE_ALIAS> tmp table would result in ambiguous field name
-    // Unwrap is safe: SQL connectors do not anything other than models as field containers.
-    let cmp_column_alias = format!(
-        "{}_{}_{}",
-        &order_by.field.container().as_model().unwrap().name(),
-        &order_by.field.name(),
-        index
-    );
-
     CursorOrderDefinition {
         sort_order: order_by.sort_order,
         order_column: order_by_def.order_column.clone(),
         order_fks: fks,
-        cmp_column: order_by_def.order_column.clone().alias(cmp_column_alias.clone()),
-        cmp_column_alias,
         on_nullable_fields: !order_by.field.is_required(),
     }
 }
@@ -394,21 +468,7 @@ fn cursor_order_def_scalar(
 fn cursor_order_def_aggregation_scalar(
     order_by: &OrderByScalarAggregation,
     order_by_def: &OrderByDefinition,
-    index: usize,
 ) -> CursorOrderDefinition {
-    let field = &order_by.field;
-
-    // Selected fields needs to be aliased in case there are two order bys on two different tables, pointing to a field of the same name.
-    // eg: orderBy: [{ id: asc }, { b: { id: asc } }]
-    // Without these aliases, selecting from the <ORDER_TABLE_ALIAS> cmp table would result in ambiguous field name
-    // Unwrap is safe: SQL connectors do not anything other than models as field containers.
-    let cmp_column_alias = format!(
-        "aggr_{}_{}_{}",
-        &field.container().as_model().unwrap().name(),
-        &field.name(),
-        index
-    );
-
     let coalesce_exprs: Vec<Expression> = vec![order_by_def.order_column.clone(), Value::integer(0).into()];
 
     // We coalesce the order column to 0 when it's compared to the cmp table since the aggregations joins
@@ -419,8 +479,6 @@ fn cursor_order_def_aggregation_scalar(
         sort_order: order_by.sort_order,
         order_column: order_column.clone(),
         order_fks: None,
-        cmp_column: order_column.alias(cmp_column_alias.clone()),
-        cmp_column_alias,
         on_nullable_fields: false,
     }
 }
@@ -429,28 +487,11 @@ fn cursor_order_def_aggregation_scalar(
 fn cursor_order_def_aggregation_rel(
     order_by: &OrderByToManyAggregation,
     order_by_def: &OrderByDefinition,
-    index: usize,
 ) -> CursorOrderDefinition {
     // If there are any ordering hop, this finds the foreign key fields for the _last_ hop (we look for the last one because the ordering is done the last one).
     // These fk fields are needed to check whether they are nullable
     // cf: part #2 of the SQL query above, when a field is nullable.
     let fks = foreign_keys_from_order_path(&order_by.path, &order_by_def.joins);
-
-    // Selected fields needs to be aliased in case there are two order bys on two different tables, pointing to a field of the same name.
-    // eg: orderBy: [{ id: asc }, { b: { id: asc } }]
-    // Without these aliases, selecting from the <ORDER_TABLE_ALIAS> cmp table would result in ambiguous field name
-    let cmp_column_alias = format!(
-        "aggr_{}_{}",
-        order_by
-            .path
-            .iter()
-            .map(|hop| match hop {
-                OrderByHop::Relation(rf) => rf.model().name().to_owned(),
-                OrderByHop::Composite(_) => unreachable!("SQL connectors don't have composite support."),
-            })
-            .join("_"),
-        index
-    );
 
     let coalesce_exprs: Vec<Expression> = vec![order_by_def.order_column.clone(), Value::integer(0).into()];
     // We coalesce the order column to 0 when it's compared to the cmp table since the aggregations joins
@@ -461,31 +502,18 @@ fn cursor_order_def_aggregation_rel(
         sort_order: order_by.sort_order,
         order_column: order_column.clone(),
         order_fks: fks,
-        cmp_column: order_column.alias(cmp_column_alias.clone()),
-        cmp_column_alias,
         on_nullable_fields: false,
     }
 }
 
 /// Build a CursorOrderDefinition for an order by relevance
-fn cursor_order_def_relevance(
-    order_by: &OrderByRelevance,
-    order_by_def: &OrderByDefinition,
-    index: usize,
-) -> CursorOrderDefinition {
+fn cursor_order_def_relevance(order_by: &OrderByRelevance, order_by_def: &OrderByDefinition) -> CursorOrderDefinition {
     let order_column = &order_by_def.order_column;
-    let cmp_column_alias = format!(
-        "relevance_{}_{}",
-        order_by.fields.iter().map(|sf| sf.name()).join("_"),
-        index
-    );
 
     CursorOrderDefinition {
         sort_order: order_by.sort_order,
         order_column: order_column.clone(),
         order_fks: None,
-        cmp_column: order_column.clone().alias(cmp_column_alias.clone()),
-        cmp_column_alias,
         on_nullable_fields: false,
     }
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/read.rs
@@ -59,7 +59,7 @@ impl SelectDefinition for QueryArguments {
         ctx: &Context<'_>,
     ) -> (Select<'static>, Vec<Expression<'static>>) {
         let order_by_definitions = OrderByBuilder::default().build(&self, ctx);
-        let (table_opt, cursor_condition) = cursor_condition::build(&self, &model, &order_by_definitions, ctx);
+        let cursor_condition = cursor_condition::build(&self, &model, &order_by_definitions, ctx);
         let aggregation_joins = nested_aggregations::build(aggr_selections, ctx);
 
         let limit = if self.ignore_take { None } else { self.take_abs() };
@@ -93,12 +93,6 @@ impl SelectDefinition for QueryArguments {
             .offset(skip as usize)
             .append_trace(&Span::current())
             .add_trace_id(ctx.trace_id);
-
-        let select_ast = if let Some(table) = table_opt {
-            select_ast.and_from(table)
-        } else {
-            select_ast
-        };
 
         let select_ast = order_by_definitions
             .iter()


### PR DESCRIPTION
This PR fixes prisma/prisma#11138, and fixes prisma/prisma#12650
Might be related to prisma/prisma#16235, prisma/prisma#17328, and probably more

The implementation of how `cursor` is implemented before is to create a subquery, store it as a temporary table, and to be used to compare with the values in the table

But the issue with that is that the database would try to use nested loop to join the temporary table and the main table, which causes it to scan through everything before it until it found a match
The explanation can be found in this [stackoverflow](https://stackoverflow.com/a/24042757) question and in [prisma/prisma#12650+issuecomment-1099064362](https://github.com/prisma/prisma/issues/12650#issuecomment-1099064362) you can see that `Index Only Scan` fetched `999,504` rows and `Join Filter` removed `999,500` rows

This PR fixes this issue by fetching the individual column to be compared direclty without creating a temporary table

Here's the difference between the generated query:
```diff
SELECT "public"."User"."id"
-FROM "public"."User",
-  (
-    SELECT "public"."User"."id" AS "User_id_0"
-    FROM "public"."User"
-    WHERE ("public"."User"."id") = ($1)
-  ) AS "order_cmp"
+FROM "public"."User"
-WHERE "public"."User"."id" >= "order_cmp"."User_id_0"
+WHERE "public"."User"."id" >= (
+    SELECT "public"."User"."id"
+    FROM "public"."User"
+    WHERE ("public"."User"."id") = ($1)
+  )
ORDER BY "public"."User"."id" ASC
LIMIT $2 OFFSET $3
```
And here's the difference running these queries with `explain (analyze,verbose)` running postgres using HDD:
```
// Before patch
Limit  (cost=0.85..1.08 rows=1 width=4) (actual time=0.583..0.584 rows=1 loops=1)
  Output: "User".id
  ->  Nested Loop  (cost=0.85..120627.11 rows=525676 width=4) (actual time=0.583..0.583 rows=1 loops=1)
        Output: "User".id
        Inner Unique: true
        Join Filter: ("User".id >= "User_1".id)
        Rows Removed by Join Filter: 999
        ->  Index Only Scan using "User_id_key" on public."User"  (cost=0.43..96963.22 rows=1577029 width=4) (actual time=0.014..0.408 rows=1000 loops=1)
              Output: "User".id
              Heap Fetches: 136
        ->  Materialize  (cost=0.43..8.45 rows=1 width=4) (actual time=0.000..0.000 rows=1 loops=1000)
              Output: "User_1".id
              ->  Index Only Scan using "User_id_key" on public."User" "User_1"  (cost=0.43..8.45 rows=1 width=4) (actual time=0.018..0.018 rows=1 loops=1)
                    Output: "User_1".id
                    Index Cond: ("User_1".id = 462273)
                    Heap Fetches: 0
Planning Time: 0.081 ms
Execution Time: 0.597 ms
```
```
// After patch
Limit  (cost=8.87..9.00 rows=1 width=4) (actual time=0.040..0.040 rows=1 loops=1)
  Output: "User".id
  InitPlan 1 (returns $0)
    ->  Index Only Scan using "User_id_key" on public."User" "User_1"  (cost=0.43..8.45 rows=1 width=4) (actual time=0.031..0.032 rows=1 loops=1)
          Output: "User_1".id
          Index Cond: ("User_1".id = 462273)
          Heap Fetches: 0
  ->  Index Only Scan using "User_id_key" on public."User"  (cost=0.43..67597.62 rows=525676 width=4) (actual time=0.039..0.039 rows=1 loops=1)
        Output: "User".id
        Index Cond: ("User".id >= $0)
        Heap Fetches: 0
Planning Time: 0.059 ms
Execution Time: 0.051 ms
```
On a more complex query, it might fetch the same column multiple times, but that's still faster than trying to scan through everything before it