### PR TITLE
refactor: introduce ArgumentValue (replaces QueryValue)

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
@@ -221,7 +221,7 @@ mod to_many {
                 }
             }"#,
             2009,
-            "`Query.findManyTestModel.where.TestModelWhereInput.to_many_as.CompositeACompositeListFilter.equals`: Value types mismatch. Have: Object([(\"a_1\", String(\"Test\")), (\"a_2\", Int(0))]), want: Object(CompositeAObjectEqualityInput)"
+            "`Query.findManyTestModel.where.TestModelWhereInput.to_many_as.CompositeACompositeListFilter.equals`: Value types mismatch. Have: Object({\"a_1\": Scalar(String(\"Test\")), \"a_2\": Scalar(Int(0))}), want: Object(CompositeAObjectEqualityInput)"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json.rs
@@ -197,7 +197,7 @@ mod json {
             &runner,
             r#"query { findManyTestModel(where: { json: "{}" }) { id }}"#,
             2009,
-            "`Value types mismatch. Have: String(\"{}\"), want: Object(JsonNullableFilter)` at `Query.findManyTestModel.where.TestModelWhereInput.json`"
+            "`Value types mismatch. Have: Scalar(String(\"{}\")), want: Object(JsonNullableFilter)` at `Query.findManyTestModel.where.TestModelWhereInput.json`"
         );
 
         assert_error!(
@@ -216,14 +216,14 @@ mod json {
             &runner,
             r#"query { findManyTestModel(where: { json: { not: { equals: "{}" }}}) { id }}"#,
             2009,
-            "`Query.findManyTestModel.where.TestModelWhereInput.json.JsonNullableFilter.not`: Value types mismatch. Have: Object([(\"equals\", String(\"{}\"))]), want: Json"
+            "`Query.findManyTestModel.where.TestModelWhereInput.json.JsonNullableFilter.not`: Value types mismatch. Have: Object({\"equals\": Scalar(String(\"{}\"))}), want: Json"
         );
 
         assert_error!(
             &runner,
             r#"query { findManyTestModel(where: { json: { not: { equals: null }}}) { id }}"#,
             2009,
-            "`Query.findManyTestModel.where.TestModelWhereInput.json.JsonNullableFilter.not`: Value types mismatch. Have: Object([(\"equals\", Null)]), want: Json"
+            "`Query.findManyTestModel.where.TestModelWhereInput.json.JsonNullableFilter.not`: Value types mismatch. Have: Object({\"equals\": Scalar(Null)}), want: Json"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -414,7 +414,7 @@ mod update {
           runner,
           query,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.to_many_as.CompositeAListUpdateEnvelopeInput.set.CompositeACreateInput.a_2`: Value types mismatch. Have: Object([(\"update\", Object([(\"increment\", Int(3))]))]), want: Int"
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.to_many_as.CompositeAListUpdateEnvelopeInput.set.CompositeACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Scalar(Int(3))})}), want: Int"
         );
 
         // Ensure `update` cannot be used in the Unchecked type
@@ -422,7 +422,7 @@ mod update {
           runner,
           query,
           2009,
-          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.to_many_as.CompositeAListUpdateEnvelopeInput.set.CompositeACreateInput.a_2`: Value types mismatch. Have: Object([(\"update\", Object([(\"increment\", Int(3))]))]), want: Int"
+          "`Mutation.updateOneTestModel.data.TestModelUpdateInput.to_many_as.CompositeAListUpdateEnvelopeInput.set.CompositeACreateInput.a_2`: Value types mismatch. Have: Object({\"update\": Object({\"increment\": Scalar(Int(3))})}), want: Int"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
@@ -109,7 +109,7 @@ mod byoid {
               createOneParent(data: {p: "Parent", id: true}){p, id}
             }"#,
             2009,
-            "`Mutation.createOneParent.data.ParentCreateInput.id`: Value types mismatch. Have: Boolean(true), want: String"
+            "`Mutation.createOneParent.data.ParentCreateInput.id`: Value types mismatch. Have: Scalar(Boolean(true)), want: String"
         );
 
         Ok(())
@@ -124,7 +124,7 @@ mod byoid {
                   createOneParent(data: {p: "Parent", id: true}){p, id}
                 }"#,
                 2009,
-                "`Mutation.createOneParent.data.ParentCreateInput.id`: Value types mismatch. Have: Boolean(true), want: String"
+                "`Mutation.createOneParent.data.ParentCreateInput.id`: Value types mismatch. Have: Scalar(Boolean(true)), want: String"
             );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid_mongo.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid_mongo.rs
@@ -97,7 +97,7 @@ mod byoi_mongo {
               createOneParent(data: {p: "Parent", id: 12}){p, id}
             }"#,
             2009,
-            "`Mutation.createOneParent.data.ParentUncheckedCreateInput.id`: Value types mismatch. Have: Int(12), want: String"
+            "`Mutation.createOneParent.data.ParentUncheckedCreateInput.id`: Value types mismatch. Have: Scalar(Int(12)), want: String"
         );
 
         Ok(())
@@ -112,7 +112,7 @@ mod byoi_mongo {
                   createOneParent(data: {p: "Parent", id: 12}){p, id}
                 }"#,
             2009,
-            "`Mutation.createOneParent.data.ParentUncheckedCreateInput.id`: Value types mismatch. Have: Int(12), want: String"
+            "`Mutation.createOneParent.data.ParentUncheckedCreateInput.id`: Value types mismatch. Have: Scalar(Int(12)), want: String"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create.rs
@@ -195,7 +195,7 @@ mod create {
             }
           ){ optString, optInt, optFloat, optBoolean, optEnum, optDateTime }}"#,
           2009,
-          "Query parsing/validation error at `Mutation.createOneScalarModel.data.ScalarModelCreateInput.optInt`: Value types mismatch. Have: Enum(\"B\"), want: Int"
+          "Query parsing/validation error at `Mutation.createOneScalarModel.data.ScalarModelCreateInput.optInt`: Value types mismatch. Have: Scalar(Enum(\"B\")), want: Int"
         );
 
         Ok(())
@@ -372,7 +372,7 @@ mod json_create {
                 }
               }"#,
             2009,
-            "Value types mismatch. Have: Enum(\"AnyNull\")"
+            "Value types mismatch. Have: Scalar(Enum(\"AnyNull\"))"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -369,7 +369,7 @@ mod json_create_many {
                 }
               }"#,
             2009,
-            "Value types mismatch. Have: Enum(\"AnyNull\")"
+            "Value types mismatch. Have: Scalar(Enum(\"AnyNull\"))"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -759,7 +759,7 @@ mod json_update {
                 }
               }"#,
             2009,
-            "Value types mismatch. Have: Enum(\"AnyNull\")"
+            "Value types mismatch. Have: Scalar(Enum(\"AnyNull\"))"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
@@ -405,7 +405,7 @@ mod json_update_many {
                 }
               }"#,
             2009,
-            "Value types mismatch. Have: Enum(\"AnyNull\")"
+            "Value types mismatch. Have: Scalar(Enum(\"AnyNull\"))"
         );
 
         Ok(())

--- a/query-engine/core/src/query_document/argument_value.rs
+++ b/query-engine/core/src/query_document/argument_value.rs
@@ -1,0 +1,67 @@
+use bigdecimal::BigDecimal;
+use indexmap::IndexMap;
+use prisma_models::PrismaValue;
+
+pub type ArgumentValueObject = IndexMap<String, ArgumentValue>;
+
+/// Represents the input values in a Document.
+/// This abstraction is mostly there to hold special kind of values such as `FieldRef` which have to be disambiguated at query-validation time.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ArgumentValue {
+    Scalar(PrismaValue),
+    Object(ArgumentValueObject),
+    List(Vec<ArgumentValue>),
+}
+
+impl ArgumentValue {
+    pub fn null() -> Self {
+        Self::Scalar(PrismaValue::Null)
+    }
+
+    pub fn int(i: i64) -> Self {
+        Self::Scalar(PrismaValue::Int(i))
+    }
+
+    pub fn float(dec: BigDecimal) -> Self {
+        Self::Scalar(PrismaValue::Float(dec))
+    }
+
+    pub fn string(str: String) -> Self {
+        Self::Scalar(PrismaValue::String(str))
+    }
+
+    pub fn bool(bool: bool) -> Self {
+        Self::Scalar(PrismaValue::Boolean(bool))
+    }
+
+    pub fn r#enum(str: String) -> Self {
+        Self::Scalar(PrismaValue::Enum(str))
+    }
+
+    pub fn object(obj: impl Into<ArgumentValueObject>) -> Self {
+        Self::Object(obj.into())
+    }
+
+    pub fn list(values: impl Into<Vec<ArgumentValue>>) -> Self {
+        Self::List(values.into())
+    }
+
+    pub fn into_object(self) -> Option<ArgumentValueObject> {
+        match self {
+            Self::Object(obj) => Some(obj),
+            _ => None,
+        }
+    }
+}
+
+impl From<PrismaValue> for ArgumentValue {
+    fn from(value: PrismaValue) -> Self {
+        match value {
+            PrismaValue::List(list) => Self::List(list.into_iter().map(ArgumentValue::from).collect()),
+            PrismaValue::Object(obj) => {
+                Self::Object(obj.into_iter().map(|(k, v)| (k, ArgumentValue::from(v))).collect())
+            }
+            _ => Self::Scalar(value),
+        }
+    }
+}

--- a/query-engine/core/src/query_document/error.rs
+++ b/query-engine/core/src/query_document/error.rs
@@ -1,4 +1,4 @@
-use crate::schema::InputType;
+use crate::{schema::InputType, ArgumentValue};
 use fmt::Display;
 use itertools::Itertools;
 use prisma_models::PrismaValue;
@@ -64,7 +64,7 @@ pub enum QueryParserErrorKind {
     ArgumentNotFoundError,
     FieldCountError(FieldCountError),
     ValueParseError(String),
-    ValueTypeMismatchError { have: PrismaValue, want: InputType },
+    ValueTypeMismatchError { have: ArgumentValue, want: InputType },
     InputUnionParseError { parsing_errors: Vec<QueryParserError> },
     ValueFitError(String),
 }

--- a/query-engine/core/src/query_document/error.rs
+++ b/query-engine/core/src/query_document/error.rs
@@ -1,7 +1,6 @@
 use crate::{schema::InputType, ArgumentValue};
 use fmt::Display;
 use itertools::Itertools;
-use prisma_models::PrismaValue;
 use std::fmt;
 
 #[derive(Debug)]

--- a/query-engine/request-handlers/src/graphql/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/graphql/protocol_adapter.rs
@@ -3,7 +3,6 @@ use bigdecimal::{BigDecimal, FromPrimitive};
 use graphql_parser::query::{
     Definition, Document, OperationDefinition, Selection as GqlSelection, SelectionSet, Value,
 };
-use prisma_models::dml::PrismaValue;
 use query_core::query_document::*;
 
 /// Protocol adapter for GraphQL -> Query Document.
@@ -13,7 +12,7 @@ use query_core::query_document::*;
 /// - Every field of a single `mutation { ... }` is mapped to an `Operation::Write`.
 /// - If the JSON payload specifies an operation name, only that specific operation is picked and the rest ignored.
 /// - Fields on the queries are mapped to `Field`s, including arguments.
-/// - Concrete values (e.g. in arguments) are mapped to `PrismaValue`s.
+/// - Concrete values (e.g. in arguments) are mapped to `ArgumentValue`s.
 ///
 /// Currently unsupported features:
 /// - Fragments in any form.
@@ -95,7 +94,7 @@ impl GraphQLProtocolAdapter {
             .into_iter()
             .map(|item| match item {
                 GqlSelection::Field(f) => {
-                    let arguments: Vec<(String, PrismaValue)> = f
+                    let arguments: Vec<(String, ArgumentValue)> = f
                         .arguments
                         .into_iter()
                         .map(|(k, v)| Ok((k, Self::convert_value(v)?)))
@@ -133,39 +132,39 @@ impl GraphQLProtocolAdapter {
         }
     }
 
-    fn convert_value(value: Value<String>) -> crate::Result<PrismaValue> {
+    fn convert_value(value: Value<String>) -> crate::Result<ArgumentValue> {
         match value {
             Value::Variable(name) => Err(HandlerError::unsupported_feature(
                 "Variable usage",
                 format!("Variable '{name}'."),
             )),
             Value::Int(i) => match i.as_i64() {
-                Some(i) => Ok(PrismaValue::Int(i)),
+                Some(i) => Ok(ArgumentValue::int(i)),
                 None => Err(HandlerError::query_conversion(format!("Invalid 64 bit integer: {i:?}"))),
             },
             Value::Float(f) => match BigDecimal::from_f64(f) {
-                Some(dec) => Ok(PrismaValue::Float(dec)),
+                Some(dec) => Ok(ArgumentValue::float(dec)),
                 None => Err(HandlerError::query_conversion(format!("invalid 64-bit float: {f:?}"))),
             },
-            Value::String(s) => Ok(PrismaValue::String(s)),
-            Value::Boolean(b) => Ok(PrismaValue::Boolean(b)),
-            Value::Null => Ok(PrismaValue::Null),
-            Value::Enum(e) => Ok(PrismaValue::Enum(e)),
+            Value::String(s) => Ok(ArgumentValue::string(s)),
+            Value::Boolean(b) => Ok(ArgumentValue::bool(b)),
+            Value::Null => Ok(ArgumentValue::null()),
+            Value::Enum(e) => Ok(ArgumentValue::r#enum(e)),
             Value::List(values) => {
-                let values: Vec<PrismaValue> = values
+                let values: Vec<ArgumentValue> = values
                     .into_iter()
                     .map(Self::convert_value)
-                    .collect::<crate::Result<Vec<PrismaValue>>>()?;
+                    .collect::<crate::Result<Vec<ArgumentValue>>>()?;
 
-                Ok(PrismaValue::List(values))
+                Ok(ArgumentValue::list(values))
             }
             Value::Object(map) => {
                 let values = map
                     .into_iter()
                     .map(|(k, v)| Self::convert_value(v).map(|v| (k, v)))
-                    .collect::<crate::Result<Vec<_>>>()?;
+                    .collect::<crate::Result<ArgumentValueObject>>()?;
 
-                Ok(PrismaValue::Object(values))
+                Ok(ArgumentValue::object(values))
             }
         }
     }
@@ -196,9 +195,9 @@ mod tests {
 
         let read = operation.into_read().unwrap();
 
-        let where_args = PrismaValue::Object(vec![(
+        let where_args = ArgumentValue::object([(
             "a_number".to_string(),
-            PrismaValue::Object([("gte".to_string(), PrismaValue::Int(1))].into()),
+            ArgumentValue::object([("gte".to_string(), ArgumentValue::int(1))]),
         )]);
 
         assert_eq!(read.arguments(), [("where".to_string(), where_args)]);
@@ -235,28 +234,19 @@ mod tests {
 
         let write = operation.into_write().unwrap();
 
-        let data_args = PrismaValue::Object(
-            [
-                ("id".to_string(), PrismaValue::Int(1)),
-                (
-                    "categories".to_string(),
-                    PrismaValue::Object(
-                        [(
-                            "create".to_string(),
-                            PrismaValue::List(
-                                [
-                                    PrismaValue::Object([("id".to_string(), PrismaValue::Int(1))].into()),
-                                    PrismaValue::Object([("id".to_string(), PrismaValue::Int(2))].into()),
-                                ]
-                                .into(),
-                            ),
-                        )]
-                        .into(),
-                    ),
-                ),
-            ]
-            .into(),
-        );
+        let data_args = ArgumentValue::object([
+            ("id".to_string(), ArgumentValue::int(1)),
+            (
+                "categories".to_string(),
+                ArgumentValue::object([(
+                    "create".to_string(),
+                    ArgumentValue::list([
+                        ArgumentValue::object([("id".to_string(), ArgumentValue::int(1))]),
+                        ArgumentValue::object([("id".to_string(), ArgumentValue::int(2))]),
+                    ]),
+                )]),
+            ),
+        ]);
         println!("args {:?}", write.arguments());
         assert_eq!(write.arguments(), [("data".to_string(), data_args)]);
     }


### PR DESCRIPTION
## Overview

Introduces `ArgumentValue`, a replacement for `QueryValue`. We need such an abstraction after all to disambiguate certain types such as `FieldRef` vs `Json`, which will be both sent as objects in the JSON protocol.

The main difference with `QueryValue` is that it does not duplicate all scalars and re-uses `PrismaValue` instead in a `Scalar` variant.

This PR doesn't contain an `ArgumentValue::FieldRef` yet. It will be added to the JSON protocol PR.