### PR TITLE
dmmf: stop using DML for models

### DIFF
--- a/psl/parser-database/src/walkers/field.rs
+++ b/psl/parser-database/src/walkers/field.rs
@@ -1,49 +1,75 @@
-use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldWalker};
+use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldWalker, Walker};
 use crate::ScalarType;
 use schema_ast::ast;
 
-#[derive(Copy, Clone)]
-enum InnerWalker<'db> {
-    Scalar(ScalarFieldWalker<'db>),
-    Relation(RelationFieldWalker<'db>),
-}
-
 /// A model field, scalar or relation.
-#[derive(Clone, Copy)]
-pub struct FieldWalker<'db> {
-    inner: InnerWalker<'db>,
-}
+pub type FieldWalker<'db> = Walker<'db, (ast::ModelId, ast::FieldId)>;
 
 impl<'db> FieldWalker<'db> {
-    /// The field name.
-    pub fn name(self) -> &'db str {
-        match self.inner {
-            InnerWalker::Scalar(f) => f.name(),
-            InnerWalker::Relation(f) => f.name(),
-        }
+    /// The AST node for the field.
+    pub fn ast_field(self) -> &'db ast::Field {
+        &self.db.ast[self.id.0][self.id.1]
     }
 
-    /// The model name.
+    /// The field name.
+    pub fn name(self) -> &'db str {
+        self.ast_field().name()
+    }
+
+    /// Traverse the field's parent model.
     pub fn model(self) -> ModelWalker<'db> {
-        match self.inner {
-            InnerWalker::Scalar(f) => f.model(),
-            InnerWalker::Relation(f) => f.model(),
+        self.walk(self.id.0)
+    }
+
+    /// Find out which kind of field this is.
+    pub fn refine(self) -> RefinedFieldWalker<'db> {
+        let Walker {
+            id: (model_id, field_id),
+            db,
+        } = self;
+        if let Some(relation_field) = &self.db.types.relation_fields.get(&self.id) {
+            RefinedFieldWalker::Relation(RelationFieldWalker {
+                model_id,
+                field_id,
+                db,
+                relation_field,
+            })
+        } else if let Some(scalar_field) = self.db.types.scalar_fields.get(&self.id) {
+            RefinedFieldWalker::Scalar(ScalarFieldWalker {
+                model_id,
+                field_id,
+                db,
+                scalar_field,
+            })
+        } else {
+            unreachable!("{:?} is neither a scalar field nor a relation field", self.id)
         }
     }
+}
+
+/// A field that has been identified as scalar field or relation field.
+#[derive(Copy, Clone)]
+pub enum RefinedFieldWalker<'db> {
+    /// A scalar field
+    Scalar(ScalarFieldWalker<'db>),
+    /// A relation field
+    Relation(RelationFieldWalker<'db>),
 }
 
 impl<'db> From<ScalarFieldWalker<'db>> for FieldWalker<'db> {
     fn from(w: ScalarFieldWalker<'db>) -> Self {
-        Self {
-            inner: InnerWalker::Scalar(w),
+        Walker {
+            db: w.db,
+            id: (w.model_id, w.field_id),
         }
     }
 }
 
 impl<'db> From<RelationFieldWalker<'db>> for FieldWalker<'db> {
     fn from(w: RelationFieldWalker<'db>) -> Self {
-        Self {
-            inner: InnerWalker::Relation(w),
+        Walker {
+            db: w.db,
+            id: (w.model_id, w.field_id),
         }
     }
 }

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -6,7 +6,7 @@ pub use primary_key::*;
 pub(crate) use unique_criteria::*;
 
 use super::{
-    CompleteInlineRelationWalker, IndexWalker, InlineRelationWalker, RelationFieldWalker, RelationWalker,
+    CompleteInlineRelationWalker, FieldWalker, IndexWalker, InlineRelationWalker, RelationFieldWalker, RelationWalker,
     ScalarFieldWalker,
 };
 use crate::{
@@ -22,6 +22,13 @@ impl<'db> ModelWalker<'db> {
     /// The name of the model.
     pub fn name(self) -> &'db str {
         self.ast_model().name()
+    }
+
+    /// Traverse the fields of the models in the order they were defined.
+    pub fn fields(self) -> impl ExactSizeIterator<Item = FieldWalker<'db>> + Clone {
+        self.ast_model()
+            .iter_fields()
+            .map(move |(field_id, _)| self.walk((self.id, field_id)))
     }
 
     /// Whether MySQL would consider the field indexed for autoincrement purposes.

--- a/psl/schema-ast/src/ast/model.rs
+++ b/psl/schema-ast/src/ast/model.rs
@@ -79,7 +79,7 @@ pub struct Model {
 }
 
 impl Model {
-    pub fn iter_fields(&self) -> impl ExactSizeIterator<Item = (FieldId, &Field)> {
+    pub fn iter_fields(&self) -> impl ExactSizeIterator<Item = (FieldId, &Field)> + Clone {
         self.fields
             .iter()
             .enumerate()

--- a/query-engine/dml/src/model.rs
+++ b/query-engine/dml/src/model.rs
@@ -22,8 +22,6 @@ pub struct Model {
     pub indices: Vec<IndexDefinition>,
     /// Describes the Primary Keys
     pub primary_key: Option<PrimaryKeyDefinition>,
-    /// Indicates if this model is generated.
-    pub is_generated: bool,
     /// Indicates if this model has to be commented out.
     pub is_commented_out: bool,
     /// Indicates if this model has to be ignored by the Client.
@@ -351,7 +349,6 @@ impl Model {
             primary_key: None,
             documentation: None,
             database_name,
-            is_generated: false,
             is_commented_out: false,
             is_ignored: false,
             is_view: false,

--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -2,25 +2,24 @@ use crate::serialization_ast::datamodel_ast::{
     Datamodel, Enum, EnumValue, Field, Function, Model, PrimaryKey, UniqueIndex,
 };
 use bigdecimal::ToPrimitive;
-use prisma_models::dml::{self, FieldType, Ignorable, PrismaValue, ScalarType, WithDatabaseName};
+use prisma_models::dml::{self, PrismaValue};
 use psl::{
     parser_database::{walkers, ScalarFieldType},
     schema_ast::ast::WithDocumentation,
 };
 
 pub fn schema_to_dmmf(schema: &psl::ValidatedSchema) -> Datamodel {
-    let dml = dml::lift(schema);
     let mut datamodel = Datamodel {
-        models: vec![],
-        enums: vec![],
-        types: Vec::with_capacity(dml.composite_types.len()),
+        models: Vec::with_capacity(schema.db.models_count()),
+        enums: Vec::with_capacity(schema.db.enums_count()),
+        types: Vec::new(),
     };
 
     for enum_model in schema.db.walk_enums() {
         datamodel.enums.push(enum_to_dmmf(enum_model));
     }
 
-    for model in dml.models().filter(|model| !model.is_ignored) {
+    for model in schema.db.walk_models().filter(|model| !model.is_ignored()) {
         datamodel.models.push(model_to_dmmf(model));
     }
 
@@ -74,9 +73,9 @@ fn composite_type_field_to_dmmf(field: walkers::CompositeTypeFieldWalker<'_>) ->
     Field {
         name: field.name().to_owned(),
         kind: match field.r#type() {
-            ScalarFieldType::CompositeType(_) => "object".into(),
-            ScalarFieldType::Enum(_) => "enum".into(),
-            ScalarFieldType::BuiltInScalar(_) => "scalar".into(),
+            ScalarFieldType::CompositeType(_) => "object",
+            ScalarFieldType::Enum(_) => "enum",
+            ScalarFieldType::BuiltInScalar(_) => "scalar",
             ScalarFieldType::Unsupported(_) => unreachable!(),
         },
         db_name: field.mapped_name().map(ToOwned::to_owned),
@@ -105,94 +104,133 @@ fn composite_type_field_to_dmmf(field: walkers::CompositeTypeFieldWalker<'_>) ->
     }
 }
 
-fn model_to_dmmf(model: &dml::Model) -> Model {
-    let primary_key = if let Some(pk) = &model.primary_key {
-        (!pk.defined_on_field).then(|| PrimaryKey {
-            name: pk.name.clone(),
-            //TODO(extended indices) add field options here
-            fields: pk.fields.clone().into_iter().map(|f| f.name).collect(),
+fn model_to_dmmf(model: walkers::ModelWalker<'_>) -> Model {
+    let primary_key = if let Some(pk) = model.primary_key() {
+        (!pk.is_defined_on_field()).then(|| PrimaryKey {
+            name: pk.name().map(ToOwned::to_owned),
+            fields: pk.fields().map(|f| f.name().to_owned()).collect(),
         })
     } else {
         None
     };
 
     Model {
-        name: model.name.clone(),
-        db_name: model.database_name.clone(),
+        name: model.name().to_owned(),
+        db_name: model.mapped_name().map(ToOwned::to_owned),
         fields: model
             .fields()
-            .filter(|field| !field.is_ignored() && !matches!(field.field_type(), FieldType::Unsupported(_)))
-            .map(|f| field_to_dmmf(model, f))
+            .filter(|field| !should_skip_model_field(field))
+            .map(field_to_dmmf)
             .collect(),
-        is_generated: Some(model.is_generated),
-        documentation: model.documentation.clone(),
+        is_generated: Some(false),
+        documentation: model.ast_model().documentation().map(ToOwned::to_owned),
         primary_key,
         unique_fields: model
-            .indices
-            .iter()
+            .indexes()
             .filter_map(|i| {
-                (i.is_unique() && !i.defined_on_field).then(|| {
-                    i.fields
-                        .clone()
-                        .into_iter()
-                        .map(|f| f.path.into_iter().map(|(field, _)| field).collect::<Vec<_>>().join("."))
-                        .collect()
-                })
+                (i.is_unique() && !i.is_defined_on_field()).then(|| i.fields().map(|f| f.name().to_owned()).collect())
             })
             .collect(),
         unique_indexes: model
-            .indices
-            .iter()
+            .indexes()
             .filter_map(|i| {
-                (i.is_unique() && !i.defined_on_field).then(|| UniqueIndex {
-                    name: i.name.clone(),
-                    //TODO(extended indices) add field options here
-                    fields: i
-                        .fields
-                        .clone()
-                        .into_iter()
-                        .map(|f| f.path.into_iter().map(|(field, _)| field).collect::<Vec<_>>().join("."))
-                        .collect(),
+                (i.is_unique() && !i.is_defined_on_field()).then(|| UniqueIndex {
+                    name: i.name().map(ToOwned::to_owned),
+                    fields: i.fields().map(|f| f.name().to_owned()).collect(),
                 })
             })
             .collect(),
     }
 }
 
-fn field_to_dmmf(model: &dml::Model, field: &dml::Field) -> Field {
-    let a_relation_field_is_based_on_this_field: bool = model
-        .relation_fields()
-        .any(|f| f.relation_info.fields.iter().any(|f| f == field.name()));
-
-    Field {
-        name: field.name().to_string(),
-        db_name: field.database_name().map(|f| f.to_string()),
-        kind: get_field_kind(field),
-        is_required: *field.arity() == dml::FieldArity::Required || *field.arity() == dml::FieldArity::List,
-        is_list: *field.arity() == dml::FieldArity::List,
-        is_id: model.field_is_primary(field.name()),
-        is_read_only: a_relation_field_is_based_on_this_field,
-        has_default_value: field.default_value().is_some(),
-        default: field.default_value().map(|dv| default_value_to_serde(dv.kind())),
-        is_unique: model.field_is_unique(field.name()),
-        relation_name: get_relation_name(field),
-        relation_from_fields: get_relation_from_fields(field),
-        relation_to_fields: get_relation_to_fields(field),
-        relation_on_delete: get_relation_delete_strategy(field),
-        field_type: get_field_type(field),
-        is_generated: Some(false),
-        is_updated_at: Some(field.is_updated_at()),
-        documentation: field.documentation().map(|v| v.to_owned()),
+fn should_skip_model_field(field: &walkers::FieldWalker<'_>) -> bool {
+    match field.refine() {
+        walkers::RefinedFieldWalker::Scalar(f) => f.is_ignored() || f.is_unsupported(),
+        walkers::RefinedFieldWalker::Relation(f) => f.is_ignored(),
     }
 }
 
-fn get_field_kind(field: &dml::Field) -> String {
-    match field.field_type() {
-        dml::FieldType::CompositeType(_) => String::from("object"),
-        dml::FieldType::Relation(_) => String::from("object"),
-        dml::FieldType::Enum(_) => String::from("enum"),
-        dml::FieldType::Scalar(_, _) => String::from("scalar"),
-        dml::FieldType::Unsupported(_) => String::from("unsupported"),
+fn field_to_dmmf(field: walkers::FieldWalker<'_>) -> Field {
+    match field.refine() {
+        walkers::RefinedFieldWalker::Scalar(sf) => scalar_field_to_dmmf(sf),
+        walkers::RefinedFieldWalker::Relation(rf) => relation_field_to_dmmf(rf),
+    }
+}
+
+fn scalar_field_to_dmmf(field: walkers::ScalarFieldWalker<'_>) -> Field {
+    let ast_field = field.ast_field();
+    let field_walker = walkers::FieldWalker::from(field);
+    let is_id = field.is_single_pk();
+    Field {
+        name: field.name().to_owned(),
+        db_name: field.mapped_name().map(ToOwned::to_owned),
+        kind: match field.scalar_field_type() {
+            ScalarFieldType::CompositeType(_) => "object",
+            ScalarFieldType::Enum(_) => "enum",
+            ScalarFieldType::BuiltInScalar(_) => "scalar",
+            ScalarFieldType::Unsupported(_) => unreachable!(),
+        },
+        is_list: ast_field.arity.is_list(),
+        is_required: matches!(ast_field.arity, dml::FieldArity::Required | dml::FieldArity::List),
+        is_unique: !is_id && field.is_unique(),
+        is_id,
+        is_read_only: field.model().relation_fields().any(|rf| {
+            rf.referencing_fields()
+                .into_iter()
+                .flatten()
+                .any(|f| f.field_id() == field.field_id())
+        }),
+        has_default_value: field.default_value().is_some(),
+        field_type: match field.scalar_field_type() {
+            ScalarFieldType::CompositeType(ct) => field_walker.walk(ct).name().to_owned(),
+            ScalarFieldType::Enum(enm) => field_walker.walk(enm).name().to_owned(),
+            ScalarFieldType::BuiltInScalar(st) => st.as_str().to_owned(),
+            ScalarFieldType::Unsupported(_) => unreachable!(),
+        },
+        default: field
+            .default_value()
+            .map(|dv| default_value_to_serde(&dml::dml_default_kind(dv.value(), field.scalar_type()))),
+        relation_name: None,
+        relation_from_fields: None,
+        relation_to_fields: None,
+        relation_on_delete: None,
+        is_generated: Some(false),
+        is_updated_at: Some(field.is_updated_at()),
+        documentation: ast_field.documentation().map(ToOwned::to_owned),
+    }
+}
+
+fn relation_field_to_dmmf(field: walkers::RelationFieldWalker<'_>) -> Field {
+    let ast_field = field.ast_field();
+    Field {
+        name: field.name().to_owned(),
+        db_name: None,
+        kind: "object",
+        is_list: ast_field.arity.is_list(),
+        is_required: matches!(ast_field.arity, dml::FieldArity::Required | dml::FieldArity::List),
+        is_unique: false,
+        is_id: false,
+        is_read_only: false,
+        has_default_value: false,
+        field_type: field.related_model().name().to_owned(),
+        default: None,
+        relation_name: Some(field.relation_name().to_string()),
+        relation_from_fields: Some(
+            field
+                .referencing_fields()
+                .map(|fields| fields.map(|f| f.name().to_owned()).collect())
+                .unwrap_or_default(),
+        ),
+        relation_to_fields: Some(
+            field
+                .referenced_fields()
+                .map(|fields| fields.map(|f| f.name().to_owned()).collect())
+                .unwrap_or_default(),
+        ),
+        relation_on_delete: field.explicit_on_delete().map(|od| od.to_string()),
+        is_generated: Some(false),
+        is_updated_at: Some(false),
+        documentation: ast_field.documentation().map(ToOwned::to_owned),
     }
 }
 
@@ -241,48 +279,6 @@ fn function_to_serde(name: &str, args: &[PrismaValue]) -> serde_json::Value {
     };
 
     serde_json::to_value(&func).expect("Failed to render function JSON")
-}
-
-fn get_field_type(field: &dml::Field) -> String {
-    match &field.field_type() {
-        dml::FieldType::CompositeType(t) => t.clone(),
-        dml::FieldType::Relation(relation_info) => relation_info.referenced_model.clone(),
-        dml::FieldType::Enum(t) => t.clone(),
-        dml::FieldType::Unsupported(t) => t.clone(),
-        dml::FieldType::Scalar(t, _) => type_to_string(t),
-    }
-}
-
-fn type_to_string(scalar: &ScalarType) -> String {
-    scalar.to_string()
-}
-
-fn get_relation_name(field: &dml::Field) -> Option<String> {
-    match &field {
-        dml::Field::RelationField(rf) => Some(rf.relation_info.name.clone()),
-        _ => None,
-    }
-}
-
-fn get_relation_from_fields(field: &dml::Field) -> Option<Vec<String>> {
-    match &field {
-        dml::Field::RelationField(rf) => Some(rf.relation_info.fields.clone()),
-        _ => None,
-    }
-}
-
-fn get_relation_to_fields(field: &dml::Field) -> Option<Vec<String>> {
-    match &field {
-        dml::Field::RelationField(rf) => Some(rf.relation_info.references.clone()),
-        _ => None,
-    }
-}
-
-fn get_relation_delete_strategy(field: &dml::Field) -> Option<String> {
-    match &field {
-        dml::Field::RelationField(rf) => rf.relation_info.on_delete.map(|ri| ri.to_string()),
-        _ => None,
-    }
 }
 
 #[cfg(test)]

--- a/query-engine/dmmf/src/serialization_ast/datamodel_ast.rs
+++ b/query-engine/dmmf/src/serialization_ast/datamodel_ast.rs
@@ -13,7 +13,7 @@ pub struct Field {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub db_name: Option<String>,
-    pub kind: String,
+    pub kind: &'static str,
     pub is_list: bool,
     pub is_required: bool,
     pub is_unique: bool,


### PR DESCRIPTION
After this, only default values rely on dml in DMMF. This unblocks a lot of progress in prisma_models.

Part of https://github.com/prisma/client-planning/issues/265