### PR TITLE
dmmf: return models _and_ views again

### DIFF
--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -19,7 +19,12 @@ pub fn schema_to_dmmf(schema: &psl::ValidatedSchema) -> Datamodel {
         datamodel.enums.push(enum_to_dmmf(enum_model));
     }
 
-    for model in schema.db.walk_models().filter(|model| !model.is_ignored()) {
+    for model in schema
+        .db
+        .walk_models()
+        .filter(|model| !model.is_ignored())
+        .chain(schema.db.walk_views())
+    {
         datamodel.models.push(model_to_dmmf(model));
     }
 
@@ -303,6 +308,7 @@ mod tests {
             "source_with_generator",
             "without_relation_name",
             "ignore",
+            "views",
         ];
 
         for test_case in test_cases {
@@ -310,12 +316,9 @@ mod tests {
 
             let datamodel_string = load_from_file(format!("{test_case}.prisma").as_str());
             let dmmf_string = render_to_dmmf(&datamodel_string);
-
-            assert_eq_json(
-                &dmmf_string,
-                &load_from_file(format!("{test_case}.json").as_str()),
-                test_case,
-            );
+            let expected_json = load_from_file(format!("{test_case}.json").as_str());
+            println!("{dmmf_string}");
+            assert_eq_json(&dmmf_string, &expected_json, test_case);
         }
     }
 

--- a/query-engine/dmmf/test_files/views.json
+++ b/query-engine/dmmf/test_files/views.json
@@ -1,0 +1,202 @@
+{
+  "enums": [],
+  "models": [
+    {
+      "name": "User",
+      "dbName": null,
+      "fields": [
+        {
+          "name": "id",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": true,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "email",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": true,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "name",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": false,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "profile",
+          "kind": "object",
+          "isList": false,
+          "isRequired": false,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "Profile",
+          "relationName": "ProfileToUser",
+          "relationFromFields": [],
+          "relationToFields": [],
+          "isGenerated": false,
+          "isUpdatedAt": false
+        }
+      ],
+      "primaryKey": null,
+      "uniqueFields": [],
+      "uniqueIndexes": [],
+      "isGenerated": false
+    },
+    {
+      "name": "Profile",
+      "dbName": null,
+      "fields": [
+        {
+          "name": "id",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": true,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "bio",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "user",
+          "kind": "object",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "User",
+          "relationName": "ProfileToUser",
+          "relationFromFields": [
+            "userId"
+          ],
+          "relationToFields": [
+            "id"
+          ],
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "userId",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": true,
+          "isId": false,
+          "isReadOnly": true,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        }
+      ],
+      "primaryKey": null,
+      "uniqueFields": [],
+      "uniqueIndexes": [],
+      "isGenerated": false
+    },
+        {
+      "name": "UserInfo",
+      "dbName": null,
+      "fields": [
+        {
+          "name": "id",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": true,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "email",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "name",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        },
+        {
+          "name": "bio",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": false,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "String",
+          "isGenerated": false,
+          "isUpdatedAt": false
+        }
+      ],
+      "primaryKey": null,
+      "uniqueFields": [],
+      "uniqueIndexes": [],
+      "isGenerated": false
+    }
+  ],
+  "types": []
+}

--- a/query-engine/dmmf/test_files/views.prisma
+++ b/query-engine/dmmf/test_files/views.prisma
@@ -1,0 +1,24 @@
+generator client {
+  provider = "prisma-client-js"
+  previewFeatures = ["views"]
+}
+
+model User {
+  id      String @id
+  email   String   @unique
+  name    String?
+  profile Profile?
+}
+model Profile {
+  id        String @id
+  bio       String
+  user      User      @relation(fields: [userId], references: [id])
+  userId    String @unique
+}
+
+view UserInfo {
+  id    String @id
+  email String
+  name  String
+  bio   String
+}


### PR DESCRIPTION
That's a difference between dml and psl: dml doesn't know about views, it's just another model at that level. PSL does. So https://github.com/prisma/prisma-engines/pull/3663 broke client tests. This commit should bring us back to identical output.