### PR TITLE
psl+dml+prisma-models: define and forward more typed identifiers 

### DIFF
--- a/psl/parser-database/src/walkers/field.rs
+++ b/psl/parser-database/src/walkers/field.rs
@@ -29,8 +29,7 @@ impl<'db> FieldWalker<'db> {
         } = self;
         if let Some(relation_field) = &self.db.types.relation_fields.get(&self.id) {
             RefinedFieldWalker::Relation(RelationFieldWalker {
-                model_id,
-                field_id,
+                id: super::RelationFieldId(model_id, field_id),
                 db,
                 relation_field,
             })
@@ -68,7 +67,7 @@ impl<'db> From<RelationFieldWalker<'db>> for FieldWalker<'db> {
     fn from(w: RelationFieldWalker<'db>) -> Self {
         Walker {
             db: w.db,
-            id: (w.model_id, w.field_id),
+            id: (w.id.0, w.id.1),
         }
     }
 }

--- a/psl/parser-database/src/walkers/field.rs
+++ b/psl/parser-database/src/walkers/field.rs
@@ -1,4 +1,4 @@
-use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldWalker, Walker};
+use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldId, ScalarFieldWalker, Walker};
 use crate::ScalarType;
 use schema_ast::ast;
 
@@ -36,8 +36,7 @@ impl<'db> FieldWalker<'db> {
             })
         } else if let Some(scalar_field) = self.db.types.scalar_fields.get(&self.id) {
             RefinedFieldWalker::Scalar(ScalarFieldWalker {
-                model_id,
-                field_id,
+                id: ScalarFieldId(model_id, field_id),
                 db,
                 scalar_field,
             })
@@ -60,7 +59,7 @@ impl<'db> From<ScalarFieldWalker<'db>> for FieldWalker<'db> {
     fn from(w: ScalarFieldWalker<'db>) -> Self {
         Walker {
             db: w.db,
-            id: (w.model_id, w.field_id),
+            id: (w.id.0, w.id.1),
         }
     }
 }

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -202,8 +202,7 @@ impl<'db> ModelWalker<'db> {
             .relation_fields
             .range((model_id, ast::FieldId::MIN)..=(model_id, ast::FieldId::MAX))
             .map(move |((_, field_id), relation_field)| RelationFieldWalker {
-                model_id,
-                field_id: *field_id,
+                id: super::RelationFieldId(model_id, *field_id),
                 db,
                 relation_field,
             })
@@ -216,8 +215,7 @@ impl<'db> ModelWalker<'db> {
     /// If the field does not exist.
     pub fn relation_field(self, field_id: ast::FieldId) -> RelationFieldWalker<'db> {
         RelationFieldWalker {
-            model_id: self.id,
-            field_id,
+            id: super::RelationFieldId(self.id, field_id),
             db: self.db,
             relation_field: &self.db.types.relation_fields[&(self.id, field_id)],
         }

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -128,8 +128,7 @@ impl<'db> ModelWalker<'db> {
     #[track_caller]
     pub fn scalar_field(self, field_id: ast::FieldId) -> ScalarFieldWalker<'db> {
         ScalarFieldWalker {
-            model_id: self.id,
-            field_id,
+            id: super::ScalarFieldId(self.id, field_id),
             db: self.db,
             scalar_field: &self.db.types.scalar_fields[&(self.id, field_id)],
         }
@@ -142,8 +141,7 @@ impl<'db> ModelWalker<'db> {
             .scalar_fields
             .range((self.id, ast::FieldId::MIN)..=(self.id, ast::FieldId::MAX))
             .map(move |((model_id, field_id), scalar_field)| ScalarFieldWalker {
-                model_id: *model_id,
-                field_id: *field_id,
+                id: super::ScalarFieldId(*model_id, *field_id),
                 db,
                 scalar_field,
             })

--- a/psl/parser-database/src/walkers/relation/inline.rs
+++ b/psl/parser-database/src/walkers/relation/inline.rs
@@ -40,8 +40,8 @@ impl<'db> InlineRelationWalker<'db> {
         match (self.forward_relation_field(), self.back_relation_field()) {
             (Some(field_a), Some(field_b)) => {
                 let walker = CompleteInlineRelationWalker {
-                    side_a: (self.referencing_model().id, field_a.field_id),
-                    side_b: (self.referenced_model().id, field_b.field_id),
+                    side_a: (self.referencing_model().id, field_a.field_id()),
+                    side_b: (self.referenced_model().id, field_b.field_id()),
                     db: self.0.db,
                 };
 

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -50,8 +50,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
             let model_id = self.referenced_model().id;
 
             ScalarFieldWalker {
-                model_id,
-                field_id: *field_id,
+                id: crate::walkers::ScalarFieldId(model_id, *field_id),
                 db: self.db,
                 scalar_field: &self.db.types.scalar_fields[&(model_id, *field_id)],
             }
@@ -69,8 +68,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
             let model_id = self.referencing_model().id;
 
             ScalarFieldWalker {
-                model_id,
-                field_id: *field_id,
+                id: crate::walkers::ScalarFieldId(model_id, *field_id),
                 db: self.db,
                 scalar_field: &self.db.types.scalar_fields[&(model_id, *field_id)],
             }

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -28,8 +28,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
 
     pub fn referencing_field(self) -> RelationFieldWalker<'db> {
         RelationFieldWalker {
-            model_id: self.side_a.0,
-            field_id: self.side_a.1,
+            id: crate::walkers::RelationFieldId(self.side_a.0, self.side_a.1),
             db: self.db,
             relation_field: &self.db.types.relation_fields[&(self.side_a.0, self.side_a.1)],
         }
@@ -37,8 +36,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
 
     pub fn referenced_field(self) -> RelationFieldWalker<'db> {
         RelationFieldWalker {
-            model_id: self.side_b.0,
-            field_id: self.side_b.1,
+            id: crate::walkers::RelationFieldId(self.side_b.0, self.side_b.1),
             db: self.db,
             relation_field: &self.db.types.relation_fields[&(self.side_b.0, self.side_b.1)],
         }

--- a/psl/parser-database/src/walkers/relation_field.rs
+++ b/psl/parser-database/src/walkers/relation_field.rs
@@ -185,8 +185,7 @@ impl<'db> RelationFieldWalker<'db> {
         let attributes = self.attributes();
         attributes.fields.as_ref().map(move |fields| {
             fields.iter().map(move |field_id| ScalarFieldWalker {
-                model_id,
-                field_id: *field_id,
+                id: super::ScalarFieldId(model_id, *field_id),
                 db: self.db,
                 scalar_field: &self.db.types.scalar_fields[&(model_id, *field_id)],
             })

--- a/psl/parser-database/src/walkers/relation_field.rs
+++ b/psl/parser-database/src/walkers/relation_field.rs
@@ -10,18 +10,22 @@ use std::{
     hash::{Hash, Hasher},
 };
 
+/// An opaque identifier for a model relation field in a schema.
+#[derive(Copy, Clone, PartialEq, Debug, Hash)]
+pub struct RelationFieldId(pub(crate) ast::ModelId, pub(crate) ast::FieldId);
+
 /// A relation field on a model in the schema.
 #[derive(Copy, Clone, Debug)]
 pub struct RelationFieldWalker<'db> {
-    pub(crate) model_id: ast::ModelId,
-    pub(crate) field_id: ast::FieldId,
+    /// The typed identifier for the relation field.
+    pub id: RelationFieldId,
     pub(crate) db: &'db ParserDatabase,
     pub(crate) relation_field: &'db RelationField,
 }
 
 impl<'db> PartialEq for RelationFieldWalker<'db> {
     fn eq(&self, other: &Self) -> bool {
-        self.model_id == other.model_id && self.field_id == other.field_id
+        self.id == other.id
     }
 }
 
@@ -29,15 +33,14 @@ impl<'db> Eq for RelationFieldWalker<'db> {}
 
 impl<'db> Hash for RelationFieldWalker<'db> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.model_id.hash(state);
-        self.field_id.hash(state);
+        self.id.hash(state);
     }
 }
 
 impl<'db> RelationFieldWalker<'db> {
     /// The ID of the AST node of the field.
     pub fn field_id(self) -> ast::FieldId {
-        self.field_id
+        self.id.1
     }
 
     /// The relation starts or ends to a view.
@@ -57,7 +60,7 @@ impl<'db> RelationFieldWalker<'db> {
 
     /// The AST node of the field.
     pub fn ast_field(self) -> &'db ast::Field {
-        &self.db.ast[self.model_id][self.field_id]
+        &self.db.ast[self.id.0][self.id.1]
     }
 
     pub(crate) fn attributes(self) -> &'db RelationField {
@@ -101,7 +104,7 @@ impl<'db> RelationFieldWalker<'db> {
 
     /// The model containing the field.
     pub fn model(self) -> ModelWalker<'db> {
-        self.db.walk(self.model_id)
+        self.db.walk(self.id.0)
     }
 
     /// The `@relation` attribute in the field AST.
@@ -132,7 +135,7 @@ impl<'db> RelationFieldWalker<'db> {
     pub fn relation(self) -> RelationWalker<'db> {
         let model = self.model();
         let mut relations = model.relations_from().chain(model.relations_to());
-        relations.find(|r| r.has_field(self.model_id, self.field_id)).unwrap()
+        relations.find(|r| r.has_field(self.id.0, self.id.1)).unwrap()
     }
 
     /// The name of the relation. Either uses the `name` (or default) argument,
@@ -181,7 +184,7 @@ impl<'db> RelationFieldWalker<'db> {
 
     /// The fields in the `fields: [...]` argument in the forward relation field.
     pub fn fields(self) -> Option<impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + Clone> {
-        let model_id = self.model_id;
+        let model_id = self.id.0;
         let attributes = self.attributes();
         attributes.fields.as_ref().map(move |fields| {
             fields.iter().map(move |field_id| ScalarFieldWalker {

--- a/query-engine/dml/src/composite_type.rs
+++ b/query-engine/dml/src/composite_type.rs
@@ -1,9 +1,6 @@
 //! Composite types defined with the `type` keyword.
 
-use crate::{
-    default_value::DefaultValue, native_type_instance::NativeTypeInstance, scalars::ScalarType, Field, FieldArity,
-    FieldType, ScalarField,
-};
+use crate::{default_value::DefaultValue, native_type_instance::NativeTypeInstance, scalars::ScalarType, FieldArity};
 use psl_core::parser_database::ast;
 
 #[derive(Debug, PartialEq, Clone)]
@@ -29,25 +26,6 @@ pub struct CompositeTypeField {
 
     /// Should we comment this field out.
     pub is_commented_out: bool,
-}
-
-impl From<CompositeTypeField> for Field {
-    fn from(f: CompositeTypeField) -> Self {
-        let sf = ScalarField {
-            name: f.name,
-            field_type: FieldType::from(f.r#type),
-            arity: f.arity,
-            database_name: f.database_name,
-            default_value: f.default_value,
-            documentation: f.documentation,
-            is_generated: false,
-            is_updated_at: false,
-            is_commented_out: f.is_commented_out,
-            is_ignored: false,
-        };
-
-        Self::ScalarField(sf)
-    }
 }
 
 impl CompositeType {

--- a/query-engine/dml/src/composite_type.rs
+++ b/query-engine/dml/src/composite_type.rs
@@ -5,6 +5,7 @@ use psl_core::parser_database::ast;
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct CompositeType {
+    pub id: ast::CompositeTypeId,
     pub name: String,
     pub fields: Vec<CompositeTypeField>,
 }

--- a/query-engine/dml/src/composite_type.rs
+++ b/query-engine/dml/src/composite_type.rs
@@ -12,6 +12,7 @@ pub struct CompositeType {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct CompositeTypeField {
+    pub id: (ast::CompositeTypeId, ast::FieldId),
     pub name: String,
     pub r#type: CompositeTypeFieldType,
     pub arity: FieldArity,

--- a/query-engine/dml/src/field.rs
+++ b/query-engine/dml/src/field.rs
@@ -7,7 +7,10 @@ use crate::scalars::ScalarType;
 use crate::traits::{Ignorable, WithDatabaseName, WithName};
 use crate::{CompositeTypeFieldType, FieldArity};
 use psl_core::{
-    parser_database::{walkers::ScalarFieldId, ReferentialAction},
+    parser_database::{
+        walkers::{RelationFieldId, ScalarFieldId},
+        ReferentialAction,
+    },
     schema_ast::ast,
 };
 
@@ -269,6 +272,8 @@ impl Ignorable for Field {
 /// Represents a relation field in a model.
 #[derive(Debug, PartialEq, Clone)]
 pub struct RelationField {
+    pub id: RelationFieldId,
+
     /// Name of the field.
     pub name: String,
 
@@ -296,8 +301,15 @@ pub struct RelationField {
 
 impl RelationField {
     /// Creates a new field with the given name and type.
-    pub fn new(name: &str, arity: FieldArity, referential_arity: FieldArity, relation_info: RelationInfo) -> Self {
+    pub fn new(
+        id: RelationFieldId,
+        name: &str,
+        arity: FieldArity,
+        referential_arity: FieldArity,
+        relation_info: RelationInfo,
+    ) -> Self {
         RelationField {
+            id,
             name: String::from(name),
             arity,
             referential_arity,

--- a/query-engine/dml/src/field.rs
+++ b/query-engine/dml/src/field.rs
@@ -6,7 +6,10 @@ use crate::relation_info::RelationInfo;
 use crate::scalars::ScalarType;
 use crate::traits::{Ignorable, WithDatabaseName, WithName};
 use crate::{CompositeTypeFieldType, FieldArity};
-use psl_core::{parser_database::ReferentialAction, schema_ast::ast};
+use psl_core::{
+    parser_database::{walkers::ScalarFieldId, ReferentialAction},
+    schema_ast::ast,
+};
 
 /// Datamodel field type.
 #[derive(Debug, PartialEq, Clone)]
@@ -366,6 +369,8 @@ impl WithName for RelationField {
 /// Represents a scalar field in a model.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ScalarField {
+    pub id: ScalarFieldId,
+
     /// Name of the field.
     pub name: String,
 
@@ -400,8 +405,9 @@ pub struct ScalarField {
 
 impl ScalarField {
     /// Creates a new field with the given name and type.
-    pub fn new(name: &str, arity: FieldArity, field_type: FieldType) -> ScalarField {
+    pub fn new(id: ScalarFieldId, name: &str, arity: FieldArity, field_type: FieldType) -> ScalarField {
         ScalarField {
+            id,
             name: String::from(name),
             arity,
             field_type,
@@ -413,14 +419,6 @@ impl ScalarField {
             is_commented_out: false,
             is_ignored: false,
         }
-    }
-
-    /// Creates a new field with the given name and type, marked as generated and optional.
-    pub fn new_generated(name: &str, field_type: FieldType) -> ScalarField {
-        let mut field = Self::new(name, FieldArity::Optional, field_type);
-        field.is_generated = true;
-
-        field
     }
 
     pub fn set_default_value(&mut self, val: DefaultValue) {

--- a/query-engine/dml/src/lift.rs
+++ b/query-engine/dml/src/lift.rs
@@ -126,8 +126,13 @@ impl<'a> LiftAstToDml<'a> {
                         // Construct a relation field in the DML for an existing relation field in the source.
                         let arity = forward_field_walker.ast_field().arity;
                         let referential_arity = forward_field_walker.referential_arity();
-                        let mut relation_field =
-                            RelationField::new(forward_field_walker.name(), arity, referential_arity, relation_info);
+                        let mut relation_field = RelationField::new(
+                            forward_field_walker.id,
+                            forward_field_walker.name(),
+                            arity,
+                            referential_arity,
+                            relation_info,
+                        );
 
                         let column_names: Vec<&str> = relation
                             .referencing_fields()
@@ -183,8 +188,13 @@ impl<'a> LiftAstToDml<'a> {
                             let ast_field = relation_field.ast_field();
                             let arity = ast_field.arity;
                             let referential_arity = relation_field.referential_arity();
-                            let mut field =
-                                RelationField::new(relation_field.name(), arity, referential_arity, relation_info);
+                            let mut field = RelationField::new(
+                                relation_field.id,
+                                relation_field.name(),
+                                arity,
+                                referential_arity,
+                                relation_info,
+                            );
 
                             common_dml_fields(&mut field, relation_field);
 
@@ -199,6 +209,7 @@ impl<'a> LiftAstToDml<'a> {
                             let arity = FieldArity::List;
                             let referential_arity = FieldArity::List;
                             let mut field = RelationField::new(
+                                relation.forward_relation_field().unwrap().id,
                                 relation.referencing_model().name(),
                                 arity,
                                 referential_arity,
@@ -218,8 +229,13 @@ impl<'a> LiftAstToDml<'a> {
                         let arity = ast_field.arity;
                         let relation_info = RelationInfo::new(relation_field.related_model().name());
                         let referential_arity = relation_field.referential_arity();
-                        let mut field =
-                            RelationField::new(relation_field.name(), arity, referential_arity, relation_info);
+                        let mut field = RelationField::new(
+                            relation_field.id,
+                            relation_field.name(),
+                            arity,
+                            referential_arity,
+                            relation_info,
+                        );
 
                         common_dml_fields(&mut field, relation_field);
 
@@ -249,8 +265,13 @@ impl<'a> LiftAstToDml<'a> {
                         let relation_info = RelationInfo::new(relation_field.related_model().name());
                         let referential_arity = relation_field.referential_arity();
 
-                        let mut field =
-                            RelationField::new(relation_field.name(), arity, referential_arity, relation_info);
+                        let mut field = RelationField::new(
+                            relation_field.id,
+                            relation_field.name(),
+                            arity,
+                            referential_arity,
+                            relation_info,
+                        );
 
                         common_dml_fields(&mut field, relation_field);
 
@@ -301,6 +322,7 @@ impl<'a> LiftAstToDml<'a> {
         }
 
         CompositeType {
+            id: walker.id,
             name: walker.name().to_owned(),
             fields,
         }

--- a/query-engine/dml/src/lift.rs
+++ b/query-engine/dml/src/lift.rs
@@ -411,7 +411,7 @@ impl<'a> LiftAstToDml<'a> {
                 _ => self.lift_scalar_field_type(ast_field, &scalar_field.scalar_field_type(), scalar_field),
             };
 
-            let mut field = ScalarField::new(ast_field.name(), ast_field.arity, field_type);
+            let mut field = ScalarField::new(scalar_field.id, ast_field.name(), ast_field.arity, field_type);
 
             field.documentation = ast_field.documentation().map(String::from);
             field.is_ignored = scalar_field.is_ignored();

--- a/query-engine/dml/src/lift.rs
+++ b/query-engine/dml/src/lift.rs
@@ -306,6 +306,7 @@ impl<'a> LiftAstToDml<'a> {
 
         for field in walker.fields() {
             let field = CompositeTypeField {
+                id: field.id,
                 name: field.name().to_owned(),
                 r#type: self.lift_composite_type_field_type(field, field.r#type()),
                 arity: field.arity(),


### PR DESCRIPTION
Part of https://github.com/prisma/client-planning/issues/265

This makes sense in the context of the refactoring explained in the linked issue. See individual commits for more details.