### PR TITLE
migration-engine: correctly detect Postgres version

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/schema_describer_loading.rs
@@ -29,7 +29,7 @@ pub async fn load_describer<'a>(
                 let pgversion = pgversion_result
                     .get(0)
                     .and_then(|r| r.get("version"))
-                    .and_then(|v| v.as_i32());
+                    .and_then(|v| v.as_integer());
 
                 match pgversion {
                     Some(version) if version >= 100000 => circumstances |= Circumstances::CanPartitionTables,

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -570,8 +570,8 @@ where
                     let version =
                         schema_exists_result
                           .get(0)
-                          .and_then(|row| row.at(1).and_then(|v| row.at(2).map(|n| (n, v))))
-                          .and_then(|(vs,vn)| vs.to_string().and_then(|v| vn.as_i32().map(|n| (v, n))));
+                          .and_then(|row| row.at(1).and_then(|ver_str| row.at(2).map(|ver_num| (ver_str, ver_num))))
+                          .and_then(|(ver_str,ver_num)| ver_str.to_string().and_then(|version| ver_num.as_i32().map(|version_number| (version, version_number))));
 
                     match version {
                         Some((version, version_num)) => {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres.rs
@@ -561,7 +561,7 @@ where
                     let schema_name = params.url.schema();
 
                     let schema_exists_result = connection.query_raw(
-                            "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1), version(), current_setting('server_version_num')::integer as numeric_version",
+                            "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = $1), version(), current_setting('server_version_num')::integer as numeric_version;",
                             &[schema_name.into()],
                             &params.url,
                         )
@@ -571,7 +571,7 @@ where
                         schema_exists_result
                           .get(0)
                           .and_then(|row| row.at(1).and_then(|ver_str| row.at(2).map(|ver_num| (ver_str, ver_num))))
-                          .and_then(|(ver_str,ver_num)| ver_str.to_string().and_then(|version| ver_num.as_i32().map(|version_number| (version, version_number))));
+                          .and_then(|(ver_str,ver_num)| ver_str.to_string().and_then(|version| ver_num.as_integer().map(|version_number| (version, version_number))));
 
                     match version {
                         Some((version, version_num)) => {

--- a/migration-engine/connectors/sql-migration-connector/src/flavour/postgres/connection.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/flavour/postgres/connection.rs
@@ -46,6 +46,10 @@ impl Connection {
             describer_circumstances |= describer::Circumstances::CockroachWithPostgresNativeTypes;
         }
 
+        if circumstances.contains(super::Circumstances::CanPartitionTables) {
+            describer_circumstances |= describer::Circumstances::CanPartitionTables;
+        }
+
         let namespaces_vec = Namespaces::to_vec(namespaces, String::from(params.url.schema()));
         let namespaces_str: Vec<&str> = namespaces_vec.iter().map(AsRef::as_ref).collect();
 

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres.rs
@@ -1,4 +1,5 @@
 mod extensions;
+mod introspection;
 mod multi_schema;
 
 use migration_core::migration_connector::DiffTarget;

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/introspection.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/introspection.rs
@@ -1,0 +1,74 @@
+use migration_engine_tests::test_api::*;
+
+#[test]
+fn introspect_partition_tables() {
+    let test_db = test_setup::only!(Postgres ; exclude: Postgres9);
+    let (_, url_str) = tok(test_setup::postgres::create_postgres_database(
+        test_db.url(),
+        "postgres_introspect_partition_tables",
+    ))
+    .unwrap();
+
+    let me = migration_core::migration_api(None, None).unwrap();
+
+    let script = r#"
+CREATE TABLE IF NOT EXISTS blocks
+(
+    id int NOT NULL,
+    account text COLLATE pg_catalog."default" NOT NULL,
+    block_source_id int,
+    CONSTRAINT blocks_pkey PRIMARY KEY (account, id)
+) PARTITION BY RANGE (id);
+
+
+CREATE TABLE blocks_p1_0 PARTITION OF blocks
+    FOR VALUES FROM (0) TO (1000);
+
+CREATE TABLE blocks_p2_0 PARTITION OF blocks
+    FOR VALUES FROM (1001) TO (2000);
+
+ALTER TABLE blocks
+      ADD CONSTRAINT block_source_block_fk FOREIGN KEY (block_source_id, account)
+        REFERENCES blocks (id, account) MATCH SIMPLE
+        ON UPDATE NO ACTION
+        ON DELETE CASCADE; "#;
+
+    tok(me.db_execute(DbExecuteParams {
+        datasource_type: DbExecuteDatasourceType::Url(UrlContainer { url: url_str.clone() }),
+        script: script.to_owned(),
+    }))
+    .unwrap();
+
+    let schema = format! {
+        r#"
+            datasource db {{
+                provider = "postgres"
+                url = "{url_str}"
+            }}
+        "#,
+    };
+
+    let result = tok(me.introspect(migration_core::json_rpc::types::IntrospectParams {
+        composite_type_depth: -1,
+        force: false,
+        schema,
+        schemas: None,
+    }))
+    .unwrap();
+
+    let expected = format!(
+        r#"
+datasource db {{
+  provider = "postgres"
+  url      = "{}"
+}}
+
+/// This table is a partition table and requires additional setup for migrations. Visit https://pris.ly/d/partition-tables for more info.
+model blocks {{
+  id Int @id @default(autoincrement())
+}}
+"#,
+        url_str
+    );
+    pretty_assertions::assert_eq!(expected, result.datamodel.as_str());
+}

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/introspection.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/introspection.rs
@@ -2,7 +2,9 @@ use migration_engine_tests::test_api::*;
 
 #[test]
 fn introspect_partition_tables() {
-    let test_db = test_setup::only!(Postgres ; exclude: Postgres9);
+    // Postgres9 does not support partition tables, and Postgres10 does not support primary keys on
+    // partition tables.
+    let test_db = test_setup::only!(Postgres11, Postgres12, Postgres13, Postgres14, Postgres15 ; exclude: CockroachDb);
     let (_, url_str) = tok(test_setup::postgres::create_postgres_database(
         test_db.url(),
         "postgres_introspect_partition_tables",

--- a/migration-engine/migration-engine-tests/tests/migrations/postgres/introspection.rs
+++ b/migration-engine/migration-engine-tests/tests/migrations/postgres/introspection.rs
@@ -57,15 +57,20 @@ ALTER TABLE blocks
     .unwrap();
 
     let expected = format!(
-        r#"
-datasource db {{
+        r#"datasource db {{
   provider = "postgres"
   url      = "{}"
 }}
 
 /// This table is a partition table and requires additional setup for migrations. Visit https://pris.ly/d/partition-tables for more info.
 model blocks {{
-  id Int @id @default(autoincrement())
+  id              Int
+  account         String
+  block_source_id Int?
+  blocks          blocks?  @relation("blocksToblocks", fields: [block_source_id, account], references: [id, account], onDelete: Cascade, onUpdate: NoAction, map: "block_source_block_fk")
+  other_blocks    blocks[] @relation("blocksToblocks")
+
+  @@id([account, id])
 }}
 "#,
         url_str


### PR DESCRIPTION
We need to clean up the entries to IE such that this is less confusing next time. This should fix getting the right Postgres version when running IE from ME, which is needed for partition tables.