### PR TITLE
fix: noop one2m nested connect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2259,7 +2259,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.30.0"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#e3f8bdb41d57e769412f53d0f479bf67fdcc0ee3"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#b5d16fb211fc6a0d5c892269536a95da803eabae"
 dependencies = [
  "bytes",
  "crossbeam",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -15,6 +15,7 @@ mod prisma_15264;
 mod prisma_15467;
 mod prisma_15581;
 mod prisma_15607;
+mod prisma_17103;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_17103.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_17103.rs
@@ -1,0 +1,44 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod prisma_17103 {
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model A {
+                #id(id, Int, @id)
+              
+                b   B? @relation(fields: [bId], references: [id])
+                bId Int?
+              }
+              
+              model B {
+                #id(id, Int, @id)
+                a   A[]
+              }
+              "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn regression(runner: Runner) -> TestResult<()> {
+        run_query!(
+            &runner,
+            r#"mutation {
+            createOneA(data: { id: 1, b: { create: { id: 1 } } }) {
+              id
+            }
+          }
+          "#
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneB(where: { id: 1 }, data: { a: { connect: { id: 1 } } }) { id } }"#),
+          @r###"{"data":{"updateOneB":{"id":1}}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -210,7 +210,10 @@ pub async fn update_records<'conn>(
         .instrument(span)
         .await?;
 
-        if update_type == UpdateType::Many && res.modified_count == 0 {
+        // It's important we check the `matched_count` and not the `modified_count` here.
+        // MongoDB returns `modified_count: 0` when performing a noop update, which breaks
+        // nested connect mutations as it rely on the returned count to know whether the update happened.
+        if update_type == UpdateType::Many && res.matched_count == 0 {
             return Ok(Vec::new());
         }
     }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -363,7 +363,7 @@ async fn update_records_from_filter(
     ctx: &Context<'_>,
 ) -> crate::Result<usize> {
     let update = build_update_and_set_query(model, args, ctx);
-    let filter_condition = record_filter.clone().filter.aliased_condition_from(None, false, ctx);
+    let filter_condition = record_filter.filter.aliased_condition_from(None, false, ctx);
 
     let update = update.so_that(filter_condition);
     let count = conn.execute(update.into()).await?;


### PR DESCRIPTION
## Overview
fixes https://github.com/prisma/prisma/issues/17103

When performing a noop update on MySQL & MongoDB, the returned count of "affected rows" by the `updateMany` mutation was 0. This was breaking nested connect mutations which ensures the mutation has happened by relying on this count.

https://github.com/prisma/prisma-engines/blob/a99c68855c9ccfaf9fb6a975aad658f59cfc260d/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs#L234-L240

This PR does the following: 
- Updates mysql_async (https://github.com/prisma/mysql_async/pull/1) so that it passes the `CLIENT_FOUND_ROWS` flag. This changes the behavior of the affected count returned for mutations (UPDATE/INSERT etc). It makes MySQL return the FOUND rows instead of the AFFECTED rows.
- Updates the `updateMany` connector logic on MongoDB to rely on the `matched_count` instead of the `modified_count`
- Adds a regression test

Note that relying on the "matched count" (found rows) instead of the "modified count" (affected rows) does not break OCC because it still would return 0 if the filter doesn't match any row (because the "discriminant" field (eg: `version` field) got updated by another update).

It does change what `updateMany` and `deleteMany` now returns for MySQL. We believe the only "meaningful" count that can be used in an application to do any kind of logic is 0 though. Since 0 will still be returned in useful cases, we don't believe this is a breaking change.