### PR TITLE
psl: bake name and columns of join tables into walker

### DIFF
--- a/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
+++ b/migration-engine/connectors/sql-migration-connector/src/sql_schema_calculator.rs
@@ -187,7 +187,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
         .filter_map(|relation| relation.refine().as_many_to_many());
 
     for m2m in m2m_relations {
-        let table_name = format!("_{}", m2m.relation_name());
+        let table_name = m2m.table_name().to_string();
         let table_name = table_name
             .chars()
             .take(datamodel.configuration.max_identifier_length())
@@ -196,8 +196,8 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
         let model_a_table_id = ctx.model_id_to_table_id[&model_a.model_id()];
         let model_b = m2m.model_b();
         let model_b_table_id = ctx.model_id_to_table_id[&model_b.model_id()];
-        let model_a_column = "A";
-        let model_b_column = "B";
+        let model_a_column = m2m.column_a_name();
+        let model_b_column = m2m.column_b_name();
         let model_a_id = model_a.primary_key().unwrap().fields().next().unwrap();
         let model_b_id = model_b.primary_key().unwrap().fields().next().unwrap();
 

--- a/psl/parser-database/src/walkers/relation.rs
+++ b/psl/parser-database/src/walkers/relation.rs
@@ -2,7 +2,7 @@ mod implicit_many_to_many;
 mod inline;
 mod two_way_embedded_many_to_many;
 
-pub use implicit_many_to_many::ImplicitManyToManyRelationWalker;
+pub use implicit_many_to_many::{ImplicitManyToManyRelationTableName, ImplicitManyToManyRelationWalker};
 pub use inline::{CompleteInlineRelationWalker, InlineRelationWalker};
 pub use two_way_embedded_many_to_many::TwoWayEmbeddedManyToManyRelationWalker;
 

--- a/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
+++ b/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use crate::{
     relations::{ManyToManyRelationId, Relation, RelationAttributes},
     walkers::{ModelWalker, RelationFieldWalker, RelationName, RelationWalker, Walker},
@@ -53,5 +55,30 @@ impl<'db> ImplicitManyToManyRelationWalker<'db> {
     /// The name of the relation.
     pub fn relation_name(self) -> RelationName<'db> {
         self.field_a().relation_name()
+    }
+
+    /// The name of the column pointing to model A in the implicit join table.
+    pub fn column_a_name(self) -> &'static str {
+        "A"
+    }
+
+    /// The name of the column pointing to model B in the implicit join table.
+    pub fn column_b_name(self) -> &'static str {
+        "B"
+    }
+
+    /// A representation of the table/collection implicit in this relation.
+    pub fn table_name(self) -> ImplicitManyToManyRelationTableName<'db> {
+        ImplicitManyToManyRelationTableName(self.relation_name())
+    }
+}
+
+/// A table name for an implicit relation's join table. Useful for its Display impl.
+pub struct ImplicitManyToManyRelationTableName<'db>(RelationName<'db>);
+
+impl Display for ImplicitManyToManyRelationTableName<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("_")?;
+        Display::fmt(&self.0, f)
     }
 }


### PR DESCRIPTION
Before this commit, the PSL walkers only know about implicit many-to-many relations as relations, they do not have any opinion on how they are implemented. sql-query-connector, sql-introspection-connector and sql-query-connector then reimplement the same conventions around the join tables for these relations (their name and the columns they contain).

Starting with this commit, that information is baked in the walker, so we don't have keep names in sync between different parts of engines.