### PR TITLE
qe: fail early with a helpful message when test setup fails

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -36,7 +36,7 @@ pub type TestResult<T> = Result<T, TestError>;
 
 lazy_static! {
     /// Test configuration, loaded once at runtime.
-    pub static ref CONFIG: TestConfig = TestConfig::load().unwrap();
+    pub static ref CONFIG: TestConfig = TestConfig::load();
 
     /// The log level from the environment.
     pub static ref ENV_LOG_LEVEL: String = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_owned());


### PR DESCRIPTION
This is similar to what the migration/introspection engine test setup
does. Instead of letting all 11.000 tests run and fail with a cryptic
message (except for 1 of them, if you look hard enough), we fail
directly with a message explaining what happened and what steps to take.

Part of https://github.com/prisma/client-planning/issues/271

See the samples below for comparison. The `BEFORE` sample is truncated.

---- BEFORE ----

.... many lines finishing with ...FAILED.

```
test writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::upsert_multi_field_uniq ... FAILED
test writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::update_multi_field_uniq ... FAILED
test writes::uniques_and_node_selectors::non_embedded_setting_node_selector_to_null::non_embedded_node_sel_to_null::where_val_to_null ... FAILED
test writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_same_field_diff_models ... FAILED
test writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_1_multi_rel ... FAILED
test writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_m_multi_rel ... FAILED
test writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_connect_one2one_rel ... FAILED
test writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_1_single_rel ... FAILED
test writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_m_single_rel ... FAILED
test writes::uniques_and_node_selectors::setting_node_selector_to_null::node_sel_to_null::where_val_to_null ... FAILED

failures:

---- writes::unchecked_writes::unchecked_create::unchecked_create::allow_write_autoinc_ids_cockroachdb stdout ----
thread 'writes::unchecked_writes::unchecked_create::unchecked_create::allow_write_autoinc_ids_cockroachdb' panicked at 'called `Result::unwrap()` on an `Err` value: ConfigError("Unable to load config from file or env.")', query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs:39:60
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- writes::unchecked_writes::unchecked_create::unchecked_create::allow_write_autoinc_ids stdout ----
thread 'writes::unchecked_writes::unchecked_create::unchecked_create::allow_write_autoinc_ids' panicked at 'Once instance has previously been poisoned', /home/tom/.cache/cargo/registry/src/github.com-1ecc6299db9ec823/lazy_static-1.4.0/src/inline_lazy.rs:30:16

---- writes::unchecked_writes::unchecked_nested_create::unchecked_nested_create::allow_write_non_parent stdout ----
thread 'writes::unchecked_writes::unchecked_nested_create::unchecked_nested_create::allow_write_non_parent' panicked at 'Once instance has previously been poisoned', /home/tom/.cache/cargo/registry/src/github.com-1ecc6299db9ec823/lazy_static-1.4.0/src/inline_lazy.rs:30:16

---- writes::unchecked_writes::unchecked_create::unchecked_create::honor_defaults_make_req_rel_sclrs_opt stdout ----
thread 'writes::unchecked_writes::unchecked_create::unchecked_create::honor_defaults_make_req_rel_sclrs_opt' panicked at 'Once instance has previously been poisoned', /home/tom/.cache/cargo/registry/src/github.com-1ecc6299db9ec823/lazy_static-1.4.0/src/inline_lazy.rs:30:16
```

..... Insert 11 000 lines of failed tests here .....

```
    writes::unchecked_writes::unchecked_update_spec::unchecked_update::allow_write_autoinc_ids_cockroachdb
    writes::unchecked_writes::unchecked_update_spec::unchecked_update::allow_write_non_inline_rels
    writes::unchecked_writes::unchecked_update_spec::unchecked_update::allow_write_non_prent_inline_rel_sclrs
    writes::unchecked_writes::unchecked_update_spec::unchecked_update::disallow_write_inline_rels
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::delete_multi_field_uniq
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_connect_one2m_rel
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_connect_one2one_rel
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_delete_multi_field_uniq
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_disconnect_multi_field_uniq
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_set_multi_field_uniq
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_update_multi_uniq_field
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::nested_upsert_multi_field_uniq
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::update_multi_field_uniq
    writes::uniques_and_node_selectors::multi_field_uniq_mutation::multi_field_uniq_mut::upsert_multi_field_uniq
    writes::uniques_and_node_selectors::non_embedded_setting_node_selector_to_null::non_embedded_node_sel_to_null::where_val_to_null
    writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_same_field_diff_models
    writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_1_multi_rel
    writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_1_single_rel
    writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_m_multi_rel
    writes::uniques_and_node_selectors::relation_uniques::compound_uniq_rel_field::compound_uniq_rel_field::compound_uniq_with_1_m_single_rel
    writes::uniques_and_node_selectors::setting_node_selector_to_null::node_sel_to_null::where_val_to_null

test result: FAILED. 0 passed; 11591 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.39s

error: test failed, to rerun pass `--test query_engine_tests`
prisma-desktop.tom.prisma-engines/query-engine/connector-test-kit-rs/query-engine-tests λ
```

--- AFTER ---

(emojis truncated by github UI)

```
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/query_engine_tests.rs (/home/tom/src/gh/prisma-engines/target/debug/deps/query_engine_tests-c87e92821019e117)

running 40 tests

=============================================
red_circle Unable to load config from file or env. red_circle
=============================================

information_source  How do I fix this? information_source

Test config can come from the environment, or a config file.

recycle  Environment

Set the following env vars:

- TEST_RUNNER
- TEST_CONNECTOR
- TEST_CONNECTOR_VERSION (optional)

file_folder Config file

Use the Makefile.

error: test failed, to rerun pass `--test query_engine_tests`
```