### PR TITLE
feat(schema): accept createMany object shorthand

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
@@ -52,6 +52,31 @@ mod nested_create_many {
         Ok(())
     }
 
+    // "A basic createMany on a create top level" should "work"
+    // TODO: Figure out why this doesn't work
+    #[connector_test(exclude(Sqlite))]
+    async fn create_many_shorthand_on_create(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+                createOneModelA(data: {
+                  id: 1,
+                  bs: {
+                    createMany: {
+                      data: { id: 1, str1: "1", str2: "1", str3: "1"}
+                    }
+                  }
+                }) {
+                  bs {
+                    id
+                  }
+                }
+              }"#),
+          @r###"{"data":{"createOneModelA":{"bs":[{"id":1}]}}}"###
+        );
+
+        Ok(())
+    }
+
     // "Nested createMany" should "error on duplicates by default"
     // TODO(dom): Not working for mongo
     #[connector_test(exclude(Sqlite, MongoDb))]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
@@ -53,7 +53,6 @@ mod nested_create_many {
     }
 
     // "A basic createMany on a create top level" should "work"
-    // TODO: Figure out why this doesn't work
     #[connector_test(exclude(Sqlite))]
     async fn create_many_shorthand_on_create(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -36,6 +36,20 @@ mod create_many {
         Ok(())
     }
 
+    #[connector_test(schema(schema_1))]
+    async fn basic_create_many_shorthand(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            createManyTest(data: { id: 1, str1: "1", str2: "1", str3: "1"}) {
+              count
+            }
+          }"#),
+          @r###"{"data":{"createManyTest":{"count":1}}}"###
+        );
+
+        Ok(())
+    }
+
     fn schema_2() -> String {
         let schema = indoc! {
             r#"model Test {

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -67,7 +67,7 @@ pub fn create_many_records(
     graph.flag_transactional();
 
     let data_list: ParsedInputList = match field.arguments.lookup(args::DATA) {
-        Some(data) => data.value.try_into()?,
+        Some(data) => utils::coerce_vec(data.value),
         None => vec![],
     };
 

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -427,7 +427,7 @@ pub fn nested_create_many(
     // Nested input is an object of { data: [...], skipDuplicates: bool }
     let mut obj: ParsedInputMap = value.try_into()?;
 
-    let data_list: ParsedInputList = obj.remove(args::DATA).unwrap().try_into()?;
+    let data_list: ParsedInputList = utils::coerce_vec(obj.remove(args::DATA).unwrap());
     let skip_duplicates: bool = match obj.remove(args::SKIP_DUPLICATES) {
         Some(val) => val.try_into()?,
         None => false,

--- a/query-engine/schema-builder/src/input_types/fields/input_fields.rs
+++ b/query-engine/schema-builder/src/input_types/fields/input_fields.rs
@@ -44,7 +44,8 @@ pub(crate) fn nested_create_many_input_field(
         && !parent_field.relation().is_many_to_many()
     {
         let envelope = nested_create_many_envelope(ctx, parent_field);
-        Some(input_field("createMany", InputType::object(envelope), None).optional())
+
+        Some(input_field(operations::CREATE_MANY, InputType::object(envelope), None).optional())
     } else {
         None
     }
@@ -63,7 +64,7 @@ fn nested_create_many_envelope(ctx: &mut BuilderContext, parent_field: &Relation
     ctx.cache_input_type(ident, input_object.clone());
 
     let create_many_type = InputType::object(create_type);
-    let data_arg = input_field("data", InputType::list(create_many_type), None);
+    let data_arg = input_field(args::DATA, list_union_type(create_many_type, true), None);
 
     let fields = if ctx.has_capability(ConnectorCapability::CreateSkipDuplicates) {
         let skip_arg = input_field(args::SKIP_DUPLICATES, InputType::boolean(), None).optional();

--- a/query-engine/schema-builder/src/input_types/mod.rs
+++ b/query-engine/schema-builder/src/input_types/mod.rs
@@ -37,14 +37,14 @@ fn map_scalar_input_type(ctx: &mut BuilderContext, typ: &TypeIdentifier, list: b
 
 /// Convenience function to return [object_type, list_object_type]
 /// (shorthand + full type) if the field is a list.
-fn list_union_object_type(input: InputObjectTypeWeakRef, as_list: bool) -> Vec<InputType> {
+pub(crate) fn list_union_object_type(input: InputObjectTypeWeakRef, as_list: bool) -> Vec<InputType> {
     let input_type = InputType::object(input);
     list_union_type(input_type, as_list)
 }
 
 /// Convenience function to return [input_type, list_input_type]
 /// (shorthand + full type) if the field is a list.
-fn list_union_type(input_type: InputType, as_list: bool) -> Vec<InputType> {
+pub(crate) fn list_union_type(input_type: InputType, as_list: bool) -> Vec<InputType> {
     if as_list {
         vec![input_type.clone(), InputType::list(input_type)]
     } else {

--- a/query-engine/schema-builder/src/mutations/create_many.rs
+++ b/query-engine/schema-builder/src/mutations/create_many.rs
@@ -4,7 +4,10 @@ use crate::{
     capitalize,
     constants::args,
     field, init_input_object_type, input_field,
-    input_types::fields::data_input_mapper::{CreateDataInputFieldMapper, DataInputFieldMapper},
+    input_types::{
+        fields::data_input_mapper::{CreateDataInputFieldMapper, DataInputFieldMapper},
+        list_union_type,
+    },
     output_types::objects,
     BuilderContext, ModelField,
 };
@@ -38,7 +41,7 @@ pub(crate) fn create_many(ctx: &mut BuilderContext, model: &ModelRef) -> Option<
 /// Builds "skip_duplicates" and "data" arguments intended for the create many field.
 pub(crate) fn create_many_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<InputField> {
     let create_many_type = InputType::object(create_many_object_type(ctx, model, None));
-    let data_arg = input_field("data", InputType::list(create_many_type), None);
+    let data_arg = input_field(args::DATA, list_union_type(create_many_type, true), None);
 
     if ctx.has_capability(ConnectorCapability::CreateSkipDuplicates) {
         let skip_arg = input_field(args::SKIP_DUPLICATES, InputType::boolean(), None).optional();


### PR DESCRIPTION
## Overview

part of [📡 JSON Protocol#237](https://github.com/prisma/client-planning/issues/237)

This PR is part of the JSON protocol work. It allows object shorthand for the `createMany` operation (top-level & nested). This is required because the client used to coerce objects as lists when the schema only allowed lists.

After the client gets schema-less with the JSON protocol, it won't be able to do so anymore. This is the only occurrence we could find of an operation that only accepted a list although the client supported the shorthand notation.

## Schema changes

As explained above, what this PR does is allow a single object to be passed to `createMany` operations. Concretely, the QE now supports the following queries:

```graphql
mutation {
  createManyTest(data: { id: 1 }) { // before: data: [{ id: 1 }]
    count
  }
}

mutation {
  createOneTest(data: {
    id: 1,
    nested: {
      createMany: { data: { id: 1 } } // before: data: [{ id: 1 }]
    }
}) {
    id
  }
}
```