### PR TITLE
feat(schema): allow composite list equal shorthand

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
@@ -19,7 +19,7 @@ mod to_many {
           @r###"{"data":{"findManyTestModel":[{"id":5}]}}"###
         );
 
-        // Implicit
+        // Implicit equal
         insta::assert_snapshot!(
           run_query!(runner, r#"{
                     findManyTestModel(where: {
@@ -29,6 +29,18 @@ mod to_many {
                     }
                 }"#),
           @r###"{"data":{"findManyTestModel":[{"id":5}]}}"###
+        );
+
+        // Implicit equal shorthand (equivalent to the one above)
+        insta::assert_snapshot!(
+            run_query!(runner, r#"{
+                    findManyTestModel(where: {
+                        to_many_as: { a_1: "Test", a_2: 0 }
+                    }) {
+                        id
+                    }
+                }"#),
+            @r###"{"data":{"findManyTestModel":[{"id":5}]}}"###
         );
 
         insta::assert_snapshot!(

--- a/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
@@ -27,6 +27,8 @@ pub(crate) fn get_field_filter_types(
         ModelField::Composite(cf) if cf.is_list() => vec![
             InputType::object(to_many_composite_filter_object(ctx, cf)),
             InputType::list(to_one_composite_filter_shorthand_types(ctx, cf)),
+            // Shorthand syntax - This is only supported because the client used to expose all
+            // list input types as T | T[]. Consider removing it one day.
             to_one_composite_filter_shorthand_types(ctx, cf),
         ],
 

--- a/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
@@ -27,6 +27,7 @@ pub(crate) fn get_field_filter_types(
         ModelField::Composite(cf) if cf.is_list() => vec![
             InputType::object(to_many_composite_filter_object(ctx, cf)),
             InputType::list(to_one_composite_filter_shorthand_types(ctx, cf)),
+            to_one_composite_filter_shorthand_types(ctx, cf),
         ],
 
         ModelField::Composite(cf) => vec![


### PR DESCRIPTION
## Overview

part of [📡 JSON Protocol#237](https://github.com/prisma/client-planning/issues/237)

This PR is part of the JSON protocol work. It allows an object shorthand for the `equal` filter on list composites. This is required because the client used to coerce objects as lists when the schema only allowed lists.

After the client gets schema-less with the JSON protocol, it won't be able to do so anymore.

In this case, the client shouldn't have allowed this syntax at all but it's there now so we need to support it.

We might review that and break it in Prisma 5.