### PR TITLE
feat(schema): allow nested composite list equal shorthand

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
@@ -232,23 +232,25 @@ mod to_many {
     }
 
     // No object coercion
-    #[connector_test]
-    async fn single_object(runner: Runner) -> TestResult<()> {
-        create_to_many_test_data(&runner).await?;
+    // TODO: This test is ignored because the JSON protocol required to enable the object syntax for equality on composite lists.
+    // TODO: It should be enabled again once we remove the object shorthand syntaxes.
+    // #[connector_test]
+    // async fn single_object(runner: Runner) -> TestResult<()> {
+    //     create_to_many_test_data(&runner).await?;
 
-        assert_error!(
-            runner,
-            r#"{
-                findManyTestModel(where: { to_many_as: { equals: { a_1: "Test", a_2: 0 } }}) {
-                    id
-                }
-            }"#,
-            2009,
-            "`Query.findManyTestModel.where.TestModelWhereInput.to_many_as.CompositeACompositeListFilter.equals`: Value types mismatch. Have: Object({\"a_1\": Scalar(String(\"Test\")), \"a_2\": Scalar(Int(0))}), want: Object(CompositeAObjectEqualityInput)"
-        );
+    //     assert_error!(
+    //         runner,
+    //         r#"{
+    //             findManyTestModel(where: { to_many_as: { equals: { a_1: "Test", a_2: 0 } }}) {
+    //                 id
+    //             }
+    //         }"#,
+    //         2009,
+    //         "`Query.findManyTestModel.where.TestModelWhereInput.to_many_as.CompositeACompositeListFilter.equals`: Value types mismatch. Have: Object({\"a_1\": Scalar(String(\"Test\")), \"a_2\": Scalar(Int(0))}), want: Object(CompositeAObjectEqualityInput)"
+    //     );
 
-        Ok(())
-    }
+    //     Ok(())
+    // }
 
     fn deep_equality_schema() -> String {
         let schema = indoc! {

--- a/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
@@ -27,7 +27,7 @@ pub(crate) fn get_field_filter_types(
         ModelField::Composite(cf) if cf.is_list() => vec![
             InputType::object(to_many_composite_filter_object(ctx, cf)),
             InputType::list(to_one_composite_filter_shorthand_types(ctx, cf)),
-            // Shorthand syntax - This is only supported because the client used to expose all
+            // The object (aka shorthand) syntax is only supported because the client used to expose all
             // list input types as T | T[]. Consider removing it one day.
             to_one_composite_filter_shorthand_types(ctx, cf),
         ],
@@ -188,7 +188,9 @@ fn to_many_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeField
     let mut fields = vec![
         input_field(
             filters::EQUALS,
-            InputType::list(InputType::object(composite_equals_object)),
+            // The object (aka shorthand) syntax is only supported because the client used to expose all
+            // list input types as T | T[]. Consider removing it one day.
+            list_union_type(InputType::object(composite_equals_object), true),
             None,
         )
         .optional(),

--- a/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
@@ -254,13 +254,13 @@ pub(crate) fn composite_equality_object(ctx: &mut BuilderContext, cf: &Composite
             .nullable_if(!sf.is_required() && !sf.is_list()),
 
         ModelField::Composite(cf) => {
-            let mut types = vec![];
-
-            if cf.is_list() {
-                types.push(InputType::list(InputType::object(composite_equality_object(ctx, cf))));
+            let types = if cf.is_list() {
+                // The object (aka shorthand) syntax is only supported because the client used to expose all
+                // list input types as T | T[]. Consider removing it one day.
+                list_union_type(InputType::object(composite_equality_object(ctx, cf)), true)
             } else {
-                types.push(InputType::object(composite_equality_object(ctx, cf)));
-            }
+                vec![InputType::object(composite_equality_object(ctx, cf))]
+            };
 
             input_field(cf.name.clone(), types, None)
                 .optional_if(!cf.is_required())


### PR DESCRIPTION
## Overview

part of [📡 JSON Protocol#237](https://github.com/prisma/client-planning/issues/237)

This PR is part of the JSON protocol work. It allows an object shorthand for the nested `equal` filters on list composites. This is required because the client used to coerce objects as lists when the schema only allowed lists.

After the client gets schema-less with the JSON protocol, it won't be able to do so anymore.

In this case, the client shouldn't have allowed this syntax at all but it's there now so we need to support it.

We might review that and break it in Prisma 5.