### PR TITLE
psl: use generic Walker struct for RelationFieldWalker

### DIFF
--- a/psl/parser-database/src/types.rs
+++ b/psl/parser-database/src/types.rs
@@ -1336,3 +1336,14 @@ impl ScalarType {
         }
     }
 }
+
+/// An opaque identifier for a model relation field in a schema.
+#[derive(Copy, Clone, PartialEq, Debug, Hash, Eq)]
+pub struct RelationFieldId(pub(crate) ast::ModelId, pub(crate) ast::FieldId);
+
+impl RelationFieldId {
+    /// Coarsen the relation field identifier to a generic field identifier.
+    pub fn coarsen(self) -> (ast::ModelId, ast::FieldId) {
+        (self.0, self.1)
+    }
+}

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -15,6 +15,7 @@ mod relation;
 mod relation_field;
 mod scalar_field;
 
+pub use crate::types::RelationFieldId;
 pub use composite_type::*;
 pub use field::*;
 pub use index::*;

--- a/psl/parser-database/src/walkers/field.rs
+++ b/psl/parser-database/src/walkers/field.rs
@@ -27,12 +27,8 @@ impl<'db> FieldWalker<'db> {
             id: (model_id, field_id),
             db,
         } = self;
-        if let Some(relation_field) = &self.db.types.relation_fields.get(&self.id) {
-            RefinedFieldWalker::Relation(RelationFieldWalker {
-                id: super::RelationFieldId(model_id, field_id),
-                db,
-                relation_field,
-            })
+        if self.db.types.relation_fields.contains_key(&self.id) {
+            RefinedFieldWalker::Relation(self.walk(super::RelationFieldId(model_id, field_id)))
         } else if let Some(scalar_field) = self.db.types.scalar_fields.get(&self.id) {
             RefinedFieldWalker::Scalar(ScalarFieldWalker {
                 id: ScalarFieldId(model_id, field_id),

--- a/psl/parser-database/src/walkers/relation.rs
+++ b/psl/parser-database/src/walkers/relation.rs
@@ -26,7 +26,7 @@ impl<'db> RelationWalker<'db> {
         [(relation.model_a, a), (relation.model_b, b)]
             .into_iter()
             .filter_map(|(model_id, field_id)| field_id.map(|f| (model_id, f)))
-            .map(move |(model, field)| self.walk(model).relation_field(field))
+            .map(move |(model, field)| self.walk(RelationFieldId(model, field)))
     }
 
     /// Is any field part of the relation ignored (`@ignore`) or unsupported?

--- a/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
+++ b/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
@@ -33,16 +33,22 @@ impl<'db> ImplicitManyToManyRelationWalker<'db> {
 
     /// The field that defines the relation in model a.
     pub fn field_a(self) -> RelationFieldWalker<'db> {
-        match self.get().attributes {
-            RelationAttributes::ImplicitManyToMany { field_a, field_b: _ } => self.model_a().relation_field(field_a),
+        let rel = self.get();
+        match rel.attributes {
+            RelationAttributes::ImplicitManyToMany { field_a, field_b: _ } => {
+                self.walk(crate::walkers::RelationFieldId(rel.model_a, field_a))
+            }
             _ => unreachable!(),
         }
     }
 
     /// The field that defines the relation in model b.
     pub fn field_b(self) -> RelationFieldWalker<'db> {
-        match self.get().attributes {
-            RelationAttributes::ImplicitManyToMany { field_a: _, field_b } => self.model_b().relation_field(field_b),
+        let rel = self.get();
+        match rel.attributes {
+            RelationAttributes::ImplicitManyToMany { field_a: _, field_b } => {
+                self.walk(crate::walkers::RelationFieldId(rel.model_b, field_b))
+            }
             _ => unreachable!(),
         }
     }

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -27,19 +27,13 @@ impl<'db> CompleteInlineRelationWalker<'db> {
     }
 
     pub fn referencing_field(self) -> RelationFieldWalker<'db> {
-        RelationFieldWalker {
-            id: crate::walkers::RelationFieldId(self.side_a.0, self.side_a.1),
-            db: self.db,
-            relation_field: &self.db.types.relation_fields[&(self.side_a.0, self.side_a.1)],
-        }
+        self.db
+            .walk(crate::walkers::RelationFieldId(self.side_a.0, self.side_a.1))
     }
 
     pub fn referenced_field(self) -> RelationFieldWalker<'db> {
-        RelationFieldWalker {
-            id: crate::walkers::RelationFieldId(self.side_b.0, self.side_b.1),
-            db: self.db,
-            relation_field: &self.db.types.relation_fields[&(self.side_b.0, self.side_b.1)],
-        }
+        self.db
+            .walk(crate::walkers::RelationFieldId(self.side_b.0, self.side_b.1))
     }
 
     /// The scalar fields defining the relation on the referenced model.
@@ -54,7 +48,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
             }
         };
 
-        match self.referencing_field().relation_field.references.as_ref() {
+        match self.referencing_field().attributes().references.as_ref() {
             Some(references) => references.iter().map(f),
             None => [].iter().map(f),
         }
@@ -72,7 +66,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
             }
         };
 
-        match self.referencing_field().relation_field.fields.as_ref() {
+        match self.referencing_field().attributes().fields.as_ref() {
             Some(references) => references.iter().map(f),
             None => [].iter().map(f),
         }

--- a/psl/parser-database/src/walkers/relation/two_way_embedded_many_to_many.rs
+++ b/psl/parser-database/src/walkers/relation/two_way_embedded_many_to_many.rs
@@ -27,9 +27,10 @@ impl<'db> TwoWayEmbeddedManyToManyRelationWalker<'db> {
 
     /// The field that defines the relation in model a.
     pub fn field_a(self) -> RelationFieldWalker<'db> {
-        match self.get().attributes {
+        let rel = self.get();
+        match rel.attributes {
             RelationAttributes::TwoWayEmbeddedManyToMany { field_a, field_b: _ } => {
-                self.model_a().relation_field(field_a)
+                self.0.walk(crate::walkers::RelationFieldId(rel.model_a, field_a))
             }
             _ => unreachable!(),
         }
@@ -37,10 +38,12 @@ impl<'db> TwoWayEmbeddedManyToManyRelationWalker<'db> {
 
     /// The field that defines the relation in model b.
     pub fn field_b(self) -> RelationFieldWalker<'db> {
-        match self.get().attributes {
+        let rel = self.get();
+        match rel.attributes {
             RelationAttributes::TwoWayEmbeddedManyToMany { field_a: _, field_b } => {
-                self.model_b().relation_field(field_b)
+                self.0.walk(crate::walkers::RelationFieldId(rel.model_b, field_b))
             }
+
             _ => unreachable!(),
         }
     }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/names.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/names.rs
@@ -1,6 +1,6 @@
 use super::constraint_namespace::ConstraintNamespace;
-use crate::ast::{FieldId, ModelId};
-use parser_database::walkers::RelationName;
+use crate::ast::ModelId;
+use parser_database::walkers::{RelationFieldId, RelationName};
 use std::collections::{HashMap, HashSet};
 
 type RelationIdentifier<'db> = (ModelId, ModelId, RelationName<'db>);
@@ -13,7 +13,7 @@ pub(super) enum NameTaken {
 }
 
 pub(super) struct Names<'db> {
-    pub(super) relation_names: HashMap<RelationIdentifier<'db>, Vec<FieldId>>,
+    pub(super) relation_names: HashMap<RelationIdentifier<'db>, Vec<RelationFieldId>>,
     index_names: HashSet<(ModelId, &'db str)>,
     unique_names: HashSet<(ModelId, &'db str)>,
     primary_key_names: HashMap<ModelId, &'db str>,
@@ -22,7 +22,7 @@ pub(super) struct Names<'db> {
 
 impl<'db> Names<'db> {
     pub(super) fn new(ctx: &super::Context<'db>) -> Self {
-        let mut relation_names: HashMap<RelationIdentifier<'db>, Vec<FieldId>> = HashMap::new();
+        let mut relation_names: HashMap<RelationIdentifier<'db>, Vec<RelationFieldId>> = HashMap::new();
         let mut index_names: HashSet<(ModelId, &'db str)> = HashSet::new();
         let mut unique_names: HashSet<(ModelId, &'db str)> = HashSet::new();
         let mut primary_key_names: HashMap<ModelId, &'db str> = HashMap::new();
@@ -37,7 +37,7 @@ impl<'db> Names<'db> {
                 let identifier = (model_id, related_model_id, field.relation_name());
                 let field_ids = relation_names.entry(identifier).or_default();
 
-                field_ids.push(field.field_id());
+                field_ids.push(field.id);
             }
 
             for index in model.indexes() {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -9,18 +9,18 @@ use diagnostics::DatamodelWarning;
 use enumflags2::BitFlags;
 use itertools::Itertools;
 use parser_database::{
-    walkers::{ModelWalker, RelationFieldWalker, RelationName},
+    walkers::{ModelWalker, RelationFieldId, RelationFieldWalker, RelationName},
     ReferentialAction,
 };
 use std::fmt;
 
 struct Fields<'db> {
-    fields: &'db [ast::FieldId],
+    fields: &'db [RelationFieldId],
     model: ModelWalker<'db>,
 }
 
 impl<'db> Fields<'db> {
-    fn new(fields: &'db [ast::FieldId], model: ModelWalker<'db>) -> Self {
+    fn new(fields: &'db [RelationFieldId], model: ModelWalker<'db>) -> Self {
         Self { fields, model }
     }
 }
@@ -30,7 +30,7 @@ impl<'db> fmt::Display for Fields<'db> {
         let mut fields = self
             .fields
             .iter()
-            .map(|field_id| self.model.relation_field(*field_id).name())
+            .map(|field_id| self.model.walk(*field_id).name())
             .map(|name| format!("`{name}`"));
 
         match fields.len() {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations.rs
@@ -10,10 +10,11 @@ use crate::{diagnostics::DatamodelError, validate::validation_pipeline::context:
 use diagnostics::DatamodelWarning;
 use indoc::formatdoc;
 use itertools::Itertools;
+use parser_database::walkers::RelationFieldId;
 use parser_database::ReferentialAction;
 use parser_database::{
     ast::WithSpan,
-    walkers::{CompleteInlineRelationWalker, InlineRelationWalker, RelationFieldWalker},
+    walkers::{CompleteInlineRelationWalker, InlineRelationWalker},
     ScalarFieldType,
 };
 use std::{
@@ -239,7 +240,7 @@ pub(super) fn cycles(relation: CompleteInlineRelationWalker<'_>, ctx: &mut Conte
     let parent_model = relation.referencing_model();
 
     while let Some((next_relation, visited_relations)) = next_relations.pop() {
-        visited.insert(next_relation.referencing_field());
+        visited.insert(next_relation.referencing_field().id);
 
         let related_model = next_relation.referenced_model();
 
@@ -279,7 +280,7 @@ pub(super) fn cycles(relation: CompleteInlineRelationWalker<'_>, ctx: &mut Conte
 
             let relations = related_model
                 .complete_inline_relations_from()
-                .filter(|r| !visited.contains(&r.referencing_field()));
+                .filter(|r| !visited.contains(&r.referencing_field().id));
 
             for relation in relations {
                 next_relations.push((relation, Rc::new(visited_relations.link_next(relation))));
@@ -338,7 +339,7 @@ pub(super) fn multiple_cascading_paths(relation: CompleteInlineRelationWalker<'_
             (
                 relation,
                 Rc::new(VisitedRelation::root(relation)),
-                HashSet::<RelationFieldWalker<'_>>::new(),
+                HashSet::<RelationFieldId>::new(),
             )
         })
         .collect();
@@ -347,7 +348,7 @@ pub(super) fn multiple_cascading_paths(relation: CompleteInlineRelationWalker<'_
         let model = next_relation.referencing_model();
         let related_model = next_relation.referenced_model();
 
-        current_path.insert(next_relation.referencing_field());
+        current_path.insert(next_relation.referencing_field().id);
 
         // Self-relations are detected elsewhere.
         if model.id == related_model.id {
@@ -362,7 +363,7 @@ pub(super) fn multiple_cascading_paths(relation: CompleteInlineRelationWalker<'_
         let mut forward_relations = related_model
             .complete_inline_relations_from()
             .filter(triggers_modifications)
-            .filter(|relation| !current_path.contains(&relation.referencing_field()))
+            .filter(|relation| !current_path.contains(&relation.referencing_field().id))
             .map(|relation| {
                 (
                     relation,

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -40,8 +40,7 @@ fn model_field_builders(model: &dml::Model, schema: &psl::ValidatedSchema) -> Ve
                 default_value: cf.default_value.clone(),
             })),
             dml::Field::RelationField(rf) => {
-                let (model_id, field_id) = rf.id.coarsen();
-                let walker = schema.db.walk(model_id).relation_field(field_id);
+                let walker = schema.db.walk(rf.id);
                 let relation = walker.relation();
 
                 if relation.is_ignored() {

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -112,13 +112,8 @@ impl RelationField {
     }
 
     pub fn relation(&self) -> RelationRef {
-        let (model_id, field_id) = self.id.coarsen();
         let internal_data_model = self.model().internal_data_model();
-        let relation_id = internal_data_model
-            .walk(model_id)
-            .relation_field(field_id)
-            .relation()
-            .id;
+        let relation_id = internal_data_model.walk(self.id).relation().id;
         internal_data_model.zip(relation_id)
     }
 


### PR DESCRIPTION
This makes them easier to construct and less surprising, at the cost of different performance characteristics (possibly more lookups in the Types::relation_fields tree).