### PR TITLE
Datasource Spans & Completions

### DIFF
--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -219,7 +219,7 @@ mod tests {
                 "DBURL": "postgresql://example.com/mydb",
             }
         });
-        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                \u001b[1;91mdirectUrl = \"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
+        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
@@ -240,7 +240,7 @@ mod tests {
                 "DBURL": "postgresql://example.com/mydb",
             }
         });
-        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                \u001b[1;91mdirectUrl = env(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
+        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
@@ -262,7 +262,7 @@ mod tests {
                 "DOES_NOT_EXIST": "",
             }
         });
-        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                \u001b[1;91mdirectUrl = env(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
+        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }

--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -219,9 +219,7 @@ mod tests {
                 "DBURL": "postgresql://example.com/mydb",
             }
         });
-        let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
-        ]];
+        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                \u001b[1;91mdirectUrl = \"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
@@ -242,9 +240,7 @@ mod tests {
                 "DBURL": "postgresql://example.com/mydb",
             }
         });
-        let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
-        ]];
+        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                \u001b[1;91mdirectUrl = env(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
@@ -266,9 +262,7 @@ mod tests {
                 "DOES_NOT_EXIST": "",
             }
         });
-        let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
-        ]];
+        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                \u001b[1;91mdirectUrl = env(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }

--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -219,7 +219,9 @@ mod tests {
                 "DBURL": "postgresql://example.com/mydb",
             }
         });
-        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
+        let expected = expect![[
+            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+        ]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
@@ -240,7 +242,9 @@ mod tests {
                 "DBURL": "postgresql://example.com/mydb",
             }
         });
-        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
+        let expected = expect![[
+            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+        ]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
@@ -262,7 +266,9 @@ mod tests {
                 "DOES_NOT_EXIST": "",
             }
         });
-        let expected = expect![[r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#]];
+        let expected = expect![[
+            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+        ]];
         let response = get_config(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }

--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -106,7 +106,7 @@ mod tests {
         });
 
         let expected = expect![[
-            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m 7 | \u001b[0m          }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
         ]];
         let response = get_dmmf(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -188,23 +188,25 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
 }
 
 fn ds_has_prop(ctx: CompletionContext<'_>, prop: &str) -> bool {
-    let Some(ds) = ctx.datasource() else { return false };
+    if let Some(ds) = ctx.datasource() {
+        match prop {
+            "schemas" => ds.schemas_span.is_some(),
+            "relationMode" => ds.relation_mode.is_some(),
+            "directurl" => ds.direct_url.is_some(),
+            "shadowDatabaseUrl" => ds.shadow_database_url.is_some(),
+            "url" => ds.url_span.end > ds.url_span.start,
+            "provider" => !ds.provider.is_empty(),
+            "extensions" => {
+                if let Some(connector_data) = ds.connector_data.downcast_ref::<PostgresDatasourceProperties>() {
+                    return connector_data.extensions().is_some();
+                }
 
-    match prop {
-        "schemas" => ds.schemas_span.is_some(),
-        "relationMode" => ds.relation_mode.is_some(),
-        "directurl" => ds.direct_url.is_some(),
-        "shadowDatabaseUrl" => ds.shadow_database_url.is_some(),
-        "url" => ds.url_span.end > ds.url_span.start,
-        "provider" => !ds.provider.is_empty(),
-        "extensions" => {
-            if let Some(connector_data) = ds.connector_data.downcast_ref::<PostgresDatasourceProperties>() {
-                return connector_data.extensions().is_some();
+                false
             }
-
-            false
+            _ => false,
         }
-        _ => false,
+    } else {
+        false
     }
 }
 

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -190,15 +190,15 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
 fn ds_has_prop(ctx: CompletionContext<'_>, prop: &str) -> bool {
     if let Some(ds) = ctx.datasource() {
         match prop {
-            "schemas" => ds.schemas_span.is_some(),
-            "relationMode" => ds.relation_mode.is_some(),
-            "directurl" => ds.direct_url.is_some(),
-            "shadowDatabaseUrl" => ds.shadow_database_url.is_some(),
-            "url" => ds.url_span.end > ds.url_span.start,
-            "provider" => !ds.provider.is_empty(),
+            "schemas" => ds.schemas_defined(),
+            "relationMode" => ds.relation_mode_defined(),
+            "directurl" => ds.direct_url_defined(),
+            "shadowDatabaseUrl" => ds.shadow_url_defined(),
+            "url" => ds.url_defined(),
+            "provider" => !ds.provider_defined(),
             "extensions" => {
                 if let Some(connector_data) = ds.connector_data.downcast_ref::<PostgresDatasourceProperties>() {
-                    return connector_data.extensions().is_some();
+                    return connector_data.extensions_defined();
                 }
 
                 false

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -136,6 +136,12 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
             {
                 datasource::schemas_completion(completion_list);
             }
+
+            if ctx.connector().provider_name() == "postgresql"
+                && ctx.preview_features().contains(PreviewFeature::PostgresqlExtensions)
+            {
+                datasource::extensions_completion(completion_list);
+            }
         }
 
         ast::SchemaPosition::DataSource(

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -138,6 +138,13 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
             }
         }
 
+        ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("url", _))
+        | ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("directUrl", _))
+        | ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("shadowDatabaseUrl", _)) => {
+            datasource::url_env_completion(completion_list);
+            datasource::url_quotes_completion(completion_list);
+        }
+
         position => ctx.connector().push_completions(ctx.db, position, completion_list),
     }
 }
@@ -185,6 +192,10 @@ fn is_inside_quote(position: &lsp_types::Position, schema: &str) -> bool {
     }
 }
 
-fn generate_pretty_doc(example: &str, description: &str) -> String {
+fn generate_pretty_doc(
+    example: &str,
+    description: &str,
+    // params: Option<HashMap<String, String>>
+) -> String {
     format!("```prisma\n{example}\n```\n___\n{description}")
 }

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -138,6 +138,21 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
             }
         }
 
+        ast::SchemaPosition::DataSource(
+            _source_id,
+            ast::SourcePosition::Property("url", ast::PropertyPosition::FunctionValue("env")),
+        ) => datasource::url_env_db_completion(completion_list, "url"),
+
+        ast::SchemaPosition::DataSource(
+            _source_id,
+            ast::SourcePosition::Property("directUrl", ast::PropertyPosition::FunctionValue("env")),
+        ) => datasource::url_env_db_completion(completion_list, "directUrl"),
+
+        ast::SchemaPosition::DataSource(
+            _source_id,
+            ast::SourcePosition::Property("shadowDatabaseUrl", ast::PropertyPosition::FunctionValue("env")),
+        ) => datasource::url_env_db_completion(completion_list, "shadowDatabaseUrl"),
+
         ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("url", _))
         | ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("directUrl", _))
         | ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("shadowDatabaseUrl", _)) => {

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -169,7 +169,7 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
             datasource::url_quotes_completion(completion_list);
         }
 
-        position => ctx.connector().push_completions(ctx.db, position, completion_list),
+        position => ctx.connector().datamodel_completions(ctx.db, position, completion_list),
     }
 }
 

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -8,7 +8,7 @@ use psl::{
     parser_database::{ast, ParserDatabase, SourceFile},
     Configuration, Datasource, Diagnostics, Generator, PreviewFeature,
 };
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::position_to_offset;
 
@@ -192,10 +192,15 @@ fn is_inside_quote(position: &lsp_types::Position, schema: &str) -> bool {
     }
 }
 
-fn generate_pretty_doc(
-    example: &str,
-    description: &str,
-    // params: Option<HashMap<String, String>>
-) -> String {
-    format!("```prisma\n{example}\n```\n___\n{description}")
+fn generate_pretty_doc(example: &str, description: &str, params: Option<HashMap<&str, &str>>) -> String {
+    let param_docs: String = match params {
+        Some(params) => params
+            .into_iter()
+            .map(|(param_label, param_doc)| format!("_@param_ {param_label} {param_doc}"))
+            .collect::<Vec<String>>()
+            .join("\n"),
+        None => Default::default(),
+    };
+
+    format!("```prisma\n{example}\n```\n___\n{description}\n\n{param_docs}")
 }

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -164,17 +164,17 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
         ast::SchemaPosition::DataSource(
             _source_id,
             ast::SourcePosition::Property("url", ast::PropertyPosition::FunctionValue("env")),
-        ) => datasource::url_env_db_completion(completion_list, "url"),
+        ) => datasource::url_env_db_completion(completion_list, "url", ctx),
 
         ast::SchemaPosition::DataSource(
             _source_id,
             ast::SourcePosition::Property("directUrl", ast::PropertyPosition::FunctionValue("env")),
-        ) => datasource::url_env_db_completion(completion_list, "directUrl"),
+        ) => datasource::url_env_db_completion(completion_list, "directUrl", ctx),
 
         ast::SchemaPosition::DataSource(
             _source_id,
             ast::SourcePosition::Property("shadowDatabaseUrl", ast::PropertyPosition::FunctionValue("env")),
-        ) => datasource::url_env_db_completion(completion_list, "shadowDatabaseUrl"),
+        ) => datasource::url_env_db_completion(completion_list, "shadowDatabaseUrl", ctx),
 
         ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("url", _))
         | ast::SchemaPosition::DataSource(_source_id, ast::SourcePosition::Property("directUrl", _))

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -1,0 +1,108 @@
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionList, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+};
+
+use super::generate_pretty_doc;
+
+pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines schemas".to_owned(),
+        insert_text: Some(r#"schemas = [$0]"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"schemas = ["foo", "bar", "baz"]"#,
+                "The list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)",
+            ),
+        })),
+        // detail: Some("schemas".to_owned()),
+        ..Default::default()
+    });
+}
+
+pub(super) fn relation_mode_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines relationMode".to_owned(),
+        insert_text: Some(r#"relationmode = $0"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"relationMode = "foreignKeys" | "prisma""#,
+                r#"Set the global relation mode for all relations. Values can be either "foreignKeys" (Default), or "prisma". [Learn more](https://pris.ly/d/relation-mode)"#
+            ),
+        })),
+        ..Default::default()
+    })
+}
+
+pub(super) fn direct_url_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines directUrl".to_owned(),
+        insert_text: Some(r#"directUrl = $0"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"directUrl = "String" | env("ENVIRONMENT_VARIABLE")"#,
+                r#"Connection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."#
+            )
+        })),
+        ..Default::default()
+    })
+}
+
+pub(super) fn shadow_db_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines shadowDatabaseUrl".to_owned(),
+        insert_text: Some(r#"shadowDatabaseUrl = $0"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"shadowDatabaseUrl = "String" | env("ENVIRONMENT_VARIABLE")"#,
+                r#"Connection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."#,
+            ),
+        })),
+        ..Default::default()
+    })
+}
+
+pub(super) fn url_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines url".to_owned(),
+        insert_text: Some(r#"url = $0"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"url = "String" | env("ENVIRONMENT_VARIABLE")"#,
+                r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."#,
+            ),
+        })),
+        ..Default::default()
+    })
+}
+
+pub(super) fn provider_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines provider".to_owned(),
+        insert_text: Some(r#"provider = $0"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"provider = "foo""#,
+                r#"Describes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."#,
+            ),
+        })),
+        ..Default::default()
+    })
+}

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -106,3 +106,37 @@ pub(super) fn provider_completion(completion_list: &mut CompletionList) {
         ..Default::default()
     })
 }
+
+pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "engines env".to_owned(),
+        insert_text: Some(r#"env($0)"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::PROPERTY),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"env(_ environmentVariable: string)"#,
+                r#"Specifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.""#
+            ),
+        })),
+        ..Default::default()
+    })
+}
+
+pub(super) fn url_quotes_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: r#"engines """#.to_owned(),
+        insert_text: Some(r#""$0""#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::PROPERTY),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#""connectionString""#,
+                r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."#
+            ),
+        })),
+        ..Default::default()
+    })
+}

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionList, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
 };
@@ -15,6 +17,7 @@ pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
             value: generate_pretty_doc(
                 r#"schemas = ["foo", "bar", "baz"]"#,
                 "The list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)",
+                None,
             ),
         })),
         // detail: Some("schemas".to_owned()),
@@ -32,7 +35,8 @@ pub(super) fn relation_mode_completion(completion_list: &mut CompletionList) {
             kind: MarkupKind::Markdown,
             value: generate_pretty_doc(
                 r#"relationMode = "foreignKeys" | "prisma""#,
-                r#"Set the global relation mode for all relations. Values can be either "foreignKeys" (Default), or "prisma". [Learn more](https://pris.ly/d/relation-mode)"#
+                r#"Set the global relation mode for all relations. Values can be either "foreignKeys" (Default), or "prisma". [Learn more](https://pris.ly/d/relation-mode)"#,
+                None,
             ),
         })),
         ..Default::default()
@@ -49,7 +53,8 @@ pub(super) fn direct_url_completion(completion_list: &mut CompletionList) {
             kind: MarkupKind::Markdown,
             value: generate_pretty_doc(
                 r#"directUrl = "String" | env("ENVIRONMENT_VARIABLE")"#,
-                r#"Connection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."#
+                r#"Connection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."#,
+                None,
             )
         })),
         ..Default::default()
@@ -67,6 +72,7 @@ pub(super) fn shadow_db_completion(completion_list: &mut CompletionList) {
             value: generate_pretty_doc(
                 r#"shadowDatabaseUrl = "String" | env("ENVIRONMENT_VARIABLE")"#,
                 r#"Connection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."#,
+                None,
             ),
         })),
         ..Default::default()
@@ -84,6 +90,7 @@ pub(super) fn url_completion(completion_list: &mut CompletionList) {
             value: generate_pretty_doc(
                 r#"url = "String" | env("ENVIRONMENT_VARIABLE")"#,
                 r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."#,
+                None,
             ),
         })),
         ..Default::default()
@@ -101,6 +108,7 @@ pub(super) fn provider_completion(completion_list: &mut CompletionList) {
             value: generate_pretty_doc(
                 r#"provider = "foo""#,
                 r#"Describes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."#,
+                None,
             ),
         })),
         ..Default::default()
@@ -117,7 +125,11 @@ pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
             kind: MarkupKind::Markdown,
             value: generate_pretty_doc(
                 r#"env(_ environmentVariable: string)"#,
-                r#"Specifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.""#
+                r#"Specifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.""#,
+                Some(HashMap::from([(
+                    "environmentVariable",
+                    "The environment variable in which the database connection URL is stored.",
+                )])),
             ),
         })),
         ..Default::default()
@@ -134,7 +146,8 @@ pub(super) fn url_quotes_completion(completion_list: &mut CompletionList) {
             kind: MarkupKind::Markdown,
             value: generate_pretty_doc(
                 r#""connectionString""#,
-                r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."#
+                r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."#,
+                None,
             ),
         })),
         ..Default::default()

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -8,7 +8,7 @@ use super::generate_pretty_doc;
 
 pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines schemas".to_owned(),
+        label: "schemas".to_owned(),
         insert_text: Some(r#"schemas = [$0]"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::FIELD),
@@ -27,7 +27,7 @@ pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn relation_mode_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines relationMode".to_owned(),
+        label: "relationMode".to_owned(),
         insert_text: Some(r#"relationmode = $0"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::FIELD),
@@ -45,7 +45,7 @@ pub(super) fn relation_mode_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn direct_url_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines directUrl".to_owned(),
+        label: "directUrl".to_owned(),
         insert_text: Some(r#"directUrl = $0"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::FIELD),
@@ -63,7 +63,7 @@ pub(super) fn direct_url_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn shadow_db_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines shadowDatabaseUrl".to_owned(),
+        label: "shadowDatabaseUrl".to_owned(),
         insert_text: Some(r#"shadowDatabaseUrl = $0"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::FIELD),
@@ -81,7 +81,7 @@ pub(super) fn shadow_db_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn url_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines url".to_owned(),
+        label: "url".to_owned(),
         insert_text: Some(r#"url = $0"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::FIELD),
@@ -99,7 +99,7 @@ pub(super) fn url_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn provider_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines provider".to_owned(),
+        label: "provider".to_owned(),
         insert_text: Some(r#"provider = $0"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::FIELD),
@@ -117,7 +117,7 @@ pub(super) fn provider_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "engines env".to_owned(),
+        label: "env".to_owned(),
         insert_text: Some(r#"env($0)"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::PROPERTY),
@@ -138,7 +138,7 @@ pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
 
 pub(super) fn url_quotes_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: r#"engines """#.to_owned(),
+        label: r#""""#.to_owned(),
         insert_text: Some(r#""$0""#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::PROPERTY),
@@ -163,7 +163,7 @@ pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: 
     };
 
     completion_list.items.push(CompletionItem {
-        label: format!("engines {text}"),
+        label: text.to_owned(),
         insert_text: Some(text.to_owned()),
         insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
         kind: Some(CompletionItemKind::PROPERTY),

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -153,3 +153,20 @@ pub(super) fn url_quotes_completion(completion_list: &mut CompletionList) {
         ..Default::default()
     })
 }
+
+pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: &str) {
+    let text = match kind {
+        "url" => "DATABASE_URL",
+        "directUrl" => "DIRECT_URL",
+        "shadowDatabaseUrl" => "SHADOW_DATABASE_URL",
+        _ => unreachable!(),
+    };
+
+    completion_list.items.push(CompletionItem {
+        label: format!("engines {text}"),
+        insert_text: Some(text.to_owned()),
+        insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
+        kind: Some(CompletionItemKind::PROPERTY),
+        ..Default::default()
+    })
+}

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -125,7 +125,7 @@ pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
             kind: MarkupKind::Markdown,
             value: generate_pretty_doc(
                 r#"env(_ environmentVariable: string)"#,
-                r#"Specifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.""#,
+                r#"Specifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma db pull`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.""#,
                 Some(HashMap::from([(
                     "environmentVariable",
                     "The environment variable in which the database connection URL is stored.",

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -3,27 +3,9 @@ use std::collections::HashMap;
 use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionList, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
 };
+use psl::datamodel_connector::format_completion_docs;
 
-use super::{add_quotes, generate_pretty_doc, CompletionContext};
-
-pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
-    completion_list.items.push(CompletionItem {
-        label: "schemas".to_owned(),
-        insert_text: Some(r#"schemas = [$0]"#.to_owned()),
-        insert_text_format: Some(InsertTextFormat::SNIPPET),
-        kind: Some(CompletionItemKind::FIELD),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
-                r#"schemas = ["foo", "bar", "baz"]"#,
-                "The list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)",
-                None,
-            ),
-        })),
-        // detail: Some("schemas".to_owned()),
-        ..Default::default()
-    });
-}
+use super::{add_quotes, CompletionContext};
 
 pub(super) fn relation_mode_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
@@ -33,7 +15,7 @@ pub(super) fn relation_mode_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::FIELD),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#"relationMode = "foreignKeys" | "prisma""#,
                 r#"Set the global relation mode for all relations. Values can be either "foreignKeys" (Default), or "prisma". [Learn more](https://pris.ly/d/relation-mode)"#,
                 None,
@@ -51,7 +33,7 @@ pub(super) fn direct_url_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::FIELD),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#"directUrl = "String" | env("ENVIRONMENT_VARIABLE")"#,
                 r#"Connection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."#,
                 None,
@@ -69,7 +51,7 @@ pub(super) fn shadow_db_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::FIELD),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#"shadowDatabaseUrl = "String" | env("ENVIRONMENT_VARIABLE")"#,
                 r#"Connection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."#,
                 None,
@@ -87,7 +69,7 @@ pub(super) fn url_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::FIELD),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#"url = "String" | env("ENVIRONMENT_VARIABLE")"#,
                 r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."#,
                 None,
@@ -105,27 +87,9 @@ pub(super) fn provider_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::FIELD),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#"provider = "foo""#,
                 r#"Describes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."#,
-                None,
-            ),
-        })),
-        ..Default::default()
-    })
-}
-
-pub(super) fn extensions_completion(completion_list: &mut CompletionList) {
-    completion_list.items.push(CompletionItem {
-        label: "extensions".to_owned(),
-        insert_text: Some("extensions = [$0]".to_owned()),
-        insert_text_format: Some(InsertTextFormat::SNIPPET),
-        kind: Some(CompletionItemKind::FIELD),
-        documentation: Some(Documentation::MarkupContent(MarkupContent {
-            kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
-                r#"extensions = [pg_trgm, postgis(version: "2.1")]"#,
-                r#"Enable PostgreSQL extensions. [Learn more](https://pris.ly/d/postgresql-extensions)"#,
                 None,
             ),
         })),
@@ -141,7 +105,7 @@ pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::PROPERTY),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#"env(_ environmentVariable: string)"#,
                 r#"Specifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma db pull`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.""#,
                 Some(HashMap::from([(
@@ -162,7 +126,7 @@ pub(super) fn url_quotes_completion(completion_list: &mut CompletionList) {
         kind: Some(CompletionItemKind::PROPERTY),
         documentation: Some(Documentation::MarkupContent(MarkupContent {
             kind: MarkupKind::Markdown,
-            value: generate_pretty_doc(
+            value: format_completion_docs(
                 r#""connectionString""#,
                 r#"Connection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."#,
                 None,

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -115,9 +115,27 @@ pub(super) fn provider_completion(completion_list: &mut CompletionList) {
     })
 }
 
+pub(super) fn extensions_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "extensions".to_owned(),
+        insert_text: Some("extensions = [$0]".to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: generate_pretty_doc(
+                r#"extensions = [pg_trgm, postgis(version: "2.1")]"#,
+                r#"Enable PostgreSQL extensions. [Learn more](https://pris.ly/d/postgresql-extensions)"#,
+                None,
+            ),
+        })),
+        ..Default::default()
+    })
+}
+
 pub(super) fn url_env_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
-        label: "env".to_owned(),
+        label: "env()".to_owned(),
         insert_text: Some(r#"env($0)"#.to_owned()),
         insert_text_format: Some(InsertTextFormat::SNIPPET),
         kind: Some(CompletionItemKind::PROPERTY),
@@ -166,7 +184,7 @@ pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: 
         label: text.to_owned(),
         insert_text: Some(text.to_owned()),
         insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
-        kind: Some(CompletionItemKind::PROPERTY),
+        kind: Some(CompletionItemKind::CONSTANT),
         ..Default::default()
     })
 }

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -4,7 +4,7 @@ use lsp_types::{
     CompletionItem, CompletionItemKind, CompletionList, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
 };
 
-use super::generate_pretty_doc;
+use super::{add_quotes, generate_pretty_doc, CompletionContext};
 
 pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
@@ -172,7 +172,7 @@ pub(super) fn url_quotes_completion(completion_list: &mut CompletionList) {
     })
 }
 
-pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: &str) {
+pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: &str, ctx: CompletionContext<'_>) {
     let text = match kind {
         "url" => "DATABASE_URL",
         "directUrl" => "DIRECT_URL",
@@ -180,9 +180,15 @@ pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: 
         _ => unreachable!(),
     };
 
+    let insert_text = if add_quotes(ctx.params, ctx.db.source()) {
+        format!(r#""{text}""#)
+    } else {
+        text.to_owned()
+    };
+
     completion_list.items.push(CompletionItem {
         label: text.to_owned(),
-        insert_text: Some(text.to_owned()),
+        insert_text: Some(insert_text),
         insert_text_format: Some(InsertTextFormat::PLAIN_TEXT),
         kind: Some(CompletionItemKind::CONSTANT),
         ..Default::default()

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -125,9 +125,9 @@ mod tests {
         });
 
         let expected = expect![[
-            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m 7 | \u001b[0m          }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
         ]];
-        let response = validate(&request.to_string()).unwrap_err();
+        let response = run(schema).unwrap_err();
         expected.assert_eq(&response);
     }
 }

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -120,10 +120,15 @@ mod tests {
           }
         "#;
 
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
         let expected = expect![[
             r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
         ]];
-        let response = run(schema).unwrap_err();
+
+        let response = validate(&request.to_string()).unwrap_err();
         expected.assert_eq(&response);
     }
 }

--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -120,10 +120,6 @@ mod tests {
           }
         "#;
 
-        let request = json!({
-            "prismaSchema": schema,
-        });
-
         let expected = expect![[
             r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m              relationMode = \"prisma\"\n\u001b[1;94m 6 | \u001b[0m              \u001b[1;91mreferentialIntegrity = \"foreignKeys\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
         ]];

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_referential_integrity/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_referential_integrity/result.json
@@ -10,8 +10,8 @@
             "character": 4
           },
           "end": {
-            "line": 4,
-            "character": 0
+            "line": 3,
+            "character": 35
           }
         },
         "severity": 2,

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/result.json
@@ -1,0 +1,55 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines provider",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."
+      },
+      "insertText": "provider = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines url",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."
+      },
+      "insertText": "url = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines shadowDatabaseUrl",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nshadowDatabaseUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."
+      },
+      "insertText": "shadowDatabaseUrl = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines directUrl",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\ndirectUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."
+      },
+      "insertText": "directUrl = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines relationMode",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSet the global relation mode for all relations. Values can be either \"foreignKeys\" (Default), or \"prisma\". [Learn more](https://pris.ly/d/relation-mode)"
+      },
+      "insertText": "relationmode = $0",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/result.json
@@ -6,7 +6,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."
+        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`.\n\n"
       },
       "insertText": "provider = $0",
       "insertTextFormat": 2
@@ -16,7 +16,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."
+        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings).\n\n"
       },
       "insertText": "url = $0",
       "insertTextFormat": 2
@@ -26,7 +26,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nshadowDatabaseUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."
+        "value": "```prisma\nshadowDatabaseUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow).\n\n"
       },
       "insertText": "shadowDatabaseUrl = $0",
       "insertTextFormat": 2
@@ -36,7 +36,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\ndirectUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."
+        "value": "```prisma\ndirectUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli).\n\n"
       },
       "insertText": "directUrl = $0",
       "insertTextFormat": 2
@@ -46,7 +46,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSet the global relation mode for all relations. Values can be either \"foreignKeys\" (Default), or \"prisma\". [Learn more](https://pris.ly/d/relation-mode)"
+        "value": "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSet the global relation mode for all relations. Values can be either \"foreignKeys\" (Default), or \"prisma\". [Learn more](https://pris.ly/d/relation-mode)\n\n"
       },
       "insertText": "relationmode = $0",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines provider",
+      "label": "provider",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -12,7 +12,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines url",
+      "label": "url",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -22,7 +22,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines shadowDatabaseUrl",
+      "label": "shadowDatabaseUrl",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -32,7 +32,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines directUrl",
+      "label": "directUrl",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -42,7 +42,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines relationMode",
+      "label": "relationMode",
       "kind": 5,
       "documentation": {
         "kind": "markdown",

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_default_completions/schema.prisma
@@ -1,0 +1,7 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    <|>
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
@@ -6,7 +6,7 @@
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\""
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
       },
       "insertText": "env($0)",
       "insertTextFormat": 2
@@ -16,7 +16,7 @@
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."
+        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema).\n\n"
       },
       "insertText": "\"$0\"",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
@@ -2,11 +2,11 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "env",
+      "label": "env()",
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma db pull`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
       },
       "insertText": "env($0)",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines env",
+      "label": "env",
       "kind": 10,
       "documentation": {
         "kind": "markdown",
@@ -12,7 +12,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines \"\"",
+      "label": "\"\"",
       "kind": 10,
       "documentation": {
         "kind": "markdown",

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines env",
+      "kind": 10,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\""
+      },
+      "insertText": "env($0)",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines \"\"",
+      "kind": 10,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."
+      },
+      "insertText": "\"$0\"",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_direct_url_arguments/schema.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = ""
+    directUrl = <|>
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/result.json
@@ -1,0 +1,11 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines DIRECT_URL",
+      "kind": 10,
+      "insertText": "DIRECT_URL",
+      "insertTextFormat": 1
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/result.json
@@ -3,7 +3,7 @@
   "items": [
     {
       "label": "DIRECT_URL",
-      "kind": 10,
+      "kind": 21,
       "insertText": "DIRECT_URL",
       "insertTextFormat": 1
     }

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines DIRECT_URL",
+      "label": "DIRECT_URL",
       "kind": 10,
       "insertText": "DIRECT_URL",
       "insertTextFormat": 1

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_direct_url/schema.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider  = "postgresql"
+    url       = env("")
+    directUrl = env("<|>")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/result.json
@@ -1,0 +1,11 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines SHADOW_DATABASE_URL",
+      "kind": 10,
+      "insertText": "SHADOW_DATABASE_URL",
+      "insertTextFormat": 1
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/result.json
@@ -3,7 +3,7 @@
   "items": [
     {
       "label": "SHADOW_DATABASE_URL",
-      "kind": 10,
+      "kind": 21,
       "insertText": "SHADOW_DATABASE_URL",
       "insertTextFormat": 1
     }

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines SHADOW_DATABASE_URL",
+      "label": "SHADOW_DATABASE_URL",
       "kind": 10,
       "insertText": "SHADOW_DATABASE_URL",
       "insertTextFormat": 1

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_shadowdb_url/schema.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider          = "postgresql"
+    url               = env("")
+    shadowDatabaseUrl = env("<|>")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/result.json
@@ -3,7 +3,7 @@
   "items": [
     {
       "label": "DATABASE_URL",
-      "kind": 10,
+      "kind": 21,
       "insertText": "DATABASE_URL",
       "insertTextFormat": 1
     }

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/result.json
@@ -1,0 +1,11 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines DATABASE_URL",
+      "kind": 10,
+      "insertText": "DATABASE_URL",
+      "insertTextFormat": 1
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines DATABASE_URL",
+      "label": "DATABASE_URL",
       "kind": 10,
       "insertText": "DATABASE_URL",
       "insertTextFormat": 1

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/schema.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("<|>")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
@@ -1,0 +1,65 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines provider",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."
+      },
+      "insertText": "provider = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines url",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."
+      },
+      "insertText": "url = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines shadowDatabaseUrl",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nshadowDatabaseUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."
+      },
+      "insertText": "shadowDatabaseUrl = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines directUrl",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\ndirectUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."
+      },
+      "insertText": "directUrl = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines relationMode",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSet the global relation mode for all relations. Values can be either \"foreignKeys\" (Default), or \"prisma\". [Learn more](https://pris.ly/d/relation-mode)"
+      },
+      "insertText": "relationmode = $0",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines schemas",
+      "kind": 5,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nschemas = [\"foo\", \"bar\", \"baz\"]\n```\n___\nThe list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)"
+      },
+      "insertText": "schemas = [$0]",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines provider",
+      "label": "provider",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -12,7 +12,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines url",
+      "label": "url",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -22,7 +22,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines shadowDatabaseUrl",
+      "label": "shadowDatabaseUrl",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -32,7 +32,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines directUrl",
+      "label": "directUrl",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -42,7 +42,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines relationMode",
+      "label": "relationMode",
       "kind": 5,
       "documentation": {
         "kind": "markdown",
@@ -52,7 +52,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines schemas",
+      "label": "schemas",
       "kind": 5,
       "documentation": {
         "kind": "markdown",

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
@@ -6,7 +6,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`."
+        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`.\n\n"
       },
       "insertText": "provider = $0",
       "insertTextFormat": 2
@@ -16,7 +16,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings)."
+        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings).\n\n"
       },
       "insertText": "url = $0",
       "insertTextFormat": 2
@@ -26,7 +26,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nshadowDatabaseUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow)."
+        "value": "```prisma\nshadowDatabaseUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info to use for Migrate's [shadow database](https://pris.ly/d/migrate-shadow).\n\n"
       },
       "insertText": "shadowDatabaseUrl = $0",
       "insertTextFormat": 2
@@ -36,7 +36,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\ndirectUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli)."
+        "value": "```prisma\ndirectUrl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL for direct connection to the database. [Learn more](https://pris.ly/d/data-proxy-cli).\n\n"
       },
       "insertText": "directUrl = $0",
       "insertTextFormat": 2
@@ -46,7 +46,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSet the global relation mode for all relations. Values can be either \"foreignKeys\" (Default), or \"prisma\". [Learn more](https://pris.ly/d/relation-mode)"
+        "value": "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSet the global relation mode for all relations. Values can be either \"foreignKeys\" (Default), or \"prisma\". [Learn more](https://pris.ly/d/relation-mode)\n\n"
       },
       "insertText": "relationmode = $0",
       "insertTextFormat": 2
@@ -56,7 +56,7 @@
       "kind": 5,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nschemas = [\"foo\", \"bar\", \"baz\"]\n```\n___\nThe list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)"
+        "value": "```prisma\nschemas = [\"foo\", \"bar\", \"baz\"]\n```\n___\nThe list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)\n\n"
       },
       "insertText": "schemas = [$0]",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/result.json
@@ -2,26 +2,6 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "provider",
-      "kind": 5,
-      "documentation": {
-        "kind": "markdown",
-        "value": "```prisma\nprovider = \"foo\"\n```\n___\nDescribes which datasource connector to use. Can be one of the following datasource providers: `postgresql`, `mysql`, `sqlserver`, `sqlite`, `mongodb` or `cockroachdb`.\n\n"
-      },
-      "insertText": "provider = $0",
-      "insertTextFormat": 2
-    },
-    {
-      "label": "url",
-      "kind": 5,
-      "documentation": {
-        "kind": "markdown",
-        "value": "```prisma\nurl = \"String\" | env(\"ENVIRONMENT_VARIABLE\")\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/connection-strings).\n\n"
-      },
-      "insertText": "url = $0",
-      "insertTextFormat": 2
-    },
-    {
       "label": "shadowDatabaseUrl",
       "kind": 5,
       "documentation": {

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/schema.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+    <|>
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
@@ -6,7 +6,7 @@
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\""
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
       },
       "insertText": "env($0)",
       "insertTextFormat": 2
@@ -16,7 +16,7 @@
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."
+        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema).\n\n"
       },
       "insertText": "\"$0\"",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
@@ -2,11 +2,11 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "env",
+      "label": "env()",
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma db pull`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
       },
       "insertText": "env($0)",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines env",
+      "label": "env",
       "kind": 10,
       "documentation": {
         "kind": "markdown",
@@ -12,7 +12,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines \"\"",
+      "label": "\"\"",
       "kind": 10,
       "documentation": {
         "kind": "markdown",

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines env",
+      "kind": 10,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\""
+      },
+      "insertText": "env($0)",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines \"\"",
+      "kind": 10,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."
+      },
+      "insertText": "\"$0\"",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_shadowdb_url_arguments/schema.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = ""
+    shadowDatabaseUrl = <|>
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
@@ -6,7 +6,7 @@
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\""
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
       },
       "insertText": "env($0)",
       "insertTextFormat": 2
@@ -16,7 +16,7 @@
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."
+        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema).\n\n"
       },
       "insertText": "\"$0\"",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
@@ -2,11 +2,11 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "env",
+      "label": "env()",
       "kind": 10,
       "documentation": {
         "kind": "markdown",
-        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma db pull`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\"\n\n_@param_ environmentVariable The environment variable in which the database connection URL is stored."
       },
       "insertText": "env($0)",
       "insertTextFormat": 2

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
@@ -2,7 +2,7 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "engines env",
+      "label": "env",
       "kind": 10,
       "documentation": {
         "kind": "markdown",
@@ -12,7 +12,7 @@
       "insertTextFormat": 2
     },
     {
-      "label": "engines \"\"",
+      "label": "\"\"",
       "kind": 10,
       "documentation": {
         "kind": "markdown",

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "engines env",
+      "kind": 10,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\nenv(_ environmentVariable: string)\n```\n___\nSpecifies a datasource via an environment variable. When running a Prisma CLI command that needs the database connection URL (e.g. `prisma generate`), you need to make sure that the `DATABASE_URL` environment variable is set. One way to do so is by creating a `.env` file. Note that the file must be in the same directory as your schema.prisma file to automatically be picked up by the Prisma CLI.\""
+      },
+      "insertText": "env($0)",
+      "insertTextFormat": 2
+    },
+    {
+      "label": "engines \"\"",
+      "kind": 10,
+      "documentation": {
+        "kind": "markdown",
+        "value": "```prisma\n\"connectionString\"\n```\n___\nConnection URL including authentication info. Each datasource provider documents the URL syntax. Most providers use the syntax provided by the database. [Learn more](https://pris.ly/d/prisma-schema)."
+      },
+      "insertText": "\"$0\"",
+      "insertTextFormat": 2
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/schema.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multischema"]
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = <|>
+}

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -36,4 +36,6 @@ scenarios! {
     referential_actions_middle_of_args_list
     referential_actions_mssql
     referential_actions_with_trailing_comma
+    datasource_default_completions
+    datasource_multischema
 }

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -38,4 +38,7 @@ scenarios! {
     referential_actions_with_trailing_comma
     datasource_default_completions
     datasource_multischema
+    datasource_url_arguments
+    datasource_direct_url_arguments
+    datasource_shadowdb_url_arguments
 }

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -41,4 +41,7 @@ scenarios! {
     datasource_url_arguments
     datasource_direct_url_arguments
     datasource_shadowdb_url_arguments
+    datasource_env_db_url
+    datasource_env_db_direct_url
+    datasource_env_db_shadowdb_url
 }

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -266,7 +266,7 @@ impl Connector for CockroachDatamodelConnector {
         Ok(())
     }
 
-    fn push_completions(
+    fn datamodel_completions(
         &self,
         _db: &ParserDatabase,
         position: SchemaPosition<'_>,

--- a/psl/builtin-connectors/src/completions.rs
+++ b/psl/builtin-connectors/src/completions.rs
@@ -3,7 +3,7 @@ use lsp_types::{
 };
 use psl_core::datamodel_connector::format_completion_docs;
 
-pub(super) fn extensions_completion(completion_list: &mut CompletionList) {
+pub(crate) fn extensions_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
         label: "extensions".to_owned(),
         insert_text: Some("extensions = [$0]".to_owned()),
@@ -21,7 +21,7 @@ pub(super) fn extensions_completion(completion_list: &mut CompletionList) {
     })
 }
 
-pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
+pub(crate) fn schemas_completion(completion_list: &mut CompletionList) {
     completion_list.items.push(CompletionItem {
         label: "schemas".to_owned(),
         insert_text: Some(r#"schemas = [$0]"#.to_owned()),

--- a/psl/builtin-connectors/src/lib.rs
+++ b/psl/builtin-connectors/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 pub mod cockroach_datamodel_connector;
+pub mod completions;
 
 pub use cockroach_datamodel_connector::CockroachType;
 pub use mongodb::MongoDbType;

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -12,11 +12,14 @@ use psl_core::{
     },
     diagnostics::{Diagnostics, Span},
     parser_database::{self, ast, ParserDatabase, ReferentialAction, ScalarType},
+    PreviewFeature,
 };
 use std::borrow::Cow;
 
 use MsSqlType::*;
 use MsSqlTypeParameter::*;
+
+use crate::completions;
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
     ConstraintScope::GlobalPrimaryKeyForeignKeyDefault,
@@ -292,6 +295,17 @@ impl Connector for MsSqlDatamodelConnector {
                 kind: Some(CompletionItemKind::PROPERTY),
                 ..Default::default()
             });
+        }
+    }
+
+    fn datasource_completions(&self, config: &psl_core::Configuration, completion_list: &mut CompletionList) {
+        let ds = match config.datasources.first() {
+            Some(ds) => ds,
+            None => return,
+        };
+
+        if config.preview_features().contains(PreviewFeature::MultiSchema) && !ds.schemas_defined() {
+            completions::schemas_completion(completion_list);
         }
     }
 }

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -279,7 +279,7 @@ impl Connector for MsSqlDatamodelConnector {
         Ok(())
     }
 
-    fn push_completions(
+    fn datamodel_completions(
         &self,
         _db: &ParserDatabase,
         position: ast::SchemaPosition<'_>,

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -1,4 +1,3 @@
-mod completions;
 mod datasource;
 mod native_types;
 mod validations;
@@ -18,6 +17,8 @@ use psl_core::{
 };
 use std::{borrow::Cow, collections::HashMap};
 use PostgresType::*;
+
+use crate::completions;
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
     ConstraintScope::GlobalPrimaryKeyKeyIndex,

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -94,6 +94,10 @@ impl PostgresDatasourceProperties {
             span: ast::Span::empty(),
         });
     }
+    // Validation for property existence
+    pub fn extensions_defined(&self) -> bool {
+        self.extensions.is_some()
+    }
 }
 
 /// An extension defined in the extensions array of the datasource.

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -96,6 +96,7 @@ impl PostgresDatasourceProperties {
             span: ast::Span::empty(),
         });
     }
+
     // Validation for property existence
     pub fn extensions_defined(&self) -> bool {
         self.extensions.is_some()
@@ -449,7 +450,7 @@ impl Connector for PostgresDatamodelConnector {
         Ok(())
     }
 
-    fn push_completions(
+    fn datamodel_completions(
         &self,
         db: &ParserDatabase,
         position: ast::SchemaPosition<'_>,

--- a/psl/builtin-connectors/src/postgres_datamodel_connector/completions.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector/completions.rs
@@ -1,0 +1,41 @@
+use lsp_types::{
+    CompletionItem, CompletionItemKind, CompletionList, Documentation, InsertTextFormat, MarkupContent, MarkupKind,
+};
+use psl_core::datamodel_connector::format_completion_docs;
+
+pub(super) fn extensions_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "extensions".to_owned(),
+        insert_text: Some("extensions = [$0]".to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format_completion_docs(
+                r#"extensions = [pg_trgm, postgis(version: "2.1")]"#,
+                r#"Enable PostgreSQL extensions. [Learn more](https://pris.ly/d/postgresql-extensions)"#,
+                None,
+            ),
+        })),
+        ..Default::default()
+    })
+}
+
+pub(super) fn schemas_completion(completion_list: &mut CompletionList) {
+    completion_list.items.push(CompletionItem {
+        label: "schemas".to_owned(),
+        insert_text: Some(r#"schemas = [$0]"#.to_owned()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        kind: Some(CompletionItemKind::FIELD),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format_completion_docs(
+                r#"schemas = ["foo", "bar", "baz"]"#,
+                "The list of database schemas. [Learn More](https://pris.ly/d/multi-schema-configuration)",
+                None,
+            ),
+        })),
+        // detail: Some("schemas".to_owned()),
+        ..Default::default()
+    });
+}

--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -381,6 +381,16 @@ impl DatamodelError {
         Self::new(msg, span)
     }
 
+    pub fn new_config_property_missing_value_error(
+        property_name: &str,
+        config_name: &str,
+        config_kind: &str,
+        span: Span,
+    ) -> DatamodelError {
+        let msg = format!("Property {property_name} in {config_kind} {config_name} needs to be assigned a value");
+        Self::new(msg, span)
+    }
+
     pub fn span(&self) -> Span {
         self.span
     }

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -245,6 +245,26 @@ impl Datasource {
 
         Ok(Some(url))
     }
+
+    // Validation for property existence
+    pub fn provider_defined(&self) -> bool {
+        !self.provider.is_empty()
+    }
+    pub fn url_defined(&self) -> bool {
+        self.url_span.end > self.url_span.start
+    }
+    pub fn direct_url_defined(&self) -> bool {
+        self.direct_url.is_some()
+    }
+    pub fn shadow_url_defined(&self) -> bool {
+        self.shadow_database_url.is_some()
+    }
+    pub fn relation_mode_defined(&self) -> bool {
+        self.relation_mode.is_some()
+    }
+    pub fn schemas_defined(&self) -> bool {
+        self.schemas_span.is_some()
+    }
 }
 
 pub(crate) fn from_url<F>(url: &StringFromEnvVar, env: F) -> Result<String, UrlValidationError>

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -250,18 +250,23 @@ impl Datasource {
     pub fn provider_defined(&self) -> bool {
         !self.provider.is_empty()
     }
+
     pub fn url_defined(&self) -> bool {
         self.url_span.end > self.url_span.start
     }
+
     pub fn direct_url_defined(&self) -> bool {
         self.direct_url.is_some()
     }
+
     pub fn shadow_url_defined(&self) -> bool {
         self.shadow_database_url.is_some()
     }
+
     pub fn relation_mode_defined(&self) -> bool {
         self.relation_mode.is_some()
     }
+
     pub fn schemas_defined(&self) -> bool {
         self.schemas_span.is_some()
     }

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -335,7 +335,12 @@ pub trait Connector: Send + Sync {
 
     fn validate_url(&self, url: &str) -> Result<(), String>;
 
-    fn push_completions(&self, _db: &ParserDatabase, _position: SchemaPosition<'_>, _completions: &mut CompletionList) {
+    fn datamodel_completions(
+        &self,
+        _db: &ParserDatabase,
+        _position: SchemaPosition<'_>,
+        _completions: &mut CompletionList,
+    ) {
     }
 
     fn datasource_completions(&self, _config: &Configuration, _completion_list: &mut CompletionList) {}

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -338,7 +338,7 @@ pub trait Connector: Send + Sync {
     fn push_completions(&self, _db: &ParserDatabase, _position: SchemaPosition<'_>, _completions: &mut CompletionList) {
     }
 
-    fn datasource_completions(&self, _config: &Configuration, _completions: &mut CompletionList) {}
+    fn datasource_completions(&self, _config: &Configuration, _completion_list: &mut CompletionList) {}
 
     fn parse_datasource_properties(
         &self,

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -7,6 +7,9 @@ pub mod constraint_names;
 /// Extensions for parser database walkers with context from the connector.
 pub mod walker_ext_traits;
 
+/// Connector completions
+pub mod completions;
+
 mod empty_connector;
 mod filters;
 mod native_types;
@@ -14,13 +17,14 @@ mod relation_mode;
 
 pub use self::{
     capabilities::{ConnectorCapabilities, ConnectorCapability},
+    completions::format_completion_docs,
     empty_connector::EmptyDatamodelConnector,
     filters::*,
     native_types::{NativeTypeArguments, NativeTypeConstructor, NativeTypeInstance},
     relation_mode::RelationMode,
 };
 
-use crate::{configuration::DatasourceConnectorData, Datasource, PreviewFeature};
+use crate::{configuration::DatasourceConnectorData, Configuration, Datasource, PreviewFeature};
 use diagnostics::{DatamodelError, Diagnostics, NativeTypeErrorFactory, Span};
 use enumflags2::BitFlags;
 use lsp_types::CompletionList;
@@ -333,6 +337,8 @@ pub trait Connector: Send + Sync {
 
     fn push_completions(&self, _db: &ParserDatabase, _position: SchemaPosition<'_>, _completions: &mut CompletionList) {
     }
+
+    fn datasource_completions(&self, _config: &Configuration, _completions: &mut CompletionList) {}
 
     fn parse_datasource_properties(
         &self,

--- a/psl/psl-core/src/datamodel_connector/completions.rs
+++ b/psl/psl-core/src/datamodel_connector/completions.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+
+/// Formats the documentation for a completion.
+/// example: How the completion is expected to be used.
+///
+/// # Example
+///
+/// ```
+/// use psl_core::datamodel_connector::format_completion_docs;
+///
+/// let doc = format_completion_docs(
+///     r#"relationMode = "foreignKeys" | "prisma""#,
+///     r#"Sets the global relation mode for relations."#,
+///     None,
+/// );
+///
+/// assert_eq!(
+///     "```prisma\nrelationMode = \"foreignKeys\" | \"prisma\"\n```\n___\nSets the global relation mode for relations.\n\n",
+///     &doc
+/// );
+/// ```
+pub fn format_completion_docs(example: &str, description: &str, params: Option<HashMap<&str, &str>>) -> String {
+    let param_docs: String = match params {
+        Some(params) => params
+            .into_iter()
+            .map(|(param_label, param_doc)| format!("_@param_ {param_label} {param_doc}"))
+            .collect::<Vec<String>>()
+            .join("\n"),
+        None => Default::default(),
+    };
+
+    format!("```prisma\n{example}\n```\n___\n{description}\n\n{param_docs}")
+}

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -6,7 +6,10 @@ use crate::{
     Datasource,
 };
 use diagnostics::DatamodelWarning;
-use parser_database::{ast::WithDocumentation, coerce, coerce_array, coerce_opt};
+use parser_database::{
+    ast::{Expression, WithDocumentation},
+    coerce, coerce_array, coerce_opt,
+};
 use std::{borrow::Cow, collections::HashMap};
 
 const PREVIEW_FEATURES_KEY: &str = "previewFeatures";
@@ -14,6 +17,7 @@ const SCHEMAS_KEY: &str = "schemas";
 const SHADOW_DATABASE_URL_KEY: &str = "shadowDatabaseUrl";
 const URL_KEY: &str = "url";
 const DIRECT_URL_KEY: &str = "directUrl";
+const PROVIDER_KEY: &str = "provider";
 
 /// Loads all datasources from the provided schema AST.
 /// - `ignore_datasource_urls`: datasource URLs are not parsed. They are replaced with dummy values.
@@ -49,84 +53,66 @@ fn lift_datasource(
     diagnostics: &mut Diagnostics,
     connectors: crate::ConnectorRegistry,
 ) -> Option<Datasource> {
-    let source_name = &ast_source.name.name;
-    let mut args: HashMap<_, _> = ast_source
+    let source_name = ast_source.name.name.as_str();
+    let mut args: HashMap<_, (_, &Expression)> = ast_source
         .properties
         .iter()
-        .map(|arg| (arg.name.name.as_str(), (arg.span, &arg.value)))
-        .collect();
+        .map(|arg| match &arg.value {
+            Some(expr) => Some((arg.name.name.as_str(), (arg.span, expr))),
+            None => {
+                diagnostics.push_error(DatamodelError::new_config_property_missing_value_error(
+                    &arg.name.name,
+                    source_name,
+                    "datasource",
+                    ast_source.span,
+                ));
+                None
+            }
+        })
+        .collect::<Option<HashMap<_, (_, _)>>>()?;
 
-    let (_, provider_arg) = match args.remove("provider") {
-        Some(provider) => provider,
+    // (arg.name.name.as_str(), (arg.span, &arg.value))
+
+    let (provider, provider_arg) = match args.remove(PROVIDER_KEY) {
+        Some((_span, provider_arg)) => {
+            if provider_arg.is_env_expression() {
+                let msg = Cow::Borrowed("A datasource must not use the env() function in the provider argument.");
+                diagnostics.push_error(DatamodelError::new_functional_evaluation_error(msg, ast_source.span));
+                return None;
+            }
+
+            let provider = match coerce_opt::string(provider_arg) {
+                Some("") => {
+                    diagnostics.push_error(DatamodelError::new_source_validation_error(
+                        "The provider argument in a datasource must not be empty",
+                        source_name,
+                        provider_arg.span(),
+                    ));
+                    return None;
+                }
+                None => {
+                    diagnostics.push_error(DatamodelError::new_source_validation_error(
+                        "The provider argument in a datasource must be a string literal",
+                        source_name,
+                        provider_arg.span(),
+                    ));
+                    return None;
+                }
+                Some(provider) => provider,
+            };
+
+            (provider, provider_arg)
+        }
+
         None => {
             diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
                 "provider",
-                &ast_source.name.name,
+                source_name,
                 ast_source.span,
             ));
             return None;
         }
     };
-
-    if provider_arg.is_env_expression() {
-        let msg = Cow::Borrowed("A datasource must not use the env() function in the provider argument.");
-        diagnostics.push_error(DatamodelError::new_functional_evaluation_error(msg, ast_source.span));
-        return None;
-    }
-
-    let provider = match coerce_opt::string(provider_arg) {
-        Some("") => {
-            diagnostics.push_error(DatamodelError::new_source_validation_error(
-                "The provider argument in a datasource must not be empty",
-                source_name,
-                provider_arg.span(),
-            ));
-            return None;
-        }
-        None => {
-            diagnostics.push_error(DatamodelError::new_source_validation_error(
-                "The provider argument in a datasource must be a string literal",
-                source_name,
-                provider_arg.span(),
-            ));
-            return None;
-        }
-        Some(provider) => provider,
-    };
-
-    let (_, url_arg) = match args.remove(URL_KEY) {
-        Some(url_arg) => url_arg,
-        None => {
-            diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
-                URL_KEY,
-                &ast_source.name.name,
-                ast_source.span,
-            ));
-            return None;
-        }
-    };
-
-    let url = StringFromEnvVar::coerce(url_arg, diagnostics)?;
-    let shadow_database_url_arg = args.remove(SHADOW_DATABASE_URL_KEY);
-
-    let direct_url_arg = args.remove(DIRECT_URL_KEY).map(|(_, url)| url);
-    let direct_url = direct_url_arg.and_then(|url_arg| StringFromEnvVar::coerce(url_arg, diagnostics));
-
-    let shadow_database_url: Option<(StringFromEnvVar, Span)> =
-        if let Some((_, shadow_database_url_arg)) = shadow_database_url_arg.as_ref() {
-            match StringFromEnvVar::coerce(shadow_database_url_arg, diagnostics) {
-                Some(shadow_database_url) => Some(shadow_database_url)
-                    .filter(|s| !s.as_literal().map(|lit| lit.is_empty()).unwrap_or(false))
-                    .map(|url| (url, shadow_database_url_arg.span())),
-                None => None,
-            }
-        } else {
-            None
-        };
-
-    preview_features_guardrail(&mut args, diagnostics);
-
-    let documentation = ast_source.documentation().map(String::from);
 
     let active_connector: &'static dyn crate::datamodel_connector::Connector =
         match connectors.iter().find(|c| c.is_provider(provider)) {
@@ -143,32 +129,70 @@ fn lift_datasource(
 
     let relation_mode = get_relation_mode(&mut args, ast_source, diagnostics, active_connector);
 
-    let (schemas, schemas_span) = args
-        .remove(SCHEMAS_KEY)
-        .and_then(|(_, expr)| coerce_array(expr, &coerce::string_with_span, diagnostics).map(|b| (b, expr.span())))
-        .map(|(mut schemas, span)| {
-            if schemas.is_empty() {
-                let error = DatamodelError::new_schemas_array_empty_error(span);
-
-                diagnostics.push_error(error);
-            }
-
-            schemas.sort_by(|(a, _), (b, _)| a.cmp(b));
-
-            for pair in schemas.windows(2) {
-                if pair[0].0 == pair[1].0 {
-                    diagnostics.push_error(DatamodelError::new_static(
-                        "Duplicated schema names are not allowed",
-                        pair[0].1,
-                    ))
-                }
-            }
-
-            (schemas, Some(span))
-        })
-        .unwrap_or_default();
-
     let connector_data = active_connector.parse_datasource_properties(&mut args, diagnostics);
+
+    let (url, url_span) = match args.remove(URL_KEY) {
+        Some((_span, url_arg)) => (StringFromEnvVar::coerce(url_arg, diagnostics)?, url_arg.span()),
+
+        None => {
+            diagnostics.push_error(DatamodelError::new_source_argument_not_found_error(
+                URL_KEY,
+                source_name,
+                ast_source.span,
+            ));
+
+            return None;
+        }
+    };
+
+    let shadow_database_url = match args.remove(SHADOW_DATABASE_URL_KEY) {
+        Some((_span, shadow_db_url_arg)) => match StringFromEnvVar::coerce(shadow_db_url_arg, diagnostics) {
+            Some(shadow_db_url) => Some(shadow_db_url)
+                .filter(|s| !s.as_literal().map(|literal| literal.is_empty()).unwrap_or(false))
+                .map(|url| (url, shadow_db_url_arg.span())),
+            None => None,
+        },
+
+        _ => None,
+    };
+
+    let (direct_url, direct_url_span) = match args.remove(DIRECT_URL_KEY) {
+        Some((direct_url_arg, direct_url)) => (StringFromEnvVar::coerce(direct_url, diagnostics), Some(direct_url_arg)),
+
+        None => (None, None),
+    };
+
+    preview_features_guardrail(&mut args, diagnostics);
+
+    let documentation = ast_source.documentation().map(String::from);
+
+    let (schemas, schemas_span) = match args.remove(SCHEMAS_KEY) {
+        Some((_span, schemas)) => coerce_array(schemas, &coerce::string_with_span, diagnostics)
+            .map(|b| (b, schemas.span()))
+            .and_then(|(mut schemas, span)| {
+                if schemas.is_empty() {
+                    diagnostics.push_error(DatamodelError::new_schemas_array_empty_error(span));
+
+                    return None;
+                }
+
+                schemas.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+                for pair in schemas.windows(2) {
+                    if pair[0].0 == pair[1].0 {
+                        diagnostics.push_error(DatamodelError::new_static(
+                            "Duplicated schema names are not allowed",
+                            pair[0].1,
+                        ))
+                    }
+                }
+
+                Some((schemas, Some(span)))
+            })
+            .unwrap_or_default(),
+
+        None => Default::default(),
+    };
 
     for (name, (span, _)) in args.into_iter() {
         diagnostics.push_error(DatamodelError::new_property_not_known_error(name, span));
@@ -177,13 +201,13 @@ fn lift_datasource(
     Some(Datasource {
         namespaces: schemas.into_iter().map(|(s, span)| (s.to_owned(), span)).collect(),
         schemas_span,
-        name: source_name.to_string(),
+        name: source_name.to_owned(),
         provider: provider.to_owned(),
         active_provider: active_connector.provider_name(),
         url,
-        url_span: url_arg.span(),
+        url_span,
         direct_url,
-        direct_url_span: direct_url_arg.map(|arg| arg.span()),
+        direct_url_span,
         documentation,
         active_connector,
         shadow_database_url,

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -155,7 +155,10 @@ fn lift_datasource(
     };
 
     let (direct_url, direct_url_span) = match args.remove(DIRECT_URL_KEY) {
-        Some((direct_url_arg, direct_url)) => (StringFromEnvVar::coerce(direct_url, diagnostics), Some(direct_url_arg)),
+        Some((_, direct_url)) => (
+            StringFromEnvVar::coerce(direct_url, diagnostics),
+            Some(direct_url.span()),
+        ),
 
         None => (None, None),
     };

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -71,8 +71,6 @@ fn lift_datasource(
         })
         .collect::<Option<HashMap<_, (_, _)>>>()?;
 
-    // (arg.name.name.as_str(), (arg.span, &arg.value))
-
     let (provider, provider_arg) = match args.remove(PROVIDER_KEY) {
         Some((_span, provider_arg)) => {
             if provider_arg.is_env_expression() {

--- a/psl/psl/tests/config/datasources.rs
+++ b/psl/psl/tests/config/datasources.rs
@@ -132,7 +132,6 @@ fn datasource_should_not_allow_arbitrary_parameters() {
         [1;94m   | [0m
         [1;94m 3 | [0m  url = "mysql://localhost"
         [1;94m 4 | [0m  [1;91mfoo = "bar"[0m
-        [1;94m 5 | [0m}
         [1;94m   | [0m
     "#]];
 

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -648,7 +648,6 @@ fn fail_when_preview_features_are_declared() {
         [1;94m   | [0m
         [1;94m 3 | [0m  url = "mysql://"
         [1;94m 4 | [0m  [1;91mpreviewFeatures = ["foo"][0m
-        [1;94m 5 | [0m}
         [1;94m   | [0m
     "#]];
 

--- a/psl/psl/tests/validation/attributes/relation_mode/referential_integrity_attr_is_deprecated.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/referential_integrity_attr_is_deprecated.prisma
@@ -8,5 +8,4 @@ datasource db {
 // [1;94m   | [0m
 // [1;94m 3 | [0m  url = "sqlite"
 // [1;94m 4 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
-// [1;94m 5 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
@@ -9,12 +9,10 @@ datasource db {
 // [1;94m   | [0m
 // [1;94m 4 | [0m  relationMode = "prisma"
 // [1;94m 5 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
-// [1;94m 6 | [0m}
 // [1;94m   | [0m
 // [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
 //   [1;94m-->[0m  [4mschema.prisma:5[0m
 // [1;94m   | [0m
 // [1;94m 4 | [0m  relationMode = "prisma"
 // [1;94m 5 | [0m  [1;91mreferentialIntegrity = "foreignKeys"[0m
-// [1;94m 6 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mongodb.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mongodb.prisma
@@ -13,5 +13,4 @@ datasource mypg {
 // [1;94m   | [0m
 // [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
 // [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
-// [1;94m10 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mysql.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mysql.prisma
@@ -13,5 +13,4 @@ datasource db {
 // [1;94m   | [0m
 // [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
 // [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
-// [1;94m10 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlite.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlite.prisma
@@ -13,5 +13,4 @@ datasource db {
 // [1;94m   | [0m
 // [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
 // [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
-// [1;94m10 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlserver.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlserver.prisma
@@ -13,5 +13,4 @@ datasource db {
 // [1;94m   | [0m
 // [1;94m 8 | [0m  url        = env("TEST_DATABASE_URL")
 // [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
-// [1;94m10 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma
@@ -12,5 +12,4 @@ datasource mypg {
 // [1;94m   | [0m
 // [1;94m 7 | [0m  url        = env("TEST_DATABASE_URL")
 // [1;94m 8 | [0m  [1;91mextensions = [ postgis ][0m
-// [1;94m 9 | [0m}
 // [1;94m   | [0m

--- a/psl/schema-ast/src/ast.rs
+++ b/psl/schema-ast/src/ast.rs
@@ -107,9 +107,17 @@ impl std::ops::Index<EnumId> for SchemaAst {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct GeneratorId(u32);
 
-/// An opaque identifier for a datasource blèck in a schema AST.
+/// An opaque identifier for a datasource block in a schema AST.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SourceId(u32);
+
+impl std::ops::Index<SourceId> for SchemaAst {
+    type Output = SourceConfig;
+
+    fn index(&self, index: SourceId) -> &Self::Output {
+        self.tops[index.0 as usize].as_source().unwrap()
+    }
+}
 
 /// An identifier for a top-level item in a schema AST. Use the `schema[top_id]`
 /// syntax to resolve the id to an `ast::Top`.

--- a/psl/schema-ast/src/ast/composite_type.rs
+++ b/psl/schema-ast/src/ast/composite_type.rs
@@ -37,6 +37,8 @@ pub struct CompositeType {
     pub(crate) documentation: Option<Comment>,
     /// The location of this type in the text representation.
     pub span: Span,
+    /// The span of the inner contents.
+    pub inner_span: Span,
 }
 
 impl CompositeType {

--- a/psl/schema-ast/src/ast/config.rs
+++ b/psl/schema-ast/src/ast/config.rs
@@ -27,7 +27,7 @@ pub struct ConfigBlockProperty {
     ///           ^^^^^^^^^^
     /// }
     /// ```
-    pub value: Expression,
+    pub value: Option<Expression>,
     /// The node span.
     pub span: Span,
 }

--- a/psl/schema-ast/src/ast/enum.rs
+++ b/psl/schema-ast/src/ast/enum.rs
@@ -70,6 +70,8 @@ pub struct Enum {
     pub(crate) documentation: Option<Comment>,
     /// The location of this enum in the text representation.
     pub span: Span,
+    /// The span of the inner contents.
+    pub inner_span: Span,
 }
 
 impl Enum {

--- a/psl/schema-ast/src/ast/find_at_position.rs
+++ b/psl/schema-ast/src/ast/find_at_position.rs
@@ -9,6 +9,9 @@ impl ast::SchemaAst {
                     SchemaPosition::Model(model_id, ModelPosition::new(&self[model_id], position))
                 }
                 ast::TopId::Enum(enum_id) => SchemaPosition::Enum(enum_id, EnumPosition::new(&self[enum_id], position)),
+                ast::TopId::Source(source_id) => {
+                    SchemaPosition::DataSource(source_id, SourcePosition::new(&self[source_id], position))
+                }
                 // Falling back to TopLevel as "not implemented"
                 _ => SchemaPosition::TopLevel,
             })
@@ -45,6 +48,8 @@ pub enum SchemaPosition<'ast> {
     Model(ast::ModelId, ModelPosition<'ast>),
     /// In an enum
     Enum(ast::EnumId, EnumPosition<'ast>),
+    /// In a datasource
+    DataSource(ast::SourceId, SourcePosition),
 }
 
 /// A cursor position in a context.
@@ -316,5 +321,25 @@ impl<'ast> ExpressionPosition<'ast> {
             }
             _ => Self::Expression,
         }
+    }
+}
+
+#[derive(Debug)]
+pub enum SourcePosition {
+    /// In the general datasource
+    Source,
+    /// In a property
+    Property,
+}
+
+impl SourcePosition {
+    fn new(source: &ast::SourceConfig, position: usize) -> Self {
+        for prop in &source.properties {
+            if prop.span.contains(position) {
+                return SourcePosition::Property;
+            }
+        }
+
+        SourcePosition::Source
     }
 }

--- a/psl/schema-ast/src/ast/find_at_position.rs
+++ b/psl/schema-ast/src/ast/find_at_position.rs
@@ -330,6 +330,8 @@ pub enum SourcePosition {
     Source,
     /// In a property
     Property,
+    ///
+    Outer,
 }
 
 impl SourcePosition {
@@ -340,6 +342,10 @@ impl SourcePosition {
             }
         }
 
-        SourcePosition::Source
+        if source.inner_span.contains(position) {
+            return SourcePosition::Source;
+        }
+
+        SourcePosition::Outer
     }
 }

--- a/psl/schema-ast/src/ast/find_at_position.rs
+++ b/psl/schema-ast/src/ast/find_at_position.rs
@@ -355,13 +355,24 @@ pub enum PropertyPosition<'ast> {
     /// prop
     Property,
     ///
-    Argument(&'ast str, usize),
+    Value(&'ast str),
+    ///
+    FunctionValue(&'ast str),
 }
 
 impl<'ast> PropertyPosition<'ast> {
     fn new(property: &'ast ast::ConfigBlockProperty, position: usize) -> Self {
+        if let Some(val) = &property.value {
+            if val.span().contains(position) && val.is_function() {
+                let func = val.as_function().unwrap();
+
+                if func.0 == "env" {
+                    return PropertyPosition::FunctionValue("env");
+                }
+            }
+        }
         if property.span.contains(position) && !property.name.span.contains(position) {
-            return PropertyPosition::Argument(&property.name.name, position);
+            return PropertyPosition::Value(&property.name.name);
         }
 
         PropertyPosition::Property

--- a/psl/schema-ast/src/ast/model.rs
+++ b/psl/schema-ast/src/ast/model.rs
@@ -76,6 +76,8 @@ pub struct Model {
     pub(crate) is_view: bool,
     /// The location of this model in the text representation.
     pub(crate) span: Span,
+    /// The span of the inner contents.
+    pub(crate) inner_span: Span,
 }
 
 impl Model {

--- a/psl/schema-ast/src/ast/model.rs
+++ b/psl/schema-ast/src/ast/model.rs
@@ -76,8 +76,8 @@ pub struct Model {
     pub(crate) is_view: bool,
     /// The location of this model in the text representation.
     pub(crate) span: Span,
-    /// The span of the inner contents.
-    pub(crate) inner_span: Span,
+    // The span of the inner contents.
+    // pub(crate) inner_span: Span,
 }
 
 impl Model {

--- a/psl/schema-ast/src/ast/model.rs
+++ b/psl/schema-ast/src/ast/model.rs
@@ -76,8 +76,6 @@ pub struct Model {
     pub(crate) is_view: bool,
     /// The location of this model in the text representation.
     pub(crate) span: Span,
-    // The span of the inner contents.
-    // pub(crate) inner_span: Span,
 }
 
 impl Model {

--- a/psl/schema-ast/src/ast/source_config.rs
+++ b/psl/schema-ast/src/ast/source_config.rs
@@ -11,6 +11,8 @@ pub struct SourceConfig {
     pub(crate) documentation: Option<Comment>,
     /// The location of this source block in the text representation.
     pub span: Span,
+    ///
+    pub inner_span: Span,
 }
 
 impl WithIdentifier for SourceConfig {

--- a/psl/schema-ast/src/ast/source_config.rs
+++ b/psl/schema-ast/src/ast/source_config.rs
@@ -11,7 +11,7 @@ pub struct SourceConfig {
     pub(crate) documentation: Option<Comment>,
     /// The location of this source block in the text representation.
     pub span: Span,
-    ///
+    /// The span of the inner contents.
     pub inner_span: Span,
 }
 

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -70,10 +70,15 @@ config_block = {
     (DATASOURCE_KEYWORD | GENERATOR_KEYWORD)
     ~ identifier
     ~ BLOCK_OPEN
-    ~ (key_value | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
+    ~ ((key_value ~ NEWLINE) | comment_block | empty_lines| BLOCK_LEVEL_CATCH_ALL)*
     ~ BLOCK_CLOSE
     }
-key_value = { identifier ~ "=" ~ expression ~ trailing_comment? ~ NEWLINE }
+
+key_value = { identifier ~ "=" ~ expression ~ trailing_comment? }
+
+config_contents = {
+    ((key_value ~ NEWLINE) | comment_block | empty_lines| BLOCK_LEVEL_CATCH_ALL)*
+}
 
 // a block definition without a keyword. Is not valid. Just acts as a catch for the parser to display a nice error.
 arbitrary_block = { identifier ~ BLOCK_OPEN ~ ((!BLOCK_CLOSE ~ ANY) | NEWLINE)* ~ BLOCK_CLOSE }

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -30,7 +30,7 @@ model_declaration = {
     (MODEL_KEYWORD | TYPE_KEYWORD | VIEW_KEYWORD)
     ~ identifier
     ~ BLOCK_OPEN
-    ~ (field_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
+    ~ model_contents
     ~ BLOCK_CLOSE
     }
 
@@ -42,6 +42,10 @@ field_declaration = {
     ~ trailing_comment?
     ~ NEWLINE
     }
+
+model_contents = {
+    (field_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
+}
 
 // ######################################
 // Field Type
@@ -90,11 +94,14 @@ enum_declaration = {
     ENUM_KEYWORD
     ~ identifier
     ~ BLOCK_OPEN
-    ~ (enum_value_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)* 
+    ~ enum_contents
     ~ BLOCK_CLOSE
     }
 
 enum_value_declaration = { identifier ~ field_attribute* ~ trailing_comment? ~ NEWLINE }
+enum_contents = {
+    (enum_value_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)* 
+}
 
 // ######################################
 // Attributes

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -70,7 +70,7 @@ config_block = {
     (DATASOURCE_KEYWORD | GENERATOR_KEYWORD)
     ~ identifier
     ~ BLOCK_OPEN
-    ~ ((key_value ~ NEWLINE) | comment_block | empty_lines| BLOCK_LEVEL_CATCH_ALL)*
+    ~ config_contents
     ~ BLOCK_CLOSE
     }
 

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -78,7 +78,7 @@ config_block = {
     ~ BLOCK_CLOSE
     }
 
-key_value = { identifier ~ "=" ~ expression ~ trailing_comment? }
+key_value = { identifier ~ "=" ~ expression? ~ trailing_comment? }
 
 config_contents = {
     ((key_value ~ NEWLINE) | comment_block | empty_lines| BLOCK_LEVEL_CATCH_ALL)*

--- a/psl/schema-ast/src/parser/parse_composite_type.rs
+++ b/psl/schema-ast/src/parser/parse_composite_type.rs
@@ -6,7 +6,7 @@ use super::{
     Rule,
 };
 use crate::ast;
-use diagnostics::{DatamodelError, Diagnostics};
+use diagnostics::{DatamodelError, Diagnostics, Span};
 
 pub(crate) fn parse_composite_type(
     pair: Pair<'_>,
@@ -16,97 +16,108 @@ pub(crate) fn parse_composite_type(
     let pair_span = pair.as_span();
     let mut name: Option<ast::Identifier> = None;
     let mut fields: Vec<ast::Field> = vec![];
-    let mut pending_field_comment: Option<Pair<'_>> = None;
     let mut pairs = pair.into_inner();
+    let mut inner_span: Option<Span> = None;
 
     while let Some(current) = pairs.next() {
-        let current_span = current.as_span();
         match current.as_rule() {
+            Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => {}
             Rule::TYPE_KEYWORD => (),
             Rule::identifier => name = Some(current.into()),
-            Rule::block_attribute => {
-                let attr = parse_attribute(current, diagnostics);
+            Rule::model_contents => {
+                let mut pending_field_comment: Option<Pair<'_>> = None;
+                inner_span = Some(current.as_span().into());
 
-                let err = match attr.name.name.as_str() {
-                    "map" => {
-                        DatamodelError::new_validation_error(
-                            "The name of a composite type is not persisted in the database, therefore it does not need a mapped database name.",
-                            current_span.into(),
-                        )
-                    }
-                    "unique" => {
-                        DatamodelError::new_validation_error(
-                            "A unique constraint should be defined in the model containing the embed.",
-                            current_span.into(),
-                        )
-                    }
-                    "index" => {
-                        DatamodelError::new_validation_error(
-                            "An index should be defined in the model containing the embed.",
-                            current_span.into(),
-                        )
-                    }
-                    "fulltext" => {
-                        DatamodelError::new_validation_error(
-                            "A fulltext index should be defined in the model containing the embed.",
-                            current_span.into(),
-                        )
-                    }
-                    "id" => {
-                        DatamodelError::new_validation_error(
-                            "A composite type cannot define an id.",
-                            current_span.into(),
-                        )
-                    }
-                    _ => {
-                        DatamodelError::new_validation_error(
-                            "A composite type cannot have block-level attributes.",
-                            current_span.into(),
-                        )
-                    }
-                };
+                for item in current.into_inner() {
+                    let current_span = item.as_span();
 
-                diagnostics.push_error(err);
-            }
-            Rule::field_declaration => match parse_field(
-                &name.as_ref().unwrap().name,
-                "type",
-                current,
-                pending_field_comment.take(),
-                diagnostics,
-            ) {
-                Ok(field) => {
-                    for attr in field.attributes.iter() {
-                        let error = match attr.name.name.as_str() {
-                            "relation" | "unique" | "id" => {
-                                let name = attr.name.name.as_str();
+                    match item.as_rule() {
+                        Rule::block_attribute => {
+                            let attr = parse_attribute(item, diagnostics);
 
-                                let msg = format!(
-                                    "Defining `@{name}` attribute for a field in a composite type is not allowed."
-                                );
+                            let err = match attr.name.name.as_str() {
+                                "map" => {
+                                    DatamodelError::new_validation_error(
+                                        "The name of a composite type is not persisted in the database, therefore it does not need a mapped database name.",
+                                        current_span.into(),
+                                    )
+                                }
+                                "unique" => {
+                                    DatamodelError::new_validation_error(
+                                        "A unique constraint should be defined in the model containing the embed.",
+                                        current_span.into(),
+                                    )
+                                }
+                                "index" => {
+                                    DatamodelError::new_validation_error(
+                                        "An index should be defined in the model containing the embed.",
+                                        current_span.into(),
+                                    )
+                                }
+                                "fulltext" => {
+                                    DatamodelError::new_validation_error(
+                                        "A fulltext index should be defined in the model containing the embed.",
+                                        current_span.into(),
+                                    )
+                                }
+                                "id" => {
+                                    DatamodelError::new_validation_error(
+                                        "A composite type cannot define an id.",
+                                        current_span.into(),
+                                    )
+                                }
+                                _ => {
+                                    DatamodelError::new_validation_error(
+                                        "A composite type cannot have block-level attributes.",
+                                        current_span.into(),
+                                    )
+                                }
+                            };
 
-                                DatamodelError::new_validation_error(&msg, current_span.into())
+                            diagnostics.push_error(err);
+                        }
+                        Rule::field_declaration => match parse_field(
+                            &name.as_ref().unwrap().name,
+                            "type",
+                            item,
+                            pending_field_comment.take(),
+                            diagnostics,
+                        ) {
+                            Ok(field) => {
+                                for attr in field.attributes.iter() {
+                                    let error = match attr.name.name.as_str() {
+                                        "relation" | "unique" | "id" => {
+                                            let name = attr.name.name.as_str();
+
+                                            let msg = format!(
+                                                "Defining `@{name}` attribute for a field in a composite type is not allowed."
+                                            );
+
+                                            DatamodelError::new_validation_error(&msg, current_span.into())
+                                        }
+                                        _ => continue,
+                                    };
+
+                                    diagnostics.push_error(error);
+                                }
+
+                                fields.push(field)
                             }
-                            _ => continue,
-                        };
-
-                        diagnostics.push_error(error);
+                            Err(err) => diagnostics.push_error(err),
+                        },
+                        Rule::comment_block => {
+                            if let Some(Rule::field_declaration) = pairs.peek().map(|p| p.as_rule()) {
+                                pending_field_comment = Some(item);
+                            }
+                        }
+                        Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
+                            "This line is not a valid field or attribute definition.",
+                            item.as_span().into(),
+                        )),
+                        _ => parsing_catch_all(&item, "composite type"),
                     }
-
-                    fields.push(field)
-                }
-                Err(err) => diagnostics.push_error(err),
-            },
-            Rule::comment_block => {
-                if let Some(Rule::field_declaration) = pairs.peek().map(|p| p.as_rule()) {
-                    pending_field_comment = Some(current);
                 }
             }
-            Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => {}
-            Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                "This line is not a valid field or attribute definition.",
-                current.as_span().into(),
-            )),
             _ => parsing_catch_all(&current, "composite type"),
         }
     }
@@ -117,6 +128,7 @@ pub(crate) fn parse_composite_type(
             fields,
             documentation: doc_comment.and_then(parse_comment_block),
             span: ast::Span::from(pair_span),
+            inner_span: inner_span.unwrap(),
         },
         _ => panic!("Encountered impossible model declaration during parsing",),
     }

--- a/psl/schema-ast/src/parser/parse_model.rs
+++ b/psl/schema-ast/src/parser/parse_model.rs
@@ -13,28 +13,38 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = Vec::new();
     let mut fields: Vec<Field> = Vec::new();
-    let mut pending_field_comment: Option<Pair<'_>> = None;
+    let mut inner_span: Option<Span> = None;
 
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::MODEL_KEYWORD | Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => {}
             Rule::identifier => name = Some(current.into()),
-            Rule::block_attribute => attributes.push(parse_attribute(current, diagnostics)),
-            Rule::field_declaration => match parse_field(
-                &name.as_ref().unwrap().name,
-                "model",
-                current,
-                pending_field_comment.take(),
-                diagnostics,
-            ) {
-                Ok(field) => fields.push(field),
-                Err(err) => diagnostics.push_error(err),
-            },
-            Rule::comment_block => pending_field_comment = Some(current),
-            Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                "This line is not a valid field or attribute definition.",
-                current.as_span().into(),
-            )),
+            Rule::model_contents => {
+                let mut pending_field_comment: Option<Pair<'_>> = None;
+                inner_span = Some(current.as_span().into());
+
+                for item in current.into_inner() {
+                    match item.as_rule() {
+                        Rule::block_attribute => attributes.push(parse_attribute(item, diagnostics)),
+                        Rule::field_declaration => match parse_field(
+                            &name.as_ref().unwrap().name,
+                            "model",
+                            item,
+                            pending_field_comment.take(),
+                            diagnostics,
+                        ) {
+                            Ok(field) => fields.push(field),
+                            Err(err) => diagnostics.push_error(err),
+                        },
+                        Rule::comment_block => pending_field_comment = Some(item),
+                        Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
+                            "This line is not a valid field or attribute definition.",
+                            item.as_span().into(),
+                        )),
+                        _ => parsing_catch_all(&item, "model"),
+                    }
+                }
+            }
             _ => parsing_catch_all(&current, "model"),
         }
     }
@@ -47,6 +57,7 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
             documentation: doc_comment.and_then(parse_comment_block),
             is_view: false,
             span: Span::from(pair_span),
+            inner_span: inner_span.unwrap(),
         },
         _ => panic!("Encountered impossible model declaration during parsing",),
     }

--- a/psl/schema-ast/src/parser/parse_model.rs
+++ b/psl/schema-ast/src/parser/parse_model.rs
@@ -13,7 +13,6 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = Vec::new();
     let mut fields: Vec<Field> = Vec::new();
-    let mut inner_span: Option<Span> = None;
 
     for current in pair.into_inner() {
         match current.as_rule() {
@@ -21,7 +20,6 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
             Rule::identifier => name = Some(current.into()),
             Rule::model_contents => {
                 let mut pending_field_comment: Option<Pair<'_>> = None;
-                inner_span = Some(current.as_span().into());
 
                 for item in current.into_inner() {
                     match item.as_rule() {
@@ -57,7 +55,6 @@ pub(crate) fn parse_model(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnos
             documentation: doc_comment.and_then(parse_comment_block),
             is_view: false,
             span: Span::from(pair_span),
-            inner_span: inner_span.unwrap(),
         },
         _ => panic!("Encountered impossible model declaration during parsing",),
     }

--- a/psl/schema-ast/src/parser/parse_source_and_generator.rs
+++ b/psl/schema-ast/src/parser/parse_source_and_generator.rs
@@ -7,29 +7,40 @@ use super::{
 use crate::ast::*;
 use diagnostics::{DatamodelError, Diagnostics};
 
+#[track_caller]
 pub(crate) fn parse_config_block(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Top {
     let pair_span = pair.as_span();
     let mut name: Option<Identifier> = None;
     let mut properties = Vec::new();
     let mut comment: Option<Comment> = None;
     let mut kw = None;
+    let mut inner_span: Option<Span> = None;
 
     for current in pair.into_inner() {
         match current.as_rule() {
+            Rule::config_contents => {
+                inner_span = Some(current.as_span().into());
+                for item in current.into_inner() {
+                    match item.as_rule() {
+                        Rule::key_value => properties.push(parse_key_value(item, diagnostics)),
+                        Rule::comment_block => comment = parse_comment_block(item),
+                        Rule::BLOCK_LEVEL_CATCH_ALL => {
+                            let msg = format!(
+                                "This line is not a valid definition within a {}.",
+                                kw.unwrap_or("configuration block")
+                            );
+
+                            let err = DatamodelError::new_validation_error(&msg, item.as_span().into());
+                            diagnostics.push_error(err);
+                        }
+                        _ => parsing_catch_all(&item, "source"),
+                    }
+                }
+            }
             Rule::identifier => name = Some(current.into()),
-            Rule::key_value => properties.push(parse_key_value(current, diagnostics)),
-            Rule::comment_block => comment = parse_comment_block(current),
             Rule::DATASOURCE_KEYWORD | Rule::GENERATOR_KEYWORD => kw = Some(current.as_str()),
             Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => {}
-            Rule::BLOCK_LEVEL_CATCH_ALL => {
-                let msg = format!(
-                    "This line is not a valid definition within a {}.",
-                    kw.unwrap_or("configuration block")
-                );
 
-                let err = DatamodelError::new_validation_error(&msg, current.as_span().into());
-                diagnostics.push_error(err);
-            }
             _ => parsing_catch_all(&current, "source"),
         }
     }
@@ -40,6 +51,7 @@ pub(crate) fn parse_config_block(pair: Pair<'_>, diagnostics: &mut Diagnostics) 
             properties,
             documentation: comment,
             span: Span::from(pair_span),
+            inner_span: inner_span.unwrap(),
         }),
         Some("generator") => Top::Generator(GeneratorConfig {
             name: name.unwrap(),

--- a/psl/schema-ast/src/parser/parse_source_and_generator.rs
+++ b/psl/schema-ast/src/parser/parse_source_and_generator.rs
@@ -81,7 +81,7 @@ fn parse_key_value(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> ConfigBlock
     }
 
     match (name, value) {
-        (Some(name), Some(value)) => ConfigBlockProperty {
+        (Some(name), value) => ConfigBlockProperty {
             name,
             value,
             span: Span::from(pair_span),

--- a/psl/schema-ast/src/parser/parse_view.rs
+++ b/psl/schema-ast/src/parser/parse_view.rs
@@ -6,35 +6,45 @@ use super::{
     Rule,
 };
 use crate::ast::{self, Attribute};
-use diagnostics::{DatamodelError, Diagnostics};
+use diagnostics::{DatamodelError, Diagnostics, Span};
 
 pub(crate) fn parse_view(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnostics: &mut Diagnostics) -> ast::Model {
     let pair_span = pair.as_span();
     let mut name: Option<ast::Identifier> = None;
     let mut fields: Vec<ast::Field> = vec![];
-    let mut pending_field_comment: Option<Pair<'_>> = None;
     let mut attributes: Vec<Attribute> = Vec::new();
+    let mut inner_span: Option<Span> = None;
 
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::VIEW_KEYWORD | Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => (),
             Rule::identifier => name = Some(current.into()),
-            Rule::block_attribute => attributes.push(parse_attribute(current, diagnostics)),
-            Rule::field_declaration => match parse_field(
-                &name.as_ref().unwrap().name,
-                "view",
-                current,
-                pending_field_comment.take(),
-                diagnostics,
-            ) {
-                Ok(field) => fields.push(field),
-                Err(err) => diagnostics.push_error(err),
-            },
-            Rule::comment_block => pending_field_comment = Some(current),
-            Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
-                "This line is not a valid field or attribute definition.",
-                current.as_span().into(),
-            )),
+            Rule::model_contents => {
+                let mut pending_field_comment: Option<Pair<'_>> = None;
+                inner_span = Some(current.as_span().into());
+
+                for item in current.into_inner() {
+                    match item.as_rule() {
+                        Rule::block_attribute => attributes.push(parse_attribute(item, diagnostics)),
+                        Rule::field_declaration => match parse_field(
+                            &name.as_ref().unwrap().name,
+                            "view",
+                            item,
+                            pending_field_comment.take(),
+                            diagnostics,
+                        ) {
+                            Ok(field) => fields.push(field),
+                            Err(err) => diagnostics.push_error(err),
+                        },
+                        Rule::comment_block => pending_field_comment = Some(item),
+                        Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
+                            "This line is not a valid field or attribute definition.",
+                            item.as_span().into(),
+                        )),
+                        _ => parsing_catch_all(&item, "view"),
+                    }
+                }
+            }
             _ => parsing_catch_all(&current, "view"),
         }
     }
@@ -47,6 +57,7 @@ pub(crate) fn parse_view(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnost
             documentation: doc_comment.and_then(parse_comment_block),
             is_view: true,
             span: ast::Span::from(pair_span),
+            inner_span: inner_span.unwrap(),
         },
         _ => panic!("Encountered impossible model declaration during parsing",),
     }

--- a/psl/schema-ast/src/parser/parse_view.rs
+++ b/psl/schema-ast/src/parser/parse_view.rs
@@ -6,14 +6,13 @@ use super::{
     Rule,
 };
 use crate::ast::{self, Attribute};
-use diagnostics::{DatamodelError, Diagnostics, Span};
+use diagnostics::{DatamodelError, Diagnostics};
 
 pub(crate) fn parse_view(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnostics: &mut Diagnostics) -> ast::Model {
     let pair_span = pair.as_span();
     let mut name: Option<ast::Identifier> = None;
     let mut fields: Vec<ast::Field> = vec![];
     let mut attributes: Vec<Attribute> = Vec::new();
-    let mut inner_span: Option<Span> = None;
 
     for current in pair.into_inner() {
         match current.as_rule() {
@@ -21,7 +20,6 @@ pub(crate) fn parse_view(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnost
             Rule::identifier => name = Some(current.into()),
             Rule::model_contents => {
                 let mut pending_field_comment: Option<Pair<'_>> = None;
-                inner_span = Some(current.as_span().into());
 
                 for item in current.into_inner() {
                     match item.as_rule() {
@@ -57,7 +55,6 @@ pub(crate) fn parse_view(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnost
             documentation: doc_comment.and_then(parse_comment_block),
             is_view: true,
             span: ast::Span::from(pair_span),
-            inner_span: inner_span.unwrap(),
         },
         _ => panic!("Encountered impossible model declaration during parsing",),
     }


### PR DESCRIPTION
## Changes
Adding datasource completions was necessary as part of this to ensure effective testing. This will require a follow-up PR in language-tools to remove the completions mentioned below from there
- [x] Added `datasource` completions :: `text_document_completions/datasource.rs`
  - [x] `schemas`
  - [x] `relationMode`
  - [x] `provider`
    - [ ] providers - [postgresql, etc...]
  - [x] `extensions`
  - [x] `directUrl`
  - [x] `shadowDatabase`
  - [x] `url`
    - [x] `""`
    - [x] `env`
      - [x] `XYZ_URL`

- [x] Completions trigger at start of line
  - this was enabled by pulling the `NEWLINE` out of the values i.e. `(key_value ~ NEWLINE)`, this has only been done for `config_block` and will need to be done for the rest later
- [x] Completions only trigger within the bounds (`{}`) of the model
  - this was enabled by the new `inner_span` in the parser from the `xyz_contents` added to the grammar
- [x] Func for generating pretty doc for params, see [language-tools/completionUtils](https://github.com/prisma/language-tools/blob/73c3c621ad8d5068a0fa887ae3b6f3f97543bf78/packages/language-server/src/completion/completionUtils.ts#L68-L98)
  - Added this through `format_completion_docs`
- [x] Specific completions should show before general
  - Previously general DS completions were showing before specific URL completions despite them showing up in the correct spot <img width="888" alt="image" src="https://user-images.githubusercontent.com/29753584/221859057-364c2950-997a-4eec-a518-f167443c84ba.png"> <img width="880" alt="image" src="https://user-images.githubusercontent.com/29753584/221859312-6d24f472-4b71-477d-9c04-5641886b6761.png">
  - This was fixed by updating config block property values to be Optional so that it was possible to select positions for properties that did not yet have a value assigned
- [x] Fix other tests
- [x] Add tests
- [x] Remove "engines" marker from new completions labels

## Bugs
- [ ] Completions shouldn't trigger on the closing line with the `}` on it :: This also existed prior to this PR with the language-tools impl.
  - Possibly relevant Pest [docs](https://docs.rs/pest/latest/pest/#push-pop-drop-and-peek). [Internal discussion](https://prisma-company.slack.com/archives/C02FNFLDUS3/p1675335077997929?thread_ts=1675096401.749589&cid=C02FNFLDUS3)
  - <img width="490" alt="image" src="https://user-images.githubusercontent.com/29753584/222594635-69ce094d-91e4-4c5a-bde8-6514d1814948.png">
  
- [ ] Property value completions can trigger anywhere _after_ the name, which can be before the `=` sign :: This is an issue with `find_at_position` and would probably require changes in the PEST grammar to include having the `=` as an identifiable piece in the parser for config blocks.
  - <img width="351" alt="image" src="https://user-images.githubusercontent.com/29753584/222593024-0180a752-d6bd-45e3-bc51-25aa18f97a81.png">
  
- [ ] Value completions are available after a value (but not _immediately_ like one space after) -- note, this only seems to affect `url` completions, completions do _not_ show up again on the same line for `provider`, `schemas`, and `relationMode`
  - <img width="475" alt="image" src="https://user-images.githubusercontent.com/29753584/222593278-63f2c4cc-f09c-4862-9598-e8a85f644b34.png">
  
- [ ] This is silly -- `XYZ_URL` showing up as a completion within the text `env` but not between `v` and `(`
  - <img width="508" alt="image" src="https://user-images.githubusercontent.com/29753584/222593617-28e7151c-4d8f-4f94-b1bb-126e170ec03b.png">
  
- [ ] `XYZ_URL` shows up as a completion anywhere between the left parenthesis and the character right after `)` in `env(...)`
  - <img width="508" alt="image" src="https://user-images.githubusercontent.com/29753584/222593998-0e88749f-6464-4556-9419-a455583042f0.png">
  
## Todo
- [ ] Remove datasource completions from https://github.com/prisma/language-tools
  - This will include sub-completions such as `env` && `""` for url, or `XYZ_URL` for inside `env` 
- [ ] update `pris.ly` links per [internal convo](https://prisma-company.slack.com/archives/C4GCG53BP/p1678699928795729?thread_ts=1677845503.850499&cid=C4GCG53BP)
- [ ] Break-up `lift_datasource` & `lift_generator` starting to get a lil unwieldy
- [ ] Make eldritch language tests more readable to avoid future issues where snapshots change and we don't know what or why
- [ ] Stub datasource so that we can validate for missing providers / urls prior to having a full datasource (i.e. both exist)?

closes https://github.com/prisma/prisma/issues/17000
Note: This does not entirely fix the issue and is instead a template for future completions additions to engines. This fixes the issue for _datasource_ completions. When, in the future, we add completions to other parts of the schema from engines, this will require similar changes as done here to the PSL.
This is built off the back of the [previous pr](https://github.com/prisma/prisma-engines/pull/3541) for adding `schemas` completions.