### PR TITLE
psl: use generic Walker struct for ScalarFieldWalker

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context.rs
@@ -185,14 +185,14 @@ impl<'a> DatamodelCalculatorContext<'a> {
         self.introspection_map
             .existing_model_scalar_fields
             .get(&id)
-            .map(|(model_id, field_id)| self.previous_schema.db.walk(*model_id).scalar_field(*field_id))
+            .map(|id| self.previous_schema.db.walk(*id))
     }
 
     pub(crate) fn existing_view_scalar_field(&self, id: sql::ViewColumnId) -> Option<walkers::ScalarFieldWalker<'a>> {
         self.introspection_map
             .existing_view_scalar_fields
             .get(&id)
-            .map(|(model_id, field_id)| self.previous_schema.db.walk(*model_id).scalar_field(*field_id))
+            .map(|id| self.previous_schema.db.walk(*id))
     }
 
     pub(crate) fn column_prisma_name(

--- a/psl/parser-database/src/walkers/field.rs
+++ b/psl/parser-database/src/walkers/field.rs
@@ -1,4 +1,4 @@
-use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldId, ScalarFieldWalker, Walker};
+use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldWalker, Walker};
 use crate::ScalarType;
 use schema_ast::ast;
 
@@ -23,18 +23,11 @@ impl<'db> FieldWalker<'db> {
 
     /// Find out which kind of field this is.
     pub fn refine(self) -> RefinedFieldWalker<'db> {
-        let Walker {
-            id: (model_id, field_id),
-            db,
-        } = self;
+        let (model_id, field_id) = self.id;
         if self.db.types.relation_fields.contains_key(&self.id) {
             RefinedFieldWalker::Relation(self.walk(super::RelationFieldId(model_id, field_id)))
-        } else if let Some(scalar_field) = self.db.types.scalar_fields.get(&self.id) {
-            RefinedFieldWalker::Scalar(ScalarFieldWalker {
-                id: ScalarFieldId(model_id, field_id),
-                db,
-                scalar_field,
-            })
+        } else if self.db.types.scalar_fields.contains_key(&self.id) {
+            RefinedFieldWalker::Scalar(self.walk(super::ScalarFieldId(model_id, field_id)))
         } else {
             unreachable!("{:?} is neither a scalar field nor a relation field", self.id)
         }

--- a/psl/parser-database/src/walkers/index.rs
+++ b/psl/parser-database/src/walkers/index.rs
@@ -1,4 +1,4 @@
-use super::CompositeTypeFieldWalker;
+use super::{CompositeTypeFieldWalker, ScalarFieldId};
 use crate::{
     ast,
     types::{IndexAlgorithm, IndexAttribute},
@@ -115,7 +115,7 @@ impl<'db> IndexWalker<'db> {
                     IndexFieldWalker::new(walker)
                 }
                 None => {
-                    let walker = self.model().scalar_field(field_id);
+                    let walker = self.db.walk(ScalarFieldId(self.model_id, field_id));
                     IndexFieldWalker::new(walker)
                 }
             }
@@ -194,7 +194,7 @@ impl<'db> IndexWalker<'db> {
     pub fn source_field(self) -> Option<ScalarFieldWalker<'db>> {
         self.index_attribute
             .source_field
-            .map(|field_id| self.model().scalar_field(field_id))
+            .map(|field_id| self.db.walk(ScalarFieldId(self.model_id, field_id)))
     }
 }
 

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -124,27 +124,13 @@ impl<'db> ModelWalker<'db> {
         })
     }
 
-    /// Walk a scalar field by id.
-    #[track_caller]
-    pub fn scalar_field(self, field_id: ast::FieldId) -> ScalarFieldWalker<'db> {
-        ScalarFieldWalker {
-            id: super::ScalarFieldId(self.id, field_id),
-            db: self.db,
-            scalar_field: &self.db.types.scalar_fields[&(self.id, field_id)],
-        }
-    }
-
     /// Iterate all the scalar fields in a given model in the order they were defined.
     pub fn scalar_fields(self) -> impl Iterator<Item = ScalarFieldWalker<'db>> {
         let db = self.db;
         db.types
             .scalar_fields
             .range((self.id, ast::FieldId::MIN)..=(self.id, ast::FieldId::MAX))
-            .map(move |((model_id, field_id), scalar_field)| ScalarFieldWalker {
-                id: super::ScalarFieldId(*model_id, *field_id),
-                db,
-                scalar_field,
-            })
+            .map(move |((model_id, field_id), _)| self.walk(super::ScalarFieldId(*model_id, *field_id)))
     }
 
     /// All unique criterias of the model; consisting of the primary key and

--- a/psl/parser-database/src/walkers/model/primary_key.rs
+++ b/psl/parser-database/src/walkers/model/primary_key.rs
@@ -1,7 +1,7 @@
 use crate::{
     ast,
     types::IdAttribute,
-    walkers::{ModelWalker, ScalarFieldAttributeWalker, ScalarFieldWalker},
+    walkers::{ModelWalker, ScalarFieldAttributeWalker, ScalarFieldId, ScalarFieldWalker},
     ParserDatabase,
 };
 
@@ -68,7 +68,7 @@ impl<'db> PrimaryKeyWalker<'db> {
     pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         self.attribute.fields.iter().map(move |field| {
             let field_id = field.path.field_in_index();
-            self.model().scalar_field(field_id)
+            self.db.walk(ScalarFieldId(self.model_id, field_id))
         })
     }
 

--- a/psl/parser-database/src/walkers/model/unique_criteria.rs
+++ b/psl/parser-database/src/walkers/model/unique_criteria.rs
@@ -1,11 +1,9 @@
 use crate::{
     ast,
     types::FieldWithArgs,
-    walkers::{IndexFieldWalker, ScalarFieldWalker},
+    walkers::{IndexFieldWalker, ScalarFieldId, ScalarFieldWalker},
     ParserDatabase,
 };
-
-use super::ModelWalker;
 
 /// Describes any unique criteria in a model. Can either be a primary
 /// key, or a unique index.
@@ -23,7 +21,7 @@ impl<'db> UniqueCriteriaWalker<'db> {
 
             match field.path.type_holding_the_indexed_field() {
                 None => {
-                    let walker = self.model().scalar_field(field_id);
+                    let walker = self.db.walk(ScalarFieldId(self.model_id, field_id));
                     IndexFieldWalker::new(walker)
                 }
                 Some(ctid) => {
@@ -54,9 +52,5 @@ impl<'db> UniqueCriteriaWalker<'db> {
 
     pub fn has_unsupported_fields(self) -> bool {
         self.fields().any(|field| field.is_unsupported())
-    }
-
-    fn model(self) -> ModelWalker<'db> {
-        self.db.walk(self.model_id)
     }
 }

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -1,7 +1,7 @@
 use schema_ast::ast;
 
 use crate::{
-    walkers::{ModelWalker, RelationFieldWalker, ScalarFieldWalker},
+    walkers::{ModelWalker, RelationFieldWalker, ScalarFieldId, ScalarFieldWalker},
     ParserDatabase, ReferentialAction,
 };
 
@@ -40,12 +40,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
     pub fn referenced_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         let f = move |field_id: &ast::FieldId| {
             let model_id = self.referenced_model().id;
-
-            ScalarFieldWalker {
-                id: crate::walkers::ScalarFieldId(model_id, *field_id),
-                db: self.db,
-                scalar_field: &self.db.types.scalar_fields[&(model_id, *field_id)],
-            }
+            self.db.walk(ScalarFieldId(model_id, *field_id))
         };
 
         match self.referencing_field().attributes().references.as_ref() {
@@ -58,12 +53,7 @@ impl<'db> CompleteInlineRelationWalker<'db> {
     pub fn referencing_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
         let f = move |field_id: &ast::FieldId| {
             let model_id = self.referencing_model().id;
-
-            ScalarFieldWalker {
-                id: crate::walkers::ScalarFieldId(model_id, *field_id),
-                db: self.db,
-                scalar_field: &self.db.types.scalar_fields[&(model_id, *field_id)],
-            }
+            self.db.walk(ScalarFieldId(model_id, *field_id))
         };
 
         match self.referencing_field().attributes().fields.as_ref() {

--- a/psl/parser-database/src/walkers/relation_field.rs
+++ b/psl/parser-database/src/walkers/relation_field.rs
@@ -99,7 +99,7 @@ impl<'db> RelationFieldWalker<'db> {
         self.attributes().references.as_ref().map(|references| {
             references
                 .iter()
-                .map(move |field_id| self.related_model().scalar_field(*field_id))
+                .map(move |field_id| self.walk(ScalarFieldId(self.related_model().id, *field_id)))
         })
     }
 
@@ -159,11 +159,9 @@ impl<'db> RelationFieldWalker<'db> {
         let model_id = self.id.0;
         let attributes = self.attributes();
         attributes.fields.as_ref().map(move |fields| {
-            fields.iter().map(move |field_id| ScalarFieldWalker {
-                id: super::ScalarFieldId(model_id, *field_id),
-                db: self.db,
-                scalar_field: &self.db.types.scalar_fields[&(model_id, *field_id)],
-            })
+            fields
+                .iter()
+                .map(move |field_id| self.db.walk(super::ScalarFieldId(model_id, *field_id)))
         })
     }
 }

--- a/psl/psl-core/src/reformat.rs
+++ b/psl/psl-core/src/reformat.rs
@@ -222,7 +222,6 @@ fn push_missing_scalar_fields(inline: walkers::InlineRelationWalker<'_>, ctx: &m
 }
 
 /// A scalar inferred by magic reformatting.
-#[derive(Debug)]
 struct InferredScalarField<'db> {
     name: String,
     arity: ast::FieldArity,


### PR DESCRIPTION
Do the same for scalar fields as what we did for relation fields in 72a5d0e5c0fb251c9ad8f37d6b682372bb5f2463.

This makes them easier to construct and less surprising, at the cost of different performance characteristics (possibly more lookups in the Types::relation_fields tree).