### PR TITLE
qe: resolve datasource overrides when ignoring env var errors

### DIFF
--- a/psl/psl-core/src/configuration/configuration_struct.rs
+++ b/psl/psl-core/src/configuration/configuration_struct.rs
@@ -63,8 +63,7 @@ impl Configuration {
             }
 
             if datasource.url.from_env_var.is_some() && datasource.url.value.is_none() {
-                let url = datasource.load_url(env);
-                datasource.url.value = match url {
+                datasource.url.value = match datasource.load_url(env) {
                     Ok(url) => Some(url),
                     Err(_) if ignore_env_var_errors => None,
                     Err(error) => return Err(error),

--- a/psl/psl-core/src/configuration/configuration_struct.rs
+++ b/psl/psl-core/src/configuration/configuration_struct.rs
@@ -51,7 +51,7 @@ impl Configuration {
         &mut self,
         url_overrides: &[(String, String)],
         env: F,
-        ignore_env_var_errors: bool,
+        ignore_env_errors: bool,
     ) -> Result<(), Diagnostics>
     where
         F: Fn(&str) -> Option<String> + Copy,
@@ -65,7 +65,7 @@ impl Configuration {
             if datasource.url.from_env_var.is_some() && datasource.url.value.is_none() {
                 datasource.url.value = match datasource.load_url(env) {
                     Ok(url) => Some(url),
-                    Err(_) if ignore_env_var_errors => None,
+                    Err(_) if ignore_env_errors => None,
                     Err(error) => return Err(error),
                 };
             }

--- a/psl/psl/tests/config/sources.rs
+++ b/psl/psl/tests/config/sources.rs
@@ -495,7 +495,7 @@ fn must_succeed_if_env_var_is_missing_but_override_was_provided() {
     let overrides = vec![("ds".to_string(), url.to_string())];
     let mut config = parse_configuration(schema);
     config
-        .resolve_datasource_urls_query_engine(&overrides, load_env_var)
+        .resolve_datasource_urls_query_engine(&overrides, load_env_var, false)
         .unwrap();
     let data_source = config.datasources.first().unwrap();
 
@@ -522,7 +522,7 @@ fn must_succeed_if_env_var_exists_and_override_was_provided() {
     let mut config = parse_configuration(schema);
 
     config
-        .resolve_datasource_urls_query_engine(&overrides, load_env_var)
+        .resolve_datasource_urls_query_engine(&overrides, load_env_var, false)
         .unwrap();
 
     let data_source = config.datasources.first().unwrap();
@@ -548,7 +548,7 @@ fn must_succeed_with_overrides() {
     let mut config = parse_configuration(schema);
 
     config
-        .resolve_datasource_urls_query_engine(overrides, load_env_var)
+        .resolve_datasource_urls_query_engine(overrides, load_env_var, false)
         .unwrap();
 
     let data_source = config.datasources.first().unwrap();

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -156,11 +156,13 @@ impl QueryEngine {
             .to_result()
             .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
 
-        if !ignore_env_var_errors {
-            config
-                .resolve_datasource_urls_query_engine(&overrides, |key| env.get(key).map(ToString::to_string))
-                .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
-        }
+        config
+            .resolve_datasource_urls_query_engine(
+                &overrides,
+                |key| env.get(key).map(ToString::to_string),
+                ignore_env_var_errors,
+            )
+            .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
 
         config
             .validate_that_one_datasource_is_provided()

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -65,11 +65,13 @@ pub fn get_config(js_env: Env, options: JsUnknown) -> napi::Result<JsUnknown> {
     let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();
     let mut config = psl::parse_configuration(&datamodel).map_err(|errors| ApiError::conversion(errors, &datamodel))?;
 
-    if !ignore_env_var_errors {
-        config
-            .resolve_datasource_urls_query_engine(&overrides, |key| env.get(key).map(ToString::to_string))
-            .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
-    }
+    config
+        .resolve_datasource_urls_query_engine(
+            &overrides,
+            |key| env.get(key).map(ToString::to_string),
+            ignore_env_var_errors,
+        )
+        .map_err(|errors| ApiError::conversion(errors, &datamodel))?;
 
     let serialized = psl::get_config::config_to_mcf_json_value(&config);
 

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -95,9 +95,7 @@ impl CliCommand {
     fn get_config(mut req: GetConfigRequest) -> PrismaResult<()> {
         let config = &mut req.config;
 
-        if !req.ignore_env_var_errors {
-            config.resolve_datasource_urls_query_engine(&[], |key| env::var(key).ok())?;
-        }
+        config.resolve_datasource_urls_query_engine(&[], |key| env::var(key).ok(), req.ignore_env_var_errors)?;
 
         let json = psl::get_config::config_to_mcf_json_value(config);
         let serialized = serde_json::to_string(&json)?;

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -154,12 +154,14 @@ impl PrismaOpt {
             Vec::new()
         };
 
-        if !ignore_env_errors {
-            schema
-                .configuration
-                .resolve_datasource_urls_query_engine(&datasource_url_overrides, |key| env::var(key).ok(), false)
-                .map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))?;
-        }
+        schema
+            .configuration
+            .resolve_datasource_urls_query_engine(
+                &datasource_url_overrides,
+                |key| env::var(key).ok(),
+                ignore_env_errors,
+            )
+            .map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))?;
 
         Ok(schema)
     }
@@ -174,20 +176,17 @@ impl PrismaOpt {
             Vec::new()
         };
 
-        let config_result = if ignore_env_errors {
-            psl::parse_configuration(datamodel_str)
-        } else {
-            psl::parse_configuration(datamodel_str).and_then(|mut config| {
+        psl::parse_configuration(datamodel_str)
+            .and_then(|mut config| {
                 config.resolve_datasource_urls_query_engine(
                     &datasource_url_overrides,
                     |key| env::var(key).ok(),
-                    false,
+                    ignore_env_errors,
                 )?;
 
                 Ok(config)
             })
-        };
-        config_result.map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))
+            .map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))
     }
 
     /// Extract the log format from on the RUST_LOG_FORMAT env var.

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -157,7 +157,7 @@ impl PrismaOpt {
         if !ignore_env_errors {
             schema
                 .configuration
-                .resolve_datasource_urls_query_engine(&datasource_url_overrides, |key| env::var(key).ok())
+                .resolve_datasource_urls_query_engine(&datasource_url_overrides, |key| env::var(key).ok(), false)
                 .map_err(|errors| PrismaError::ConversionError(errors, datamodel_str.to_string()))?;
         }
 
@@ -178,7 +178,11 @@ impl PrismaOpt {
             psl::parse_configuration(datamodel_str)
         } else {
             psl::parse_configuration(datamodel_str).and_then(|mut config| {
-                config.resolve_datasource_urls_query_engine(&datasource_url_overrides, |key| env::var(key).ok())?;
+                config.resolve_datasource_urls_query_engine(
+                    &datasource_url_overrides,
+                    |key| env::var(key).ok(),
+                    false,
+                )?;
 
                 Ok(config)
             })


### PR DESCRIPTION
Previously when `ignore_env_var_errors` option was passed from the client, the whole datasource url resolution via `resolve_datasource_urls_query_engine` method of `psl_core::Configuration` was skipped. This caused issues with datasource overrides, as those were never resolved in that case.

`resolve_datasource_urls_query_engine` was always used in the following pattern (except in tests):

```rust
if !ignore_env_var_errors {
  config.resolve_datasource_urls_query_engine(&overrides, get_env_var_somehow)?;
}
```

This PR moves `ignore_env_var_errors` inside the function as a parameter since they always go together, and fixes the behavior to match the name of the variable by only ignoring the env errors instead of skipping the whole function.

This is related to making it possible to get rid of `get_config` in the Node-API library engine, and is necessary to redo https://github.com/prisma/prisma/pull/17455 without a [regression](https://github.com/prisma/prisma/issues/17797) we had in 4.10.0.

Ref: https://github.com/prisma/prisma/pull/17830
Fixes: https://github.com/prisma/prisma/issues/17873