### PR TITLE
psl: stop using DML for test assertions on relation fields

### DIFF
--- a/psl/psl/tests/attributes/ignore_positive.rs
+++ b/psl/psl/tests/attributes/ignore_positive.rs
@@ -32,7 +32,7 @@ fn allow_ignore_on_valid_model() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = parse_schema(dml);
     datamodel.assert_has_model("ModelId").assert_ignored(true);
     datamodel.assert_has_model("ModelUnique").assert_ignored(true);
     datamodel.assert_has_model("ModelCompoundId").assert_ignored(true);
@@ -74,7 +74,7 @@ fn allow_ignore_on_invalid_models() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = parse_schema(dml);
     datamodel.assert_has_model("ModelNoFields").assert_ignored(true);
     datamodel.assert_has_model("ModelNoId").assert_ignored(true);
     datamodel.assert_has_model("ModelOptionalId").assert_ignored(true);
@@ -114,7 +114,7 @@ fn allow_ignore_on_valid_models_in_relations() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = psl::parse_schema(dml).unwrap();
     datamodel
         .assert_has_model("ModelValidA")
         .assert_ignored(true)
@@ -169,7 +169,7 @@ fn allow_ignore_on_invalid_models_in_relations() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = parse_schema(dml);
     datamodel
         .assert_has_model("ModelInvalidA")
         .assert_ignored(true)
@@ -212,7 +212,7 @@ fn allow_ignore_on_scalar_fields() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = parse_schema(dml);
     datamodel
         .assert_has_model("ModelA")
         .assert_has_scalar_field("b")
@@ -233,7 +233,7 @@ fn allow_ignore_on_scalar_fields_that_are_used() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = parse_schema(dml);
     datamodel
         .assert_has_model("ModelA")
         .assert_has_scalar_field("b")
@@ -277,7 +277,7 @@ fn allow_ignore_on_relation_fields_on_valid_models() {
     }
     "#;
 
-    let datamodel = parse(dml);
+    let datamodel = parse_schema(dml);
     datamodel
         .assert_has_model("ModelValidA")
         .assert_has_relation_field("rel_b")

--- a/psl/psl/tests/attributes/relations/referential_actions.rs
+++ b/psl/psl/tests/attributes/relations/referential_actions.rs
@@ -27,7 +27,7 @@ fn on_delete_actions() {
             action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -55,7 +55,7 @@ fn on_update_actions() {
             action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_update_strategy(*action);
@@ -88,7 +88,7 @@ fn actions_on_mongo() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -126,7 +126,7 @@ fn actions_on_mysql_with_prisma_relation_mode() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -164,7 +164,7 @@ fn actions_on_sqlserver_with_prisma_relation_mode() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -202,7 +202,7 @@ fn actions_on_cockroachdb_with_prisma_relation_mode() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -240,7 +240,7 @@ fn actions_on_postgres_with_prisma_relation_mode() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -278,7 +278,7 @@ fn actions_on_sqlite_with_prisma_relation_mode() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -316,7 +316,7 @@ fn on_delete_actions_should_work_on_prisma_relation_mode() {
             action = action
         );
 
-        parse(&dml)
+        parse_schema(&dml)
             .assert_has_model("B")
             .assert_has_relation_field("a")
             .assert_relation_delete_strategy(*action);
@@ -348,7 +348,7 @@ fn on_update_no_action_should_work_on_prisma_relation_mode() {
         }
     "#};
 
-    parse(dml)
+    parse_schema(dml)
         .assert_has_model("B")
         .assert_has_relation_field("a")
         .assert_relation_update_strategy(ReferentialAction::NoAction);

--- a/psl/psl/tests/attributes/relations/relations_new.rs
+++ b/psl/psl/tests/attributes/relations/relations_new.rs
@@ -17,22 +17,16 @@ fn relation_happy_path() {
     }
     "#;
 
-    let schema = parse(dml);
+    let schema = parse_schema(dml);
     let user_model = schema.assert_has_model("User");
     let post_model = schema.assert_has_model("Post");
     user_model
         .assert_has_relation_field("posts")
-        .assert_arity(&dml::FieldArity::List)
-        .assert_relation_to(post_model.id)
-        .assert_relation_base_fields(&[])
-        .assert_relation_referenced_fields(&[]);
+        .assert_relation_to(post_model.id);
 
     post_model
         .assert_has_relation_field("user")
-        .assert_arity(&dml::FieldArity::Required)
-        .assert_relation_to(user_model.id)
-        .assert_relation_base_fields(&["userId"])
-        .assert_relation_referenced_fields(&["id"]);
+        .assert_relation_to(user_model.id);
 }
 
 #[test]
@@ -123,7 +117,7 @@ fn optional_relation_field_must_succeed_when_all_underlying_fields_are_optional(
     "#;
 
     // must not crash
-    let _ = parse(dml);
+    let _ = parse_schema(dml);
 }
 
 #[test]
@@ -184,7 +178,7 @@ fn optional_relation_field_must_succeed_when_at_least_one_underlying_fields_is_o
     "#;
 
     // must not crash
-    let _ = parse(dml);
+    parse_schema(dml);
 }
 
 #[test]

--- a/psl/psl/tests/base/array_sugar.rs
+++ b/psl/psl/tests/base/array_sugar.rs
@@ -16,12 +16,11 @@ fn should_treat_single_values_as_arrays_of_length_one() {
     }
     "#;
 
-    let schema = parse(dml);
+    let schema = parse_schema(dml);
 
     let user_model = schema.assert_has_model("User");
     let post_model = schema.assert_has_model("Post");
     post_model
         .assert_has_relation_field("user")
-        .assert_relation_to(user_model.id)
-        .assert_relation_referenced_fields(&["id"]);
+        .assert_relation_to(user_model.id);
 }


### PR DESCRIPTION
With prisma_models, this is one of the only two places left where we use DML.

A few assertions were not carried over because they test aspects of the schema that are covered very exhaustively by other tests. Feedback welcome on this point.