### PR TITLE
feat(wasm): add support for human-friendly Wasm panic message

### DIFF
--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -1,44 +1,77 @@
+use std::panic;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
+extern "C" {
+    /// This function registers the reason for a Wasm panic via the JS function `globalThis.WASM_PANIC_REGISTRY()`
+    #[wasm_bindgen(js_namespace = ["global", "WASM_PANIC_REGISTRY"], js_name = "set_message")]
+    fn prisma_set_wasm_panic_message(s: &str);
+}
+
+/// Registers a singleton panic hook that will register the reason for the Wasm panic in JS.
+/// Without this, the panic message would be lost: you'd see `RuntimeError: unreachable` message in JS,
+/// with no reference to the Rust function and line that panicked.
+/// This function should be manually called before any other public function in this module.
+/// Note: no method is safe to call after a panic has occurred.
+fn register_panic_hook() {
+    use std::sync::Once;
+    static SET_HOOK: Once = Once::new();
+
+    SET_HOOK.call_once(|| {
+        panic::set_hook(Box::new(|info| {
+            let message = &info.to_string();
+            prisma_set_wasm_panic_message(&message);
+        }));
+    });
+}
+
+#[wasm_bindgen]
 pub fn format(schema: String, params: String) -> String {
+    register_panic_hook();
     prisma_fmt::format(&schema, &params)
 }
 
 /// Docs: https://prisma.github.io/prisma-engines/doc/prisma_fmt/fn.get_config.html
 #[wasm_bindgen]
 pub fn get_config(params: String) -> Result<String, JsError> {
+    register_panic_hook();
     prisma_fmt::get_config(params).map_err(|e| JsError::new(&e))
 }
 
 /// Docs: https://prisma.github.io/prisma-engines/doc/prisma_fmt/fn.get_dmmf.html
 #[wasm_bindgen]
 pub fn get_dmmf(params: String) -> Result<String, JsError> {
+    register_panic_hook();
     prisma_fmt::get_dmmf(params).map_err(|e| JsError::new(&e))
 }
 
 #[wasm_bindgen]
 pub fn lint(input: String) -> String {
+    register_panic_hook();
     prisma_fmt::lint(input)
 }
 
 #[wasm_bindgen]
 pub fn validate(params: String) -> Result<(), String> {
+    register_panic_hook();
     prisma_fmt::validate(params)
 }
 
 #[wasm_bindgen]
 pub fn native_types(input: String) -> String {
+    register_panic_hook();
     prisma_fmt::native_types(input)
 }
 
 #[wasm_bindgen]
 pub fn referential_actions(input: String) -> String {
+    register_panic_hook();
     prisma_fmt::referential_actions(input)
 }
 
 #[wasm_bindgen]
 pub fn preview_features() -> String {
+    register_panic_hook();
     prisma_fmt::preview_features()
 }
 
@@ -48,6 +81,7 @@ pub fn preview_features() -> String {
 /// being a `CompletionList` object.
 #[wasm_bindgen]
 pub fn text_document_completion(schema: String, params: String) -> String {
+    register_panic_hook();
     prisma_fmt::text_document_completion(schema, &params)
 }
 
@@ -58,6 +92,7 @@ pub fn text_document_completion(schema: String, params: String) -> String {
 /// `CodeActionOrCommand` objects.
 #[wasm_bindgen]
 pub fn code_actions(schema: String, params: String) -> String {
+    register_panic_hook();
     prisma_fmt::code_actions(schema, &params)
 }
 
@@ -65,6 +100,7 @@ pub fn code_actions(schema: String, params: String) -> String {
 /// handling.
 #[wasm_bindgen]
 pub fn debug_panic() {
+    register_panic_hook();
     panic!("This is the panic triggered by `prisma_fmt::debug_panic()`");
 }
 

--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -3,7 +3,8 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 extern "C" {
-    /// This function registers the reason for a Wasm panic via the JS function `globalThis.WASM_PANIC_REGISTRY()`
+    /// This function registers the reason for a Wasm panic via the
+    /// JS function `globalThis.WASM_PANIC_REGISTRY.set_message()`
     #[wasm_bindgen(js_namespace = ["global", "WASM_PANIC_REGISTRY"], js_name = "set_message")]
     fn prisma_set_wasm_panic_message(s: &str);
 }
@@ -20,7 +21,7 @@ fn register_panic_hook() {
     SET_HOOK.call_once(|| {
         panic::set_hook(Box::new(|info| {
             let message = &info.to_string();
-            prisma_set_wasm_panic_message(&message);
+            prisma_set_wasm_panic_message(message);
         }));
     });
 }


### PR DESCRIPTION
Rust implementation of https://github.com/prisma/prisma-private/issues/212.

This PR registers a singleton panic hook for every method exposed to `@prisma/prisma-fmt-wasm` and registers the human-readable reason for the panic to the JS-side, via the `globalThis.WASM_PANIC_REGISTRY.set_message()` JS function.

This makes the difference from a useless `RuntimeError: unreachable` to, e.g.:

```
RuntimeError: panicked at 'This is the panic triggered by `prisma_fmt::debug_panic()`', prisma-fmt-wasm/src/lib.rs:104:5`. 
```

## Example

Consider this TS script, `src/panic.ts`:

```typescript
import * as wasm from './prisma_fmt_build'

/**
 * Branded type for Wasm panics.
 */
export type WasmPanic = Error & { name: 'RuntimeError' }

/**
 * Returns true if the given error is a Wasm panic.
 */
export function isWasmPanic(error: Error): error is WasmPanic {
  return error.name === 'RuntimeError'
}

class WasmPanicRegistry {
  #message = ''

  get() {
    return `${this.#message}`
  }

  // Don't use this method directly, it's only used by the Wasm panic hook in @prisma/prisma-fmt-wasm.
  private set_message(value: string) {
    this.#message = `RuntimeError: ${value}`
  }
}

declare module globalThis {
  let WASM_PANIC_REGISTRY: WasmPanicRegistry
}

globalThis.WASM_PANIC_REGISTRY = new WasmPanicRegistry()

function main() {
  wasm.debug_panic() // triggers an artificial panic
}

// @ts-ignore
const USE_STACKTRACE = process.env.USE_STACKTRACE === '1'

try {
  main()
} catch (e) {
  const error = e as Error

  if (isWasmPanic(error)) {
    if (USE_STACKTRACE) {
      const message = [
        `${globalThis.WASM_PANIC_REGISTRY.get()}`,
        ...(error.stack || '').split('\n').slice(1)
      ].join('\n')
      console.log('wasm stacktrace (with human-readable header)\n', message)
    } else {
      const message = `${error.stack}`
      console.log('wasm stacktrace (obfuscated)\n', message)
    }
  } else {
    console.info('std error')
    throw error
  }
}
```

### Current behavior

Notice that the error message states `RuntimeError: unreachable`, without any reference to the Rust line that triggered the panic:

```bash
❯ USE_STACKTRACE=0 ts-node src/panic.ts
wasm stacktrace (obfuscated)
 RuntimeError: unreachable
    at rust_panic (wasm://wasm/009ec4ee:wasm-function[2898]:0x1963de)
    at std::panicking::rust_panic_with_hook::hb42d415afcc11f2f (wasm://wasm/009ec4ee:wasm-function[1046]:0x164017)
    at std::panicking::begin_panic_handler::{{closure}}::h57dd84c078404aa2 (wasm://wasm/009ec4ee:wasm-function[1564]:0x17e7b2)
    at std::sys_common::backtrace::__rust_end_short_backtrace::hef94dcc71d3b37f5 (wasm://wasm/009ec4ee:wasm-function[2493]:0x193c44)
    at rust_begin_unwind (wasm://wasm/009ec4ee:wasm-function[2302]:0x19131e)
    at core::panicking::panic_fmt::h32de9c76c9d5eb0c (wasm://wasm/009ec4ee:wasm-function[2346]:0x191da3)
    at debug_panic (wasm://wasm/009ec4ee:wasm-function[2315]:0x191642)
    at Object.module.exports.debug_panic (/Users/jkomyno/work/prisma/prisma-engines/prisma-fmt-wasm/nodejs/src/prisma_fmt_build.js:342:10)
    at main (/Users/jkomyno/work/prisma/prisma-engines/prisma-fmt-wasm/nodejs/src/panic.ts:35:8)
    at Object.<anonymous> (/Users/jkomyno/work/prisma/prisma-engines/prisma-fmt-wasm/nodejs/src/panic.ts:42:3)
```

### New behavior

Now the message header reports the original panic message and its location in the Rust codebase (e.g., `prisma-fmt-wasm/src/lib.rs:104:5`, although the rest of the stacktrace is still mostly obfuscated)

```bash
❯ USE_STACKTRACE=1 ts-node src/panic.ts
wasm stacktrace (with human-readable header)
 RuntimeError: panicked at 'This is the panic triggered by `prisma_fmt::debug_panic()`', prisma-fmt-wasm/src/lib.rs:104:5
    at rust_panic (wasm://wasm/009ec4ee:wasm-function[2898]:0x1963de)
    at std::panicking::rust_panic_with_hook::hb42d415afcc11f2f (wasm://wasm/009ec4ee:wasm-function[1046]:0x164017)
    at std::panicking::begin_panic_handler::{{closure}}::h57dd84c078404aa2 (wasm://wasm/009ec4ee:wasm-function[1564]:0x17e7b2)
    at std::sys_common::backtrace::__rust_end_short_backtrace::hef94dcc71d3b37f5 (wasm://wasm/009ec4ee:wasm-function[2493]:0x193c44)
    at rust_begin_unwind (wasm://wasm/009ec4ee:wasm-function[2302]:0x19131e)
    at core::panicking::panic_fmt::h32de9c76c9d5eb0c (wasm://wasm/009ec4ee:wasm-function[2346]:0x191da3)
    at debug_panic (wasm://wasm/009ec4ee:wasm-function[2315]:0x191642)
    at Object.module.exports.debug_panic (/Users/jkomyno/work/prisma/prisma-engines/prisma-fmt-wasm/nodejs/src/prisma_fmt_build.js:342:10)
    at main (/Users/jkomyno/work/prisma/prisma-engines/prisma-fmt-wasm/nodejs/src/panic.ts:35:8)
    at Object.<anonymous> (/Users/jkomyno/work/prisma/prisma-engines/prisma-fmt-wasm/nodejs/src/panic.ts:42:3)
```

