### PR TITLE
feat(wasm): standardise validate's error to JsError

### DIFF
--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -23,8 +23,8 @@ pub fn lint(input: String) -> String {
 }
 
 #[wasm_bindgen]
-pub fn validate(params: String) -> Result<(), String> {
-    prisma_fmt::validate(params)
+pub fn validate(params: String) -> Result<(), JsError> {
+    prisma_fmt::validate(params).map_err(|e| JsError::new(&e))
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
Closes https://github.com/prisma/prisma-engines/issues/3713