### PR TITLE
qe/prisma-models: introduce identifiers for ScalarField

### DIFF
--- a/query-engine/prisma-models/src/builders/field_builders/scalar_field_builder.rs
+++ b/query-engine/prisma-models/src/builders/field_builders/scalar_field_builder.rs
@@ -5,6 +5,7 @@ use std::{fmt::Debug, sync::Arc};
 
 #[derive(Debug)]
 pub struct ScalarFieldBuilder {
+    pub id: crate::ScalarFieldId,
     pub name: String,
     pub type_identifier: TypeIdentifier,
     pub is_unique: bool,
@@ -22,6 +23,7 @@ pub struct ScalarFieldBuilder {
 impl ScalarFieldBuilder {
     pub fn build(self, container: ParentContainer) -> ScalarFieldRef {
         let scalar = ScalarField {
+            id: self.id,
             name: self.name,
             type_identifier: self.type_identifier,
             is_id: self.is_id,

--- a/query-engine/prisma-models/src/builders/internal_dm_builder.rs
+++ b/query-engine/prisma-models/src/builders/internal_dm_builder.rs
@@ -63,6 +63,7 @@ fn model_field_builders(model: &dml::Model, schema: &psl::ValidatedSchema) -> Ve
                     None
                 } else {
                     Some(FieldBuilder::Scalar(ScalarFieldBuilder {
+                        id: crate::ScalarFieldId::InModel(sf.id),
                         name: sf.name.clone(),
                         type_identifier: sf.type_identifier(),
                         is_unique: model.field_is_unique(&sf.name),
@@ -103,6 +104,7 @@ fn composite_field_builders(composite: &dml::CompositeType) -> Vec<FieldBuilder>
                     None
                 } else {
                     Some(FieldBuilder::Scalar(ScalarFieldBuilder {
+                        id: crate::ScalarFieldId::InCompositeType(field.id),
                         name: field.name.clone(),
                         type_identifier: type_ident,
                         is_unique: false, // Composites can't have uniques or ids at the moment.

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -1,6 +1,7 @@
 use crate::{ast, parent_container::ParentContainer, prelude::*};
 use dml::{DefaultValue, FieldArity, NativeTypeInstance};
 use once_cell::sync::OnceCell;
+use psl::parser_database::walkers;
 use std::{
     fmt::{Debug, Display},
     hash::{Hash, Hasher},
@@ -10,7 +11,14 @@ use std::{
 pub type ScalarFieldRef = Arc<ScalarField>;
 pub type ScalarFieldWeak = Weak<ScalarField>;
 
+#[derive(Debug, Clone)]
+pub enum ScalarFieldId {
+    InModel(walkers::ScalarFieldId),
+    InCompositeType((ast::CompositeTypeId, ast::FieldId)),
+}
+
 pub struct ScalarField {
+    pub id: ScalarFieldId,
     pub(crate) name: String,
     pub(crate) type_identifier: TypeIdentifier,
     pub(crate) is_id: bool,


### PR DESCRIPTION
Part of https://github.com/prisma/client-planning/issues/265

This will help with the ongoing work on relation fields.