### PR TITLE
chore(qe): scalars and lists where printed equally in debug traces

### DIFF
--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -204,9 +204,9 @@ impl Debug for InputType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             InputType::Object(obj) => write!(f, "Object({})", obj.into_arc().identifier.name()),
-            InputType::Scalar(s) => write!(f, "{s:?}"),
-            InputType::Enum(e) => write!(f, "{e:?}"),
-            InputType::List(l) => write!(f, "{l:?}"),
+            InputType::Scalar(s) => write!(f, "Scalar({s:?})"),
+            InputType::Enum(e) => write!(f, "Enum({e:?})"),
+            InputType::List(l) => write!(f, "List({l:?})"),
         }
     }
 }


### PR DESCRIPTION
This led to a very misleading debugging session of the JSON protocol parser logic.