### PR TITLE
feat(wasm): renamed WASM_PANIC_REGISTRY into PRISMA_WASM_PANIC_REGISTRY for future-proofness

### DIFF
--- a/prisma-fmt-wasm/src/lib.rs
+++ b/prisma-fmt-wasm/src/lib.rs
@@ -4,8 +4,8 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen]
 extern "C" {
     /// This function registers the reason for a Wasm panic via the
-    /// JS function `globalThis.WASM_PANIC_REGISTRY.set_message()`
-    #[wasm_bindgen(js_namespace = ["global", "WASM_PANIC_REGISTRY"], js_name = "set_message")]
+    /// JS function `globalThis.PRISMA_WASM_PANIC_REGISTRY.set_message()`
+    #[wasm_bindgen(js_namespace = ["global", "PRISMA_WASM_PANIC_REGISTRY"], js_name = "set_message")]
     fn prisma_set_wasm_panic_message(s: &str);
 }
 


### PR DESCRIPTION
Context: https://github.com/prisma/prisma/pull/17950#discussion_r1109898830

Contributes to https://github.com/prisma/prisma-private/issues/212.