### PR TITLE
Set `vendored-openssl` feature to fix issue with OpenSSL version mismatch between Node 18 and some systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ features = [
   "postgresql",
   "sqlite",
   "uuid",
+  "vendored-openssl",
 ]
 
 [profile.dev.package.backtrace]


### PR DESCRIPTION
This probably isn't the "best" way to fix the issue but I built the library with and without this and was able to confirm it fixes the issue. It will increase build size of the library (~20%) but it prevents the issue with system OpenSSL and Node OpenSSL using different versions. It implies that the libraries will need to be built for each version of OpenSSL used by Node, not the system.

eg:
- `libquery_engine-darwin-arm64-node18.dylib.node`
- `libquery_engine-darwin-arm64-node16.dylib.node`
- ...

Fixes: https://github.com/prisma/prisma/issues/10649

See also: https://github.com/prisma/prisma-engines/pull/3243/files which removed this but was never cut into a release.