### PR TITLE
qe: simplify referential action selection in relationMode = prisma

### DIFF
--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -399,8 +399,9 @@ pub fn insert_emulated_on_delete(
 
     for rf in relation_fields {
         match rf.relation().on_delete() {
-            ReferentialAction::NoAction => continue, // Explicitly do nothing.
-            ReferentialAction::Restrict => emulate_on_delete_restrict(graph, &rf, parent_node, child_node)?,
+            ReferentialAction::NoAction | ReferentialAction::Restrict => {
+                emulate_on_delete_restrict(graph, &rf, parent_node, child_node)?
+            }
             ReferentialAction::SetNull => {
                 emulate_on_delete_set_null(graph, connector_ctx, &rf, parent_node, child_node)?
             }
@@ -671,8 +672,7 @@ pub fn emulate_on_delete_set_null(
     // For every relation fields sharing one common foreign key on the updated model, apply onUpdate emulations.
     for rf in overlapping_relation_fields {
         match rf.relation().on_update() {
-            ReferentialAction::NoAction => continue,
-            ReferentialAction::Restrict => {
+            ReferentialAction::NoAction | ReferentialAction::Restrict => {
                 emulate_on_update_restrict(graph, &rf, &dependent_records_node, &set_null_dependents_node)?
             }
             ReferentialAction::SetNull => emulate_on_update_set_null(
@@ -816,8 +816,7 @@ pub fn emulate_on_update_set_null(
     // For every relation fields sharing one common foreign key, recurse
     for rf in overlapping_relation_fields {
         match rf.relation().on_update() {
-            ReferentialAction::NoAction => continue,
-            ReferentialAction::Restrict => {
+            ReferentialAction::NoAction | ReferentialAction::Restrict => {
                 emulate_on_update_restrict(graph, &rf, &dependent_records_node, &set_null_dependents_node)?
             }
             ReferentialAction::SetNull => emulate_on_update_set_null(
@@ -965,8 +964,9 @@ pub fn insert_emulated_on_update_with_intermediary_node(
 
     for rf in relation_fields {
         match rf.relation().on_update() {
-            ReferentialAction::NoAction => continue, // Explicitly do nothing.
-            ReferentialAction::Restrict => emulate_on_update_restrict(graph, &rf, &join_node, child_node)?,
+            ReferentialAction::NoAction | ReferentialAction::Restrict => {
+                emulate_on_update_restrict(graph, &rf, &join_node, child_node)?
+            }
             ReferentialAction::SetNull => {
                 emulate_on_update_set_null(graph, &rf, connector_ctx, &join_node, child_node)?
             }
@@ -996,8 +996,9 @@ pub fn insert_emulated_on_update(
 
     for rf in relation_fields {
         match rf.relation().on_update() {
-            ReferentialAction::NoAction => continue, // Explicitly do nothing.
-            ReferentialAction::Restrict => emulate_on_update_restrict(graph, &rf, parent_node, child_node)?,
+            ReferentialAction::NoAction | ReferentialAction::Restrict => {
+                emulate_on_update_restrict(graph, &rf, parent_node, child_node)?
+            }
             ReferentialAction::SetNull => {
                 emulate_on_update_set_null(graph, &rf, connector_ctx, parent_node, child_node)?
             }

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -223,14 +223,6 @@ impl RelationField {
         self.scalar_fields().into_iter().map(|f| f.db_name().to_owned())
     }
 
-    pub fn on_delete(&self) -> Option<&ReferentialAction> {
-        self.relation_info.on_delete.as_ref()
-    }
-
-    pub fn on_update(&self) -> Option<&ReferentialAction> {
-        self.relation_info.on_update.as_ref()
-    }
-
     pub fn relation_info(&self) -> &RelationInfo {
         &self.relation_info
     }

--- a/query-engine/prisma-models/src/relation.rs
+++ b/query-engine/prisma-models/src/relation.rs
@@ -1,9 +1,6 @@
 use crate::prelude::*;
 use dml::ReferentialAction;
-use psl::{
-    datamodel_connector::RelationMode,
-    parser_database::{walkers, RelationId},
-};
+use psl::parser_database::{walkers, RelationId};
 
 pub type Relation = crate::Zipper<RelationId>;
 pub type RelationRef = Relation;
@@ -78,33 +75,19 @@ impl Relation {
 
     /// Retrieves the onDelete policy for this relation.
     pub fn on_delete(&self) -> ReferentialAction {
-        let action = self
-            .field_a()
-            .on_delete()
-            .cloned()
-            .or_else(|| self.field_b().on_delete().cloned())
-            .unwrap_or(self.field_a().on_delete_default);
-
-        match (action, self.dm.schema.relation_mode()) {
-            // NoAction is an alias for Restrict when relationMode = "prisma"
-            (ReferentialAction::NoAction, RelationMode::Prisma) => ReferentialAction::Restrict,
-            (action, _) => action,
-        }
+        self.field_a()
+            .relation_info
+            .on_delete
+            .or_else(|| self.field_b().relation_info.on_delete)
+            .unwrap_or(self.field_a().on_delete_default)
     }
 
     /// Retrieves the onUpdate policy for this relation.
     pub fn on_update(&self) -> ReferentialAction {
-        let action = self
-            .field_a()
-            .on_update()
-            .cloned()
-            .or_else(|| self.field_b().on_update().cloned())
-            .unwrap_or(self.field_a().on_update_default);
-
-        match (action, self.dm.schema.relation_mode()) {
-            // NoAction is an alias for Restrict when relationMode = "prisma"
-            (ReferentialAction::NoAction, RelationMode::Prisma) => ReferentialAction::Restrict,
-            (action, _) => action,
-        }
+        self.field_a()
+            .relation_info
+            .on_update
+            .or_else(|| self.field_b().relation_info.on_update)
+            .unwrap_or(self.field_a().on_update_default)
     }
 }

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -1,76 +1,7 @@
 #![allow(non_snake_case)]
-use prisma_models::{dml::ReferentialAction, *};
+
+use prisma_models::*;
 use std::sync::Arc;
-
-#[test]
-fn no_action_is_alias_for_restrict_when_prisma_relation_mode() {
-    let datamodel = convert(
-        r#"
-        generator client {
-            provider = "prisma-client-js"
-        }
-
-        datasource db {
-            provider = "mysql"
-            url      = "mysql://"
-            relationMode = "prisma"
-        }
-
-        model A {
-            id Int @id
-            bs B[]
-        }
-
-        model B {
-            id Int @id
-            aId Int
-            a A @relation(fields: [aId], references: [id], onUpdate: NoAction, onDelete: NoAction)
-        }
-        "#,
-    );
-
-    let mut relations = datamodel.relations();
-    assert_eq!(relations.clone().count(), 1);
-
-    let relation = relations.next().unwrap();
-    assert_eq!(relation.on_update(), ReferentialAction::Restrict);
-    assert_eq!(relation.on_delete(), ReferentialAction::Restrict);
-}
-
-#[test]
-fn no_action_is_not_alias_for_restrict_when_foreign_keys_relation_mode() {
-    let datamodel = convert(
-        r#"
-        generator client {
-            provider = "prisma-client-js"
-        }
-
-        datasource db {
-            provider = "mysql"
-            url      = "mysql://"
-            relationMode = "foreignKeys"
-        }
-
-        model A {
-            id Int @id
-            bs B[]
-        }
-
-        model B {
-            id Int @id
-            aId Int
-            a A @relation(fields: [aId], references: [id], onUpdate: NoAction, onDelete: NoAction)
-        }
-        "#,
-    );
-
-    let mut relations = datamodel.relations();
-    assert_eq!(relations.clone().count(), 1);
-
-    let relation = relations.next().unwrap();
-    assert_eq!(relation.on_update(), ReferentialAction::NoAction);
-    assert_eq!(relation.on_delete(), ReferentialAction::NoAction);
-}
 
 #[test]
 fn an_empty_datamodel_must_work() {


### PR DESCRIPTION
Stop intercepting and transforming NoAction to Restrict in prisma-models based on relation mode. Instead, treat them the same in the emulated referential actions implementation. This is simpler because it eliminates a conditional transformation (in prisma-models) and a few dead branches (in core).