### PR TITLE
nix: disable lld on darwin for now

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -9,6 +9,7 @@ in
       [ devToolchain llvmPackages_latest.bintools ]
       ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
     inputsFrom = [ self'.packages.prisma-engines ];
-    shellHook = "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";
+    shellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux
+      "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";
   };
 }


### PR DESCRIPTION
Binaries linked with lld from LLVM 14 crash when unwinding stack on Darwin:

```
$ cargo test -p nope
(...snip...)
  process didn't exit successfully: `/Users/aqrln/prisma/prisma-engines/target/debug/deps/nope-1f664a558f55dd64` (signal: 11, SIGSEGV: invalid memory reference)

$ lldb target/debug/deps/nope-1f664a558f55dd64
(...snip...)

running 1 test
Process 96800 stopped
* thread #2, name = 'tests::it_works', stop reason = EXC_BAD_ACCESS (code=1, address=0x0)
    frame #0: 0x000000019c32d408 libunwind.dylib`libunwind::CFI_Parser<libunwind::LocalAddressSpace>::decodeFDE(libunwind::LocalAddressSpace&, unsigned long, libunwind::CFI_Parser<libunwind::LocalAddressSpace>::FDE_Info*, libunwind::CFI_Parser<libunwind::LocalAddressSpace>::CIE_Info*) + 48
libunwind.dylib`libunwind::CFI_Parser<libunwind::LocalAddressSpace>::decodeFDE:
->  0x19c32d408 <+48>: ldr    w22, [x23], #0x4
    0x19c32d40c <+52>: cmn    w22, #0x1
    0x19c32d410 <+56>: b.eq   0x19c32d534               ; <+348>
    0x19c32d414 <+60>: cbz    x22, 0x19c32d540          ; <+360>
Target 0: (nope-1f664a558f55dd64) stopped.
(lldb) p $x23
(unsigned long) $0 = 0
```

Checked with Homebrew-installed LLVM 15 that it fixes the issue, and
also confirmed that it's an upstream LLVM issue and not something
Nix-specific using Homebrew-installed LLVM 14.

We can switch back to lld on Darwin when LLVM 15 is fully ready in
nixpkgs and `llvmPackages_latest` is switched to `llvmPackages_15`, or
we can even try to go with `llvmPackages_15` now, but we'll need to
update the flake first because we're on a commit where
`llvmPackages_15` isn't available yet.
