### PR TITLE
Introspection of SQL Server views

### DIFF
--- a/introspection-engine/introspection-engine-tests/tests/views/sqlserver.rs
+++ b/introspection-engine/introspection-engine-tests/tests/views/sqlserver.rs
@@ -36,12 +36,407 @@ async fn simple_view_from_one_table(api: &TestApi) -> TestResult {
           first_name String  @db.VarChar(255)
           last_name  String? @db.VarChar(255)
         }
+
+        /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        view B {
+          id         Int
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+
+          @@ignore
+        }
     "#]];
 
     api.expect_datamodel(&expected).await;
 
-    let expected = expect![[r#"[]"#]];
+    let expected = expect![[r#"
+        [
+          {
+            "code": 24,
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "affected": [
+              {
+                "view": "B"
+              }
+            ]
+          }
+        ]"#]];
+
     api.expect_warnings(&expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn simple_view_from_two_tables(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE A (
+            id INT,
+            first_name VARCHAR(255) NOT NULL,
+            last_name VARCHAR(255) NULL,
+            CONSTRAINT A_pkey PRIMARY KEY (id)
+        );
+
+        CREATE TABLE B (
+            user_id INT,
+            introduction VARCHAR(MAX),
+            CONSTRAINT Profile_User_fkey FOREIGN KEY (user_id) REFERENCES A(id) ON DELETE CASCADE ON UPDATE CASCADE,
+            CONSTRAINT B_pkey PRIMARY KEY (user_id)
+        );
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW AB AS
+            SELECT
+                a.id,
+                CONCAT(a.first_name, ' ', a.last_name) AS name,
+                b.introduction
+            FROM A a
+            INNER JOIN B b ON a.id = b.user_id;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["views"]
+        }
+
+        datasource db {
+          provider = "sqlserver"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model A {
+          id         Int     @id
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+          B          B?
+        }
+
+        model B {
+          user_id      Int     @id
+          introduction String? @db.VarChar(Max)
+          A            A       @relation(fields: [user_id], references: [id], onDelete: Cascade, map: "Profile_User_fkey")
+        }
+
+        /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        view AB {
+          id           Int
+          name         String  @db.VarChar(511)
+          introduction String? @db.VarChar(Max)
+
+          @@ignore
+        }
+    "#]];
+
+    api.expect_datamodel(&expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn re_intro_keeps_view_uniques(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE A (
+            id INT NOT NULL,
+            first_name VARCHAR(255) NOT NULL,
+            last_name VARCHAR(255) NOT NULL,
+            CONSTRAINT A_pkey PRIMARY KEY (id)
+        );
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW B AS
+            SELECT id, first_name, last_name FROM A;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let input = indoc! {r#"
+        model A {
+          id         Int     @id @default(autoincrement())
+          first_name String? @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+        }
+
+        view B {
+          id         Int     @unique
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+        }  
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id         Int    @id
+          first_name String @db.VarChar(255)
+          last_name  String @db.VarChar(255)
+        }
+
+        view B {
+          id         Int    @unique
+          first_name String @db.VarChar(255)
+          last_name  String @db.VarChar(255)
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn re_intro_keeps_id(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE A (
+            id INT,
+            first_name VARCHAR(255) NOT NULL,
+            last_name VARCHAR(255) NULL,
+            CONSTRAINT A_pkey PRIMARY KEY (id)
+        );
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW B AS
+            SELECT id, first_name, last_name FROM A;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let input = indoc! {r#"
+        model A {
+          id         Int     @id @default(autoincrement())
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+        }
+
+        view B {
+          id         Int     @id
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+        }  
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id         Int     @id
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+        }
+
+        view B {
+          id         Int     @id
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn re_intro_keeps_compound_unique(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE A (
+            side_a INT NOT NULL,
+            side_b INT NOT NULL,
+            first_name VARCHAR(255) NOT NULL,
+            last_name VARCHAR(255) NULL,
+            CONSTRAINT A_pkey PRIMARY KEY (side_a, side_b)
+        );
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW B AS SELECT side_a, side_b, first_name, last_name FROM A;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let input = indoc! {r#"
+        model A {
+          side_a     Int
+          side_b     Int
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+
+          @@id([side_a, side_b])
+        }
+
+        view B {
+          side_a     Int
+          side_b     Int
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+
+          @@unique([side_a, side_b])
+        }  
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          side_a     Int
+          side_b     Int
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+
+          @@id([side_a, side_b])
+        }
+
+        view B {
+          side_a     Int
+          side_b     Int
+          first_name String  @db.VarChar(255)
+          last_name  String? @db.VarChar(255)
+
+          @@unique([side_a, side_b])
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn re_intro_keeps_view_to_view_relations(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE VIEW A AS SELECT 1 AS id;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW B AS SELECT 2 AS id, 1 AS a_id;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let input = indoc! {r#"
+        view A {
+          id Int @unique
+          b  B[]
+        }
+
+        view B {
+          id   Int  @unique
+          a_id Int?
+          a    A?   @relation(fields: [a_id], references: [id])
+        }
+    "#};
+
+    let expected = expect![[r#"
+        view A {
+          id Int @unique
+          b  B[]
+        }
+
+        view B {
+          id   Int @unique
+          a_id Int
+          a    A?  @relation(fields: [a_id], references: [id])
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn views_cannot_have_default_values(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE A (id INT CONSTRAINT A_pkey PRIMARY KEY, val INT CONSTRAINT A_val_df DEFAULT 2);
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW B AS SELECT id, val FROM A;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["views"]
+        }
+
+        datasource db {
+          provider = "sqlserver"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model A {
+          id  Int  @id
+          val Int? @default(2)
+        }
+
+        /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        view B {
+          id  Int
+          val Int?
+
+          @@ignore
+        }
+    "#]];
+
+    api.expect_datamodel(&expected).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(Mssql), preview_features("views"))]
+async fn prisma_defaults_are_kept(api: &TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE A (id INT CONSTRAINT A_pkey PRIMARY KEY, val VARCHAR(255));
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let setup = indoc! {r#"
+        CREATE VIEW B AS SELECT id, val FROM A;
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let input = indoc! {r#"
+        model A {
+          id  Int     @id
+          val String? @db.VarChar(255)
+        }
+
+        view B {
+          id  Int     @id
+          val String? @db.VarChar(255) @default(cuid())
+        }
+    "#};
+
+    let expected = expect![[r#"
+        model A {
+          id  Int     @id
+          val String? @db.VarChar(255)
+        }
+
+        view B {
+          id  Int     @id
+          val String? @default(cuid()) @db.VarChar(255)
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expected).await;
 
     Ok(())
 }

--- a/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/libs/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -852,6 +852,23 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                 ),
                 (
                     TableId(
+                        0,
+                    ),
+                    Column {
+                        name: "int",
+                        tpe: ColumnType {
+                            full_data_type: "int",
+                            family: Int,
+                            arity: Nullable,
+                            native_type: Some(
+                                NativeTypeInstance(..),
+                            ),
+                        },
+                        auto_increment: false,
+                    },
+                ),
+                (
+                    TableId(
                         1,
                     ),
                     Column {
@@ -870,23 +887,6 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                 (
                     TableId(
                         1,
-                    ),
-                    Column {
-                        name: "int",
-                        tpe: ColumnType {
-                            full_data_type: "int",
-                            family: Int,
-                            arity: Nullable,
-                            native_type: Some(
-                                NativeTypeInstance(..),
-                            ),
-                        },
-                        auto_increment: false,
-                    },
-                ),
-                (
-                    TableId(
-                        0,
                     ),
                     Column {
                         name: "int",
@@ -940,7 +940,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                         1,
                     ),
                     column_id: TableColumnId(
-                        1,
+                        2,
                     ),
                     sort_order: Some(
                         Asc,
@@ -1056,23 +1056,6 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                 ),
                 (
                     TableId(
-                        1,
-                    ),
-                    Column {
-                        name: "id_2",
-                        tpe: ColumnType {
-                            full_data_type: "int",
-                            family: Int,
-                            arity: Required,
-                            native_type: Some(
-                                NativeTypeInstance(..),
-                            ),
-                        },
-                        auto_increment: true,
-                    },
-                ),
-                (
-                    TableId(
                         0,
                     ),
                     Column {
@@ -1090,10 +1073,10 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                 ),
                 (
                     TableId(
-                        3,
+                        1,
                     ),
                     Column {
-                        name: "id_1",
+                        name: "id_2",
                         tpe: ColumnType {
                             full_data_type: "int",
                             family: Int,
@@ -1137,6 +1120,23 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                    },
+                ),
+                (
+                    TableId(
+                        3,
+                    ),
+                    Column {
+                        name: "id_1",
+                        tpe: ColumnType {
+                            full_data_type: "int",
+                            family: Int,
+                            arity: Required,
+                            native_type: Some(
+                                NativeTypeInstance(..),
+                            ),
+                        },
+                        auto_increment: true,
                     },
                 ),
                 (
@@ -1230,6 +1230,17 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                         6,
                     ),
                     referenced_column: TableColumnId(
+                        1,
+                    ),
+                },
+                ForeignKeyColumn {
+                    foreign_key_id: ForeignKeyId(
+                        0,
+                    ),
+                    constrained_column: TableColumnId(
+                        4,
+                    ),
+                    referenced_column: TableColumnId(
                         2,
                     ),
                 },
@@ -1241,7 +1252,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                         8,
                     ),
                     referenced_column: TableColumnId(
-                        2,
+                        1,
                     ),
                 },
             ],
@@ -1251,6 +1262,20 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                         0,
                     ),
                     index_name: "Table_0_pkey",
+                    tpe: PrimaryKey,
+                },
+                Index {
+                    table_id: TableId(
+                        1,
+                    ),
+                    index_name: "Table_0_pkey",
+                    tpe: PrimaryKey,
+                },
+                Index {
+                    table_id: TableId(
+                        3,
+                    ),
+                    index_name: "Table_1_pkey",
                     tpe: PrimaryKey,
                 },
                 Index {
@@ -1274,7 +1299,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                         0,
                     ),
                     column_id: TableColumnId(
-                        2,
+                        1,
                     ),
                     sort_order: Some(
                         Asc,
@@ -1286,7 +1311,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                         1,
                     ),
                     column_id: TableColumnId(
-                        4,
+                        2,
                     ),
                     sort_order: Some(
                         Asc,
@@ -1296,6 +1321,30 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                 IndexColumn {
                     index_id: IndexId(
                         2,
+                    ),
+                    column_id: TableColumnId(
+                        5,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        3,
+                    ),
+                    column_id: TableColumnId(
+                        3,
+                    ),
+                    sort_order: Some(
+                        Asc,
+                    ),
+                    length: None,
+                },
+                IndexColumn {
+                    index_id: IndexId(
+                        4,
                     ),
                     column_id: TableColumnId(
                         7,


### PR DESCRIPTION
This adds support for SQL Server view introspection. Notable differences to PostgreSQL:

- A view column can be required in SQL Server, not in PostgreSQL. In PostgreSQL we keep arities defined by the user, but now we have to skip that for SQL Server due to its columns being able to be required.
- A view default values in SQL Server cannot be reflected _at all_, in PostgreSQL we can alter a view to have a default value. This is not possible with SQL Server.

Closes: https://github.com/prisma/prisma/issues/17415