### PR TITLE
Revert "qe: Add extra non-user-facing spans for schema builder and dmmf"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3821,7 +3821,6 @@ dependencies = [
  "prisma-models",
  "psl",
  "schema",
- "tracing",
 ]
 
 [[package]]

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -229,12 +229,7 @@ impl QueryEngine {
 
                 let executor = executor::load(data_source, preview_features, &url).await?;
                 let connector = executor.primary_connector();
-                let conn_span = tracing::info_span!(
-                    "prisma:engine:connection",
-                    user_facing = true,
-                    "db.type" = connector.name(),
-                );
-                connector.get_connection().instrument(conn_span).await?;
+                connector.get_connection().await?;
 
                 // Build internal data model
                 let internal_data_model = prisma_models::convert(Arc::clone(&builder.schema));
@@ -380,27 +375,13 @@ impl QueryEngine {
     }
 
     #[napi]
-    pub async fn dmmf(&self, trace: String) -> napi::Result<String> {
+    pub async fn dmmf(&self) -> napi::Result<String> {
         async_panic_to_js_error(async {
             let inner = self.inner.read().await;
             let engine = inner.as_engine()?;
+            let dmmf = dmmf::render_dmmf(engine.query_schema.clone());
 
-            let dispatcher = self.logger.dispatcher();
-
-            tracing::dispatcher::with_default(&dispatcher, || {
-                let span = tracing::info_span!("prisma:engine:dmmf");
-                let _ = telemetry::helpers::set_parent_context_from_json_str(&span, &trace);
-                let _guard = span.enter();
-                let dmmf = dmmf::render_dmmf(engine.query_schema.clone());
-
-                let json = {
-                    let span = tracing::info_span!("prisma:engine:dmmf_to_json");
-                    let _guard = span.enter();
-                    serde_json::to_string(&dmmf)?
-                };
-
-                Ok(json)
-            })
+            Ok(serde_json::to_string(&dmmf)?)
         })
         .await
     }

--- a/query-engine/request-handlers/src/dmmf/mod.rs
+++ b/query-engine/request-handlers/src/dmmf/mod.rs
@@ -1,7 +1,6 @@
 use dmmf_crate::DataModelMetaFormat;
 use query_core::schema::QuerySchemaRef;
 
-#[tracing::instrument(name = "prisma:engine:render_dmmf")]
 pub fn render_dmmf(query_schema: QuerySchemaRef) -> DataModelMetaFormat {
     dmmf_crate::from_precomputed_parts(query_schema)
 }

--- a/query-engine/schema-builder/Cargo.toml
+++ b/query-engine/schema-builder/Cargo.toml
@@ -8,7 +8,6 @@ psl.workspace = true
 schema = { path = "../schema" }
 prisma-models = { path = "../prisma-models" }
 once_cell = "1.3"
-tracing = "0.1"
 
 [dev-dependencies.criterion]
 version = "0.4.0"

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -173,8 +173,6 @@ impl TypeCache {
 }
 
 pub fn build(internal_data_model: InternalDataModelRef, enable_raw_queries: bool) -> QuerySchema {
-    let span = tracing::info_span!("prisma:engine:schema");
-    let _guard = span.enter();
     let mut ctx = BuilderContext::new(internal_data_model, enable_raw_queries);
 
     output_types::objects::initialize_caches(&mut ctx);


### PR DESCRIPTION
Somehow, that broke sampled tracing in the client: some of the new spans appear even when tracing is disabled. 

Revert it for now to unblock CI, will publish a fix later.

Reverts prisma/prisma-engines#3729