### PR TITLE
Add link to the docs for missing uniques in views

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/warnings/generators.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/warnings/generators.rs
@@ -437,7 +437,7 @@ pub(super) fn warning_enriched_with_map_on_view(affected: &[View]) -> Warning {
 pub(super) fn warning_views_without_identifier(affected: &[View]) -> Warning {
     Warning {
         code: 24,
-        message: "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.".into(),
+        message: "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers".into(),
         affected: serde_json::to_value(affected).unwrap(),
     }
 }

--- a/introspection-engine/introspection-engine-tests/tests/views/mysql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/views/mysql.rs
@@ -48,7 +48,7 @@ async fn simple_view_from_one_table(api: &TestApi) -> TestResult {
         [
           {
             "code": 24,
-            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers",
             "affected": [
               {
                 "view": "B"

--- a/introspection-engine/introspection-engine-tests/tests/views/postgresql.rs
+++ b/introspection-engine/introspection-engine-tests/tests/views/postgresql.rs
@@ -86,7 +86,7 @@ async fn simple_view_from_one_table(api: &TestApi) -> TestResult {
         [
           {
             "code": 24,
-            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers",
             "affected": [
               {
                 "view": "Schwuser"
@@ -708,7 +708,7 @@ async fn unsupported_types_trigger_a_warning(api: &TestApi) -> TestResult {
         [
           {
             "code": 24,
-            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers",
             "affected": [
               {
                 "view": "A"
@@ -971,7 +971,7 @@ async fn invalid_field_names_trigger_warnings(api: &TestApi) -> TestResult {
         [
           {
             "code": 24,
-            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers",
             "affected": [
               {
                 "view": "A"
@@ -1045,7 +1045,7 @@ async fn dupes_are_renamed(api: &TestApi) -> TestResult {
         [
           {
             "code": 24,
-            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers",
             "affected": [
               {
                 "view": "public_A"

--- a/introspection-engine/introspection-engine-tests/tests/views/sqlserver.rs
+++ b/introspection-engine/introspection-engine-tests/tests/views/sqlserver.rs
@@ -53,7 +53,7 @@ async fn simple_view_from_one_table(api: &TestApi) -> TestResult {
         [
           {
             "code": 24,
-            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client.",
+            "message": "The following views were ignored as they do not have a valid unique identifier or id. This is currently not supported by the Prisma Client. Please refer to the documentation on defining unique identifiers in views: https://pris.ly/d/view-identifiers",
             "affected": [
               {
                 "view": "B"


### PR DESCRIPTION
We don't have an issue for this, just an internal slack discussion.

pris.ly: https://github.com/prisma/pris.ly/pull/90
docs: https://github.com/prisma/docs/pull/4544

All have to be merged for 4.11.0