### PR TITLE
qe/schema-builder: fix performance regression

### DIFF
--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -130,13 +130,13 @@ impl crate::ParserDatabase {
     pub fn walk_complete_inline_relations(&self) -> impl Iterator<Item = CompleteInlineRelationWalker<'_>> + '_ {
         self.relations
             .iter_relations()
-            .filter(|(_, _, relation)| !relation.is_implicit_many_to_many())
-            .filter_map(move |(model_a, model_b, relation)| {
+            .filter(|(relation, _)| !relation.is_implicit_many_to_many())
+            .filter_map(move |(relation, _)| {
                 relation
                     .as_complete_fields()
                     .map(|(field_a, field_b)| CompleteInlineRelationWalker {
-                        side_a: (model_a, field_a),
-                        side_b: (model_b, field_b),
+                        side_a: (relation.model_a, field_a),
+                        side_b: (relation.model_b, field_b),
                         db: self,
                     })
             })

--- a/psl/parser-database/src/walkers/relation.rs
+++ b/psl/parser-database/src/walkers/relation.rs
@@ -68,10 +68,6 @@ impl<'db> RelationWalker<'db> {
         self.get().relation_name.map(|string_id| &self.db[string_id])
     }
 
-    pub(crate) fn has_field(self, model_id: ast::ModelId, field_id: ast::FieldId) -> bool {
-        self.get().has_field(model_id, field_id)
-    }
-
     /// The relation name, explicit or inferred.
     ///
     /// ```ignore

--- a/psl/parser-database/src/walkers/relation_field.rs
+++ b/psl/parser-database/src/walkers/relation_field.rs
@@ -111,9 +111,7 @@ impl<'db> RelationFieldWalker<'db> {
 
     /// The relation this field is part of.
     pub fn relation(self) -> RelationWalker<'db> {
-        let model = self.model();
-        let mut relations = model.relations_from().chain(model.relations_to());
-        relations.find(|r| r.has_field(self.id.0, self.id.1)).unwrap()
+        self.walk(self.db.relations[self.id])
     }
 
     /// The name of the relation. Either uses the `name` (or default) argument,


### PR DESCRIPTION
The schema-builder benchmarks show a significant performance degradation on large schemas (~700ms -> 1800ms on the odoo schema) compared to a release ago.

A quick look into perf metrics with hotspot showed that Relation::has_fields() was invoked a lot, and that it was slow. This commit adds a secondary index for relation field -> relation in the parser database, making the query for RelationFieldWalker::relation() a single hash table lookup. The benchmarks confirm that the schema builder is as fast or faster than a release ago, and the profiles look much flatter. The slow method got exposed more as a result of https://github.com/prisma/client-planning/issues/265