### PR TITLE
qe/prisma-models: opportunistic clean ups

### DIFF
--- a/query-engine/prisma-models/src/composite_type.rs
+++ b/query-engine/prisma-models/src/composite_type.rs
@@ -2,8 +2,6 @@ use crate::Field;
 use psl::schema_ast::ast;
 
 pub type CompositeType = crate::Zipper<ast::CompositeTypeId>;
-pub type CompositeTypeRef = CompositeType;
-pub type CompositeTypeWeakRef = CompositeType;
 
 impl CompositeType {
     pub fn name(&self) -> &str {

--- a/query-engine/prisma-models/src/convert.rs
+++ b/query-engine/prisma-models/src/convert.rs
@@ -1,6 +1,6 @@
-use crate::{InternalDataModel, InternalDataModelRef};
+use crate::InternalDataModel;
 use std::sync::Arc;
 
-pub fn convert(schema: Arc<psl::ValidatedSchema>) -> InternalDataModelRef {
-    Arc::new(InternalDataModel { schema })
+pub fn convert(schema: Arc<psl::ValidatedSchema>) -> InternalDataModel {
+    InternalDataModel { schema }
 }

--- a/query-engine/prisma-models/src/field/composite.rs
+++ b/query-engine/prisma-models/src/field/composite.rs
@@ -1,4 +1,4 @@
-use crate::{parent_container::ParentContainer, CompositeTypeRef};
+use crate::{parent_container::ParentContainer, CompositeType};
 use dml::FieldArity;
 use psl::{parser_database::walkers, schema_ast::ast};
 use std::fmt::{Debug, Display};
@@ -21,7 +21,7 @@ impl CompositeField {
         }
     }
 
-    pub fn typ(&self) -> CompositeTypeRef {
+    pub fn typ(&self) -> CompositeType {
         let id = match self.id {
             CompositeFieldId::InModel(sfid) => self.dm.walk(sfid).scalar_field_type().as_composite_type().unwrap(),
             CompositeFieldId::InCompositeType(ctid) => self.dm.walk(ctid).r#type().as_composite_type().unwrap(),

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -55,7 +55,7 @@ impl RelationField {
             .collect()
     }
 
-    pub fn relation(&self) -> RelationRef {
+    pub fn relation(&self) -> Relation {
         let internal_data_model = self.model().internal_data_model();
         let relation_id = internal_data_model.walk(self.id).relation().id;
         internal_data_model.zip(relation_id)

--- a/query-engine/prisma-models/src/fields.rs
+++ b/query-engine/prisma-models/src/fields.rs
@@ -5,11 +5,11 @@ use std::collections::BTreeSet;
 
 #[derive(Debug, Clone)]
 pub struct Fields {
-    model: ModelWeakRef,
+    model: Model,
 }
 
 impl Fields {
-    pub(crate) fn new(model: ModelWeakRef) -> Fields {
+    pub(crate) fn new(model: Model) -> Fields {
         Fields { model }
     }
 

--- a/query-engine/prisma-models/src/model.rs
+++ b/query-engine/prisma-models/src/model.rs
@@ -3,18 +3,6 @@ use psl::{parser_database::walkers, schema_ast::ast};
 
 pub type Model = crate::Zipper<ast::ModelId>;
 pub type ModelRef = Model;
-pub type ModelWeakRef = Model;
-
-// pub struct Model {
-//     pub id: ast::ModelId,
-//     pub(crate) name: String,
-//     pub(crate) manifestation: Option<String>,
-//     pub(crate) fields: OnceCell<Fields>,
-//     pub(crate) primary_identifier: OnceCell<FieldSelection>,
-//     pub(crate) dml_model: dml::Model,
-
-//     pub internal_data_model: InternalDataModelWeakRef,
-// }
 
 impl Model {
     pub fn name(&self) -> &str {

--- a/query-engine/prisma-models/src/parent_container.rs
+++ b/query-engine/prisma-models/src/parent_container.rs
@@ -1,11 +1,11 @@
-use crate::{CompositeTypeRef, CompositeTypeWeakRef, Field, InternalDataModelRef, ModelRef, ModelWeakRef};
+use crate::{CompositeType, Field, InternalDataModelRef, Model, ModelRef};
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
 #[derive(Clone)]
 pub enum ParentContainer {
-    Model(ModelWeakRef),
-    CompositeType(CompositeTypeWeakRef),
+    Model(Model),
+    CompositeType(CompositeType),
 }
 
 impl ParentContainer {
@@ -24,14 +24,14 @@ impl ParentContainer {
         }
     }
 
-    pub fn as_model_weak(&self) -> Option<ModelWeakRef> {
+    pub fn as_model_weak(&self) -> Option<Model> {
         match self {
             ParentContainer::Model(m) => Some(m.clone()),
             ParentContainer::CompositeType(_) => None,
         }
     }
 
-    pub fn as_composite(&self) -> Option<CompositeTypeRef> {
+    pub fn as_composite(&self) -> Option<CompositeType> {
         match self {
             ParentContainer::Model(_) => None,
             ParentContainer::CompositeType(ct) => Some(ct.clone()),
@@ -82,8 +82,8 @@ impl From<ModelRef> for ParentContainer {
     }
 }
 
-impl From<CompositeTypeRef> for ParentContainer {
-    fn from(composite: CompositeTypeRef) -> Self {
+impl From<CompositeType> for ParentContainer {
+    fn from(composite: CompositeType) -> Self {
         Self::CompositeType(composite)
     }
 }

--- a/query-engine/prisma-models/src/relation.rs
+++ b/query-engine/prisma-models/src/relation.rs
@@ -6,8 +6,6 @@ use psl::{
 };
 
 pub type Relation = crate::Zipper<RelationId>;
-pub type RelationRef = Relation;
-pub type RelationWeakRef = Relation;
 
 impl Relation {
     pub fn name(&self) -> String {

--- a/query-engine/prisma-models/src/zipper.rs
+++ b/query-engine/prisma-models/src/zipper.rs
@@ -42,5 +42,4 @@ impl<I: Hash> Hash for Zipper<I> {
 }
 
 pub type InternalEnum = Zipper<ast::EnumId>;
-pub type InternalEnumRef = InternalEnum;
 pub type InternalEnumValue = Zipper<ast::EnumValueId>;

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -264,17 +264,17 @@ fn duplicate_relation_name() {
     convert(schema);
 }
 
-fn convert(datamodel: &str) -> Arc<InternalDataModel> {
+fn convert(datamodel: &str) -> InternalDataModel {
     let schema = psl::parse_schema(datamodel).unwrap();
     prisma_models::convert(Arc::new(schema))
 }
 
 trait DatamodelAssertions {
-    fn assert_model(self: &Arc<Self>, name: &str) -> Model;
+    fn assert_model(&self, name: &str) -> Model;
 }
 
 impl DatamodelAssertions for InternalDataModel {
-    fn assert_model(self: &Arc<Self>, name: &str) -> Model {
+    fn assert_model(&self, name: &str) -> Model {
         self.clone().find_model(name).unwrap()
     }
 }

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -44,7 +44,7 @@ pub use self::utils::{compound_id_field_name, compound_index_field_name};
 
 use cache::TypeRefCache;
 use prisma_models::{
-    ast, CompositeTypeRef, Field as ModelField, InternalDataModelRef, ModelRef, RelationFieldRef, TypeIdentifier,
+    ast, CompositeType, Field as ModelField, InternalDataModelRef, ModelRef, RelationFieldRef, TypeIdentifier,
 };
 use psl::{
     datamodel_connector::{Connector, ConnectorCapability},
@@ -125,10 +125,10 @@ impl BuilderContext {
     }
 
     pub fn models(&self) -> Vec<ModelRef> {
-        self.internal_data_model.models_cloned()
+        self.internal_data_model.models().collect()
     }
 
-    pub fn composite_types(&self) -> Vec<CompositeTypeRef> {
+    pub fn composite_types(&self) -> Vec<CompositeType> {
         self.internal_data_model.composite_types().collect()
     }
 

--- a/query-engine/schema-builder/src/output_types/objects/composite.rs
+++ b/query-engine/schema-builder/src/output_types/objects/composite.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::unnecessary_to_owned)]
 
 use super::*;
-use prisma_models::CompositeTypeRef;
+use prisma_models::CompositeType;
 
 /// Compute initial composites cache. No fields are computed because we first
 /// need all composites to be present, then we can compute fields in a second pass.
@@ -22,7 +22,7 @@ pub(crate) fn initialize_fields(ctx: &mut BuilderContext) {
     });
 }
 
-pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeTypeRef) -> ObjectTypeWeakRef {
+pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeType) -> ObjectTypeWeakRef {
     let ident = Identifier::new(ct.name(), MODEL_NAMESPACE);
     ctx.get_output_type(&ident)
         .expect("Invariant violation: Initialized output object type for each composite.")
@@ -30,7 +30,7 @@ pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeTypeRef) -> Objec
 
 /// Computes composite output type fields.
 /// Requires an initialized cache.
-fn compute_composite_object_type_fields(ctx: &mut BuilderContext, composite: &CompositeTypeRef) -> Vec<OutputField> {
+fn compute_composite_object_type_fields(ctx: &mut BuilderContext, composite: &CompositeType) -> Vec<OutputField> {
     composite
         .fields()
         .into_iter()

--- a/query-engine/schema/src/enum_type.rs
+++ b/query-engine/schema/src/enum_type.rs
@@ -1,5 +1,5 @@
 use super::*;
-use prisma_models::{InternalEnumRef, PrismaValue, ScalarFieldRef};
+use prisma_models::{InternalEnum, PrismaValue, ScalarFieldRef};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum EnumType {
@@ -27,7 +27,7 @@ impl EnumType {
         }
     }
 
-    pub fn database(identifier: Identifier, internal_enum: InternalEnumRef) -> Self {
+    pub fn database(identifier: Identifier, internal_enum: InternalEnum) -> Self {
         Self::Database(DatabaseEnumType {
             identifier,
             internal_enum,
@@ -67,7 +67,7 @@ impl StringEnumType {
 #[derive(Debug, Clone, PartialEq)]
 pub struct DatabaseEnumType {
     pub identifier: Identifier,
-    pub internal_enum: InternalEnumRef,
+    pub internal_enum: InternalEnum,
 }
 
 impl DatabaseEnumType {


### PR DESCRIPTION
This commit changes absolutely nothing to functionality. It is just less
code, fewer names.

It _does_ save us an indirection when accessing anything on an
InternalDataModel.

Previously, to reach pslthe ::ValidatedSchema from an
InternalDataModelRef, two `Arc`'s would need to be dereferenced.

```
        Before

Arc<InternalDataModel> -> Arc<ValidatedSchema> -> ValidatedSchema
                      deref                   deref

        After

InternalDataModel.schema=Arc<ValidatedSchema> -> ValidatedSchema
                                             deref
```

This appears to make a small but measurable difference. The "change"
sections in the measurements below are relative to current main
(https://github.com/prisma/prisma-engines/commit/8fde8fef4033376662cad983758335009d522acb).

```

prisma-desktop.tom.~/src/gh/prisma-engines λ cargo bench --bench schema_builder_bench --profile=release schema_builder::build
   Compiling prisma-models v0.0.0 (/home/tom/src/gh/prisma-engines/query-engine/prisma-models)
   Compiling schema v0.1.0 (/home/tom/src/gh/prisma-engines/query-engine/schema)
   Compiling schema-builder v0.1.0 (/home/tom/src/gh/prisma-engines/query-engine/schema-builder)
    Finished release [optimized] target(s) in 23.85s
     Running benches/schema_builder_bench.rs (target/release/deps/schema_builder_bench-1b88ec6258598a03)

schema_builder::build (small)
                        time:   [2.8859 ms 2.8876 ms 2.8891 ms]
                        change: [-1.9240% -1.5326% -1.1790%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  10 (10.00%) low severe
  10 (10.00%) low mild

schema_builder::build (medium)
                        time:   [24.821 ms 24.832 ms 24.847 ms]
                        change: [-1.0125% -0.9355% -0.8579%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

Benchmarking schema_builder::build (large): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 65.4s, or reduce sample count to 10.
schema_builder::build (large)
                        time:   [652.05 ms 652.44 ms 652.86 ms]
                        change: [-2.2818% -2.1973% -2.1103%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild
```