### PR TITLE
SQLite view introspection, flavours

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour.rs
@@ -1,0 +1,20 @@
+mod mysql;
+mod postgresql;
+mod sqlite;
+mod sqlserver;
+
+use sql_schema_describer as sql;
+
+pub(super) use mysql::MysqlIntrospectionFlavour;
+pub(super) use postgresql::PostgresIntrospectionFlavour;
+pub(super) use sqlite::SqliteIntrospectionFlavour;
+pub(super) use sqlserver::SqlServerIntrospectionFlavour;
+
+pub(crate) trait IntrospectionFlavour {
+    /// For columns in PostgreSQL or SQLite views, if changed in PSL,
+    /// we use the changed arity instead of the always optional value from the
+    /// database.
+    fn keep_previous_scalar_field_arity(&self, _: sql::ColumnWalker<'_>) -> bool {
+        false
+    }
+}

--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/cockroachdb.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/cockroachdb.rs
@@ -1,0 +1,3 @@
+pub(crate) struct CockroachDbIntrospectionFlavour;
+
+impl super::IntrospectionFlavour for CockroachDbIntrospectionFlavour {}

--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/mysql.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/mysql.rs
@@ -1,0 +1,3 @@
+pub(crate) struct MysqlIntrospectionFlavour;
+
+impl super::IntrospectionFlavour for MysqlIntrospectionFlavour {}

--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/postgresql.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/postgresql.rs
@@ -1,0 +1,9 @@
+use sql_schema_describer as sql;
+
+pub(crate) struct PostgresIntrospectionFlavour;
+
+impl super::IntrospectionFlavour for PostgresIntrospectionFlavour {
+    fn keep_previous_scalar_field_arity(&self, next: sql::ColumnWalker<'_>) -> bool {
+        next.is_in_view() && next.column_type().arity.is_nullable()
+    }
+}

--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/sqlite.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/sqlite.rs
@@ -1,0 +1,9 @@
+use sql_schema_describer as sql;
+
+pub(crate) struct SqliteIntrospectionFlavour;
+
+impl super::IntrospectionFlavour for SqliteIntrospectionFlavour {
+    fn keep_previous_scalar_field_arity(&self, next: sql::ColumnWalker<'_>) -> bool {
+        next.is_in_view() && next.column_type().arity.is_nullable()
+    }
+}

--- a/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/sqlserver.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/datamodel_calculator/context/flavour/sqlserver.rs
@@ -1,0 +1,3 @@
+pub(crate) struct SqlServerIntrospectionFlavour;
+
+impl super::IntrospectionFlavour for SqlServerIntrospectionFlavour {}

--- a/introspection-engine/connectors/sql-introspection-connector/src/pair/scalar_field.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/pair/scalar_field.rs
@@ -59,15 +59,9 @@ impl<'a> ScalarFieldPair<'a> {
         self.previous.and_then(|f| f.ast_field().documentation())
     }
 
-    /// Optional, required or a list. For columns in PostgreSQL views, if changed in PSL,
-    /// we use the changed arity instead of the always optional value from the
-    /// database.
+    /// Optional, required or a list.
     pub fn arity(self) -> ColumnArity {
-        let keep_previous_arity = self.next.is_in_view()
-            && self.next.column_type().arity.is_nullable()
-            && self.context.sql_family.is_postgres();
-
-        if keep_previous_arity {
+        if self.context.flavour.keep_previous_scalar_field_arity(self.next) {
             match self.previous.map(|prev| prev.ast_field().arity) {
                 Some(arity) if arity.is_required() => ColumnArity::Required,
                 Some(arity) if arity.is_list() => ColumnArity::List,

--- a/introspection-engine/introspection-engine-tests/tests/simple/sqlite/views/simple.sql
+++ b/introspection-engine/introspection-engine-tests/tests/simple/sqlite/views/simple.sql
@@ -1,0 +1,38 @@
+-- preview_features=views
+-- tags=sqlite
+
+CREATE TABLE A (
+    id INT NOT NULL PRIMARY KEY,
+    first_name VARCHAR(255) NOT NULL,
+    last_name VARCHAR(255) NULL
+);
+
+CREATE VIEW B AS SELECT id, first_name, last_name FROM A;
+
+
+/*
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["views"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+model A {
+  id         Int     @id
+  first_name String
+  last_name  String?
+}
+
+/// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+view B {
+  id         Int?
+  first_name String?
+  last_name  String?
+
+  @@ignore
+}
+*/

--- a/libs/sql-schema-describer/src/lib.rs
+++ b/libs/sql-schema-describer/src/lib.rs
@@ -345,6 +345,16 @@ impl SqlSchema {
         id
     }
 
+    pub fn push_view(&mut self, name: String, namespace_id: NamespaceId, definition: Option<String>) -> ViewId {
+        let id = ViewId(self.views.len() as u32);
+        self.views.push(View {
+            namespace_id,
+            name,
+            definition,
+        });
+        id
+    }
+
     pub fn push_table_with_properties(
         &mut self,
         name: String,


### PR DESCRIPTION
Gotchas:

- Column arity is always optional for views, so we do the same trick in re-intro as we do with PostgreSQL.
- No default values in views.

Closes: https://github.com/prisma/prisma/issues/17416