### PR TITLE
qe: remove prisma_models::convert() from schema builder benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5181,9 +5181,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5191,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -5206,9 +5206,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5216,9 +5216,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5229,9 +5229,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "wasm-logger"

--- a/flake.lock
+++ b/flake.lock
@@ -14,11 +14,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674348649,
-        "narHash": "sha256-hBRlaUlsrmW1wAPevwQnkrT0XiLrmlAHWabWYmLeQlQ=",
+        "lastModified": 1678152261,
+        "narHash": "sha256-cPRDxwygVMleiSEGELrvAiq9vYAN4c3KK/K4UEO13vU=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "ccea7b33178daf6010aae3ea2b3fb5b0241b9146",
+        "rev": "5291dd0aa7a52d607fc952763ef60714e4c881d4",
         "type": "github"
       },
       "original": {
@@ -30,11 +30,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -50,11 +50,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674771137,
-        "narHash": "sha256-Zpk1GbEsYrqKmuIZkx+f+8pU0qcCYJoSUwNz1Zk+R00=",
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7c7a8bce3dffe71203dcd4276504d1cb49dfe05f",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1674641431,
-        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
+        "lastModified": 1678654296,
+        "narHash": "sha256-aVfw3ThpY7vkUeF1rFy10NAkpKDS2imj3IakrzT0Occ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
+        "rev": "5a1dc8acd977ff3dccd1328b7c4a6995429a656b",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1674786480,
-        "narHash": "sha256-n25V3Ug/dJewbJaxj1gL0cUMBdOonrVkIQCHd9yHHvw=",
+        "lastModified": 1678674283,
+        "narHash": "sha256-MnFqHP7AwvjK3VLRmDnzbJWSL8lbDrmYESjQDaRmAVo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "296dd673b46aaebe1c8355f1848ceb7c905dda35",
+        "rev": "f25d4bc2f6a0a3f9a2f15d3b9e3edb0ee5099a3d",
         "type": "github"
       },
       "original": {

--- a/introspection-engine/introspection-engine-tests/tests/simple.rs
+++ b/introspection-engine/introspection-engine-tests/tests/simple.rs
@@ -84,7 +84,7 @@ source .test_database_urls/mysql_5_6
         database_url = format!("{}.db", sqlite_test_url(test_function_name));
 
         let file = database_url.trim_start_matches("file:");
-        std::fs::remove_file(&file).ok();
+        std::fs::remove_file(file).ok();
     }
 
     let conn = tok(Quaint::new(&database_url)).unwrap();

--- a/libs/sql-schema-describer/src/walkers/table.rs
+++ b/libs/sql-schema-describer/src/walkers/table.rs
@@ -26,13 +26,12 @@ impl<'a> TableWalker<'a> {
     /// Traverse the table's columns.
     pub fn columns(self) -> impl ExactSizeIterator<Item = TableColumnWalker<'a>> {
         self.columns_range()
-            .into_iter()
             .map(move |idx| self.walk(TableColumnId(idx as u32)))
     }
 
     /// The number of foreign key constraints on the table.
     pub fn foreign_key_count(self) -> usize {
-        self.foreign_keys_range().into_iter().len()
+        self.foreign_keys_range().len()
     }
 
     /// Traverse the indexes on the table.

--- a/libs/sql-schema-describer/src/walkers/view.rs
+++ b/libs/sql-schema-describer/src/walkers/view.rs
@@ -26,9 +26,7 @@ impl<'a> ViewWalker<'a> {
 
     /// Traverse the view's columns.
     pub fn columns(self) -> impl ExactSizeIterator<Item = ViewColumnWalker<'a>> {
-        self.columns_range()
-            .into_iter()
-            .map(move |idx| self.walk(ViewColumnId(idx as u32)))
+        self.columns_range().map(move |idx| self.walk(ViewColumnId(idx as u32)))
     }
 
     fn columns_range(self) -> Range<usize> {

--- a/prisma-fmt-wasm/Cargo.toml
+++ b/prisma-fmt-wasm/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.83"
+wasm-bindgen = "=0.2.84"
 wasm-logger = { version = "0.2.0", optional = true }
 prisma-fmt = { path = "../prisma-fmt" }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bigint.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bigint.rs
@@ -13,7 +13,7 @@ mod bigint {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { bInt } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"bInt":"10000000000"}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod bigint {
                 let res = run_query!(runner, r#"{ findManyTestModel { bInt } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"bInt":"10000000000"},{"bInt":"-10000000000"},{"bInt":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bool.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bool.rs
@@ -13,7 +13,7 @@ mod bool {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { bool } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"bool":true}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod bool {
                 let res = run_query!(runner, r#"{ findManyTestModel { bool } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"bool":true},{"bool":false},{"bool":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bytes.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bytes.rs
@@ -13,7 +13,7 @@ mod bytes {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { bytes } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"bytes":"AQID"}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod bytes {
                 let res = run_query!(runner, r#"{ findManyTestModel { bytes } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"bytes":"AQID"},{"bytes":"dGVzdA=="},{"bytes":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/datetime.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/datetime.rs
@@ -13,7 +13,7 @@ mod datetime {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { dt } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"dt":"1900-10-10T01:10:10.001Z"}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod datetime {
                 let res = run_query!(runner, r#"{ findManyTestModel { dt } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"dt":"1900-10-10T01:10:10.001Z"},{"dt":"1969-01-01T10:33:59.000Z"},{"dt":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/decimal.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/decimal.rs
@@ -24,7 +24,7 @@ mod decimal {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { decimal } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"decimal":"12.3456"}}}"###
                 );
             }
@@ -65,7 +65,7 @@ mod decimal {
                 let res = run_query!(runner, r#"{ findManyTestModel { decimal } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"decimal":"12.3456"},{"decimal":"-1.2345678"},{"decimal":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/enum_type.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/enum_type.rs
@@ -31,7 +31,7 @@ mod enum_type {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { my_enum } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"my_enum":"A"}}}"###
                 );
             }
@@ -72,7 +72,7 @@ mod enum_type {
                 let res = run_query!(runner, r#"{ findManyTestModel { my_enum } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"my_enum":"A"},{"my_enum":"B"},{"my_enum":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/float.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/float.rs
@@ -13,7 +13,7 @@ mod float {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { float } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"float":1.2}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod float {
                 let res = run_query!(runner, r#"{ findManyTestModel { float } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"float":1.2},{"float":13.37},{"float":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/int.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/int.rs
@@ -13,7 +13,7 @@ mod int {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { int } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"int":-42}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod int {
                 let res = run_query!(runner, r#"{ findManyTestModel { int } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"int":-42},{"int":1337},{"int":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
@@ -13,7 +13,7 @@ mod json {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { json } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"json":"{}"}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod json {
                 let res = run_query!(runner, r#"{ findManyTestModel { json } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"json":"{}"},{"json":"{\"a\":\"b\"}"},{"json":"1"},{"json":"\"hello\""},{"json":"[1,\"a\",{\"b\":true}]"}]}}"###
                 );
             }
@@ -93,7 +93,7 @@ mod json {
                 let res = run_query!(runner, r#"{ findManyTestModel { json } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"json":null},{"json":"null"}]}}"###
                 );
             }
@@ -123,11 +123,11 @@ mod json {
     }
 
     async fn create_test_data(runner: &Runner) -> TestResult<()> {
-        create_row(&runner, r#"{ id: 1, json: "{}" }"#).await?;
-        create_row(&runner, r#"{ id: 2, json: "{\"a\":\"b\"}" }"#).await?;
-        create_row(&runner, r#"{ id: 3, json: "1" }"#).await?;
-        create_row(&runner, r#"{ id: 4, json: "\"hello\"" }"#).await?;
-        create_row(&runner, r#"{ id: 5, json: "[1, \"a\", {\"b\": true}]" }"#).await?;
+        create_row(runner, r#"{ id: 1, json: "{}" }"#).await?;
+        create_row(runner, r#"{ id: 2, json: "{\"a\":\"b\"}" }"#).await?;
+        create_row(runner, r#"{ id: 3, json: "1" }"#).await?;
+        create_row(runner, r#"{ id: 4, json: "\"hello\"" }"#).await?;
+        create_row(runner, r#"{ id: 5, json: "[1, \"a\", {\"b\": true}]" }"#).await?;
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/string.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/string.rs
@@ -13,7 +13,7 @@ mod string {
                 let res = run_query!(runner, r#"{ findUniqueTestModel(where: { id: 1 }) { string } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findUniqueTestModel":{"string":"abc"}}}"###
                 );
             }
@@ -54,7 +54,7 @@ mod string {
                 let res = run_query!(runner, r#"{ findManyTestModel { string } }"#);
 
                 insta::assert_snapshot!(
-                  res.to_string(),
+                  res,
                   @r###"{"data":{"findManyTestModel":[{"string":"abc"},{"string":"defg"},{"string":null}]}}"###
                 );
             }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/templating/parse_models.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/templating/parse_models.rs
@@ -47,7 +47,6 @@ impl IdFragment {
         let field_name = field_name.into_value_string()?;
         let field_type = field_type.into_value_string()?;
         let directives = args
-            .into_iter()
             .map(|arg| arg.into_directive())
             .collect::<TemplatingResult<Vec<_>>>()?;
 

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -141,7 +141,7 @@ impl QueryArguments {
 
         // Indicates whether or not a combination of contained fields is on the source model (we don't check for relations for now).
         let order_by_contains_unique_index = self.model.unique_indexes().any(|index| {
-            index.fields().into_iter().all(|f| {
+            index.fields().all(|f| {
                 on_model
                     .iter()
                     .any(|o| Some(o.field.id) == f.as_scalar_field().map(|sf| ScalarFieldId::InModel(sf.id)))

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -441,7 +441,6 @@ impl WriteArgs {
 pub fn pick_args(projection: &ModelProjection, args: &WriteArgs) -> WriteArgs {
     let pairs = projection
         .scalar_fields()
-        .into_iter()
         .filter_map(|field| {
             args.get_field_value(field.db_name())
                 .map(|v| (DatasourceFieldName::from(&field), v.clone()))

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -165,7 +165,7 @@ pub(crate) async fn create_records(
 
     // Compute the set of fields affected by the createMany.
     let mut fields = HashSet::new();
-    args.iter().for_each(|arg| fields.extend(arg.keys().into_iter()));
+    args.iter().for_each(|arg| fields.extend(arg.keys()));
 
     #[allow(clippy::mutable_key_type)]
     let affected_fields: HashSet<ScalarFieldRef> = fields

--- a/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter_conversion.rs
@@ -8,15 +8,11 @@ use std::convert::TryInto;
 #[derive(Clone, Copy, Debug)]
 /// A distinction in aliasing to separate the parent table and the joined data
 /// in the statement.
+#[derive(Default)]
 pub enum AliasMode {
+    #[default]
     Table,
     Join,
-}
-
-impl Default for AliasMode {
-    fn default() -> Self {
-        AliasMode::Table
-    }
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/query-engine/connectors/sql-query-connector/src/join_utils.rs
+++ b/query-engine/connectors/sql-query-connector/src/join_utils.rs
@@ -175,7 +175,6 @@ fn compute_aggr_join_m2m(
 
     let left_join_conditions: Vec<Expression> = child_ids
         .as_columns(ctx)
-        .into_iter()
         .map(|c| c.equals(rf.m2m_columns(ctx)).into())
         .collect();
 

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/table.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/table.rs
@@ -25,7 +25,7 @@ impl AsTable for Model {
 
         let table = table.add_unique_index(id_cols);
 
-        self.unique_indexes().into_iter().fold(table, |table, index| {
+        self.unique_indexes().fold(table, |table, index| {
             let fields: Vec<_> = index
                 .fields()
                 .map(|f| prisma_models::ScalarFieldRef::from((self.dm.clone(), f)))

--- a/query-engine/core-tests/tests/query_validation_tests.rs
+++ b/query-engine/core-tests/tests/query_validation_tests.rs
@@ -10,7 +10,7 @@ fn run_query_validation_test(query_file_path: &str) {
     let schema_path = query_file_path.with_file_name("schema.prisma");
 
     let query = std::fs::read_to_string(&query_file_path).unwrap();
-    let schema = std::fs::read_to_string(&schema_path).unwrap();
+    let schema = std::fs::read_to_string(schema_path).unwrap();
 
     let parsed_schema = psl::parse_schema(schema).unwrap();
     let prisma_models_schema = prisma_models::convert(Arc::new(parsed_schema));
@@ -76,7 +76,7 @@ fn format_chunks(chunks: Vec<dissimilar::Chunk<'_>>) -> String {
 }
 
 fn validate(query: &str, schema: schema::QuerySchemaRef) -> Result<(), request_handlers::HandlerError> {
-    let json_request: JsonSingleQuery = serde_json::from_str(&query).unwrap();
+    let json_request: JsonSingleQuery = serde_json::from_str(query).unwrap();
     let operation = request_handlers::JsonProtocolAdapter::convert_single(json_request, &schema)?;
     QueryGraphBuilder::new(schema)
         .build(operation)

--- a/query-engine/core/src/error.rs
+++ b/query-engine/core/src/error.rs
@@ -173,19 +173,18 @@ impl From<CoreError> for user_facing_errors::Error {
                 path,
                 error_kind,
             })) => {
-                let known_error = match error_kind {
-                    QueryParserErrorKind::RequiredValueNotSetError => {
-                        user_facing_errors::KnownError::new(user_facing_errors::query_engine::MissingRequiredValue {
-                            path: format!("{}", path),
-                        })
-                    }
-                    _ => user_facing_errors::KnownError::new(
-                        user_facing_errors::query_engine::LegacyQueryValidationFailed {
-                            query_validation_error: format!("{}", error_kind),
-                            query_position: format!("{}", path),
-                        },
-                    ),
-                };
+                let known_error =
+                    match error_kind {
+                        QueryParserErrorKind::RequiredValueNotSetError => user_facing_errors::KnownError::new(
+                            user_facing_errors::query_engine::MissingRequiredValue { path: path.to_string() },
+                        ),
+                        _ => user_facing_errors::KnownError::new(
+                            user_facing_errors::query_engine::LegacyQueryValidationFailed {
+                                query_validation_error: error_kind.to_string(),
+                                query_position: path.to_string(),
+                            },
+                        ),
+                    };
 
                 known_error.into()
             }

--- a/query-engine/core/src/query_document/error.rs
+++ b/query-engine/core/src/query_document/error.rs
@@ -18,7 +18,7 @@ impl fmt::Display for QueryParserError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Legacy { path, error_kind } => {
-                write!(f, "Query parsing/validation error at `{}`: {}", path, error_kind,)
+                write!(f, "Query parsing/validation error at `{path}`: {error_kind}")
             }
             Self::Structured(_) => todo!(),
         }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -846,7 +846,6 @@ impl ToGraphviz for QueryGraph {
         let nodes = self
             .graph
             .node_indices()
-            .into_iter()
             .map(|idx| (idx, self.graph.node_weight(idx).unwrap().borrow().unwrap()))
             .map(|(idx, node)| {
                 if self.is_result_node(&NodeRef { node_ix: idx }) {
@@ -878,7 +877,6 @@ impl ToGraphviz for QueryGraph {
         let edges = self
             .graph
             .edge_references()
-            .into_iter()
             .map(|edge| {
                 let idx = edge.id();
                 let edge_content = self.graph.edge_weight(idx).unwrap().borrow().unwrap();

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -185,11 +185,9 @@ impl<'a> ScalarFilterParser<'a> {
             aggregations::UNDERSCORE_MIN => self.aggregation_filter(input, Filter::min, false),
             aggregations::UNDERSCORE_MAX => self.aggregation_filter(input, Filter::max, false),
 
-            _ => {
-                return Err(QueryGraphBuilderError::InputError(format!(
-                    "{filter_name} is not a valid scalar filter operation"
-                )))
-            }
+            _ => Err(QueryGraphBuilderError::InputError(format!(
+                "{filter_name} is not a valid scalar filter operation"
+            ))),
         }
     }
 
@@ -396,11 +394,9 @@ impl<'a> ScalarFilterParser<'a> {
                 JsonTargetType::String,
             )]),
 
-            _ => {
-                return Err(QueryGraphBuilderError::InputError(format!(
-                    "{filter_name} is not a valid scalar filter operation"
-                )))
-            }
+            _ => Err(QueryGraphBuilderError::InputError(format!(
+                "{filter_name} is not a valid scalar filter operation"
+            ))),
         }
     }
 

--- a/query-engine/prisma-models/src/composite_type.rs
+++ b/query-engine/prisma-models/src/composite_type.rs
@@ -13,10 +13,10 @@ impl CompositeType {
     }
 
     pub fn find_field(&self, prisma_name: &str) -> Option<Field> {
-        self.fields().into_iter().find(|f| f.name() == prisma_name)
+        self.fields().find(|f| f.name() == prisma_name)
     }
 
     pub fn find_field_by_db_name(&self, db_name: &str) -> Option<Field> {
-        self.fields().into_iter().find(|f| f.db_name() == db_name)
+        self.fields().find(|f| f.db_name() == db_name)
     }
 }

--- a/query-engine/prisma-models/src/parent_container.rs
+++ b/query-engine/prisma-models/src/parent_container.rs
@@ -57,7 +57,7 @@ impl ParentContainer {
         match self {
             ParentContainer::Model(weak) => weak.fields().find_from_all(prisma_name).ok(),
 
-            ParentContainer::CompositeType(weak) => weak.fields().into_iter().find(|field| field.name() == prisma_name),
+            ParentContainer::CompositeType(weak) => weak.fields().find(|field| field.name() == prisma_name),
         }
     }
 

--- a/query-engine/prisma-models/src/projections/model_projection.rs
+++ b/query-engine/prisma-models/src/projections/model_projection.rs
@@ -77,7 +77,6 @@ impl ModelProjection {
                 Field::Relation(rf) => rf.scalar_fields(),
                 Field::Composite(_) => todo!(), // [Composites] todo
             })
-            .into_iter()
             .unique_by(|field| field.name().to_owned())
     }
 

--- a/query-engine/prisma-models/src/record.rs
+++ b/query-engine/prisma-models/src/record.rs
@@ -161,7 +161,6 @@ impl Record {
     ) -> crate::Result<SelectionResult> {
         let pairs: Vec<_> = extraction_selection
             .selections()
-            .into_iter()
             .map(|selection| {
                 self.get_field_value(field_names, selection.db_name())
                     .and_then(|val| Ok((selection.clone(), selection.coerce_value(val.clone())?)))
@@ -178,7 +177,6 @@ impl Record {
     ) -> crate::Result<Vec<&PrismaValue>> {
         let x: Vec<&PrismaValue> = model_projection
             .fields()
-            .into_iter()
             .flat_map(|field| {
                 field
                     .scalar_fields()

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -394,7 +394,7 @@ mod tests {
     #[test]
     pub fn default_scalar_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "findFirst",
             "query": {
@@ -452,7 +452,7 @@ mod tests {
     #[test]
     pub fn default_composite_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "createOne",
             "query": {
@@ -505,7 +505,7 @@ mod tests {
     #[test]
     pub fn explicit_select() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "findFirst",
             "query": {
@@ -542,7 +542,7 @@ mod tests {
     #[test]
     pub fn arguments() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "findFirst",
             "query": {
@@ -618,7 +618,7 @@ mod tests {
     #[test]
     pub fn nested_arguments() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "findFirst",
             "query": {
@@ -722,7 +722,7 @@ mod tests {
     #[test]
     pub fn composite_selection_should_be_based_on_schema_1() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "deleteMany",
             "query": {
@@ -759,7 +759,7 @@ mod tests {
     #[test]
     pub fn simple_mutation() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -796,7 +796,7 @@ mod tests {
     #[test]
     pub fn scalar_wildcard_and_scalar_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -824,7 +824,7 @@ mod tests {
     #[test]
     pub fn composite_wildcard_and_composite_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -855,7 +855,7 @@ mod tests {
     #[test]
     pub fn composite_wildcard_and_scalar_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -920,7 +920,7 @@ mod tests {
     #[test]
     pub fn custom_arg_datetime() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -955,7 +955,7 @@ mod tests {
     #[test]
     pub fn custom_arg_bigint() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -1001,7 +1001,7 @@ mod tests {
     #[test]
     pub fn custom_arg_decimal() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -1036,7 +1036,7 @@ mod tests {
     #[test]
     pub fn custom_arg_bytes() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -1076,7 +1076,7 @@ mod tests {
     #[test]
     pub fn custom_arg_json() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -1111,7 +1111,7 @@ mod tests {
     #[test]
     pub fn unknown_custom_arg() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "updateOne",
             "query": {
@@ -1155,7 +1155,7 @@ mod tests {
     #[test]
     pub fn invalid_operation() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "modelName": "User",
             "action": "queryRaw",
             "query": {
@@ -1184,7 +1184,7 @@ mod tests {
     #[test]
     pub fn query_raw() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
             "action": "runCommandRaw",
             "query": {
                 "arguments": {
@@ -1269,7 +1269,7 @@ mod tests {
     #[test]
     fn nested_composite_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"
+            r#"
             {
               "modelName": "Comment",
               "action": "createOne",
@@ -1340,7 +1340,7 @@ mod tests {
     #[test]
     pub fn nested_composite_wildcard_and_composite_selection() {
         let query: JsonSingleQuery = serde_json::from_str(
-            &r#"{
+            r#"{
                 "modelName": "Comment",
                 "action": "createOne",
                 "query": {

--- a/query-engine/schema-builder/benches/schema_builder_bench.rs
+++ b/query-engine/schema-builder/benches/schema_builder_bench.rs
@@ -13,11 +13,6 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         });
 
         let validated_schema = std::sync::Arc::new(psl::validate(source_file));
-
-        c.bench_function(&format!("prisma_models::convert ({name})"), |b| {
-            b.iter(|| black_box(prisma_models::convert(validated_schema.clone())))
-        });
-
         let idm = prisma_models::convert(validated_schema);
 
         c.bench_function(&format!("schema_builder::build ({name})"), |b| {

--- a/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
@@ -107,7 +107,6 @@ pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext, model: &ModelRe
     // @@unique compound fields.
     let compound_uniques: Vec<_> = model
         .unique_indexes()
-        .into_iter()
         .filter(|index| index.fields().len() > 1)
         .map(|index| {
             let fields = index
@@ -255,7 +254,7 @@ pub(crate) fn composite_equality_object(ctx: &mut BuilderContext, cf: &Composite
     let mut fields = vec![];
 
     let composite_type = cf.typ();
-    let input_fields = composite_type.fields().into_iter().map(|f| match f {
+    let input_fields = composite_type.fields().map(|f| match f {
         ModelField::Scalar(sf) => input_field(sf.name(), map_scalar_input_type_for_field(ctx, &sf), None)
             .optional_if(!sf.is_required())
             .nullable_if(!sf.is_required() && !sf.is_list()),

--- a/query-engine/schema-builder/src/output_types/objects/composite.rs
+++ b/query-engine/schema-builder/src/output_types/objects/composite.rs
@@ -31,9 +31,5 @@ pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeType) -> ObjectTy
 /// Computes composite output type fields.
 /// Requires an initialized cache.
 fn compute_composite_object_type_fields(ctx: &mut BuilderContext, composite: &CompositeType) -> Vec<OutputField> {
-    composite
-        .fields()
-        .into_iter()
-        .map(|f| field::map_output_field(ctx, &f))
-        .collect()
+    composite.fields().map(|f| field::map_output_field(ctx, &f)).collect()
 }


### PR DESCRIPTION
This step was refactored away. Since
https://github.com/prisma/prisma-engines/pull/3753, it does not perform any work at all, so there is no longer a point to measuring it — it shows up as a few nanoseconds on the benchmarks results and only adds noise.