### PR TITLE
psl: normalize types::RelationField storage

### DIFF
--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -135,8 +135,8 @@ impl crate::ParserDatabase {
                 relation
                     .as_complete_fields()
                     .map(|(field_a, field_b)| CompleteInlineRelationWalker {
-                        side_a: (relation.model_a, field_a),
-                        side_b: (relation.model_b, field_b),
+                        side_a: field_a,
+                        side_b: field_b,
                         db: self,
                     })
             })

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -6,8 +6,8 @@ pub use primary_key::*;
 pub(crate) use unique_criteria::*;
 
 use super::{
-    CompleteInlineRelationWalker, FieldWalker, IndexWalker, InlineRelationWalker, RelationFieldId, RelationFieldWalker,
-    RelationWalker, ScalarFieldWalker,
+    CompleteInlineRelationWalker, FieldWalker, IndexWalker, InlineRelationWalker, RelationFieldWalker, RelationWalker,
+    ScalarFieldWalker,
 };
 use crate::{
     ast::{self, WithName},
@@ -184,9 +184,8 @@ impl<'db> ModelWalker<'db> {
 
         self.db
             .types
-            .relation_fields
-            .range((model_id, ast::FieldId::MIN)..=(model_id, ast::FieldId::MAX))
-            .map(move |((_, field_id), _)| self.walk(RelationFieldId(model_id, *field_id)))
+            .range_model_relation_fields(model_id)
+            .map(move |(id, _)| self.walk(id))
     }
 
     /// All relations that start from this model.

--- a/psl/parser-database/src/walkers/relation.rs
+++ b/psl/parser-database/src/walkers/relation.rs
@@ -21,12 +21,8 @@ impl<'db> RelationWalker<'db> {
 
     /// The relation fields that define the relation. A then B.
     pub fn relation_fields(self) -> impl Iterator<Item = RelationFieldWalker<'db>> {
-        let relation = self.get();
-        let (a, b) = relation.attributes.fields();
-        [(relation.model_a, a), (relation.model_b, b)]
-            .into_iter()
-            .filter_map(|(model_id, field_id)| field_id.map(|f| (model_id, f)))
-            .map(move |(model, field)| self.walk(RelationFieldId(model, field)))
+        let (a, b) = self.get().attributes.fields();
+        [a, b].into_iter().flatten().map(move |field| self.walk(field))
     }
 
     /// Is any field part of the relation ignored (`@ignore`) or unsupported?

--- a/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
+++ b/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
@@ -35,9 +35,7 @@ impl<'db> ImplicitManyToManyRelationWalker<'db> {
     pub fn field_a(self) -> RelationFieldWalker<'db> {
         let rel = self.get();
         match rel.attributes {
-            RelationAttributes::ImplicitManyToMany { field_a, field_b: _ } => {
-                self.walk(crate::walkers::RelationFieldId(rel.model_a, field_a))
-            }
+            RelationAttributes::ImplicitManyToMany { field_a, field_b: _ } => self.walk(field_a),
             _ => unreachable!(),
         }
     }
@@ -46,9 +44,7 @@ impl<'db> ImplicitManyToManyRelationWalker<'db> {
     pub fn field_b(self) -> RelationFieldWalker<'db> {
         let rel = self.get();
         match rel.attributes {
-            RelationAttributes::ImplicitManyToMany { field_a: _, field_b } => {
-                self.walk(crate::walkers::RelationFieldId(rel.model_b, field_b))
-            }
+            RelationAttributes::ImplicitManyToMany { field_a: _, field_b } => self.walk(field_b),
             _ => unreachable!(),
         }
     }

--- a/psl/parser-database/src/walkers/relation/inline.rs
+++ b/psl/parser-database/src/walkers/relation/inline.rs
@@ -40,8 +40,8 @@ impl<'db> InlineRelationWalker<'db> {
         match (self.forward_relation_field(), self.back_relation_field()) {
             (Some(field_a), Some(field_b)) => {
                 let walker = CompleteInlineRelationWalker {
-                    side_a: (self.referencing_model().id, field_a.field_id()),
-                    side_b: (self.referenced_model().id, field_b.field_id()),
+                    side_a: field_a.id,
+                    side_b: field_b.id,
                     db: self.0.db,
                 };
 
@@ -85,9 +85,7 @@ impl<'db> InlineRelationWalker<'db> {
             RelationAttributes::OneToOne(OneToOneRelationFields::Forward(a))
             | RelationAttributes::OneToOne(OneToOneRelationFields::Both(a, _))
             | RelationAttributes::OneToMany(OneToManyRelationFields::Both(a, _))
-            | RelationAttributes::OneToMany(OneToManyRelationFields::Forward(a)) => {
-                Some(self.0.walk(RelationFieldId(rel.model_a, a)))
-            }
+            | RelationAttributes::OneToMany(OneToManyRelationFields::Forward(a)) => Some(self.0.walk(a)),
             RelationAttributes::OneToMany(OneToManyRelationFields::Back(_)) => None,
             RelationAttributes::ImplicitManyToMany { field_a: _, field_b: _ } => unreachable!(),
             RelationAttributes::TwoWayEmbeddedManyToMany { field_a: _, field_b: _ } => unreachable!(),
@@ -105,9 +103,7 @@ impl<'db> InlineRelationWalker<'db> {
         match rel.attributes {
             RelationAttributes::OneToOne(OneToOneRelationFields::Both(_, b))
             | RelationAttributes::OneToMany(OneToManyRelationFields::Both(_, b))
-            | RelationAttributes::OneToMany(OneToManyRelationFields::Back(b)) => {
-                Some(self.0.walk(RelationFieldId(rel.model_b, b)))
-            }
+            | RelationAttributes::OneToMany(OneToManyRelationFields::Back(b)) => Some(self.0.walk(b)),
             RelationAttributes::OneToMany(OneToManyRelationFields::Forward(_))
             | RelationAttributes::OneToOne(OneToOneRelationFields::Forward(_)) => None,
             RelationAttributes::ImplicitManyToMany { field_a: _, field_b: _ } => unreachable!(),

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -1,16 +1,15 @@
-use schema_ast::ast;
-
 use crate::{
-    walkers::{ModelWalker, RelationFieldWalker, ScalarFieldId, ScalarFieldWalker},
+    walkers::{ModelWalker, RelationFieldId, RelationFieldWalker, ScalarFieldId, ScalarFieldWalker},
     ParserDatabase, ReferentialAction,
 };
+use schema_ast::ast;
 
 /// Represents a relation that has fields and references defined in one of the
 /// relation fields. Includes 1:1 and 1:n relations that are defined from both sides.
 #[derive(Copy, Clone)]
 pub struct CompleteInlineRelationWalker<'db> {
-    pub(crate) side_a: (ast::ModelId, ast::FieldId),
-    pub(crate) side_b: (ast::ModelId, ast::FieldId),
+    pub(crate) side_a: RelationFieldId,
+    pub(crate) side_b: RelationFieldId,
     pub(crate) db: &'db ParserDatabase,
 }
 
@@ -18,22 +17,20 @@ pub struct CompleteInlineRelationWalker<'db> {
 impl<'db> CompleteInlineRelationWalker<'db> {
     /// The model that defines the relation fields and actions.
     pub fn referencing_model(self) -> ModelWalker<'db> {
-        self.db.walk(self.side_a.0)
+        self.db.walk(self.side_a).model()
     }
 
     /// The implicit relation side.
     pub fn referenced_model(self) -> ModelWalker<'db> {
-        self.db.walk(self.side_b.0)
+        self.db.walk(self.side_b).model()
     }
 
     pub fn referencing_field(self) -> RelationFieldWalker<'db> {
-        self.db
-            .walk(crate::walkers::RelationFieldId(self.side_a.0, self.side_a.1))
+        self.db.walk(self.side_a)
     }
 
     pub fn referenced_field(self) -> RelationFieldWalker<'db> {
-        self.db
-            .walk(crate::walkers::RelationFieldId(self.side_b.0, self.side_b.1))
+        self.db.walk(self.side_b)
     }
 
     /// The scalar fields defining the relation on the referenced model.

--- a/psl/parser-database/src/walkers/relation/two_way_embedded_many_to_many.rs
+++ b/psl/parser-database/src/walkers/relation/two_way_embedded_many_to_many.rs
@@ -29,9 +29,7 @@ impl<'db> TwoWayEmbeddedManyToManyRelationWalker<'db> {
     pub fn field_a(self) -> RelationFieldWalker<'db> {
         let rel = self.get();
         match rel.attributes {
-            RelationAttributes::TwoWayEmbeddedManyToMany { field_a, field_b: _ } => {
-                self.0.walk(crate::walkers::RelationFieldId(rel.model_a, field_a))
-            }
+            RelationAttributes::TwoWayEmbeddedManyToMany { field_a, field_b: _ } => self.0.walk(field_a),
             _ => unreachable!(),
         }
     }
@@ -40,9 +38,7 @@ impl<'db> TwoWayEmbeddedManyToManyRelationWalker<'db> {
     pub fn field_b(self) -> RelationFieldWalker<'db> {
         let rel = self.get();
         match rel.attributes {
-            RelationAttributes::TwoWayEmbeddedManyToMany { field_a: _, field_b } => {
-                self.0.walk(crate::walkers::RelationFieldId(rel.model_b, field_b))
-            }
+            RelationAttributes::TwoWayEmbeddedManyToMany { field_a: _, field_b } => self.0.walk(field_b),
 
             _ => unreachable!(),
         }


### PR DESCRIPTION
Profiles for schema_builder::build() showed we spend 10%+ of the schema
build time looking for RelationField structs in the BTreeMap in
parser_database::types::relation_fields.

In this commit, we make getting to the RelationField data from a
RelationFieldId O(1): it is just a slice lookup by index. The
RelationFields are in a sorted vector, so we can still have existence
lookups and efficient range queries.

Another advantage of the new setup is that we do not need to temporarily
swap RelationField values with dummy values anymore to deal with
ownership issues in attribute validation.

The benchmark results below show a ~20% speedup for
schema_builder::build() on the largest schema compared to current main
(https://github.com/prisma/prisma-engines/commit/16389e43d330c38a01ca4988f3002910fe5a7d0a)

psl::validate (small)   time:   [430.44 µs 430.80 µs 431.24 µs]
                        change: [-3.8420% -3.7014% -3.5337%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

prisma_models::convert (small)
                        time:   [8.3639 ns 8.3647 ns 8.3654 ns]
                        change: [-0.9745% -0.9176% -0.8666%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

schema_builder::build (small)
                        time:   [2.7510 ms 2.7516 ms 2.7522 ms]
                        change: [-3.5348% -3.4844% -3.4396%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) low mild

psl::validate (medium)  time:   [3.0616 ms 3.0622 ms 3.0629 ms]
                        change: [-6.1691% -6.1256% -6.0870%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

prisma_models::convert (medium)
                        time:   [8.3645 ns 8.3652 ns 8.3660 ns]
                        change: [-0.7565% -0.7275% -0.6929%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  6 (6.00%) high mild
  4 (4.00%) high severe

schema_builder::build (medium)
                        time:   [23.376 ms 23.389 ms 23.405 ms]
                        change: [-6.7037% -6.3746% -6.1050%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

psl::validate (large)   time:   [12.786 ms 12.791 ms 12.797 ms]
                        change: [-9.6416% -9.2302% -8.8662%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

prisma_models::convert (large)
                        time:   [8.3690 ns 8.3719 ns 8.3755 ns]
                        change: [-1.3089% -0.7984% -0.4945%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 18 outliers among 100 measurements (18.00%)
  5 (5.00%) high mild
  13 (13.00%) high severe

Benchmarking schema_builder::build (large): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 50.4s, or reduce sample count to 10.
schema_builder::build (large)
                        time:   [500.81 ms 501.27 ms 501.74 ms]
                        change: [-22.894% -22.804% -22.719%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild