### PR TITLE
query-core: make more items private/crate-public

### DIFF
--- a/query-engine/core/src/interpreter/expression.rs
+++ b/query-engine/core/src/interpreter/expression.rs
@@ -1,7 +1,7 @@
 use super::{Env, ExpressionResult, InterpretationResult};
 use crate::Query;
 
-pub enum Expression {
+pub(crate) enum Expression {
     Sequence {
         seq: Vec<Expression>,
     },
@@ -38,7 +38,7 @@ pub enum Expression {
     },
 }
 
-pub struct Binding {
+pub(crate) struct Binding {
     pub name: String,
     pub expr: Expression,
 }

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -4,7 +4,7 @@ use super::{
 use crate::{query_graph::*, Query};
 use std::{collections::VecDeque, convert::TryInto};
 
-pub struct Expressionista;
+pub(crate) struct Expressionista;
 
 /// Helper accumulator struct.
 #[derive(Default)]

--- a/query-engine/core/src/interpreter/interpreter.rs
+++ b/query-engine/core/src/interpreter/interpreter.rs
@@ -12,7 +12,7 @@ use std::{collections::HashMap, fmt};
 use tracing::Instrument;
 
 #[derive(Debug, Clone)]
-pub enum ExpressionResult {
+pub(crate) enum ExpressionResult {
     /// A result from a query execution.
     Query(QueryResult),
 
@@ -119,20 +119,20 @@ impl ExpressionResult {
 }
 
 #[derive(Default, Debug, Clone)]
-pub struct Env {
+pub(crate) struct Env {
     env: HashMap<String, ExpressionResult>,
 }
 
 impl Env {
-    pub fn get(&self, key: &str) -> Option<&ExpressionResult> {
+    pub(crate) fn get(&self, key: &str) -> Option<&ExpressionResult> {
         self.env.get(key)
     }
 
-    pub fn insert(&mut self, key: String, value: ExpressionResult) {
+    pub(crate) fn insert(&mut self, key: String, value: ExpressionResult) {
         self.env.insert(key, value);
     }
 
-    pub fn remove(&mut self, key: &str) -> InterpretationResult<ExpressionResult> {
+    pub(crate) fn remove(&mut self, key: &str) -> InterpretationResult<ExpressionResult> {
         match self.env.remove(key) {
             Some(val) => Ok(val),
             None => Err(InterpreterError::EnvVarNotFound(key.to_owned())),
@@ -166,7 +166,7 @@ impl<'conn> QueryInterpreter<'conn> {
         Self { conn, log }
     }
 
-    pub fn interpret(
+    pub(crate) fn interpret(
         &mut self,
         exp: Expression,
         env: Env,

--- a/query-engine/core/src/interpreter/mod.rs
+++ b/query-engine/core/src/interpreter/mod.rs
@@ -4,9 +4,8 @@ mod expressionista;
 mod interpreter;
 mod query_interpreters;
 
-pub use error::*;
-pub use expression::*;
-pub use expressionista::*;
-pub use interpreter::*;
+pub(crate) use error::*;
+pub(crate) use expressionista::*;
+pub(crate) use interpreter::*;
 
 type InterpretationResult<T> = std::result::Result<T, InterpreterError>;

--- a/query-engine/core/src/interpreter/query_interpreters/mod.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/mod.rs
@@ -1,4 +1,5 @@
 mod inmemory_record_processor;
 mod nested_read;
-pub mod read;
-pub mod write;
+
+pub(crate) mod read;
+pub(crate) mod write;

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -8,7 +8,7 @@ use prisma_models::{FieldSelection, ManyRecords, Record, RelationFieldRef, Selec
 use prisma_value::PrismaValue;
 use std::collections::HashMap;
 
-pub async fn m2m(
+pub(crate) async fn m2m(
     tx: &mut dyn ConnectionLike,
     query: &RelatedRecordsQuery,
     parent_result: Option<&ManyRecords>,

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -9,7 +9,7 @@ use prisma_models::ManyRecords;
 use std::collections::HashMap;
 use user_facing_errors::KnownError;
 
-pub fn execute<'conn>(
+pub(crate) fn execute<'conn>(
     tx: &'conn mut dyn ConnectionLike,
     query: ReadQuery,
     parent_result: Option<&'conn ManyRecords>,
@@ -242,7 +242,7 @@ fn process_nested<'conn>(
 /// This means the SQL result we get back from the database contains additional aggregation data that needs to be remapped according to the schema
 /// This function takes care of removing the aggregation data from the database result and collects it separately
 /// so that it can be serialized separately later according to the schema
-pub fn extract_aggregation_rows_from_scalars(
+pub(crate) fn extract_aggregation_rows_from_scalars(
     mut scalars: ManyRecords,
     aggr_selections: Vec<RelAggregationSelection>,
 ) -> (ManyRecords, Option<Vec<RelAggregationRow>>) {

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use connector::{ConnectionLike, NativeUpsert, QueryArguments};
 
-pub async fn execute(
+pub(crate) async fn execute(
     tx: &mut dyn ConnectionLike,
     write_query: WriteQuery,
     trace_id: Option<String>,

--- a/query-engine/core/src/query_ast/mod.rs
+++ b/query-engine/core/src/query_ast/mod.rs
@@ -10,20 +10,20 @@ use prisma_models::{FieldSelection, ModelRef, SelectionResult};
 
 #[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
-pub enum Query {
+pub(crate) enum Query {
     Read(ReadQuery),
     Write(WriteQuery),
 }
 
 impl Query {
-    pub fn returns(&self, fields: &FieldSelection) -> bool {
+    pub(crate) fn returns(&self, fields: &FieldSelection) -> bool {
         match self {
             Self::Read(rq) => rq.returns(fields),
             Self::Write(wq) => wq.returns(fields),
         }
     }
 
-    pub fn model(&self) -> ModelRef {
+    pub(crate) fn model(&self) -> ModelRef {
         match self {
             Self::Read(rq) => rq.model(),
             Self::Write(wq) => wq.model(),

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -8,7 +8,7 @@ use std::fmt::Display;
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
-pub enum ReadQuery {
+pub(crate) enum ReadQuery {
     RecordQuery(RecordQuery),
     ManyRecordsQuery(ManyRecordsQuery),
     RelatedRecordsQuery(RelatedRecordsQuery),
@@ -147,7 +147,7 @@ pub struct RecordQuery {
     pub model: ModelRef,
     pub filter: Option<Filter>,
     pub selected_fields: FieldSelection,
-    pub nested: Vec<ReadQuery>,
+    pub(crate) nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
     pub options: QueryOptions,
@@ -160,7 +160,7 @@ pub struct ManyRecordsQuery {
     pub model: ModelRef,
     pub args: QueryArguments,
     pub selected_fields: FieldSelection,
-    pub nested: Vec<ReadQuery>,
+    pub(crate) nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
     pub options: QueryOptions,
@@ -173,7 +173,7 @@ pub struct RelatedRecordsQuery {
     pub parent_field: RelationFieldRef,
     pub args: QueryArguments,
     pub selected_fields: FieldSelection,
-    pub nested: Vec<ReadQuery>,
+    pub(crate) nested: Vec<ReadQuery>,
     pub selection_order: Vec<String>,
     pub aggregation_selections: Vec<RelAggregationSelection>,
 

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -6,7 +6,7 @@ use prisma_models::prelude::*;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
-pub enum WriteQuery {
+pub(crate) enum WriteQuery {
     CreateRecord(CreateRecord),
     CreateManyRecords(CreateManyRecords),
     UpdateRecord(UpdateRecord),

--- a/query-engine/core/src/query_document/error.rs
+++ b/query-engine/core/src/query_document/error.rs
@@ -65,6 +65,7 @@ impl fmt::Display for QueryPath {
 }
 
 #[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
 pub enum QueryParserErrorKind {
     AssertionError(String),
     RequiredValueNotSetError,

--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -22,13 +22,13 @@ mod parser;
 mod selection;
 mod transformers;
 
-pub use argument_value::*;
-pub use error::*;
-pub use operation::*;
-pub use parse_ast::*;
-pub use parser::*;
-pub use selection::*;
-pub use transformers::*;
+pub use argument_value::{ArgumentValue, ArgumentValueObject};
+pub use operation::Operation;
+pub use selection::{In, Selection, SelectionArgument, SelectionSet};
+
+pub(crate) use error::*;
+pub(crate) use parse_ast::*;
+pub(crate) use parser::*;
 
 use crate::query_graph_builder::resolve_compound_field;
 use prisma_models::ModelRef;
@@ -36,7 +36,7 @@ use schema::QuerySchemaRef;
 use schema_builder::constants::*;
 use std::collections::HashMap;
 
-pub type QueryParserResult<T> = std::result::Result<T, QueryParserError>;
+pub(crate) type QueryParserResult<T> = std::result::Result<T, QueryParserError>;
 
 #[derive(Debug)]
 pub enum QueryDocument {

--- a/query-engine/core/src/query_document/parse_ast.rs
+++ b/query-engine/core/src/query_document/parse_ast.rs
@@ -7,12 +7,12 @@ use std::ops::{Deref, DerefMut};
 
 use crate::QueryParserResult;
 
-pub type ParsedInputList = Vec<ParsedInputValue>;
+pub(crate) type ParsedInputList = Vec<ParsedInputValue>;
 
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct ParsedInputMap {
     pub tag: Option<ObjectTag>,
-    pub map: IndexMap<String, ParsedInputValue>,
+    pub(crate) map: IndexMap<String, ParsedInputValue>,
 }
 
 impl ParsedInputMap {
@@ -98,15 +98,15 @@ pub struct ParsedField {
 }
 
 impl ParsedField {
-    pub fn where_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
+    pub(crate) fn where_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
         self.look_arg("where")
     }
 
-    pub fn create_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
+    pub(crate) fn create_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
         self.look_arg("create")
     }
 
-    pub fn update_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
+    pub(crate) fn update_arg(&mut self) -> QueryParserResult<Option<ParsedInputMap>> {
         self.look_arg("update")
     }
 
@@ -122,7 +122,7 @@ impl ParsedField {
 #[derive(Debug, Clone)]
 pub struct ParsedArgument {
     pub name: String,
-    pub value: ParsedInputValue,
+    pub(crate) value: ParsedInputValue,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -134,16 +134,7 @@ pub enum ParsedInputValue {
     Map(ParsedInputMap),
 }
 
-impl ParsedArgument {
-    pub fn into_value(self) -> Option<PrismaValue> {
-        match self.value {
-            ParsedInputValue::Single(val) => Some(val),
-            _ => None,
-        }
-    }
-}
-
-pub trait ArgumentListLookup {
+pub(crate) trait ArgumentListLookup {
     fn lookup(&mut self, name: &str) -> Option<ParsedArgument>;
 }
 

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -3,9 +3,7 @@ mod formatters;
 mod guard;
 mod transformers;
 
-pub use error::*;
-pub use formatters::*;
-pub use transformers::*;
+pub(crate) use error::*;
 
 use crate::{
     interpreter::ExpressionResult, FilteredQuery, ManyRecordsQuery, Query, QueryGraphBuilderResult, QueryOptions,
@@ -25,7 +23,7 @@ use std::{borrow::Borrow, collections::HashSet, fmt};
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
 
 #[allow(clippy::large_enum_variant)]
-pub enum Node {
+pub(crate) enum Node {
     /// Nodes representing actual queries to the underlying connector.
     Query(Query),
 
@@ -69,7 +67,7 @@ impl Flow {
 }
 
 // Current limitation: We need to narrow it down to ID diffs for Hash and EQ.
-pub enum Computation {
+pub(crate) enum Computation {
     Diff(DiffNode),
 }
 
@@ -111,15 +109,15 @@ impl EdgeRef {
     }
 }
 
-pub type ProjectedDataDependencyFn =
+pub(crate) type ProjectedDataDependencyFn =
     Box<dyn FnOnce(Node, Vec<SelectionResult>) -> QueryGraphBuilderResult<Node> + Send + Sync + 'static>;
 
-pub type DataDependencyFn =
+pub(crate) type DataDependencyFn =
     Box<dyn FnOnce(Node, &ExpressionResult) -> QueryGraphBuilderResult<Node> + Send + Sync + 'static>;
 
 /// Stored on the edges of the QueryGraph, a QueryGraphDependency contains information on how children are connected to their parents,
 /// expressing for example the need for additional information from the parent to be able to execute at runtime.
-pub enum QueryGraphDependency {
+pub(crate) enum QueryGraphDependency {
     /// Simple dependency indicating order of execution. Effectively an ordering and reachability tool for now.
     ExecutionOrder,
 
@@ -288,7 +286,7 @@ impl QueryGraph {
 
     /// Creates a node with content `t` and adds it to the graph.
     /// Returns a `NodeRef` to the newly added node.
-    pub fn create_node<T>(&mut self, t: T) -> NodeRef
+    pub(crate) fn create_node<T>(&mut self, t: T) -> NodeRef
     where
         T: Into<Node>,
     {
@@ -301,7 +299,7 @@ impl QueryGraph {
     /// Checks are run after edge creation to ensure validity of the query graph.
     /// Returns an `EdgeRef` to the newly added edge.
     /// Todo currently panics, change interface to result type.
-    pub fn create_edge(
+    pub(crate) fn create_edge(
         &mut self,
         from: &NodeRef,
         to: &NodeRef,
@@ -314,33 +312,33 @@ impl QueryGraph {
     }
 
     /// Mark the query graph to need a transaction.
-    pub fn flag_transactional(&mut self) {
+    pub(crate) fn flag_transactional(&mut self) {
         self.needs_transaction = true;
     }
 
     /// If true, the graph should be executed inside of a transaction.
-    pub fn needs_transaction(&self) -> bool {
+    pub(crate) fn needs_transaction(&self) -> bool {
         self.needs_transaction
     }
 
     /// Returns a reference to the content of `node`, if the content is still present.
-    pub fn node_content(&self, node: &NodeRef) -> Option<&Node> {
+    pub(crate) fn node_content(&self, node: &NodeRef) -> Option<&Node> {
         self.graph.node_weight(node.node_ix).unwrap().borrow()
     }
 
     /// Returns a reference to the content of `edge`, if the content is still present.
-    pub fn edge_content(&self, edge: &EdgeRef) -> Option<&QueryGraphDependency> {
+    pub(crate) fn edge_content(&self, edge: &EdgeRef) -> Option<&QueryGraphDependency> {
         self.graph.edge_weight(edge.edge_ix).unwrap().borrow()
     }
 
     /// Returns the node from where `edge` originates (e.g. source).
-    pub fn edge_source(&self, edge: &EdgeRef) -> NodeRef {
+    pub(crate) fn edge_source(&self, edge: &EdgeRef) -> NodeRef {
         let (node_ix, _) = self.graph.edge_endpoints(edge.edge_ix).unwrap();
         NodeRef { node_ix }
     }
 
     /// Returns the node to which `edge` points (e.g. target).
-    pub fn edge_target(&self, edge: &EdgeRef) -> NodeRef {
+    pub(crate) fn edge_target(&self, edge: &EdgeRef) -> NodeRef {
         let (_, node_ix) = self.graph.edge_endpoints(edge.edge_ix).unwrap();
         NodeRef { node_ix }
     }
@@ -357,19 +355,19 @@ impl QueryGraph {
 
     /// Removes the edge from the graph but leaves the graph intact by keeping the empty
     /// edge in the graph by plucking the content of the edge, but not the edge itself.
-    pub fn pluck_edge(&mut self, edge: &EdgeRef) -> QueryGraphDependency {
+    pub(crate) fn pluck_edge(&mut self, edge: &EdgeRef) -> QueryGraphDependency {
         self.graph.edge_weight_mut(edge.edge_ix).unwrap().unset()
     }
 
     /// Removes the node from the graph but leaves the graph intact by keeping the empty
     /// node in the graph by plucking the content of the node, but not the node itself.
-    pub fn pluck_node(&mut self, node: &NodeRef) -> Node {
+    pub(crate) fn pluck_node(&mut self, node: &NodeRef) -> Node {
         self.graph.node_weight_mut(node.node_ix).unwrap().unset()
     }
 
     /// Completely removes the edge from the graph, returning it's content.
     /// This operation is destructive on the underlying graph and invalidates references.
-    pub fn remove_edge(&mut self, edge: EdgeRef) -> Option<QueryGraphDependency> {
+    pub(crate) fn remove_edge(&mut self, edge: EdgeRef) -> Option<QueryGraphDependency> {
         self.graph.remove_edge(edge.edge_ix).unwrap().into_inner()
     }
 

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -10,7 +10,7 @@ pub static PRISMA_RENDER_DOT_FILE: Lazy<bool> = Lazy::new(|| match std::env::var
 });
 
 pub struct QueryGraphBuilder {
-    pub query_schema: QuerySchemaRef,
+    query_schema: QuerySchemaRef,
 }
 
 impl fmt::Debug for QueryGraphBuilder {

--- a/query-engine/core/src/query_graph_builder/read/aggregations/aggregate.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/aggregate.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{query_document::ParsedField, AggregateRecordsQuery};
 use prisma_models::ModelRef;
 
-pub fn aggregate(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn aggregate(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let name = field.name;
     let alias = field.alias;
     let model = model;

--- a/query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/group_by.rs
@@ -6,7 +6,7 @@ use connector::Filter;
 use prisma_models::{ModelRef, OrderBy, ScalarFieldRef};
 use schema_builder::constants::args;
 
-pub fn group_by(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn group_by(mut field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let name = field.name;
     let alias = field.alias;
     let model = model;

--- a/query-engine/core/src/query_graph_builder/read/aggregations/mod.rs
+++ b/query-engine/core/src/query_graph_builder/read/aggregations/mod.rs
@@ -5,8 +5,8 @@ use super::*;
 mod aggregate;
 mod group_by;
 
-pub use aggregate::*;
-pub use group_by::*;
+pub(crate) use aggregate::*;
+pub(crate) use group_by::*;
 
 use connector::AggregationSelection;
 use itertools::Itertools;

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -3,12 +3,12 @@ use prisma_models::ModelRef;
 use super::*;
 use crate::ParsedField;
 
-pub fn find_first(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn find_first(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let many_query = many::find_many(field, model)?;
     try_limit_to_one(many_query)
 }
 
-pub fn find_first_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn find_first_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     let many_query = many::find_many_or_throw(field, model)?;
     try_limit_to_one(many_query)
 }

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -2,11 +2,11 @@ use super::*;
 use crate::{query_document::ParsedField, ManyRecordsQuery, QueryOption, QueryOptions, ReadQuery};
 use prisma_models::ModelRef;
 
-pub fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn find_many(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     find_many_with_options(field, model, QueryOptions::none())
 }
 
-pub fn find_many_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn find_many_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     find_many_with_options(field, model, QueryOption::ThrowOnEmpty.into())
 }
 

--- a/query-engine/core/src/query_graph_builder/read/mod.rs
+++ b/query-engine/core/src/query_graph_builder/read/mod.rs
@@ -7,11 +7,10 @@ mod one;
 mod related;
 mod utils;
 
-pub use aggregations::*;
-pub use first::*;
-pub use many::*;
-pub use one::*;
-pub use related::*;
+pub(crate) use aggregations::*;
+pub(crate) use first::*;
+pub(crate) use many::*;
+pub(crate) use one::*;
 
 use super::*;
 use crate::{Query, QueryGraph, ReadQuery};

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -4,17 +4,17 @@ use prisma_models::ModelRef;
 use schema_builder::constants::args;
 use std::convert::TryInto;
 
-pub fn find_unique(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn find_unique(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     find_unique_with_options(field, model, QueryOptions::none())
 }
 
-pub fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
+pub(crate) fn find_unique_or_throw(field: ParsedField, model: ModelRef) -> QueryGraphBuilderResult<ReadQuery> {
     find_unique_with_options(field, model, QueryOption::ThrowOnEmpty.into())
 }
 
 /// Builds a read query from a parsed incoming read query field.
 #[inline]
-pub fn find_unique_with_options(
+fn find_unique_with_options(
     mut field: ParsedField,
     model: ModelRef,
     options: QueryOptions,

--- a/query-engine/core/src/query_graph_builder/read/related.rs
+++ b/query-engine/core/src/query_graph_builder/read/related.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::{query_document::ParsedField, ReadQuery, RelatedRecordsQuery};
 use prisma_models::{ModelRef, RelationFieldRef};
 
-pub fn find_related(
+pub(crate) fn find_related(
     field: ParsedField,
     parent: RelationFieldRef,
     model: ModelRef,

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -70,7 +70,10 @@ fn extract_composite_selection(pf: ParsedField, cf: CompositeFieldRef) -> Select
     })
 }
 
-pub fn collect_nested_queries(from: Vec<FieldPair>, model: &ModelRef) -> QueryGraphBuilderResult<Vec<ReadQuery>> {
+pub(crate) fn collect_nested_queries(
+    from: Vec<FieldPair>,
+    model: &ModelRef,
+) -> QueryGraphBuilderResult<Vec<ReadQuery>> {
     from.into_iter()
         .filter_map(|pair| {
             if is_aggr_selection(&pair) {
@@ -97,7 +100,7 @@ pub fn collect_nested_queries(from: Vec<FieldPair>, model: &ModelRef) -> QueryGr
 /// to resolve the nested queries.
 /// A lookback on the parent is also performed to ensure that fields required for
 /// resolving the parent relation are present.
-pub fn merge_relation_selections(
+pub(crate) fn merge_relation_selections(
     selected_fields: FieldSelection,
     parent_relation: Option<RelationFieldRef>,
     nested_queries: &[ReadQuery],

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -11,7 +11,7 @@ use schema::ConnectorContext;
 
 /// Coerces single values (`ParsedInputValue::Single` and `ParsedInputValue::Map`) into a vector.
 /// Simply unpacks `ParsedInputValue::List`.
-pub fn coerce_vec(val: ParsedInputValue) -> Vec<ParsedInputValue> {
+pub(crate) fn coerce_vec(val: ParsedInputValue) -> Vec<ParsedInputValue> {
     match val {
         ParsedInputValue::List(l) => l,
         m @ ParsedInputValue::Map(_) => vec![m],
@@ -19,7 +19,7 @@ pub fn coerce_vec(val: ParsedInputValue) -> Vec<ParsedInputValue> {
     }
 }
 
-pub fn node_is_create(graph: &QueryGraph, node: &NodeRef) -> bool {
+pub(crate) fn node_is_create(graph: &QueryGraph, node: &NodeRef) -> bool {
     matches!(
         graph.node_content(node).unwrap(),
         Node::Query(Query::Write(WriteQuery::CreateRecord(_)))
@@ -27,7 +27,7 @@ pub fn node_is_create(graph: &QueryGraph, node: &NodeRef) -> bool {
 }
 
 /// Produces a non-failing read query that fetches the requested selection of records for a given filterable.
-pub fn read_ids_infallible<T>(model: ModelRef, selection: FieldSelection, filter: T) -> Query
+pub(crate) fn read_ids_infallible<T>(model: ModelRef, selection: FieldSelection, filter: T) -> Query
 where
     T: Into<Filter>,
 {

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -34,7 +34,7 @@ type UncheckedItemsWithParents = IndexMap<Option<SelectionResult>, Vec<Item>>;
 /// // todo more here
 ///
 /// Returns a map of pairs of (parent ID, response)
-pub fn serialize_internal(
+pub(crate) fn serialize_internal(
     result: QueryResult,
     field: &OutputFieldRef,
     is_list: bool,

--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -8,14 +8,14 @@ use std::borrow::Borrow;
 pub struct IrSerializer {
     /// Serialization key for root DataItem
     /// Note: This will change
-    pub key: String,
+    pub(crate) key: String,
 
     /// Output field describing the possible shape of the result
-    pub output_field: OutputFieldRef,
+    pub(crate) output_field: OutputFieldRef,
 }
 
 impl IrSerializer {
-    pub fn serialize(&self, result: ExpressionResult) -> crate::Result<ResponseData> {
+    pub(crate) fn serialize(&self, result: ExpressionResult) -> crate::Result<ResponseData> {
         let _span = info_span!("prisma:engine:serialize", user_facing = true);
         match result {
             ExpressionResult::Query(QueryResult::Json(json)) => {

--- a/query-engine/core/src/response_ir/mod.rs
+++ b/query-engine/core/src/response_ir/mod.rs
@@ -12,14 +12,15 @@ mod internal;
 mod ir_serializer;
 mod response;
 
+pub use response::*;
+
+pub(crate) use ir_serializer::*;
+
 use crate::ArgumentValue;
 use indexmap::IndexMap;
 use prisma_models::PrismaValue;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::{collections::HashMap, fmt, sync::Arc};
-
-pub use ir_serializer::*;
-pub use response::*;
 
 /// A `key -> value` map to an IR item
 pub type Map = IndexMap<String, Item>;

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -2,7 +2,7 @@ use connector::{AggregationRow, QueryArguments, RelAggregationRow};
 use prisma_models::{ManyRecords, ModelRef, SelectionResult};
 
 #[derive(Debug, Clone)]
-pub enum QueryResult {
+pub(crate) enum QueryResult {
     Id(Option<SelectionResult>),
     Count(usize),
     RecordSelection(Box<RecordSelection>),
@@ -25,7 +25,7 @@ pub struct RecordSelection {
 
     /// Nested query results
     // Todo this is only here because reads are still resolved in one go
-    pub nested: Vec<QueryResult>,
+    pub(crate) nested: Vec<QueryResult>,
 
     /// Required for result processing
     pub query_arguments: QueryArguments,
@@ -44,10 +44,10 @@ impl From<RecordSelection> for QueryResult {
 }
 
 #[derive(Debug, Clone)]
-pub struct RecordAggregations {
+pub(crate) struct RecordAggregations {
     /// Ordered list of selected fields as defined by the original incoming query.
-    pub selection_order: Vec<(String, Option<Vec<String>>)>,
+    pub(crate) selection_order: Vec<(String, Option<Vec<String>>)>,
 
     /// Actual aggregation results.
-    pub results: Vec<AggregationRow>,
+    pub(crate) results: Vec<AggregationRow>,
 }


### PR DESCRIPTION
Smaller public APIs are easier to read and understand.