### PR TITLE
nix: fix nix-direnv ignoring changes in the dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -39,6 +39,9 @@ fi
 if command -v nix &> /dev/null
 then
     if nix flake metadata > /dev/null; then
+        if type nix_direnv_watch_file &> /dev/null; then
+          nix_direnv_watch_file nix/shell.nix nix/all-engines.nix
+        fi
         use flake
     fi
 fi

--- a/.envrc
+++ b/.envrc
@@ -40,7 +40,7 @@ if command -v nix &> /dev/null
 then
     if nix flake metadata > /dev/null; then
         if type nix_direnv_watch_file &> /dev/null; then
-          nix_direnv_watch_file nix/shell.nix nix/all-engines.nix nix/args.nix
+            nix_direnv_watch_file nix/shell.nix nix/all-engines.nix nix/args.nix
         fi
         use flake
     fi

--- a/.envrc
+++ b/.envrc
@@ -40,7 +40,7 @@ if command -v nix &> /dev/null
 then
     if nix flake metadata > /dev/null; then
         if type nix_direnv_watch_file &> /dev/null; then
-          nix_direnv_watch_file nix/shell.nix nix/all-engines.nix
+          nix_direnv_watch_file nix/shell.nix nix/all-engines.nix nix/args.nix
         fi
         use flake
     fi


### PR DESCRIPTION
Hash relevant nix files to recalculate the dev shell when it changes.

By default [nix-direnv](https://github.com/nix-community/nix-direnv) only watches `flake.nix` and `flake.lock`.
