### PR TITLE
qe/schema-builder: make the namespace part of Identifier typed

### DIFF
--- a/query-engine/schema-builder/src/enum_types.rs
+++ b/query-engine/schema-builder/src/enum_types.rs
@@ -3,7 +3,7 @@ use crate::constants::{filters, itx, json_null, ordering};
 use schema::EnumType;
 
 pub(crate) fn sort_order_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
-    let ident = Identifier::new(ordering::SORT_ORDER, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(ordering::SORT_ORDER);
     return_cached_enum!(ctx, &ident);
 
     let typ = Arc::new(EnumType::string(
@@ -16,7 +16,7 @@ pub(crate) fn sort_order_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
 }
 
 pub(crate) fn nulls_order_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
-    let ident = Identifier::new(ordering::NULLS_ORDER, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(ordering::NULLS_ORDER);
     return_cached_enum!(ctx, &ident);
 
     let typ = Arc::new(EnumType::string(
@@ -29,7 +29,7 @@ pub(crate) fn nulls_order_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
 }
 
 pub(crate) fn map_schema_enum_type(ctx: &mut BuilderContext, enum_id: ast::EnumId) -> EnumTypeWeakRef {
-    let ident = Identifier::new(ctx.internal_data_model.walk(enum_id).name(), MODEL_NAMESPACE);
+    let ident = Identifier::new_model(ctx.internal_data_model.walk(enum_id).name());
     return_cached_enum!(ctx, &ident);
 
     let schema_enum = ctx.internal_data_model.clone().zip(enum_id);
@@ -41,7 +41,7 @@ pub(crate) fn map_schema_enum_type(ctx: &mut BuilderContext, enum_id: ast::EnumI
 
 pub(crate) fn model_field_enum(ctx: &mut BuilderContext, model: &ModelRef) -> EnumTypeWeakRef {
     let name = format!("{}ScalarFieldEnum", capitalize(model.name()));
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_enum!(ctx, &ident);
 
     let values = model
@@ -58,7 +58,7 @@ pub(crate) fn model_field_enum(ctx: &mut BuilderContext, model: &ModelRef) -> En
 }
 
 pub(crate) fn json_null_filter_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
-    let ident = Identifier::new(json_null::FILTER_ENUM_NAME, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(json_null::FILTER_ENUM_NAME);
     return_cached_enum!(ctx, &ident);
 
     let typ = Arc::new(EnumType::string(
@@ -76,9 +76,9 @@ pub(crate) fn json_null_filter_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef
 
 pub(crate) fn json_null_input_enum(ctx: &mut BuilderContext, nullable: bool) -> EnumTypeWeakRef {
     let ident = if nullable {
-        Identifier::new(json_null::NULLABLE_INPUT_ENUM_NAME, PRISMA_NAMESPACE)
+        Identifier::new_prisma(json_null::NULLABLE_INPUT_ENUM_NAME)
     } else {
-        Identifier::new(json_null::INPUT_ENUM_NAME, PRISMA_NAMESPACE)
+        Identifier::new_prisma(json_null::INPUT_ENUM_NAME)
     };
 
     return_cached_enum!(ctx, &ident);
@@ -102,7 +102,7 @@ pub(crate) fn order_by_relevance_enum(
     values: Vec<String>,
 ) -> EnumTypeWeakRef {
     let name = format!("{container}OrderByRelevanceFieldEnum");
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_enum!(ctx, &ident);
 
     let typ = Arc::new(EnumType::string(ident.clone(), values));
@@ -112,7 +112,7 @@ pub(crate) fn order_by_relevance_enum(
 }
 
 pub(crate) fn query_mode_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
-    let ident = Identifier::new("QueryMode", PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma("QueryMode");
     return_cached_enum!(ctx, &ident);
 
     let typ = Arc::new(EnumType::string(
@@ -125,7 +125,7 @@ pub(crate) fn query_mode_enum(ctx: &mut BuilderContext) -> EnumTypeWeakRef {
 }
 
 pub(crate) fn itx_isolation_levels(ctx: &mut BuilderContext) -> Option<EnumTypeWeakRef> {
-    let ident = Identifier::new("TransactionIsolationLevel", PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma("TransactionIsolationLevel");
     if let e @ Some(_) = ctx.get_enum_type(&ident) {
         return e;
     }

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/create.rs
@@ -37,10 +37,7 @@ impl DataInputFieldMapper for CreateDataInputFieldMapper {
 
     fn map_scalar_list(&self, ctx: &mut BuilderContext, sf: &ScalarFieldRef) -> InputField {
         let typ = map_scalar_input_type_for_field(ctx, sf);
-        let ident = Identifier::new(
-            format!("{}Create{}Input", sf.container().name(), sf.name()),
-            PRISMA_NAMESPACE,
-        );
+        let ident = Identifier::new_prisma(format!("{}Create{}Input", sf.container().name(), sf.name()));
 
         let input_object = match ctx.get_input_type(&ident) {
             Some(cached) => cached,
@@ -70,16 +67,13 @@ impl DataInputFieldMapper for CreateDataInputFieldMapper {
         let arity_part = if rf.is_list() { "NestedMany" } else { "NestedOne" };
         let without_part = format!("Without{}", capitalize(related_field.name()));
         let unchecked_part = if self.unchecked { "Unchecked" } else { "" };
-        let ident = Identifier::new(
-            format!(
-                "{}{}Create{}{}Input",
-                related_model.name(),
-                unchecked_part,
-                arity_part,
-                without_part
-            ),
-            PRISMA_NAMESPACE,
-        );
+        let ident = Identifier::new_prisma(format!(
+            "{}{}Create{}{}Input",
+            related_model.name(),
+            unchecked_part,
+            arity_part,
+            without_part
+        ));
 
         let input_object = match ctx.get_input_type(&ident) {
             Some(t) => t,
@@ -159,7 +153,7 @@ fn composite_create_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
 
     let name = format!("{}{}CreateEnvelopeInput", cf.typ().name(), arity);
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -190,7 +184,7 @@ pub(crate) fn composite_create_object_type(ctx: &mut BuilderContext, cf: &Compos
     // It's called "Create" input because it's used across multiple create-type operations, not only "set".
     let name = format!("{}CreateInput", cf.typ().name());
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
@@ -63,10 +63,7 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
 
     fn map_scalar_list(&self, ctx: &mut BuilderContext, sf: &ScalarFieldRef) -> InputField {
         let list_input_type = map_scalar_input_type(ctx, &sf.type_identifier(), sf.is_list());
-        let ident = Identifier::new(
-            format!("{}Update{}Input", sf.container().name(), sf.name()),
-            PRISMA_NAMESPACE,
-        );
+        let ident = Identifier::new_prisma(format!("{}Update{}Input", sf.container().name(), sf.name()));
 
         let input_object = match ctx.get_input_type(&ident) {
             Some(t) => t,
@@ -115,16 +112,13 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
 
         let without_part = format!("Without{}", capitalize(related_field.name()));
         let unchecked_part = if self.unchecked { "Unchecked" } else { "" };
-        let ident = Identifier::new(
-            format!(
-                "{}{}Update{}{}NestedInput",
-                related_model.name(),
-                unchecked_part,
-                arity_part,
-                without_part
-            ),
-            PRISMA_NAMESPACE,
-        );
+        let ident = Identifier::new_prisma(format!(
+            "{}{}Update{}{}NestedInput",
+            related_model.name(),
+            unchecked_part,
+            arity_part,
+            without_part
+        ));
 
         let input_object = match ctx.get_input_type(&ident) {
             Some(t) => t,
@@ -174,10 +168,7 @@ fn update_operations_object_type(
     // Different names are required to construct and cache different objects.
     // - "Nullable" affects the `set` operation (`set` is nullable)
     let nullable = if !sf.is_required() { "Nullable" } else { "" };
-    let ident = Identifier::new(
-        format!("{nullable}{prefix}FieldUpdateOperationsInput"),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{nullable}{prefix}FieldUpdateOperationsInput"));
     return_cached_input!(ctx, &ident);
 
     let mut obj = init_input_object_type(ident.clone());
@@ -226,7 +217,7 @@ fn composite_update_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
     };
 
     let name = format!("{}{}UpdateEnvelopeInput", cf.typ().name(), arity);
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
 
     return_cached_input!(ctx, &ident);
 
@@ -255,7 +246,7 @@ fn composite_update_envelope_object_type(ctx: &mut BuilderContext, cf: &Composit
 fn composite_update_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     let name = format!("{}UpdateInput", cf.typ().name());
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -324,7 +315,7 @@ fn composite_push_update_input_field(ctx: &mut BuilderContext, cf: &CompositeFie
 fn composite_upsert_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     let name = format!("{}UpsertInput", cf.typ().name());
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -359,7 +350,7 @@ fn composite_upsert_update_input_field(ctx: &mut BuilderContext, cf: &CompositeF
 fn composite_update_many_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     let name = format!("{}UpdateManyInput", cf.typ().name());
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -385,7 +376,7 @@ fn composite_update_many_object_type(ctx: &mut BuilderContext, cf: &CompositeFie
 fn composite_delete_many_object_type(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     let name = format!("{}DeleteManyInput", cf.typ().name());
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());

--- a/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_filter_types.rs
@@ -66,10 +66,7 @@ fn to_one_relation_filter_shorthand_types(ctx: &mut BuilderContext, rf: &Relatio
 
 fn to_many_relation_filter_object(ctx: &mut BuilderContext, rf: &RelationFieldRef) -> InputObjectTypeWeakRef {
     let related_model = rf.related_model();
-    let ident = Identifier::new(
-        format!("{}ListRelationFilter", capitalize(related_model.name())),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}ListRelationFilter", capitalize(related_model.name())));
 
     return_cached_input!(ctx, &ident);
 
@@ -94,10 +91,7 @@ fn to_many_relation_filter_object(ctx: &mut BuilderContext, rf: &RelationFieldRe
 fn to_one_relation_filter_object(ctx: &mut BuilderContext, rf: &RelationFieldRef) -> InputObjectTypeWeakRef {
     let related_model = rf.related_model();
     let related_input_type = filter_objects::where_object_type(ctx, &related_model);
-    let ident = Identifier::new(
-        format!("{}RelationFilter", capitalize(related_model.name())),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}RelationFilter", capitalize(related_model.name())));
 
     return_cached_input!(ctx, &ident);
     let mut object = init_input_object_type(ident.clone());
@@ -128,10 +122,7 @@ fn to_one_composite_filter_shorthand_types(ctx: &mut BuilderContext, cf: &Compos
 
 fn to_one_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
     let nullable = if cf.is_optional() { "Nullable" } else { "" };
-    let ident = Identifier::new(
-        format!("{}{}CompositeFilter", capitalize(cf.typ().name()), nullable),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}{}CompositeFilter", capitalize(cf.typ().name()), nullable));
     return_cached_input!(ctx, &ident);
 
     let mut object = init_input_object_type(ident.clone());
@@ -166,10 +157,7 @@ fn to_one_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeFieldR
 }
 
 fn to_many_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(
-        format!("{}CompositeListFilter", capitalize(cf.typ().name())),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}CompositeListFilter", capitalize(cf.typ().name())));
     return_cached_input!(ctx, &ident);
 
     let mut object = init_input_object_type(ident.clone());
@@ -207,16 +195,13 @@ fn to_many_composite_filter_object(ctx: &mut BuilderContext, cf: &CompositeField
 }
 
 fn scalar_list_filter_type(ctx: &mut BuilderContext, sf: &ScalarFieldRef) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(
-        scalar_filter_name(
-            &sf.type_identifier().type_name(&ctx.internal_data_model.schema),
-            true,
-            !sf.is_required(),
-            false,
-            false,
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(scalar_filter_name(
+        &sf.type_identifier().type_name(&ctx.internal_data_model.schema),
+        true,
+        !sf.is_required(),
+        false,
+        false,
+    ));
     return_cached_input!(ctx, &ident);
 
     let mut object = init_input_object_type(ident.clone());
@@ -262,10 +247,13 @@ fn full_scalar_filter_type(
     let native_type_name = native_type.map(|nt| nt.name());
     let scalar_type_name = typ.type_name(&ctx.internal_data_model.schema).into_owned();
     let type_name = ctx.connector.scalar_filter_name(scalar_type_name, native_type_name);
-    let ident = Identifier::new(
-        scalar_filter_name(&type_name, list, nullable, nested, include_aggregates),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(scalar_filter_name(
+        &type_name,
+        list,
+        nullable,
+        nested,
+        include_aggregates,
+    ));
 
     return_cached_input!(ctx, &ident);
 

--- a/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
@@ -18,7 +18,7 @@ impl WithFieldRefInputExt for InputType {
 }
 
 fn field_ref_input_object_type(ctx: &mut BuilderContext, allow_type: InputType) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(field_ref_input_type_name(&allow_type), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(field_ref_input_type_name(&allow_type));
 
     return_cached_input!(ctx, &ident);
 

--- a/query-engine/schema-builder/src/input_types/fields/input_fields.rs
+++ b/query-engine/schema-builder/src/input_types/fields/input_fields.rs
@@ -57,7 +57,7 @@ fn nested_create_many_envelope(ctx: &mut BuilderContext, parent_field: &Relation
     let nested_ident = &create_type.into_arc().identifier;
     let name = format!("{}Envelope", nested_ident.name());
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));

--- a/query-engine/schema-builder/src/input_types/objects/connect_or_create_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/connect_or_create_objects.rs
@@ -14,14 +14,11 @@ pub(crate) fn nested_connect_or_create_input_object(
         return None;
     }
 
-    let ident = Identifier::new(
-        format!(
-            "{}CreateOrConnectWithout{}Input",
-            related_model.name(),
-            capitalize(parent_field.related_field().name())
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}CreateOrConnectWithout{}Input",
+        related_model.name(),
+        capitalize(parent_field.related_field().name())
+    ));
 
     let create_types = create_one::create_one_input_types(ctx, &related_model, Some(parent_field));
 

--- a/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
@@ -9,10 +9,7 @@ pub(crate) fn scalar_filter_object_type(
     include_aggregates: bool,
 ) -> InputObjectTypeWeakRef {
     let aggregate = if include_aggregates { "WithAggregates" } else { "" };
-    let ident = Identifier::new(
-        format!("{}ScalarWhere{}Input", model.name(), aggregate),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}ScalarWhere{}Input", model.name(), aggregate));
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -55,7 +52,7 @@ where
     T: Into<ParentContainer>,
 {
     let container = container.into();
-    let ident = Identifier::new(format!("{}WhereInput", container.name()), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("{}WhereInput", container.name()));
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -95,7 +92,7 @@ where
 }
 
 pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}WhereUniqueInput", model.name()), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("{}WhereUniqueInput", model.name()));
     return_cached_input!(ctx, &ident);
 
     // Split unique & ID fields vs all the other fields
@@ -214,14 +211,11 @@ fn compound_field_unique_object_type(
     alias: Option<&str>,
     from_fields: Vec<ScalarFieldRef>,
 ) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(
-        format!(
-            "{}{}CompoundUniqueInput",
-            model.name(),
-            compound_object_name(alias, &from_fields)
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}{}CompoundUniqueInput",
+        model.name(),
+        compound_object_name(alias, &from_fields)
+    ));
 
     return_cached_input!(ctx, &ident);
 
@@ -245,7 +239,7 @@ fn compound_field_unique_object_type(
 /// Object used for full composite equality, e.g. `{ field: "value", field2: 123 } == { field: "value" }`.
 /// If the composite is a list, only lists are allowed for comparison, no shorthands are used.
 pub(crate) fn composite_equality_object(ctx: &mut BuilderContext, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}ObjectEqualityInput", cf.typ().name()), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("{}ObjectEqualityInput", cf.typ().name()));
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));

--- a/query-engine/schema-builder/src/input_types/objects/order_by_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/order_by_objects.rs
@@ -40,10 +40,7 @@ pub(crate) fn order_by_object_type(
     container: &ParentContainer,
     options: &OrderByOptions,
 ) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(
-        format!("{}OrderBy{}Input", container.name(), options.type_suffix()),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}OrderBy{}Input", container.name(), options.type_suffix()));
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -165,7 +162,7 @@ fn orderby_field_mapper(field: &ModelField, ctx: &mut BuilderContext, options: &
 }
 
 fn sort_nulls_object_type(ctx: &mut BuilderContext) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new("SortOrderInput", PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma("SortOrderInput");
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));
@@ -208,10 +205,7 @@ fn order_by_object_type_aggregate(
     container: &ParentContainer,
     scalar_fields: Vec<ScalarFieldRef>,
 ) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(
-        format!("{}{}OrderByAggregateInput", container.name(), suffix),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}{}OrderByAggregateInput", container.name(), suffix));
 
     return_cached_input!(ctx, &ident);
 
@@ -239,10 +233,7 @@ fn order_by_to_many_aggregate_object_type(
         ParentContainer::CompositeType(_) => "Composite",
     };
 
-    let ident = Identifier::new(
-        format!("{}OrderBy{}AggregateInput", container.name(), container_type),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}OrderBy{}AggregateInput", container.name(), container_type));
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
@@ -292,7 +283,7 @@ fn order_by_object_type_text_search(
     container: &ParentContainer,
     scalar_fields: Vec<ScalarFieldRef>,
 ) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}OrderByRelevanceInput", container.name()), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("{}OrderByRelevanceInput", container.name()));
 
     return_cached_input!(ctx, &ident);
 

--- a/query-engine/schema-builder/src/input_types/objects/update_many_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/update_many_objects.rs
@@ -20,7 +20,7 @@ pub(crate) fn update_many_input_types(
 
 /// Builds "<x>UpdateManyMutationInput" input object type.
 pub(crate) fn checked_update_many_input_type(ctx: &mut BuilderContext, model: &ModelRef) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new(format!("{}UpdateManyMutationInput", model.name()), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("{}UpdateManyMutationInput", model.name()));
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));
@@ -53,7 +53,7 @@ pub(crate) fn unchecked_update_many_input_type(
         _ => format!("{}UncheckedUpdateManyInput", model.name()),
     };
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));
@@ -84,7 +84,7 @@ pub(crate) fn update_many_where_combination_object(
         capitalize(parent_field.related_field().name())
     );
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));

--- a/query-engine/schema-builder/src/input_types/objects/update_one_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/update_one_objects.rs
@@ -29,7 +29,7 @@ fn checked_update_one_input_type(
         _ => format!("{}UpdateInput", model.name()),
     };
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));
@@ -54,7 +54,7 @@ fn unchecked_update_one_input_type(
         _ => format!("{}UncheckedUpdateInput", model.name()),
     };
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));
@@ -178,14 +178,11 @@ pub(crate) fn update_one_where_combination_object(
 ) -> InputObjectTypeWeakRef {
     let related_model = parent_field.related_model();
     let where_input_object = filter_objects::where_unique_object_type(ctx, &related_model);
-    let ident = Identifier::new(
-        format!(
-            "{}UpdateWithWhereUniqueWithout{}Input",
-            related_model.name(),
-            capitalize(parent_field.related_field().name())
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}UpdateWithWhereUniqueWithout{}Input",
+        related_model.name(),
+        capitalize(parent_field.related_field().name())
+    ));
 
     return_cached_input!(ctx, &ident);
 
@@ -209,14 +206,11 @@ pub(crate) fn update_to_one_rel_where_combination_object(
     parent_field: &RelationFieldRef,
 ) -> InputObjectTypeWeakRef {
     let related_model = parent_field.related_model();
-    let ident = Identifier::new(
-        format!(
-            "{}UpdateToOneWithWhereWithout{}Input",
-            related_model.name(),
-            capitalize(parent_field.related_field().name())
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}UpdateToOneWithWhereWithout{}Input",
+        related_model.name(),
+        capitalize(parent_field.related_field().name())
+    ));
 
     return_cached_input!(ctx, &ident);
 

--- a/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
@@ -29,14 +29,11 @@ fn nested_upsert_list_input_object(
         return None;
     }
 
-    let ident = Identifier::new(
-        format!(
-            "{}UpsertWithWhereUniqueWithout{}Input",
-            related_model.name(),
-            capitalize(parent_field.related_field().name())
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}UpsertWithWhereUniqueWithout{}Input",
+        related_model.name(),
+        capitalize(parent_field.related_field().name())
+    ));
 
     match ctx.get_input_type(&ident) {
         None => {
@@ -69,14 +66,11 @@ fn nested_upsert_nonlist_input_object(
         return None;
     }
 
-    let ident = Identifier::new(
-        format!(
-            "{}UpsertWithout{}Input",
-            related_model.name(),
-            capitalize(parent_field.related_field().name())
-        ),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}UpsertWithout{}Input",
+        related_model.name(),
+        capitalize(parent_field.related_field().name())
+    ));
 
     match ctx.get_input_type(&ident) {
         None => {

--- a/query-engine/schema-builder/src/mutations/create_many.rs
+++ b/query-engine/schema-builder/src/mutations/create_many.rs
@@ -13,10 +13,7 @@ use crate::{
 };
 use prisma_models::{ModelRef, RelationFieldRef};
 use psl::datamodel_connector::ConnectorCapability;
-use schema::{
-    Identifier, InputField, InputObjectTypeWeakRef, InputType, OutputField, OutputType, QueryInfo, QueryTag,
-    PRISMA_NAMESPACE,
-};
+use schema::{Identifier, InputField, InputObjectTypeWeakRef, InputType, OutputField, OutputType, QueryInfo, QueryTag};
 
 /// Builds a create many mutation field (e.g. createManyUsers) for given model.
 pub(crate) fn create_many(ctx: &mut BuilderContext, model: &ModelRef) -> Option<OutputField> {
@@ -66,7 +63,7 @@ pub(crate) fn create_many_object_type(
         _ => format!("{}CreateManyInput", model.name()),
     };
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));

--- a/query-engine/schema-builder/src/mutations/create_one.rs
+++ b/query-engine/schema-builder/src/mutations/create_one.rs
@@ -9,10 +9,7 @@ use crate::{
     BuilderContext, ModelField,
 };
 use prisma_models::{ModelRef, RelationFieldRef};
-use schema::{
-    Identifier, InputField, InputObjectTypeWeakRef, InputType, OutputField, OutputType, QueryInfo, QueryTag,
-    PRISMA_NAMESPACE,
-};
+use schema::{Identifier, InputField, InputObjectTypeWeakRef, InputType, OutputField, OutputType, QueryInfo, QueryTag};
 
 /// Builds a create mutation field (e.g. createUser) for given model.
 pub(crate) fn create_one(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
@@ -77,7 +74,7 @@ fn checked_create_input_type(
         _ => format!("{}CreateInput", model.name()),
     };
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));
@@ -108,7 +105,7 @@ fn unchecked_create_input_type(
         _ => format!("{}UncheckedCreateInput", model.name()),
     };
 
-    let ident = Identifier::new(name, PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(name);
     return_cached_input!(ctx, &ident);
 
     let input_object = Arc::new(init_input_object_type(ident.clone()));

--- a/query-engine/schema-builder/src/output_types/aggregation/group_by.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/group_by.rs
@@ -4,10 +4,7 @@ use std::convert::identity;
 
 /// Builds group by aggregation object type for given model (e.g. GroupByUserOutputType).
 pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
-    let ident = Identifier::new(
-        format!("{}GroupByOutputType", capitalize(model.name())),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!("{}GroupByOutputType", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
     let object = Arc::new(ObjectType::new(ident.clone(), Some(ModelRef::clone(model))));

--- a/query-engine/schema-builder/src/output_types/aggregation/mod.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/mod.rs
@@ -80,10 +80,11 @@ where
     F: Fn(&mut BuilderContext, &ScalarFieldRef) -> OutputType,
     G: Fn(ObjectType) -> ObjectType,
 {
-    let ident = Identifier::new(
-        format!("{}{}AggregateOutputType", capitalize(model.name()), capitalize(suffix)),
-        PRISMA_NAMESPACE,
-    );
+    let ident = Identifier::new_prisma(format!(
+        "{}{}AggregateOutputType",
+        capitalize(model.name()),
+        capitalize(suffix)
+    ));
     return_cached_output!(ctx, &ident);
 
     // Non-numerical fields are always set as nullable

--- a/query-engine/schema-builder/src/output_types/aggregation/plain.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/plain.rs
@@ -5,7 +5,7 @@ use std::convert::identity;
 
 /// Builds plain aggregation object type for given model (e.g. AggregateUser).
 pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
-    let ident = Identifier::new(format!("Aggregate{}", capitalize(model.name())), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("Aggregate{}", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
     let object = ObjectTypeStrongRef::new(ObjectType::new(ident.clone(), Some(ModelRef::clone(model))));

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -111,7 +111,7 @@ where
     F: Fn(&mut BuilderContext, &RelationFieldRef) -> OutputType,
     G: Fn(ObjectType) -> ObjectType,
 {
-    let ident = Identifier::new(format!("{}CountOutputType", capitalize(model.name())), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma(format!("{}CountOutputType", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
     let fields: Vec<OutputField> = fields

--- a/query-engine/schema-builder/src/output_types/mutation_type.rs
+++ b/query-engine/schema-builder/src/output_types/mutation_type.rs
@@ -7,8 +7,8 @@ use psl::datamodel_connector::ConnectorCapability;
 /// Builds the root `Mutation` type.
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
     let mut fields: Vec<OutputField> = ctx
+        .internal_data_model
         .models()
-        .into_iter()
         .flat_map(|model| {
             let mut vec = vec![];
 
@@ -40,7 +40,7 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
         fields.push(create_mongodb_run_command_raw());
     }
 
-    let ident = Identifier::new("Mutation".to_owned(), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma("Mutation".to_owned());
     let strong_ref = Arc::new(object_type(ident, fields, None));
 
     (OutputType::Object(Arc::downgrade(&strong_ref)), strong_ref)

--- a/query-engine/schema-builder/src/output_types/objects/composite.rs
+++ b/query-engine/schema-builder/src/output_types/objects/composite.rs
@@ -6,24 +6,24 @@ use prisma_models::CompositeType;
 /// Compute initial composites cache. No fields are computed because we first
 /// need all composites to be present, then we can compute fields in a second pass.
 pub(crate) fn initialize_cache(ctx: &mut BuilderContext) {
-    ctx.composite_types().into_iter().for_each(|composite| {
-        let ident = Identifier::new(composite.name(), MODEL_NAMESPACE);
+    for composite in ctx.internal_data_model.composite_types() {
+        let ident = Identifier::new_model(composite.name());
         ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, None)));
-    });
+    }
 }
 
 // Compute fields on all cached composite object types.
 pub(crate) fn initialize_fields(ctx: &mut BuilderContext) {
-    ctx.composite_types().into_iter().for_each(|composite| {
+    for composite in ctx.internal_data_model.composite_types() {
         let fields = compute_composite_object_type_fields(ctx, &composite);
         let obj: ObjectTypeWeakRef = map_type(ctx, &composite);
 
         obj.into_arc().set_fields(fields);
-    });
+    }
 }
 
 pub(crate) fn map_type(ctx: &mut BuilderContext, ct: &CompositeType) -> ObjectTypeWeakRef {
-    let ident = Identifier::new(ct.name(), MODEL_NAMESPACE);
+    let ident = Identifier::new_model(ct.name());
     ctx.get_output_type(&ident)
         .expect("Invariant violation: Initialized output object type for each composite.")
 }

--- a/query-engine/schema-builder/src/output_types/objects/mod.rs
+++ b/query-engine/schema-builder/src/output_types/objects/mod.rs
@@ -17,7 +17,7 @@ pub(crate) fn initialize_caches(ctx: &mut BuilderContext) {
 }
 
 pub(crate) fn affected_records_object_type(ctx: &mut BuilderContext) -> ObjectTypeWeakRef {
-    let ident = Identifier::new("AffectedRowsOutput".to_owned(), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma("AffectedRowsOutput".to_owned());
     return_cached_output!(ctx, &ident);
 
     let object_type = Arc::new(object_type(

--- a/query-engine/schema-builder/src/output_types/objects/model.rs
+++ b/query-engine/schema-builder/src/output_types/objects/model.rs
@@ -7,15 +7,15 @@ use std::convert::identity;
 /// Compute initial model cache. No fields are computed because we first
 /// need all models to be present, then we can compute fields in a second pass.
 pub(crate) fn initialize_cache(ctx: &mut BuilderContext) {
-    ctx.models().into_iter().for_each(|model| {
-        let ident = Identifier::new(model.name(), MODEL_NAMESPACE);
+    for model in ctx.internal_data_model.models() {
+        let ident = Identifier::new_model(model.name());
         ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model))));
-    });
+    }
 }
 
 // Compute fields on all cached model object types.
 pub(crate) fn initialize_fields(ctx: &mut BuilderContext) {
-    ctx.models().into_iter().for_each(|model| {
+    for model in ctx.internal_data_model.models() {
         let obj: ObjectTypeWeakRef = map_type(ctx, &model);
         let mut fields = compute_model_object_type_fields(ctx, &model);
 
@@ -35,13 +35,13 @@ pub(crate) fn initialize_fields(ctx: &mut BuilderContext) {
         );
 
         obj.into_arc().set_fields(fields);
-    });
+    }
 }
 
 /// Returns an output object type for the given model.
 /// Relies on the output type cache being initalized.
 pub(crate) fn map_type(ctx: &mut BuilderContext, model: &ModelRef) -> ObjectTypeWeakRef {
-    let ident = Identifier::new(model.name(), MODEL_NAMESPACE);
+    let ident = Identifier::new_model(model.name());
     ctx.get_output_type(&ident)
         .expect("Invariant violation: Initialized output object type for each model.")
 }

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -4,8 +4,8 @@ use input_types::fields::arguments;
 /// Builds the root `Query` type.
 pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRef) {
     let fields: Vec<_> = ctx
+        .internal_data_model
         .models()
-        .into_iter()
         .flat_map(|model| {
             let mut vec = vec![
                 find_first_field(ctx, &model),
@@ -27,7 +27,7 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
         })
         .collect();
 
-    let ident = Identifier::new("Query".to_owned(), PRISMA_NAMESPACE);
+    let ident = Identifier::new_prisma("Query");
     let strong_ref = Arc::new(object_type(ident, fields, None));
 
     (OutputType::Object(Arc::downgrade(&strong_ref)), strong_ref)

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -15,9 +15,6 @@ pub use renderer::*;
 
 use std::sync::{Arc, Weak};
 
-pub static PRISMA_NAMESPACE: &str = "prisma";
-pub static MODEL_NAMESPACE: &str = "model";
-
 pub type ObjectTypeStrongRef = Arc<ObjectType>;
 pub type ObjectTypeWeakRef = Weak<ObjectType>;
 

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -269,18 +269,33 @@ impl From<String> for QueryTag {
 #[derive(PartialEq, Hash, Eq, Debug, Clone)]
 pub struct Identifier {
     name: String,
-    namespace: String,
+    namespace: IdentifierNamespace,
+}
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+enum IdentifierNamespace {
+    Prisma,
+    Model,
 }
 
 impl Identifier {
-    pub fn new<T, U>(name: T, namespace: U) -> Self
+    pub fn new_prisma<T>(name: T) -> Self
     where
         T: Into<String>,
-        U: Into<String>,
     {
         Self {
             name: name.into(),
-            namespace: namespace.into(),
+            namespace: IdentifierNamespace::Prisma,
+        }
+    }
+
+    pub fn new_model<T>(name: T) -> Self
+    where
+        T: Into<String>,
+    {
+        Self {
+            name: name.into(),
+            namespace: IdentifierNamespace::Model,
         }
     }
 
@@ -289,7 +304,10 @@ impl Identifier {
     }
 
     pub fn namespace(&self) -> &str {
-        &self.namespace
+        match self.namespace {
+            IdentifierNamespace::Prisma => "prisma",
+            IdentifierNamespace::Model => "model",
+        }
     }
 }
 


### PR DESCRIPTION
Two reasons:

- It is more precise. Rather than a string that can only ever be "prisma" or "model", we have an enum with two possible values.
- It is cheaper. A small integer rather than allocated strings.