### PR TITLE
test-cli: produce dmmf directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4383,6 +4383,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "colored",
+ "dmmf",
  "enumflags2",
  "introspection-connector",
  "introspection-core",

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -8,6 +8,7 @@ anyhow = "1.0.26"
 colored = "2"
 structopt = "0.3.8"
 enumflags2 = "0.7"
+dmmf = { path = "../../query-engine/dmmf" }
 migration-core = { path = "../../migration-engine/core" }
 migration-connector = { path = "../../migration-engine/connectors/migration-connector" }
 introspection-core = { path = "../../introspection-engine/core" }

--- a/libs/test-cli/src/main.rs
+++ b/libs/test-cli/src/main.rs
@@ -47,10 +47,6 @@ enum Command {
 
 #[derive(Debug, StructOpt)]
 struct DmmfCommand {
-    /// The path to the `query-engine` binary. Defaults to the value of the `PRISMA_BINARY_PATH`
-    /// env var, or just `query-engine`.
-    #[structopt(env = "PRISMA_BINARY_PATH", default_value = "query-engine")]
-    query_engine_binary_path: String,
     /// A database URL to introspect and generate DMMF for.
     #[structopt(long = "url")]
     url: Option<String>,
@@ -340,19 +336,9 @@ async fn generate_dmmf(cmd: &DmmfCommand) -> anyhow::Result<()> {
         }
     };
 
-    eprintln!(
-        "{} {}",
-        "Using the query engine binary at".yellow(),
-        cmd.query_engine_binary_path.bold()
-    );
-
-    let cmd = std::process::Command::new(&cmd.query_engine_binary_path)
-        .arg("cli")
-        .arg("dmmf")
-        .env("PRISMA_DML_PATH", schema_path)
-        .spawn()?;
-
-    cmd.wait_with_output()?;
+    let prisma_schema = std::fs::read_to_string(schema_path).unwrap();
+    let result = dmmf::dmmf_json_from_schema(&prisma_schema);
+    println!("{result}");
 
     Ok(())
 }


### PR DESCRIPTION
i.e. without using an external query engine binary. We import the dmmf crate instead. A long time ago, when this was made, it wasn't possible, but now it is.