### PR TITLE
psl/parser-database: normalize scalar fields

### DIFF
--- a/introspection-engine/connectors/sql-introspection-connector/src/introspection_map.rs
+++ b/introspection-engine/connectors/sql-introspection-connector/src/introspection_map.rs
@@ -6,7 +6,7 @@ use crate::{
     datamodel_calculator::DatamodelCalculatorContext, introspection_helpers as helpers, pair::RelationFieldDirection,
 };
 use psl::{
-    parser_database::{self, ast, walkers},
+    parser_database::{self, ast, ScalarFieldId},
     PreviewFeature,
 };
 use relation_names::RelationNames;
@@ -28,8 +28,8 @@ pub(crate) struct IntrospectionMap<'a> {
     pub(crate) existing_views: HashMap<sql::ViewId, ast::ModelId>,
     pub(crate) missing_tables_for_previous_models: HashSet<ast::ModelId>,
     pub(crate) missing_views_for_previous_models: HashSet<ast::ModelId>,
-    pub(crate) existing_model_scalar_fields: HashMap<sql::TableColumnId, walkers::ScalarFieldId>,
-    pub(crate) existing_view_scalar_fields: HashMap<sql::ViewColumnId, walkers::ScalarFieldId>,
+    pub(crate) existing_model_scalar_fields: HashMap<sql::TableColumnId, ScalarFieldId>,
+    pub(crate) existing_view_scalar_fields: HashMap<sql::ViewColumnId, ScalarFieldId>,
     pub(crate) existing_inline_relations: HashMap<sql::ForeignKeyId, parser_database::RelationId>,
     pub(crate) existing_m2m_relations: HashMap<sql::TableId, parser_database::ManyToManyRelationId>,
     pub(crate) relation_names: RelationNames<'a>,

--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -9,11 +9,11 @@ use crate::{
     coerce, coerce_array,
     context::Context,
     types::{
-        EnumAttributes, FieldWithArgs, IndexAlgorithm, IndexAttribute, IndexFieldPath, IndexType, ModelAttributes,
-        OperatorClassStore, RelationField, ScalarField, ScalarFieldType, SortOrder,
+        CompositeTypeField, EnumAttributes, FieldWithArgs, IndexAlgorithm, IndexAttribute, IndexFieldPath, IndexType,
+        ModelAttributes, OperatorClassStore, RelationField, ScalarField, ScalarFieldType, SortOrder,
     },
     walkers::RelationFieldId,
-    DatamodelError, StringId,
+    DatamodelError, ScalarFieldId, StringId,
 };
 use diagnostics::Span;
 use std::borrow::Cow;
@@ -25,7 +25,7 @@ pub(super) fn resolve_attributes(ctx: &mut Context<'_>) {
 
     for top in ctx.ast.iter_tops() {
         match top {
-            (ast::TopId::Model(model_id), ast::Top::Model(model)) => resolve_model_attributes(model_id, model, ctx),
+            (ast::TopId::Model(model_id), ast::Top::Model(_)) => resolve_model_attributes(model_id, ctx),
             (ast::TopId::Enum(enum_id), ast::Top::Enum(ast_enum)) => resolve_enum_attributes(enum_id, ast_enum, ctx),
             (ast::TopId::CompositeType(ctid), ast::Top::CompositeType(ct)) => {
                 resolve_composite_type_attributes(ctid, ct, ctx)
@@ -41,35 +41,35 @@ fn resolve_composite_type_attributes<'db>(
     ctx: &mut Context<'db>,
 ) {
     for (field_id, field) in ct.iter_fields() {
-        let mut ctfield = ctx.types.composite_type_fields[&(ctid, field_id)].clone();
+        let CompositeTypeField { r#type, .. } = ctx.types.composite_type_fields[&(ctid, field_id)];
 
         ctx.visit_attributes((ctid, field_id).into());
 
-        if let ScalarFieldType::BuiltInScalar(_scalar_type) = ctfield.r#type {
+        if let ScalarFieldType::BuiltInScalar(_scalar_type) = r#type {
             // native type attributes
             if let Some((datasource_name, type_name, args)) = ctx.visit_datasource_scoped() {
                 native_types::visit_composite_type_field_native_type_attribute(
+                    (ctid, field_id),
                     datasource_name,
                     type_name,
                     &ctx.ast[args],
-                    &mut ctfield,
+                    ctx,
                 )
             }
         }
 
         // @map
         if ctx.visit_optional_single_attr("map") {
-            map::composite_type_field(ct, field, ctid, field_id, &mut ctfield, ctx);
+            map::composite_type_field(ct, field, ctid, field_id, ctx);
             ctx.validate_visited_arguments();
         }
 
         // @default
         if ctx.visit_optional_single_attr("default") {
-            default::visit_composite_field_default(&mut ctfield, ctid, field_id, ctx);
+            default::visit_composite_field_default(ctid, field_id, r#type, ctx);
             ctx.validate_visited_arguments();
         }
 
-        ctx.types.composite_type_fields.insert((ctid, field_id), ctfield);
         ctx.validate_visited_attributes();
     }
 }
@@ -114,24 +114,12 @@ fn resolve_enum_attributes<'db>(enum_id: ast::EnumId, ast_enum: &'db ast::Enum, 
     ctx.validate_visited_attributes();
 }
 
-fn resolve_model_attributes<'db>(model_id: ast::ModelId, ast_model: &'db ast::Model, ctx: &mut Context<'db>) {
+fn resolve_model_attributes(model_id: ast::ModelId, ctx: &mut Context<'_>) {
     let mut model_attributes = ModelAttributes::default();
 
     // First resolve all the attributes defined on fields **in isolation**.
-    for (field_id, ast_field) in ast_model.iter_fields() {
-        if let Some(mut scalar_field) = ctx.types.take_scalar_field(model_id, field_id) {
-            visit_scalar_field_attributes(
-                model_id,
-                field_id,
-                ast_model,
-                ast_field,
-                &mut model_attributes,
-                &mut scalar_field,
-                ctx,
-            );
-
-            ctx.types.scalar_fields.insert((model_id, field_id), scalar_field);
-        }
+    for sfid in ctx.types.range_model_scalar_field_ids(model_id) {
+        visit_scalar_field_attributes(sfid, &mut model_attributes, ctx);
     }
 
     // Resolve all the attributes defined on the model itself **in isolation**.
@@ -186,29 +174,33 @@ fn resolve_model_attributes<'db>(model_id: ast::ModelId, ast_model: &'db ast::Mo
     ctx.validate_visited_attributes();
 }
 
-fn visit_scalar_field_attributes<'db>(
-    model_id: ast::ModelId,
-    field_id: ast::FieldId,
-    ast_model: &'db ast::Model,
-    ast_field: &'db ast::Field,
-    model_attributes: &mut ModelAttributes,
-    scalar_field_data: &mut ScalarField,
-    ctx: &mut Context<'db>,
+fn visit_scalar_field_attributes(
+    scalar_field_id: ScalarFieldId,
+    model_data: &mut ModelAttributes,
+    ctx: &mut Context<'_>,
 ) {
+    let ScalarField {
+        model_id,
+        field_id,
+        r#type,
+        ..
+    } = ctx.types[scalar_field_id];
+    let ast_model = &ctx.ast[model_id];
+    let ast_field = &ast_model[field_id];
     ctx.visit_scalar_field_attributes(model_id, field_id);
 
     // @map
     if ctx.visit_optional_single_attr("map") {
-        map::scalar_field(ast_model, ast_field, model_id, field_id, scalar_field_data, ctx);
+        map::scalar_field(scalar_field_id, ast_model, ast_field, model_id, field_id, ctx);
         ctx.validate_visited_arguments();
     }
 
     // @ignore
     if ctx.visit_optional_single_attr("ignore") {
-        if matches!(scalar_field_data.r#type, ScalarFieldType::Unsupported(_)) {
+        if matches!(r#type, ScalarFieldType::Unsupported(_)) {
             ctx.push_attribute_validation_error("Fields of type `Unsupported` cannot take an `@ignore` attribute. They are already treated as ignored by the client due to their type.");
         } else {
-            scalar_field_data.is_ignored = true;
+            ctx.types[scalar_field_id].is_ignored = true;
         }
         ctx.validate_visited_arguments();
     }
@@ -221,16 +213,13 @@ fn visit_scalar_field_attributes<'db>(
 
     // @id
     if ctx.visit_optional_single_attr("id") {
-        id::field(ast_model, field_id, model_attributes, ctx);
+        id::field(ast_model, scalar_field_id, field_id, model_data, ctx);
         ctx.validate_visited_arguments();
     }
 
     // @updatedAt
     if ctx.visit_optional_single_attr("updatedAt") {
-        if !matches!(
-            scalar_field_data.r#type,
-            ScalarFieldType::BuiltInScalar(crate::ScalarType::DateTime)
-        ) {
+        if !matches!(r#type, ScalarFieldType::BuiltInScalar(crate::ScalarType::DateTime)) {
             ctx.push_attribute_validation_error("Fields that are marked with @updatedAt must be of type DateTime.");
         }
 
@@ -238,39 +227,40 @@ fn visit_scalar_field_attributes<'db>(
             ctx.push_attribute_validation_error("Fields that are marked with @updatedAt cannot be lists.");
         }
 
-        scalar_field_data.is_updated_at = true;
+        ctx.types[scalar_field_id].is_updated_at = true;
         ctx.validate_visited_arguments();
     }
 
     // @default
     if ctx.visit_optional_single_attr("default") {
-        default::visit_model_field_default(scalar_field_data, model_id, field_id, ctx);
+        default::visit_model_field_default(scalar_field_id, model_id, field_id, r#type, ctx);
         ctx.validate_visited_arguments();
     }
 
-    if let ScalarFieldType::BuiltInScalar(_scalar_type) = scalar_field_data.r#type {
+    if let ScalarFieldType::BuiltInScalar(_scalar_type) = r#type {
         // native type attributes
         if let Some((datasource_name, type_name, attribute_id)) = ctx.visit_datasource_scoped() {
             let attribute = &ctx.ast[attribute_id];
             native_types::visit_model_field_native_type_attribute(
+                scalar_field_id,
                 datasource_name,
                 type_name,
                 attribute,
-                scalar_field_data,
+                ctx,
             );
         }
     }
 
     // @unique
     if ctx.visit_optional_single_attr("unique") {
-        visit_field_unique(field_id, model_attributes, ctx);
+        visit_field_unique(scalar_field_id, model_data, ctx);
         ctx.validate_visited_arguments();
     }
 
     ctx.validate_visited_attributes();
 }
 
-fn visit_field_unique(field_id: ast::FieldId, model_attributes: &mut ModelAttributes, ctx: &mut Context<'_>) {
+fn visit_field_unique(scalar_field_id: ScalarFieldId, model_data: &mut ModelAttributes, ctx: &mut Context<'_>) {
     let mapped_name = match ctx
         .visit_optional_arg("map")
         .and_then(|arg| coerce::string(arg, ctx.diagnostics))
@@ -305,17 +295,18 @@ fn visit_field_unique(field_id: ast::FieldId, model_attributes: &mut ModelAttrib
 
     let clustered = validate_clustering_setting(ctx);
 
-    model_attributes.ast_indexes.push((
-        ctx.current_attribute_id(),
+    let attribute_id = ctx.current_attribute_id();
+    model_data.ast_indexes.push((
+        attribute_id,
         IndexAttribute {
             r#type: IndexType::Unique,
             fields: vec![FieldWithArgs {
-                path: IndexFieldPath::new(field_id),
+                path: IndexFieldPath::new(scalar_field_id),
                 sort_order,
                 length,
                 operator_class: None,
             }],
-            source_field: Some(field_id),
+            source_field: Some(scalar_field_id),
             mapped_name,
             clustered,
             ..Default::default()
@@ -372,7 +363,8 @@ fn visit_relation_field_attributes(rfid: RelationFieldId, ctx: &mut Context<'_>)
         let mut suggested_fields = Vec::new();
 
         for underlying_field in ctx.types[rfid].fields.iter().flatten() {
-            suggested_fields.push(ctx.ast[model_id][*underlying_field].name());
+            let ScalarField { model_id, field_id, .. } = ctx.types[*underlying_field];
+            suggested_fields.push(ctx.ast[model_id][field_id].name());
         }
 
         let suggestion = match suggested_fields.len() {
@@ -404,11 +396,11 @@ fn visit_model_ignore(model_id: ast::ModelId, model_data: &mut ModelAttributes, 
         .types
         .range_model_scalar_fields(model_id)
         .filter(|(_, sf)| sf.is_ignored)
-        .map(|(field_id, _)| {
+        .map(|(_, sf)| {
             DatamodelError::new_attribute_validation_error(
                 "Fields on an already ignored Model do not need an `@ignore` annotation.",
                 "@ignore",
-                ctx.ast[model_id][field_id].span(),
+                ctx.ast[sf.model_id][sf.field_id].span(),
             )
         })
         .collect();
@@ -643,7 +635,8 @@ fn common_index_validations(
                         .iter()
                         .flatten();
                     for underlying_field in fields {
-                        suggested_fields.push(ctx.ast[model_id][*underlying_field].name());
+                        let ScalarField { model_id, field_id, .. } = ctx.types[*underlying_field];
+                        suggested_fields.push(ctx.ast[model_id][field_id].name());
                     }
                 }
 
@@ -827,7 +820,7 @@ fn resolve_field_array_without_args<'db>(
     attribute_span: ast::Span,
     model_id: ast::ModelId,
     ctx: &mut Context<'db>,
-) -> Result<Vec<ast::FieldId>, FieldResolutionError<'db>> {
+) -> Result<Vec<ScalarFieldId>, FieldResolutionError<'db>> {
     let constant_array = match coerce_array(values, &coerce::constant, ctx.diagnostics) {
         Some(values) => values,
         None => {
@@ -835,7 +828,7 @@ fn resolve_field_array_without_args<'db>(
         }
     };
 
-    let mut field_ids = Vec::with_capacity(constant_array.len());
+    let mut field_ids: Vec<ScalarFieldId> = Vec::with_capacity(constant_array.len());
     let mut unknown_fields = Vec::new();
     let mut relation_fields = Vec::new();
     let ast_model = &ctx.ast[model_id];
@@ -855,13 +848,13 @@ fn resolve_field_array_without_args<'db>(
         };
 
         // Is the field a scalar field?
-        if !ctx.types.scalar_fields.contains_key(&(model_id, field_id)) {
+        let Some(sfid) = ctx.types.find_model_scalar_field(model_id, field_id) else{
             relation_fields.push((&ctx.ast[model_id][field_id], field_id));
             continue;
-        }
+        };
 
         // Is the field used twice?
-        if field_ids.contains(&field_id) {
+        if field_ids.contains(&sfid) {
             ctx.push_error(DatamodelError::new_model_validation_error(
                 &format!(
                     "The unique index definition refers to the field {} multiple times.",
@@ -874,7 +867,7 @@ fn resolve_field_array_without_args<'db>(
             return Err(FieldResolutionError::AlreadyDealtWith);
         }
 
-        field_ids.push(field_id);
+        field_ids.push(sfid);
     }
 
     if !unknown_fields.is_empty() || !relation_fields.is_empty() {
@@ -940,13 +933,13 @@ fn resolve_field_array_with_args<'db>(
                         }
                     };
 
-                    if !ctx.types.scalar_fields.contains_key(&(model_id, field_id)) {
+                    let Some(sfid) = ctx.types.find_model_scalar_field(model_id, field_id) else {
                         relation_fields.push((&ctx.ast[model_id][field_id], field_id));
                         continue 'fields;
-                    }
+                    };
 
-                    match &ctx.types.scalar_fields[&(model_id, field_id)].r#type {
-                        ScalarFieldType::CompositeType(ctid) => (IndexFieldPath::new(field_id), *ctid),
+                    match &ctx.types[sfid].r#type {
+                        ScalarFieldType::CompositeType(ctid) => (IndexFieldPath::new(sfid), ctid),
                         _ => {
                             unknown_fields.push((ast::TopId::Model(model_id), attrs.field_name));
                             continue 'fields;
@@ -961,19 +954,19 @@ fn resolve_field_array_with_args<'db>(
             };
 
             for (i, field_shard) in path_in_schema {
-                let field_id = match ctx.find_composite_type_field(next_type, field_shard) {
+                let field_id = match ctx.find_composite_type_field(*next_type, field_shard) {
                     Some(field_id) => field_id,
                     None => {
-                        unknown_fields.push((ast::TopId::CompositeType(next_type), field_shard));
+                        unknown_fields.push((ast::TopId::CompositeType(*next_type), field_shard));
                         continue 'fields;
                     }
                 };
 
-                path.push_field(next_type, field_id);
+                path.push_field(*next_type, field_id);
 
-                match &ctx.types.composite_type_fields[&(next_type, field_id)].r#type {
+                match &ctx.types.composite_type_fields[&(*next_type, field_id)].r#type {
                     ScalarFieldType::CompositeType(ctid) => {
-                        next_type = *ctid;
+                        next_type = ctid;
                     }
                     _ if i < field_count - 1 => {
                         unknown_fields.push((ast::TopId::Model(model_id), attrs.field_name));
@@ -986,11 +979,12 @@ fn resolve_field_array_with_args<'db>(
             path
         } else if let Some(field_id) = ctx.find_model_field(model_id, attrs.field_name) {
             // Is the field a scalar field?
-            if !ctx.types.scalar_fields.contains_key(&(model_id, field_id)) {
-                relation_fields.push((&ctx.ast[model_id][field_id], field_id));
-                continue;
-            } else {
-                IndexFieldPath::new(field_id)
+            match ctx.types.find_model_scalar_field(model_id, field_id) {
+                Some(sfid) => IndexFieldPath::new(sfid),
+                None => {
+                    relation_fields.push((&ctx.ast[model_id][field_id], field_id));
+                    continue;
+                }
             }
         } else {
             unknown_fields.push((ast::TopId::Model(model_id), attrs.field_name));
@@ -999,10 +993,9 @@ fn resolve_field_array_with_args<'db>(
 
         // Is the field used twice?
         if field_ids.contains(&path) {
-            let path_str = match path.type_holding_the_indexed_field() {
-                None => Cow::from(attrs.field_name),
-                Some(ctid) => {
-                    let field_id = path.field_in_index();
+            let path_str = match path.field_in_index() {
+                either::Either::Left(_) => Cow::from(attrs.field_name),
+                either::Either::Right((ctid, field_id)) => {
                     let field_name = &ctx.ast[ctid][field_id].name();
                     let composite_type = &ctx.ast[ctid].name();
 

--- a/psl/parser-database/src/attributes/default.rs
+++ b/psl/parser-database/src/attributes/default.rs
@@ -2,15 +2,16 @@ use crate::{
     ast::{self, WithName},
     coerce,
     context::Context,
-    types::{CompositeTypeField, DefaultAttribute, ScalarField, ScalarFieldType, ScalarType},
-    DatamodelError, StringId,
+    types::{DefaultAttribute, ScalarFieldType, ScalarType},
+    DatamodelError, ScalarFieldId, StringId,
 };
 
 /// @default on model scalar fields
 pub(super) fn visit_model_field_default(
-    field_data: &mut ScalarField,
+    scalar_field_id: ScalarFieldId,
     model_id: ast::ModelId,
     field_id: ast::FieldId,
+    r#type: ScalarFieldType,
     ctx: &mut Context<'_>,
 ) {
     let (argument_idx, value) = match ctx.visit_default_arg_with_idx("value") {
@@ -24,41 +25,42 @@ pub(super) fn visit_model_field_default(
     let mapped_name = default_attribute_mapped_name(ctx);
     let default_attribute_id = ctx.current_attribute_id();
 
-    let accept = || {
+    let mut accept = move |ctx: &mut Context<'_>| {
         let default_value = DefaultAttribute {
             argument_idx,
             mapped_name,
             default_attribute: default_attribute_id,
         };
 
-        field_data.default = Some(default_value);
+        ctx.types[scalar_field_id].default = Some(default_value);
     };
 
     // @default(dbgenerated(...)) is always valid.
     match value {
         ast::Expression::Function(name, funcargs, _span) if name == FN_DBGENERATED => {
-            validate_dbgenerated_args(&funcargs.arguments, accept, ctx);
+            validate_dbgenerated_args(&funcargs.arguments, &mut accept, ctx);
             return;
         }
         _ => (),
     }
 
-    match field_data.r#type {
+    match r#type {
         ScalarFieldType::CompositeType(ctid) => {
             validate_default_value_on_composite_type(ctid, ast_field, ctx);
         }
         ScalarFieldType::Enum(enum_id) => {
             if ast_field.arity.is_list() {
-                validate_enum_list_default(value, enum_id, accept, ctx);
+                validate_enum_list_default(value, enum_id, &mut accept, ctx);
             } else {
-                validate_enum_default(value, enum_id, accept, ctx);
+                validate_enum_default(value, enum_id, &mut accept, ctx);
             }
         }
         ScalarFieldType::BuiltInScalar(scalar_type) => validate_model_builtin_scalar_type_default(
+            scalar_field_id,
             scalar_type,
             value,
             mapped_name,
-            accept,
+            &mut accept,
             (model_id, field_id),
             ctx,
         ),
@@ -72,9 +74,9 @@ pub(super) fn visit_model_field_default(
 
 /// @default on composite type fields
 pub(super) fn visit_composite_field_default(
-    field_data: &mut CompositeTypeField,
     ct_id: ast::CompositeTypeId,
     field_id: ast::FieldId,
+    r#type: ScalarFieldType,
     ctx: &mut Context<'_>,
 ) {
     let (argument_idx, value) = match ctx.visit_default_arg_with_idx("value") {
@@ -91,13 +93,14 @@ pub(super) fn visit_composite_field_default(
 
     let default_attribute = ctx.current_attribute_id();
 
-    let accept = || {
+    let mut accept = move |ctx: &mut Context<'_>| {
         let default_value = DefaultAttribute {
             argument_idx,
             mapped_name: None,
             default_attribute,
         };
 
+        let field_data = ctx.types.composite_type_fields.get_mut(&(ct_id, field_id)).unwrap();
         field_data.default = Some(default_value);
     };
 
@@ -112,19 +115,19 @@ pub(super) fn visit_composite_field_default(
 
     // Resolve the default to a DefaultValue. We must loop in order to
     // resolve type aliases.
-    match field_data.r#type {
+    match r#type {
         ScalarFieldType::CompositeType(ctid) => {
             validate_default_value_on_composite_type(ctid, ast_field, ctx);
         }
         ScalarFieldType::Enum(enum_id) => {
             if ast_field.arity.is_list() {
-                validate_enum_list_default(value, enum_id, accept, ctx);
+                validate_enum_list_default(value, enum_id, &mut accept, ctx);
             } else {
-                validate_enum_default(value, enum_id, accept, ctx);
+                validate_enum_default(value, enum_id, &mut accept, ctx);
             }
         }
         ScalarFieldType::BuiltInScalar(scalar_type) => {
-            validate_composite_builtin_scalar_type_default(scalar_type, value, accept, ast_field.arity, ctx)
+            validate_composite_builtin_scalar_type_default(scalar_type, value, &mut accept, ast_field.arity, ctx)
         }
         ScalarFieldType::Unsupported(_) => {
             ctx.push_attribute_validation_error("Composite field of type `Unsupported` cannot have default values.")
@@ -135,7 +138,7 @@ pub(super) fn visit_composite_field_default(
 fn validate_singular_scalar_default_literal(
     scalar_type: ScalarType,
     value: &ast::Expression,
-    accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     ctx: &mut Context<'_>,
 ) {
     if let ast::Expression::Array(..) = value {
@@ -148,7 +151,7 @@ fn validate_singular_scalar_default_literal(
 fn validate_scalar_default_literal(
     scalar_type: ScalarType,
     value: &ast::Expression,
-    mut accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     ctx: &mut Context<'_>,
 ) {
     match (scalar_type, value) {
@@ -160,7 +163,7 @@ fn validate_scalar_default_literal(
         | (ScalarType::Float, ast::Expression::NumericValue(_, _))
         | (ScalarType::DateTime, ast::Expression::StringValue(_, _))
         | (ScalarType::Decimal, ast::Expression::NumericValue(_, _))
-        | (ScalarType::Decimal, ast::Expression::StringValue(_, _)) => accept(),
+        | (ScalarType::Decimal, ast::Expression::StringValue(_, _)) => accept(ctx),
         (ScalarType::Boolean, ast::Expression::ConstantValue(val, span)) => {
             validate_default_bool_value(val, *span, accept, ctx)
         }
@@ -173,10 +176,11 @@ fn validate_scalar_default_literal(
 }
 
 fn validate_model_builtin_scalar_type_default(
+    scalar_field_id: ScalarFieldId,
     scalar_type: ScalarType,
     value: &ast::Expression,
     mapped_name: Option<StringId>,
-    mut accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     field_id: (ast::ModelId, ast::FieldId),
     ctx: &mut Context<'_>,
 ) {
@@ -209,8 +213,8 @@ fn validate_model_builtin_scalar_type_default(
         }
 
         (_, ast::Expression::Function(funcname, _, _)) if !KNOWN_FUNCTIONS.contains(&funcname.as_str()) => {
-            ctx.types.unknown_function_defaults.push(field_id);
-            accept();
+            ctx.types.unknown_function_defaults.push(scalar_field_id);
+            accept(ctx);
         }
 
         // Invalid function default.
@@ -232,7 +236,7 @@ fn validate_model_builtin_scalar_type_default(
 fn validate_composite_builtin_scalar_type_default(
     scalar_type: ScalarType,
     value: &ast::Expression,
-    accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     field_arity: ast::FieldArity,
     ctx: &mut Context<'_>,
 ) {
@@ -284,14 +288,9 @@ fn default_attribute_mapped_name(ctx: &mut Context<'_>) -> Option<StringId> {
     }
 }
 
-fn validate_default_bool_value(
-    bool_value: &str,
-    span: diagnostics::Span,
-    mut accept: impl FnMut(),
-    ctx: &mut Context<'_>,
-) {
+fn validate_default_bool_value(bool_value: &str, span: diagnostics::Span, accept: AcceptFn<'_>, ctx: &mut Context<'_>) {
     match bool_value {
-        "true" | "false" => accept(),
+        "true" | "false" => accept(ctx),
         _ => ctx.push_error(DatamodelError::new_attribute_validation_error(
             "A boolean literal must be `true` or `false`.",
             "@default",
@@ -337,14 +336,9 @@ fn validate_default_value_on_composite_type(ctid: ast::CompositeTypeId, ast_fiel
     ));
 }
 
-fn validate_empty_function_args(
-    fn_name: &str,
-    args: &[ast::Argument],
-    mut accept: impl FnMut(),
-    ctx: &mut Context<'_>,
-) {
+fn validate_empty_function_args(fn_name: &str, args: &[ast::Argument], accept: AcceptFn<'_>, ctx: &mut Context<'_>) {
     if args.is_empty() {
-        return accept();
+        return accept(ctx);
     }
 
     ctx.push_attribute_validation_error(&format!(
@@ -352,15 +346,15 @@ fn validate_empty_function_args(
     ));
 }
 
-fn validate_auto_args(args: &[ast::Argument], mut accept: impl FnMut(), ctx: &mut Context<'_>) {
+fn validate_auto_args(args: &[ast::Argument], accept: AcceptFn<'_>, ctx: &mut Context<'_>) {
     if !args.is_empty() {
         ctx.push_attribute_validation_error("`auto()` takes no arguments");
     } else {
-        accept()
+        accept(ctx)
     }
 }
 
-fn validate_dbgenerated_args(args: &[ast::Argument], mut accept: impl FnMut(), ctx: &mut Context<'_>) {
+fn validate_dbgenerated_args(args: &[ast::Argument], accept: AcceptFn<'_>, ctx: &mut Context<'_>) {
     let mut bail = || {
         // let's not mention what we don't want to see.
         ctx.push_attribute_validation_error("`dbgenerated()` takes a single String argument")
@@ -376,12 +370,12 @@ fn validate_dbgenerated_args(args: &[ast::Argument], mut accept: impl FnMut(), c
                 "dbgenerated() takes either no argument, or a single nonempty string argument.",
             );
         }
-        None | Some(ast::Expression::StringValue(_, _)) => accept(),
+        None | Some(ast::Expression::StringValue(_, _)) => accept(ctx),
         _ => bail(),
     }
 }
 
-fn validate_nanoid_args(args: &[ast::Argument], mut accept: impl FnMut(), ctx: &mut Context<'_>) {
+fn validate_nanoid_args(args: &[ast::Argument], accept: AcceptFn<'_>, ctx: &mut Context<'_>) {
     let mut bail = || ctx.push_attribute_validation_error("`nanoid()` takes a single Int argument.");
 
     if args.len() > 1 {
@@ -394,7 +388,7 @@ fn validate_nanoid_args(args: &[ast::Argument], mut accept: impl FnMut(), ctx: &
                 "`nanoid()` takes either no argument, or a single integer argument >= 2.",
             );
         }
-        None | Some(ast::Expression::NumericValue(_, _)) => accept(),
+        None | Some(ast::Expression::NumericValue(_, _)) => accept(ctx),
         _ => bail(),
     }
 }
@@ -402,13 +396,13 @@ fn validate_nanoid_args(args: &[ast::Argument], mut accept: impl FnMut(), ctx: &
 fn validate_enum_default(
     found_value: &ast::Expression,
     enum_id: ast::EnumId,
-    mut accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     ctx: &mut Context<'_>,
 ) {
     match found_value {
         ast::Expression::ConstantValue(enum_value, _) => {
             if ctx.ast[enum_id].values.iter().any(|v| v.name() == enum_value) {
-                accept()
+                accept(ctx)
             } else {
                 validate_invalid_default_enum_value(enum_value, ctx);
             }
@@ -420,7 +414,7 @@ fn validate_enum_default(
 fn validate_enum_list_default(
     found_value: &ast::Expression,
     enum_id: ast::EnumId,
-    mut accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     ctx: &mut Context<'_>,
 ) {
     match found_value {
@@ -432,7 +426,7 @@ fn validate_enum_list_default(
                 validate_enum_default(
                     enum_value,
                     enum_id,
-                    || {
+                    &mut |_| {
                         valid = true;
                     },
                     ctx,
@@ -440,7 +434,7 @@ fn validate_enum_list_default(
             }
 
             if valid {
-                accept();
+                accept(ctx);
             }
         }
         bad_value => validate_invalid_default_enum_expr(bad_value, ctx),
@@ -450,7 +444,7 @@ fn validate_enum_list_default(
 fn validate_builtin_scalar_list_default(
     scalar_type: ScalarType,
     found_value: &ast::Expression,
-    mut accept: impl FnMut(),
+    accept: AcceptFn<'_>,
     ctx: &mut Context<'_>,
 ) {
     match found_value {
@@ -462,7 +456,7 @@ fn validate_builtin_scalar_list_default(
                 validate_scalar_default_literal(
                     scalar_type,
                     value,
-                    || {
+                    &mut |_| {
                         valid = true;
                     },
                     ctx,
@@ -470,7 +464,7 @@ fn validate_builtin_scalar_list_default(
             }
 
             if valid {
-                accept()
+                accept(ctx)
             }
         }
         _bad_value => ctx.push_attribute_validation_error("The default value of a list field must be a list."),
@@ -494,3 +488,5 @@ const KNOWN_FUNCTIONS: &[&str] = &[
     FN_UUID,
     FN_AUTO,
 ];
+
+type AcceptFn<'a> = &'a mut dyn for<'b, 'c> FnMut(&'b mut Context<'c>);

--- a/psl/parser-database/src/attributes/map.rs
+++ b/psl/parser-database/src/attributes/map.rs
@@ -2,8 +2,8 @@ use crate::{
     ast::{self, WithName, WithSpan},
     coerce,
     context::Context,
-    types::{CompositeTypeField, ModelAttributes, ScalarField},
-    DatamodelError, StringId,
+    types::ModelAttributes,
+    DatamodelError, ScalarFieldId, StringId,
 };
 
 pub(super) fn model(model_attributes: &mut ModelAttributes, ctx: &mut Context<'_>) {
@@ -16,11 +16,11 @@ pub(super) fn model(model_attributes: &mut ModelAttributes, ctx: &mut Context<'_
 }
 
 pub(super) fn scalar_field(
+    sfid: ScalarFieldId,
     ast_model: &ast::Model,
     ast_field: &ast::Field,
     model_id: ast::ModelId,
     field_id: ast::FieldId,
-    scalar_field_data: &mut ScalarField,
     ctx: &mut Context<'_>,
 ) {
     let mapped_name = match visit_map_attribute(ctx) {
@@ -28,7 +28,7 @@ pub(super) fn scalar_field(
         None => return,
     };
 
-    scalar_field_data.mapped_name = Some(mapped_name);
+    ctx.types[sfid].mapped_name = Some(mapped_name);
 
     if ctx
         .mapped_model_scalar_field_names
@@ -44,25 +44,24 @@ pub(super) fn scalar_field(
     }
 
     if let Some(field_id) = ctx.names.model_fields.get(&(model_id, mapped_name)) {
-        // @map only conflicts with _scalar_ fields
-        if !ctx.types.scalar_fields.contains_key(&(model_id, *field_id)) {
-            return;
-        }
-
         match ctx
             .types
-            .scalar_fields
-            .get(&(model_id, *field_id))
-            .and_then(|sf| sf.mapped_name)
+            .range_model_scalar_fields(model_id)
+            .find(|(_, sf)| sf.field_id == *field_id)
+            .map(|(_, sf)| sf.mapped_name)
         {
-            Some(name) if name != mapped_name => {}
-            _ => ctx.push_error(DatamodelError::new_duplicate_field_error(
-                ast_model.name(),
-                ast_field.name(),
-                if ast_model.is_view() { "view" } else { "model" },
-                ast_field.span(),
-            )),
+            // @map only conflicts with _scalar_ fields
+            None => return,
+            Some(Some(sf_mapped_name)) if sf_mapped_name != mapped_name => return,
+            Some(_) => {}
         }
+
+        ctx.push_error(DatamodelError::new_duplicate_field_error(
+            ast_model.name(),
+            ast_field.name(),
+            if ast_model.is_view() { "view" } else { "model" },
+            ast_field.span(),
+        ))
     }
 }
 
@@ -71,7 +70,6 @@ pub(super) fn composite_type_field(
     ast_field: &ast::Field,
     ctid: ast::CompositeTypeId,
     field_id: ast::FieldId,
-    field: &mut CompositeTypeField,
     ctx: &mut Context<'_>,
 ) {
     let mapped_name_id = match visit_map_attribute(ctx) {
@@ -79,7 +77,10 @@ pub(super) fn composite_type_field(
         None => return,
     };
 
-    field.mapped_name = Some(mapped_name_id);
+    {
+        let mut field = ctx.types.composite_type_fields.get_mut(&(ctid, field_id)).unwrap();
+        field.mapped_name = Some(mapped_name_id);
+    }
 
     if ctx
         .mapped_composite_type_names

--- a/psl/parser-database/src/attributes/native_types.rs
+++ b/psl/parser-database/src/attributes/native_types.rs
@@ -1,29 +1,28 @@
-use crate::{
-    ast,
-    types::{CompositeTypeField, ScalarField},
-    StringId,
-};
+use crate::{ast, context::Context, ScalarFieldId, StringId};
 
 pub(super) fn visit_model_field_native_type_attribute(
+    id: ScalarFieldId,
     datasource_name: StringId,
     type_name: StringId,
     attr: &ast::Attribute,
-    scalar_field: &mut ScalarField,
+    ctx: &mut Context<'_>,
 ) {
     let args = &attr.arguments;
     let args: Vec<String> = args.arguments.iter().map(|arg| arg.value.to_string()).collect();
 
-    scalar_field.native_type = Some((datasource_name, type_name, args, attr.span))
+    ctx.types[id].native_type = Some((datasource_name, type_name, args, attr.span))
 }
 
 pub(super) fn visit_composite_type_field_native_type_attribute(
+    id: (ast::CompositeTypeId, ast::FieldId),
     datasource_name: StringId,
     type_name: StringId,
     attr: &ast::Attribute,
-    composite_type_field: &mut CompositeTypeField,
+    ctx: &mut Context<'_>,
 ) {
     let args = &attr.arguments;
     let args: Vec<String> = args.arguments.iter().map(|arg| arg.value.to_string()).collect();
 
+    let mut composite_type_field = ctx.types.composite_type_fields.get_mut(&id).unwrap();
     composite_type_field.native_type = Some((datasource_name, type_name, args, attr.span))
 }

--- a/psl/parser-database/src/lib.rs
+++ b/psl/parser-database/src/lib.rs
@@ -40,7 +40,10 @@ pub use coerce_expression::{coerce, coerce_array, coerce_opt};
 pub use names::is_reserved_type_name;
 pub use relations::{ManyToManyRelationId, ReferentialAction, RelationId};
 pub use schema_ast::{ast, SourceFile};
-pub use types::{IndexAlgorithm, IndexFieldPath, IndexType, OperatorClass, ScalarFieldType, ScalarType, SortOrder};
+pub use types::{
+    IndexAlgorithm, IndexFieldPath, IndexType, OperatorClass, RelationFieldId, ScalarFieldId, ScalarFieldType,
+    ScalarType, SortOrder,
+};
 
 use self::{context::Context, interner::StringId, relations::Relations, types::Types};
 use diagnostics::{DatamodelError, Diagnostics};

--- a/psl/parser-database/src/relations.rs
+++ b/psl/parser-database/src/relations.rs
@@ -365,8 +365,12 @@ pub(super) fn ingest_relation<'db>(evidence: RelationEvidence<'db>, relations: &
                             .ast_indexes
                             .iter()
                             .any(|(_, idx)| {
-                                idx.is_unique()
-                                    && &idx.fields.iter().map(|f| f.path.field_in_index()).collect::<Vec<_>>() == fields
+                                idx.is_unique() && idx.fields.len() == fields.len() && {
+                                    idx.fields
+                                        .iter()
+                                        .zip(fields.iter())
+                                        .all(|(idx_field, field)| matches!(idx_field.path.field_in_index(), either::Either::Left(id) if id == *field))
+                                }
                             });
                     if fields_are_unique {
                         RelationAttributes::OneToOne(OneToOneRelationFields::Forward(evidence.field_id))

--- a/psl/parser-database/src/types.rs
+++ b/psl/parser-database/src/types.rs
@@ -24,7 +24,7 @@ pub(super) fn resolve_types(ctx: &mut Context<'_>) {
 #[derive(Debug, Default)]
 pub(super) struct Types {
     pub(super) composite_type_fields: BTreeMap<(ast::CompositeTypeId, ast::FieldId), CompositeTypeField>,
-    pub(super) scalar_fields: BTreeMap<(ast::ModelId, ast::FieldId), ScalarField>,
+    scalar_fields: Vec<ScalarField>,
     /// This contains only the relation fields actually present in the schema
     /// source text.
     relation_fields: Vec<RelationField>,
@@ -33,21 +33,31 @@ pub(super) struct Types {
     /// Sorted array of scalar fields that have an `@default()` attribute with a function that is
     /// not part of the base Prisma ones. This is meant for later validation in the datamodel
     /// connector.
-    pub(super) unknown_function_defaults: Vec<(ast::ModelId, ast::FieldId)>,
+    pub(super) unknown_function_defaults: Vec<ScalarFieldId>,
 }
 
 impl Types {
+    pub(super) fn find_model_scalar_field(
+        &self,
+        model_id: ast::ModelId,
+        field_id: ast::FieldId,
+    ) -> Option<ScalarFieldId> {
+        self.scalar_fields
+            .binary_search_by_key(&(model_id, field_id), |sf| (sf.model_id, sf.field_id))
+            .ok()
+            .map(|idx| ScalarFieldId(idx as u32))
+    }
+
     pub(super) fn range_model_scalar_fields(
         &self,
         model_id: ast::ModelId,
-    ) -> impl Iterator<Item = (ast::FieldId, &ScalarField)> {
-        self.scalar_fields
-            .range((model_id, ast::FieldId::MIN)..=(model_id, ast::FieldId::MAX))
-            .map(|((_, field_id), scalar_field)| (*field_id, scalar_field))
-    }
-
-    pub(super) fn take_scalar_field(&mut self, model_id: ast::ModelId, field_id: ast::FieldId) -> Option<ScalarField> {
-        self.scalar_fields.remove(&(model_id, field_id))
+    ) -> impl Iterator<Item = (ScalarFieldId, &ScalarField)> {
+        let start = self.scalar_fields.partition_point(|sf| sf.model_id < model_id);
+        self.scalar_fields[start..]
+            .iter()
+            .take_while(move |sf| sf.model_id == model_id)
+            .enumerate()
+            .map(move |(idx, sf)| (ScalarFieldId((start + idx) as u32), sf))
     }
 
     pub(super) fn iter_relation_field_ids(&self) -> impl Iterator<Item = RelationFieldId> + 'static {
@@ -59,6 +69,15 @@ impl Types {
             .iter()
             .enumerate()
             .map(|(idx, rf)| (RelationFieldId(idx as u32), rf))
+    }
+
+    pub(super) fn range_model_scalar_field_ids(
+        &self,
+        model_id: ast::ModelId,
+    ) -> impl Iterator<Item = ScalarFieldId> + Clone {
+        let end = self.scalar_fields.partition_point(|sf| sf.model_id <= model_id);
+        let start = self.scalar_fields[..end].partition_point(|sf| sf.model_id < model_id);
+        (start..end).map(|idx| ScalarFieldId(idx as u32))
     }
 
     pub(super) fn range_model_relation_fields(
@@ -73,21 +92,27 @@ impl Types {
             .map(move |(idx, rf)| (RelationFieldId((first_relation_field_idx + idx) as u32), rf))
     }
 
-    pub(super) fn refine_field(
-        &self,
-        id: (ast::ModelId, ast::FieldId),
-    ) -> Either<RelationFieldId, crate::walkers::ScalarFieldId> {
+    pub(super) fn refine_field(&self, id: (ast::ModelId, ast::FieldId)) -> Either<RelationFieldId, ScalarFieldId> {
         self.relation_fields
             .binary_search_by_key(&id, |rf| (rf.model_id, rf.field_id))
             .map(|idx| Either::Left(RelationFieldId(idx as u32)))
-            // INVARIANT: every field is either a relation field or a scalar field, so we don't
-            // need to check.
-            .unwrap_or_else(|_| Either::Right(crate::walkers::ScalarFieldId(id.0, id.1)))
+            .or_else(|_| {
+                self.scalar_fields
+                    .binary_search_by_key(&id, |sf| (sf.model_id, sf.field_id))
+                    .map(|id| Either::Right(ScalarFieldId(id as u32)))
+            })
+            .expect("expected field to be either scalar or relation field")
     }
 
     pub(super) fn push_relation_field(&mut self, relation_field: RelationField) -> RelationFieldId {
         let id = RelationFieldId(self.relation_fields.len() as u32);
         self.relation_fields.push(relation_field);
+        id
+    }
+
+    pub(super) fn push_scalar_field(&mut self, scalar_field: ScalarField) -> ScalarFieldId {
+        let id = ScalarFieldId(self.scalar_fields.len() as u32);
+        self.scalar_fields.push(scalar_field);
         id
     }
 }
@@ -103,6 +128,20 @@ impl std::ops::Index<RelationFieldId> for Types {
 impl std::ops::IndexMut<RelationFieldId> for Types {
     fn index_mut(&mut self, index: RelationFieldId) -> &mut Self::Output {
         &mut self.relation_fields[index.0 as usize]
+    }
+}
+
+impl std::ops::Index<ScalarFieldId> for Types {
+    type Output = ScalarField;
+
+    fn index(&self, index: ScalarFieldId) -> &Self::Output {
+        &self.scalar_fields[index.0 as usize]
+    }
+}
+
+impl std::ops::IndexMut<ScalarFieldId> for Types {
+    fn index_mut(&mut self, index: ScalarFieldId) -> &mut Self::Output {
+        &mut self.scalar_fields[index.0 as usize]
     }
 }
 
@@ -229,6 +268,8 @@ pub(crate) struct DefaultAttribute {
 
 #[derive(Debug)]
 pub(crate) struct ScalarField {
+    pub(crate) model_id: ast::ModelId,
+    pub(crate) field_id: ast::FieldId,
     pub(crate) r#type: ScalarFieldType,
     pub(crate) is_ignored: bool,
     pub(crate) is_updated_at: bool,
@@ -251,9 +292,9 @@ pub(crate) struct RelationField {
     pub(crate) on_delete: Option<(crate::ReferentialAction, ast::Span)>,
     pub(crate) on_update: Option<(crate::ReferentialAction, ast::Span)>,
     /// The fields _explicitly present_ in the AST.
-    pub(crate) fields: Option<Vec<ast::FieldId>>,
+    pub(crate) fields: Option<Vec<ScalarFieldId>>,
     /// The `references` fields _explicitly present_ in the AST.
-    pub(crate) references: Option<Vec<ast::FieldId>>,
+    pub(crate) references: Option<Vec<ScalarFieldId>>,
     /// The name _explicitly present_ in the AST.
     pub(crate) name: Option<StringId>,
     pub(crate) is_ignored: bool,
@@ -427,7 +468,7 @@ pub enum IndexType {
 pub(crate) struct IndexAttribute {
     pub(crate) r#type: IndexType,
     pub(crate) fields: Vec<FieldWithArgs>,
-    pub(crate) source_field: Option<ast::FieldId>,
+    pub(crate) source_field: Option<ScalarFieldId>,
     pub(crate) name: Option<StringId>,
     pub(crate) mapped_name: Option<StringId>,
     pub(crate) algorithm: Option<IndexAlgorithm>,
@@ -490,7 +531,7 @@ pub struct IndexFieldPath {
     ///   @@index([a.field])
     /// }
     /// ```
-    root: ast::FieldId,
+    root: ScalarFieldId,
     /// Path from the root, one composite type at a time. The final item is the
     /// field that gets included in the index.
     ///
@@ -510,7 +551,7 @@ pub struct IndexFieldPath {
 }
 
 impl IndexFieldPath {
-    pub(crate) fn new(root: ast::FieldId) -> Self {
+    pub(crate) fn new(root: ScalarFieldId) -> Self {
         Self { root, path: Vec::new() }
     }
 
@@ -534,7 +575,7 @@ impl IndexFieldPath {
     ///   @@index([a.field])
     /// }
     /// ```
-    pub fn root(&self) -> ast::FieldId {
+    pub fn root(&self) -> ScalarFieldId {
         self.root
     }
 
@@ -562,15 +603,11 @@ impl IndexFieldPath {
     /// or in a composite type embedded in the model. Returns the same value as
     /// the [`root`](Self::root()) method if the field is in a model rather than in a
     /// composite type.
-    pub fn field_in_index(&self) -> ast::FieldId {
-        self.path.last().map(|(_, field_id)| *field_id).unwrap_or(self.root)
-    }
-
-    /// If the indexed field is in a composite type embedded to the model, gives
-    /// a pointer to the type. Use this method to determine the type of the
-    /// index field.
-    pub fn type_holding_the_indexed_field(&self) -> Option<ast::CompositeTypeId> {
-        self.path.last().map(|(ctid, _)| *ctid)
+    pub fn field_in_index(&self) -> Either<ScalarFieldId, (ast::CompositeTypeId, ast::FieldId)> {
+        self.path
+            .last()
+            .map(|id| Either::Right(*id))
+            .unwrap_or(Either::Left(self.root))
     }
 }
 
@@ -602,16 +639,16 @@ fn visit_model<'db>(model_id: ast::ModelId, ast_model: &'db ast::Model, ctx: &mu
                 ctx.types.push_relation_field(rf);
             }
             Ok(FieldType::Scalar(scalar_field_type)) => {
-                let field_data = ScalarField {
+                ctx.types.push_scalar_field(ScalarField {
+                    model_id,
+                    field_id,
                     r#type: scalar_field_type,
                     is_ignored: false,
                     is_updated_at: false,
                     default: None,
                     mapped_name: None,
                     native_type: None,
-                };
-
-                ctx.types.scalar_fields.insert((model_id, field_id), field_data);
+                });
             }
             Err(supported) => ctx.push_error(DatamodelError::new_type_not_found_error(
                 supported,
@@ -1407,3 +1444,7 @@ impl ScalarType {
 /// An opaque identifier for a model relation field in a schema.
 #[derive(Copy, Clone, PartialEq, Debug, Hash, Eq, PartialOrd, Ord)]
 pub struct RelationFieldId(u32);
+
+/// An opaque identifier for a model scalar field in a schema.
+#[derive(Copy, Clone, PartialEq, Debug, Eq, Hash)]
+pub struct ScalarFieldId(u32);

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -104,14 +104,10 @@ impl crate::ParserDatabase {
         self.types
             .unknown_function_defaults
             .iter()
-            .map(|(model_id, field_id)| DefaultValueWalker {
-                model_id: *model_id,
-                field_id: *field_id,
+            .map(|id| DefaultValueWalker {
+                field_id: *id,
                 db: self,
-                default: self.types.scalar_fields[&(*model_id, *field_id)]
-                    .default
-                    .as_ref()
-                    .unwrap(),
+                default: self.types[*id].default.as_ref().unwrap(),
             })
     }
 

--- a/psl/parser-database/src/walkers/field.rs
+++ b/psl/parser-database/src/walkers/field.rs
@@ -1,5 +1,8 @@
 use super::{CompositeTypeFieldWalker, ModelWalker, RelationFieldWalker, ScalarFieldWalker, Walker};
-use crate::{types::RelationField, ScalarType};
+use crate::{
+    types::{RelationField, ScalarField},
+    ScalarType,
+};
 use schema_ast::ast;
 
 /// A model field, scalar or relation.
@@ -41,9 +44,10 @@ pub enum RefinedFieldWalker<'db> {
 
 impl<'db> From<ScalarFieldWalker<'db>> for FieldWalker<'db> {
     fn from(w: ScalarFieldWalker<'db>) -> Self {
+        let ScalarField { model_id, field_id, .. } = w.db.types[w.id];
         Walker {
             db: w.db,
-            id: (w.id.0, w.id.1),
+            id: (model_id, field_id),
         }
     }
 }

--- a/psl/parser-database/src/walkers/index.rs
+++ b/psl/parser-database/src/walkers/index.rs
@@ -1,4 +1,6 @@
-use super::{CompositeTypeFieldWalker, ScalarFieldId};
+use either::Either;
+
+use super::CompositeTypeFieldWalker;
 use crate::{
     ast,
     types::{IndexAlgorithm, IndexAttribute},
@@ -105,21 +107,13 @@ impl<'db> IndexWalker<'db> {
 
     /// The scalar fields covered by the index.
     pub fn fields(self) -> impl ExactSizeIterator<Item = IndexFieldWalker<'db>> {
-        self.index_attribute.fields.iter().map(move |attributes| {
-            let path = &attributes.path;
-            let field_id = path.field_in_index();
-
-            match path.type_holding_the_indexed_field() {
-                Some(ctid) => {
-                    let walker = self.db.walk((ctid, field_id));
-                    IndexFieldWalker::new(walker)
-                }
-                None => {
-                    let walker = self.db.walk(ScalarFieldId(self.model_id, field_id));
-                    IndexFieldWalker::new(walker)
-                }
-            }
-        })
+        self.index_attribute
+            .fields
+            .iter()
+            .map(move |attributes| match attributes.path.field_in_index() {
+                Either::Left(ctid) => IndexFieldWalker::new(self.db.walk(ctid)),
+                Either::Right(id) => IndexFieldWalker::new(self.db.walk(id)),
+            })
     }
 
     /// The scalar fields covered by the index, and their arguments.
@@ -129,7 +123,6 @@ impl<'db> IndexWalker<'db> {
             .iter()
             .enumerate()
             .map(move |(field_arg_id, _)| ScalarFieldAttributeWalker {
-                model_id: self.model_id,
                 fields: &self.attribute().fields,
                 db: self.db,
                 field_arg_id,
@@ -192,9 +185,7 @@ impl<'db> IndexWalker<'db> {
 
     /// The field the model was defined on, if any.
     pub fn source_field(self) -> Option<ScalarFieldWalker<'db>> {
-        self.index_attribute
-            .source_field
-            .map(|field_id| self.db.walk(ScalarFieldId(self.model_id, field_id)))
+        self.index_attribute.source_field.map(|field_id| self.db.walk(field_id))
     }
 }
 

--- a/psl/parser-database/src/walkers/model/primary_key.rs
+++ b/psl/parser-database/src/walkers/model/primary_key.rs
@@ -1,8 +1,8 @@
 use crate::{
     ast,
     types::IdAttribute,
-    walkers::{ModelWalker, ScalarFieldAttributeWalker, ScalarFieldId, ScalarFieldWalker},
-    ParserDatabase,
+    walkers::{ModelWalker, ScalarFieldAttributeWalker, ScalarFieldWalker},
+    ParserDatabase, ScalarFieldId,
 };
 
 /// An `@(@)id` attribute in the schema.
@@ -66,10 +66,10 @@ impl<'db> PrimaryKeyWalker<'db> {
 
     /// The scalar fields constrained by the id.
     pub fn fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
-        self.attribute.fields.iter().map(move |field| {
-            let field_id = field.path.field_in_index();
-            self.db.walk(ScalarFieldId(self.model_id, field_id))
-        })
+        self.attribute
+            .fields
+            .iter()
+            .map(move |field| self.db.walk(field.path.root()))
     }
 
     /// The scalar fields covered by the id, and their arguments.
@@ -79,7 +79,6 @@ impl<'db> PrimaryKeyWalker<'db> {
             .iter()
             .enumerate()
             .map(move |(field_arg_id, _)| ScalarFieldAttributeWalker {
-                model_id: self.model_id,
                 fields: &self.attribute.fields,
                 db: self.db,
                 field_arg_id,
@@ -87,14 +86,14 @@ impl<'db> PrimaryKeyWalker<'db> {
     }
 
     /// Do the constrained fields match exactly these?
-    pub(crate) fn contains_exactly_fields_by_id(self, fields: &[ast::FieldId]) -> bool {
+    pub(crate) fn contains_exactly_fields_by_id(self, fields: &[ScalarFieldId]) -> bool {
         self.attribute.fields.len() == fields.len()
             && self
                 .attribute
                 .fields
                 .iter()
                 .zip(fields)
-                .all(|(a, b)| a.path.field_in_index() == *b)
+                .all(|(a, b)| matches!(a.path.field_in_index(), either::Either::Left(id)  if id == *b))
     }
 
     /// Do the constrained fields match exactly these?

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -1,5 +1,5 @@
 use crate::{
-    walkers::{ModelWalker, RelationFieldId, RelationFieldWalker, ScalarFieldId, ScalarFieldWalker},
+    walkers::{ModelWalker, RelationFieldId, RelationFieldWalker, ScalarFieldWalker},
     ParserDatabase, ReferentialAction,
 };
 use schema_ast::ast;
@@ -35,28 +35,22 @@ impl<'db> CompleteInlineRelationWalker<'db> {
 
     /// The scalar fields defining the relation on the referenced model.
     pub fn referenced_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
-        let f = move |field_id: &ast::FieldId| {
-            let model_id = self.referenced_model().id;
-            self.db.walk(ScalarFieldId(model_id, *field_id))
-        };
-
-        match self.referencing_field().attributes().references.as_ref() {
-            Some(references) => references.iter().map(f),
-            None => [].iter().map(f),
-        }
+        (match self.referencing_field().attributes().references.as_ref() {
+            Some(references) => references.as_slice(),
+            None => &[],
+        })
+        .iter()
+        .map(|id| self.db.walk(*id))
     }
 
     /// The scalar fields on the defining the relation on the referencing model.
     pub fn referencing_fields(self) -> impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + 'db {
-        let f = move |field_id: &ast::FieldId| {
-            let model_id = self.referencing_model().id;
-            self.db.walk(ScalarFieldId(model_id, *field_id))
-        };
-
-        match self.referencing_field().attributes().fields.as_ref() {
-            Some(references) => references.iter().map(f),
-            None => [].iter().map(f),
-        }
+        (match self.referencing_field().attributes().fields.as_ref() {
+            Some(references) => references.as_slice(),
+            None => &[],
+        })
+        .iter()
+        .map(|id| self.db.walk(*id))
     }
 
     /// Gives the onUpdate referential action of the relation. If not defined

--- a/psl/parser-database/src/walkers/relation_field.rs
+++ b/psl/parser-database/src/walkers/relation_field.rs
@@ -98,11 +98,10 @@ impl<'db> RelationFieldWalker<'db> {
 
     /// The fields in the `@relation(references: ...)` argument.
     pub fn referenced_fields(self) -> Option<impl ExactSizeIterator<Item = ScalarFieldWalker<'db>>> {
-        self.attributes().references.as_ref().map(|references| {
-            references
-                .iter()
-                .map(move |field_id| self.walk(ScalarFieldId(self.related_model().id, *field_id)))
-        })
+        self.attributes()
+            .references
+            .as_ref()
+            .map(|references| references.iter().map(move |field_id| self.walk(*field_id)))
     }
 
     /// The relation this field is part of.
@@ -157,11 +156,10 @@ impl<'db> RelationFieldWalker<'db> {
     /// The fields in the `fields: [...]` argument in the forward relation field.
     pub fn fields(self) -> Option<impl ExactSizeIterator<Item = ScalarFieldWalker<'db>> + Clone> {
         let attributes = &self.db.types[self.id];
-        attributes.fields.as_ref().map(move |fields| {
-            fields
-                .iter()
-                .map(move |field_id| self.db.walk(super::ScalarFieldId(attributes.model_id, *field_id)))
-        })
+        attributes
+            .fields
+            .as_ref()
+            .map(move |fields| fields.iter().map(move |field_id| self.db.walk(*field_id)))
     }
 }
 

--- a/query-engine/dml/src/field.rs
+++ b/query-engine/dml/src/field.rs
@@ -6,7 +6,8 @@ use crate::relation_info::RelationInfo;
 use crate::scalars::ScalarType;
 use crate::traits::{WithDatabaseName, WithName};
 use crate::FieldArity;
-use psl_core::{parser_database::walkers::ScalarFieldId, schema_ast::ast};
+use psl_core::parser_database::ScalarFieldId;
+use psl_core::schema_ast::ast;
 
 /// Datamodel field type.
 #[derive(Debug, PartialEq, Clone)]

--- a/query-engine/prisma-models/src/field/composite.rs
+++ b/query-engine/prisma-models/src/field/composite.rs
@@ -1,11 +1,11 @@
 use crate::{parent_container::ParentContainer, CompositeType};
 use dml::FieldArity;
-use psl::{parser_database::walkers, schema_ast::ast};
+use psl::{parser_database::ScalarFieldId, schema_ast::ast};
 use std::fmt::{Debug, Display};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum CompositeFieldId {
-    InModel(walkers::ScalarFieldId),
+    InModel(ScalarFieldId),
     InCompositeType((ast::CompositeTypeId, ast::FieldId)),
 }
 

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -8,7 +8,7 @@ pub type ScalarFieldRef = ScalarField;
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum ScalarFieldId {
-    InModel(walkers::ScalarFieldId),
+    InModel(psl::parser_database::ScalarFieldId),
     InCompositeType((ast::CompositeTypeId, ast::FieldId)),
 }
 


### PR DESCRIPTION
Do for scalar fields what we did for relation fields in
b2df30f451ffb49da741b3174c448f78a7004dd7. We see similar advantage in
code organization, and a smaller but still very appreciable performance
gain in the chema builder benchmarks. We see 10 to 15% improvements on
speed for psl::validate() and schema_builder::build() across the board.

Full benchmark results below (difference between this commit and current
main, 9fc74ad978eed3bdc571514107b4406fe7174c95):

Benchmarking psl::validate (small): Collecting 100 samples in estimated 5.9219 s (15k
psl::validate (small)   time:   [390.50 µs 390.58 µs 390.65 µs]
                        change: [-9.3097% -8.7443% -8.3227%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  3 (3.00%) high severe

Benchmarking schema_builder::build (small): Collecting 100 samples in estimated 5.1860
schema_builder::build (small)
                        time:   [1.9907 ms 1.9910 ms 1.9912 ms]
                        change: [-14.481% -14.459% -14.437%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  1 (1.00%) high mild

Benchmarking psl::validate (medium): Collecting 100 samples in estimated 5.1496 s (190
psl::validate (medium)  time:   [2.7070 ms 2.7077 ms 2.7084 ms]
                        change: [-10.966% -10.937% -10.911%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking schema_builder::build (medium): Collecting 100 samples in estimated 6.230
schema_builder::build (medium)
                        time:   [15.549 ms 15.556 ms 15.563 ms]
                        change: [-16.949% -16.896% -16.846%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) low mild
 
psl::validate (large)   time:   [11.551 ms 11.557 ms 11.565 ms]
                        change: [-9.1041% -9.0521% -8.9906%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
 
Benchmarking schema_builder::build (large): Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 22.9s, or reduce sample count to 20.
schema_builder::build (large)
                        time:   [226.69 ms 226.94 ms 227.22 ms]
                        change: [-16.626% -16.510% -16.390%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  9 (9.00%) high mild
  1 (1.00%) high severe