### PR TITLE
Add onlyCreate boolean flag to create record operation

### DIFF
--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -75,7 +75,7 @@ impl QueryGraphBuilder {
             (QueryTag::FindMany, Some(m)) => read::find_many(parsed_field, m).map(Into::into),
             (QueryTag::Aggregate, Some(m)) => read::aggregate(parsed_field, m).map(Into::into),
             (QueryTag::GroupBy, Some(m)) => read::group_by(parsed_field, m).map(Into::into),
-            (QueryTag::CreateOne, Some(m)) => QueryGraph::root(|g| write::create_record(g, connector_ctx, m, parsed_field, Some(true))),
+            (QueryTag::CreateOne, Some(m)) => QueryGraph::root(|g| write::create_record(g, connector_ctx, m, parsed_field, Option(None))),
             (QueryTag::CreateMany, Some(m)) => QueryGraph::root(|g| write::create_many_records(g,  connector_ctx,m, parsed_field)),
             (QueryTag::UpdateOne, Some(m)) => QueryGraph::root(|g| write::update_record(g, connector_ctx, m, parsed_field)),
             (QueryTag::UpdateMany, Some(m)) => QueryGraph::root(|g| write::update_many_records(g, connector_ctx, m, parsed_field)),

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -75,7 +75,7 @@ impl QueryGraphBuilder {
             (QueryTag::FindMany, Some(m)) => read::find_many(parsed_field, m).map(Into::into),
             (QueryTag::Aggregate, Some(m)) => read::aggregate(parsed_field, m).map(Into::into),
             (QueryTag::GroupBy, Some(m)) => read::group_by(parsed_field, m).map(Into::into),
-            (QueryTag::CreateOne, Some(m)) => QueryGraph::root(|g| write::create_record(g, connector_ctx, m, parsed_field)),
+            (QueryTag::CreateOne, Some(m)) => QueryGraph::root(|g| write::create_record(g, connector_ctx, m, parsed_field, Some(true))),
             (QueryTag::CreateMany, Some(m)) => QueryGraph::root(|g| write::create_many_records(g,  connector_ctx,m, parsed_field)),
             (QueryTag::UpdateOne, Some(m)) => QueryGraph::root(|g| write::update_record(g, connector_ctx, m, parsed_field)),
             (QueryTag::UpdateMany, Some(m)) => QueryGraph::root(|g| write::update_many_records(g, connector_ctx, m, parsed_field)),

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -75,7 +75,7 @@ impl QueryGraphBuilder {
             (QueryTag::FindMany, Some(m)) => read::find_many(parsed_field, m).map(Into::into),
             (QueryTag::Aggregate, Some(m)) => read::aggregate(parsed_field, m).map(Into::into),
             (QueryTag::GroupBy, Some(m)) => read::group_by(parsed_field, m).map(Into::into),
-            (QueryTag::CreateOne, Some(m)) => QueryGraph::root(|g| write::create_record(g, connector_ctx, m, parsed_field, Option(None))),
+            (QueryTag::CreateOne, Some(m)) => QueryGraph::root(|g| write::create_record(g, connector_ctx, m, parsed_field, tracing::log::__private_api::Option::Some(true))),
             (QueryTag::CreateMany, Some(m)) => QueryGraph::root(|g| write::create_many_records(g,  connector_ctx,m, parsed_field)),
             (QueryTag::UpdateOne, Some(m)) => QueryGraph::root(|g| write::update_record(g, connector_ctx, m, parsed_field)),
             (QueryTag::UpdateMany, Some(m)) => QueryGraph::root(|g| write::update_many_records(g, connector_ctx, m, parsed_field)),

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -30,9 +30,9 @@ pub fn create_record(
 
     // if only_create is defined and it is set to true, we don't need to follow up with a read query
     if only_create.is_some() && only_create.unwrap() {
+        graph.add_result_node(&create_node);
         return Ok(());
     }
-
 
     // Follow-up read query on the write
     let read_query = read::find_unique(field, model.clone())?;

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -17,6 +17,7 @@ pub fn create_record(
     connector_ctx: &ConnectorContext,
     model: ModelRef,
     mut field: ParsedField,
+    only_create: Option<bool>
 ) -> QueryGraphBuilderResult<()> {
     graph.flag_transactional();
 
@@ -26,6 +27,12 @@ pub fn create_record(
     };
 
     let create_node = create::create_record_node(graph, connector_ctx, model.clone(), data_map)?;
+
+    // if only_create is defined and it is set to true, we don't need to follow up with a read query
+    if only_create.is_some() && only_create.unwrap() {
+        return Ok(());
+    }
+
 
     // Follow-up read query on the write
     let read_query = read::find_unique(field, model.clone())?;


### PR DESCRIPTION
Prisma has an open issue that claims for the possibility to skip the default select query that is made after creating a record.

_Referred issue_: [4246](https://github.com/prisma/prisma/issues/4246)

As the first step to solve this, I have added a new parameter called `only_create`  to the `create_record` function. This parameter is a boolean option, and it will determine if the select query should be executed or not.

I am facing some problems running the unit tests on my machine, trying to solve this as soon as possible to ensure that all tests pass with this new change in the code.