### PR TITLE
psl: remove recently introduced let..else instances

### DIFF
--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -848,7 +848,9 @@ fn resolve_field_array_without_args<'db>(
         };
 
         // Is the field a scalar field?
-        let Some(sfid) = ctx.types.find_model_scalar_field(model_id, field_id) else{
+        let sfid = if let Some(sfid) = ctx.types.find_model_scalar_field(model_id, field_id) {
+            sfid
+        } else {
             relation_fields.push((&ctx.ast[model_id][field_id], field_id));
             continue;
         };
@@ -933,7 +935,9 @@ fn resolve_field_array_with_args<'db>(
                         }
                     };
 
-                    let Some(sfid) = ctx.types.find_model_scalar_field(model_id, field_id) else {
+                    let sfid = if let Some(sfid) = ctx.types.find_model_scalar_field(model_id, field_id) {
+                        sfid
+                    } else {
                         relation_fields.push((&ctx.ast[model_id][field_id], field_id));
                         continue 'fields;
                     };


### PR DESCRIPTION
We are still constrained to an older rustc version by the debian build images. This will change with Prisma 5. See https://buildkite.com/prisma/release-prisma-engines/builds/2926#0186eb73-3fb7-4627-9210-be68edc4fb74