### PR TITLE
query-core: enforce rust_2018_idioms

### DIFF
--- a/query-engine/core/src/interpreter/error.rs
+++ b/query-engine/core/src/interpreter/error.rs
@@ -26,7 +26,7 @@ pub enum InterpreterError {
 }
 
 impl fmt::Display for InterpreterError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::QueryGraphBuilderError(e) => write!(f, "{e:?}"),
             _ => write!(f, "Error occurred during query execution:\n{self:?}"),

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -156,7 +156,7 @@ impl<'conn> QueryInterpreter<'conn> {
         tracing::level_filters::STATIC_MAX_LEVEL == tracing::level_filters::LevelFilter::TRACE
     }
 
-    pub fn new(conn: &'conn mut dyn ConnectionLike) -> QueryInterpreter {
+    pub fn new(conn: &'conn mut dyn ConnectionLike) -> QueryInterpreter<'_> {
         let log = SegQueue::new();
 
         if Self::log_enabled() {

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate tracing;
 
@@ -39,5 +41,5 @@ use self::{
 pub type Result<T> = std::result::Result<T, CoreError>;
 
 // Re-exports
-pub extern crate schema;
-pub extern crate schema_builder;
+pub use schema;
+pub use schema_builder;

--- a/query-engine/core/src/query_ast/mod.rs
+++ b/query-engine/core/src/query_ast/mod.rs
@@ -93,7 +93,7 @@ pub trait FilteredNestedMutation {
 }
 
 impl std::fmt::Display for Query {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Read(q) => write!(f, "{q}"),
             Self::Write(q) => write!(f, "{q}"),

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -55,7 +55,7 @@ impl FilteredQuery for ReadQuery {
 }
 
 impl Display for ReadQuery {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::RecordQuery(q) => write!(
                 f,

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -130,7 +130,7 @@ impl FilteredQuery for WriteQuery {
 }
 
 impl std::fmt::Display for WriteQuery {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::CreateRecord(q) => write!(f, "CreateRecord(model: {}, args: {:?})", q.model.name(), q.args),
             Self::CreateManyRecords(q) => write!(f, "CreateManyRecord(model: {})", q.model.name()),

--- a/query-engine/core/src/query_document/error.rs
+++ b/query-engine/core/src/query_document/error.rs
@@ -15,7 +15,7 @@ pub enum QueryParserError {
 }
 
 impl fmt::Display for QueryParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Legacy { path, error_kind } => {
                 write!(f, "Query parsing/validation error at `{path}`: {error_kind}")
@@ -59,7 +59,7 @@ impl QueryPath {
 }
 
 impl fmt::Display for QueryPath {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.segments.join("."))
     }
 }

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -52,7 +52,7 @@ fn stringify_nodes(graph: &QueryGraph, nodes: Vec<NodeRef>, seen_nodes: &mut Vec
 }
 
 impl Display for Flow {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::If(_) => write!(f, "(If (condition func)"),
             Self::Return(_) => write!(f, "(return results)"),
@@ -61,7 +61,7 @@ impl Display for Flow {
 }
 
 impl Display for Computation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Diff(_) => write!(f, "Diff"),
         }
@@ -69,7 +69,7 @@ impl Display for Computation {
 }
 
 impl Display for Node {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Query(q) => write!(f, "{q}"),
             Self::Flow(flow) => write!(f, "{flow}"),
@@ -91,19 +91,19 @@ impl ToGraphviz for Node {
 }
 
 impl Display for NodeRef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Node {}", self.id())
     }
 }
 
 impl Display for QueryGraph {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", format(self))
     }
 }
 
 impl Display for QueryGraphDependency {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ExecutionOrder => write!(f, "ExecutionOrder"),
             Self::DataDependency(_) => write!(f, "ParentResult"),

--- a/query-engine/core/src/telemetry/capturing/helpers.rs
+++ b/query-engine/core/src/telemetry/capturing/helpers.rs
@@ -2,7 +2,7 @@ use tracing::Metadata;
 
 /// Filters-in spans and events that are statically determined to be relevant for capturing
 /// Dynamic filtering will be done by the [`crate::capturer::Processor`]
-pub fn span_and_event_filter(meta: &Metadata) -> bool {
+pub fn span_and_event_filter(meta: &Metadata<'_>) -> bool {
     if meta.fields().iter().any(|f| f.name() == "user_facing") {
         return true;
     }

--- a/query-engine/core/src/telemetry/helpers.rs
+++ b/query-engine/core/src/telemetry/helpers.rs
@@ -109,7 +109,7 @@ pub fn env_filter(log_queries: bool, qe_log_level: QueryEngineLogLevel) -> EnvFi
     filter
 }
 
-pub fn user_facing_span_only_filter(meta: &Metadata) -> bool {
+pub fn user_facing_span_only_filter(meta: &Metadata<'_>) -> bool {
     if !meta.is_span() {
         return false;
     }

--- a/query-engine/core/src/telemetry/models.rs
+++ b/query-engine/core/src/telemetry/models.rs
@@ -67,7 +67,7 @@ impl From<SpanData> for TraceSpan {
 
         let is_quaint_query = matches!(span.name, Cow::Borrowed("quaint:query"));
 
-        let name: Cow<str> = if is_quaint_query {
+        let name: Cow<'_, str> = if is_quaint_query {
             "prisma:engine:db_query".into()
         } else {
             span.name.clone()


### PR DESCRIPTION
This mostly means that lifetime parameters of types can't be omitted. For clarity.