### PR TITLE
qe: remove trait indirection in query schema rendering

### DIFF
--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
@@ -17,23 +17,19 @@ use std::{
 };
 use type_renderer::*;
 
-pub struct DmmfQuerySchemaRenderer;
+pub(crate) fn render(query_schema: QuerySchemaRef) -> (DmmfSchema, DmmfOperationMappings) {
+    let mut ctx = RenderContext::new();
+    ctx.mark_to_be_rendered(&query_schema);
 
-impl QuerySchemaRenderer<(DmmfSchema, DmmfOperationMappings)> for DmmfQuerySchemaRenderer {
-    fn render(query_schema: QuerySchemaRef) -> (DmmfSchema, DmmfOperationMappings) {
-        let mut ctx = RenderContext::new();
-        ctx.mark_to_be_rendered(&query_schema);
+    while !ctx.next_pass.is_empty() {
+        let renderers = std::mem::take(&mut ctx.next_pass);
 
-        while !ctx.next_pass.is_empty() {
-            let renderers = std::mem::take(&mut ctx.next_pass);
-
-            for renderer in renderers {
-                renderer.render(&mut ctx)
-            }
+        for renderer in renderers {
+            renderer.render(&mut ctx)
         }
-
-        ctx.finalize()
     }
+
+    ctx.finalize()
 }
 
 #[derive(Default)]

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -6,8 +6,8 @@ mod tests;
 
 pub use serialization_ast::DataModelMetaFormat;
 
-use ast_builders::{schema_to_dmmf, DmmfQuerySchemaRenderer};
-use schema::{QuerySchemaRef, QuerySchemaRenderer};
+use ast_builders::schema_to_dmmf;
+use schema::QuerySchemaRef;
 use std::sync::Arc;
 
 pub fn dmmf_json_from_schema(schema: &str) -> String {
@@ -23,7 +23,7 @@ pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
 
 pub fn from_precomputed_parts(query_schema: QuerySchemaRef) -> DataModelMetaFormat {
     let data_model = schema_to_dmmf(&query_schema.internal_data_model.schema);
-    let (schema, mappings) = DmmfQuerySchemaRenderer::render(query_schema);
+    let (schema, mappings) = ast_builders::render(query_schema);
 
     DataModelMetaFormat {
         data_model,

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -2,13 +2,10 @@ use crate::{engine::executor::TransactionOptions, error::ApiError, log_callback:
 use futures::FutureExt;
 use psl::PreviewFeature;
 use query_core::{
-    executor,
-    protocol::EngineProtocol,
-    schema::{QuerySchema, QuerySchemaRenderer},
-    schema_builder, telemetry, QueryExecutor, TxId,
+    executor, protocol::EngineProtocol, schema::QuerySchema, schema_builder, telemetry, QueryExecutor, TxId,
 };
 use query_engine_metrics::{MetricFormat, MetricRegistry};
-use request_handlers::{dmmf, GraphQLSchemaRenderer, RequestBody, RequestHandler};
+use request_handlers::{dmmf, render_graphql_schema, RequestBody, RequestHandler};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -434,7 +431,7 @@ impl QueryEngine {
             let inner = self.inner.read().await;
             let engine = inner.as_engine()?;
 
-            Ok(GraphQLSchemaRenderer::render(engine.query_schema().clone()))
+            Ok(render_graphql_schema(engine.query_schema().clone()))
         })
         .await
     }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -7,11 +7,9 @@ use opentelemetry::trace::TraceContextExt;
 use opentelemetry::{global, propagation::Extractor};
 use query_core::helpers::*;
 use query_core::telemetry::capturing::TxTraceExt;
-use query_core::{
-    schema::QuerySchemaRenderer, telemetry, ExtendedTransactionUserFacingError, TransactionOptions, TxId,
-};
+use query_core::{telemetry, ExtendedTransactionUserFacingError, TransactionOptions, TxId};
 use query_engine_metrics::MetricFormat;
-use request_handlers::{dmmf, GraphQLSchemaRenderer, RequestBody, RequestHandler};
+use request_handlers::{dmmf, render_graphql_schema, RequestBody, RequestHandler};
 use serde_json::json;
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -65,7 +63,7 @@ pub async fn routes(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<Respon
             .unwrap(),
 
         (&Method::GET, "/sdl") => {
-            let schema = GraphQLSchemaRenderer::render(cx.query_schema().clone());
+            let schema = render_graphql_schema(cx.query_schema().clone());
 
             Response::builder()
                 .status(StatusCode::OK)

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/enum_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/enum_renderer.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-pub struct GqlEnumRenderer<'a> {
+pub(crate) struct GqlEnumRenderer<'a> {
     enum_type: &'a EnumType,
 }
 
@@ -19,7 +19,7 @@ impl<'a> Renderer for GqlEnumRenderer<'a> {
 }
 
 impl<'a> GqlEnumRenderer<'a> {
-    pub fn new(enum_type: &EnumType) -> GqlEnumRenderer {
+    pub(crate) fn new(enum_type: &EnumType) -> GqlEnumRenderer {
         GqlEnumRenderer { enum_type }
     }
 

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[derive(Debug)]
-pub enum GqlFieldRenderer {
+pub(crate) enum GqlFieldRenderer {
     Input(InputFieldRef),
     Output(OutputFieldRef),
 }

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
@@ -13,11 +13,8 @@ use std::{
 };
 use type_renderer::*;
 
-#[allow(dead_code)]
-pub struct GraphQLSchemaRenderer;
-
 /// Top level GraphQL schema renderer.
-pub struct GqlSchemaRenderer {
+struct GqlSchemaRenderer {
     query_schema: QuerySchemaRef,
 }
 
@@ -29,29 +26,27 @@ impl Renderer for GqlSchemaRenderer {
 }
 
 impl GqlSchemaRenderer {
-    pub fn new(query_schema: QuerySchemaRef) -> GqlSchemaRenderer {
+    fn new(query_schema: QuerySchemaRef) -> GqlSchemaRenderer {
         GqlSchemaRenderer { query_schema }
     }
 }
 
-impl QuerySchemaRenderer<String> for GraphQLSchemaRenderer {
-    fn render(query_schema: QuerySchemaRef) -> String {
-        let mut context = RenderContext::new();
-        query_schema.into_renderer().render(&mut context);
+pub fn render_graphql_schema(query_schema: QuerySchemaRef) -> String {
+    let mut context = RenderContext::new();
+    query_schema.into_renderer().render(&mut context);
 
-        // Add custom scalar types (required for graphql.js implementations)
-        format!(
-            "{}\n\nscalar DateTime\nscalar Json\nscalar UUID\nscalar BigInt\nscalar Decimal\nscalar Bytes",
-            context.format()
-        )
-    }
+    // Add custom scalar types (required for graphql.js implementations)
+    format!(
+        "{}\n\nscalar DateTime\nscalar Json\nscalar UUID\nscalar BigInt\nscalar Decimal\nscalar Bytes",
+        context.format()
+    )
 }
 
-pub trait Renderer {
+trait Renderer {
     fn render(&self, ctx: &mut RenderContext) -> String;
 }
 
-pub struct RenderContext {
+struct RenderContext {
     /// Output queue for all (top level) elements that need to be rendered,
     output_queue: Vec<String>,
 
@@ -77,32 +72,32 @@ impl Default for RenderContext {
 }
 
 impl RenderContext {
-    pub fn new() -> RenderContext {
+    fn new() -> RenderContext {
         Self::default()
     }
 
-    pub fn format(self) -> String {
+    fn format(self) -> String {
         self.output_queue.join("\n\n")
     }
 
-    pub fn already_rendered(&self, cache_key: &str) -> bool {
+    fn already_rendered(&self, cache_key: &str) -> bool {
         self.rendered.contains_key(cache_key)
     }
 
-    pub fn mark_as_rendered(&mut self, cache_key: String) {
+    fn mark_as_rendered(&mut self, cache_key: String) {
         self.rendered.insert(cache_key, ());
     }
 
-    pub fn add_output(&mut self, output: String) {
+    fn add_output(&mut self, output: String) {
         self.output_queue.push(output);
     }
 
-    pub fn add(&mut self, cache_key: String, output: String) {
+    fn add(&mut self, cache_key: String, output: String) {
         self.add_output(output);
         self.mark_as_rendered(cache_key);
     }
 
-    pub fn indent(&self) -> String {
+    fn indent(&self) -> String {
         self.indent_str.repeat(self.indent)
     }
 }

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -1,4 +1,3 @@
-#![warn(warnings)]
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 mod enum_type;
@@ -6,7 +5,6 @@ mod identifier_type;
 mod input_types;
 mod output_types;
 mod query_schema;
-mod renderer;
 mod utils;
 
 pub use enum_type::*;
@@ -14,7 +12,6 @@ pub use identifier_type::*;
 pub use input_types::*;
 pub use output_types::*;
 pub use query_schema::*;
-pub use renderer::*;
 pub use utils::*;
 
 use std::sync::{Arc, Weak};

--- a/query-engine/schema/src/renderer.rs
+++ b/query-engine/schema/src/renderer.rs
@@ -1,6 +1,0 @@
-use super::QuerySchemaRef;
-
-/// Trait that should be implemented in order to be able to render a query schema.
-pub trait QuerySchemaRenderer<T> {
-    fn render(query_schema: QuerySchemaRef) -> T;
-}


### PR DESCRIPTION
We have a trait with a generic parameter (QuerySchemaRenderer) that can be replaced with two pure, plain functions with one argument. The complexity isn't justified.