### PR TITLE
tests: upgrade vitess (vttestserver) images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -181,7 +181,7 @@ services:
     tmpfs: /var/lib/mariadb
 
   vitess-test-5_7:
-    image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
+    image: vitess/vttestserver:mysql57@sha256:fb4ddbe55a96e66d979dd57e0ccfc14c506b1cd26c699e25d879200274d5abf3
     restart: always
     ports:
       - 33577:33577
@@ -193,7 +193,7 @@ services:
       FOREIGN_KEY_MODE: "disallow"
 
   vitess-test-8_0:
-    image: vitess/vttestserver:mysql80@sha256:9412e3d51bde38e09c3039090b5c68808e299579f12c79178a4ec316f7831889
+    image: vitess/vttestserver:mysql80@sha256:f7a568447510dab3dd58ee9f6b84241d58645f6db8969babb3e0ad9bbda8c22a
     restart: always
     ports:
       - 33807:33807
@@ -203,9 +203,10 @@ services:
       NUM_SHARDS: "1"
       MYSQL_BIND_HOST: "0.0.0.0"
       FOREIGN_KEY_MODE: "disallow"
+      TABLET_REFRESH_INTERVAL: "500ms"
 
   vitess-shadow-5_7:
-    image: vitess/vttestserver:mysql57@sha256:2b132a22d08b3b227d9391f8f58ed7ab5c081ca07bf0f87a0c166729124d360a
+    image: vitess/vttestserver:mysql57@sha256:fb4ddbe55a96e66d979dd57e0ccfc14c506b1cd26c699e25d879200274d5abf3
     restart: always
     ports:
       - 33578:33577
@@ -217,7 +218,7 @@ services:
       FOREIGN_KEY_MODE: "disallow"
 
   vitess-shadow-8_0:
-    image: vitess/vttestserver:mysql80@sha256:9412e3d51bde38e09c3039090b5c68808e299579f12c79178a4ec316f7831889
+    image: vitess/vttestserver:mysql80@sha256:f7a568447510dab3dd58ee9f6b84241d58645f6db8969babb3e0ad9bbda8c22a
     restart: always
     ports:
       - 33808:33807
@@ -227,6 +228,7 @@ services:
       NUM_SHARDS: "1"
       MYSQL_BIND_HOST: "0.0.0.0"
       FOREIGN_KEY_MODE: "disallow"
+      TABLET_REFRESH_INTERVAL: "500ms"
 
   mssql-2017:
     image: mcr.microsoft.com/mssql/server:2017-latest

--- a/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/mod.rs
@@ -529,7 +529,9 @@ fn making_a_column_required_in_an_empty_table_should_not_warn(api: TestApi) {
     });
 }
 
-#[test_connector(capabilities(Enums))]
+// Excluding Vitess because schema changes being asynchronous messes with our assertions
+// (dump_table).
+#[test_connector(tags(Mysql, Postgres), exclude(Vitess))]
 fn enum_variants_can_be_added_without_data_loss(api: TestApi) {
     let dm1 = r#"
         model Cat {
@@ -632,7 +634,9 @@ fn enum_variants_can_be_added_without_data_loss(api: TestApi) {
     }
 }
 
-#[test_connector(capabilities(Enums))]
+// Excluding Vitess because schema changes being asynchronous messes with our assertions
+// (dump_table).
+#[test_connector(tags(Mysql, Postgres), exclude(Vitess))]
 fn enum_variants_can_be_dropped_without_data_loss(api: TestApi) {
     let dm1 = r#"
         model Cat {
@@ -778,8 +782,10 @@ fn set_default_current_timestamp_on_existing_column_works(api: TestApi) {
     });
 }
 
+// Excluding Vitess because schema changes being asynchronous messes with our assertions
+// (dump_table).
 // exclude: there is a cockroach-specific test. It's unexecutable there.
-#[test_connector(exclude(CockroachDb))]
+#[test_connector(exclude(CockroachDb, Vitess))]
 fn primary_key_migrations_do_not_cause_data_loss(api: TestApi) {
     let dm1 = r#"
         model Dog {

--- a/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/sql_unexecutable_migrations/added_unimplementable_unique_constraint.rs
@@ -44,7 +44,9 @@ fn adding_a_unique_constraint_should_warn(api: TestApi) {
         });
 }
 
-#[test_connector(tags(Mysql, Postgres))]
+// Excluding Vitess because schema changes being asynchronous messes with our assertions
+// (dump_table).
+#[test_connector(tags(Mysql, Postgres), exclude(Vitess))]
 fn dropping_enum_values_should_warn(api: TestApi) {
     let dm1 = r#"
         model Test {

--- a/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
+++ b/migration-engine/migration-engine-tests/tests/existing_data/type_migration_tests.rs
@@ -189,6 +189,10 @@ fn int_to_string_conversions_work(api: TestApi) {
         .assert_green()
         .assert_has_executed_steps();
 
+    if api.is_vitess() {
+        return; // asynchronous migrations mess with the following assertion
+    }
+
     api.dump_table("Cat")
         .assert_single_row(|row| row.assert_text_value("tag", "20"));
 }


### PR DESCRIPTION
Schema changes became (more) asynchronous, meaning a bunch of tests
started failing. The old image started failing in other interesting ways
when we sped up QE tests in https://github.com/prisma/prisma-engines/pull/3635

The main change is that the destructive change checker now retries
queries with exponential backoff on error on mysql. This is necessary
because destructive change checks can come after a migration, and _on
Vitess_, schema changes are asynchronous, they can take time to take
effect. That causes failures in destructive change checks. Trying again
later, in this case, works.

closes https://github.com/prisma/prisma-engines/pull/3400
closes https://github.com/prisma/prisma-engines/issues/3520