### PR TITLE
Add a test to not regress back to prisma/issues/18186

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -17,6 +17,7 @@ mod prisma_15581;
 mod prisma_15607;
 mod prisma_16760;
 mod prisma_17103;
+mod prisma_18186;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_18186.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_18186.rs
@@ -1,0 +1,75 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod prisma_18186 {
+    fn schema() -> String {
+        let schema = indoc! {
+        r#"model A {
+            id   Int    @id
+            name String
+
+            b B? @relation("a_to_b")
+            }
+
+            model B {
+            id   Int
+            name String
+
+            a_id Int? @unique
+            a    A?   @relation("a_to_b", fields: [a_id], references: [id])
+
+            @@unique([id, name])
+            }
+         "#
+        };
+
+        schema.to_owned()
+    }
+
+    // Excluded on MongoDB because all models require an @id attribute
+    // Excluded on SQLServer because models with unique nulls can't have multiple NULLs, unlike other dbs.
+    #[connector_test(exclude(MongoDb, SqlServer))]
+    async fn regression(runner: Runner) -> TestResult<()> {
+        for i in 0..2 {
+            run_query!(
+                &runner,
+                format!(
+                    r#"mutation {{
+                        createOneA(data: {{ id: {}, name: "a {}" }}) {{
+                            id
+                        }}
+                    }}"#,
+                    i, i
+                )
+            );
+
+            run_query!(
+                &runner,
+                format!(
+                    r#"mutation {{
+                        createOneB(data: {{ id: {}, name: "b {}" }}) {{
+                            id
+                        }}
+                    }}"#,
+                    i, i
+                )
+            );
+        }
+
+        insta::assert_snapshot!(run_query!(
+            &runner,
+            r#"mutation {
+                updateOneA(where: {id: 0}, data: { b: { connect: { id_name: { id: 1, name: "b 1"}}}}) {
+                    id
+                    b {
+                        name
+                    }   
+                }
+            }"#),
+            @r###"{"data":{"updateOneA":{"id":0,"b":{"name":"b 1"}}}}"###
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
The regression documented in https://github.com/prisma/prisma/issues/18186 started in https://github.com/prisma/prisma-engines/commit/9984a8d895d559733fb241093dead8a0a925bdd8
and was fixed later in https://github.com/prisma/prisma-engines/commit/2f443b14ed9aa025d84bac879ebc2fbe9979b7e1

This PR adds a test to not get back to it

