### PR TITLE
qe/schema-builder: optimize field type

### DIFF
--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -39,8 +39,11 @@ impl QueryGraphBuilder {
         root_object: &ObjectTypeStrongRef, // Either the query or mutation object.
     ) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         let mut selections = vec![selection];
-        let mut parsed_object =
-            QueryDocumentParser::new(crate::executor::get_request_now()).parse(&selections, root_object)?;
+        let mut parsed_object = QueryDocumentParser::new(crate::executor::get_request_now()).parse(
+            &selections,
+            root_object,
+            &self.query_schema,
+        )?;
 
         // Because we're processing root objects, there can only be one query / mutation.
         let field_pair = parsed_object.fields.pop().unwrap();

--- a/query-engine/dmmf/src/ast_builders/mod.rs
+++ b/query-engine/dmmf/src/ast_builders/mod.rs
@@ -1,5 +1,5 @@
 mod datamodel_ast_builder;
 mod schema_ast_builder;
 
-pub use datamodel_ast_builder::*;
-pub use schema_ast_builder::*;
+pub(crate) use datamodel_ast_builder::*;
+pub(crate) use schema_ast_builder::*;

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
@@ -5,9 +5,9 @@ use super::{
 use schema::{InputFieldRef, InputType, OutputFieldRef, ScalarType};
 
 pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderContext) -> DmmfInputField {
-    let type_references = render_input_types(&input_field.field_types, ctx);
+    let type_references = render_input_types(input_field.field_types(ctx.query_schema), ctx);
     let nullable = input_field
-        .field_types
+        .field_types(ctx.query_schema)
         .iter()
         .any(|typ| matches!(typ, InputType::Scalar(ScalarType::Null)));
 

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
@@ -18,7 +18,7 @@ use std::{
 use type_renderer::*;
 
 pub(crate) fn render(query_schema: QuerySchemaRef) -> (DmmfSchema, DmmfOperationMappings) {
-    let mut ctx = RenderContext::new();
+    let mut ctx = RenderContext::new(&query_schema);
     ctx.mark_to_be_rendered(&query_schema);
 
     while !ctx.next_pass.is_empty() {
@@ -32,8 +32,9 @@ pub(crate) fn render(query_schema: QuerySchemaRef) -> (DmmfSchema, DmmfOperation
     ctx.finalize()
 }
 
-#[derive(Default)]
-pub struct RenderContext {
+pub(crate) struct RenderContext<'a> {
+    query_schema: &'a QuerySchema,
+
     /// Aggregator for query schema
     schema: DmmfSchema,
 
@@ -49,9 +50,15 @@ pub struct RenderContext {
     next_pass: Vec<Box<dyn Renderer>>,
 }
 
-impl RenderContext {
-    pub fn new() -> Self {
-        Self::default()
+impl<'a> RenderContext<'a> {
+    pub fn new(query_schema: &'a QuerySchema) -> Self {
+        RenderContext {
+            query_schema,
+            schema: Default::default(),
+            mappings: Default::default(),
+            rendered: Default::default(),
+            next_pass: Default::default(),
+        }
     }
 
     pub fn finalize(self) -> (DmmfSchema, DmmfOperationMappings) {
@@ -153,7 +160,7 @@ impl RenderContext {
     }
 }
 
-pub trait Renderer {
+pub(crate) trait Renderer {
     fn render(&self, ctx: &mut RenderContext);
 }
 

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
@@ -17,7 +17,9 @@ impl Renderer for GqlFieldRenderer {
 
 impl GqlFieldRenderer {
     fn render_input_field(&self, input_field: InputFieldRef, ctx: &mut RenderContext) -> String {
-        let rendered_type = pick_input_type(&input_field.field_types).into_renderer().render(ctx);
+        let rendered_type = pick_input_type(input_field.field_types(ctx.query_schema))
+            .into_renderer()
+            .render(ctx);
         let required = if input_field.is_required { "!" } else { "" };
 
         format!("{}: {}{}", input_field.name, rendered_type, required)
@@ -59,7 +61,9 @@ impl GqlFieldRenderer {
     }
 
     fn render_argument(&self, arg: &InputFieldRef, ctx: &mut RenderContext) -> String {
-        let rendered_type = pick_input_type(&arg.field_types).into_renderer().render(ctx);
+        let rendered_type = pick_input_type(arg.field_types(ctx.query_schema))
+            .into_renderer()
+            .render(ctx);
         let required = if arg.is_required { "!" } else { "" };
 
         format!("{}: {}{}", arg.name, rendered_type, required)

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
@@ -32,7 +32,7 @@ impl GqlSchemaRenderer {
 }
 
 pub fn render_graphql_schema(query_schema: QuerySchemaRef) -> String {
-    let mut context = RenderContext::new();
+    let mut context = RenderContext::new(&query_schema);
     query_schema.into_renderer().render(&mut context);
 
     // Add custom scalar types (required for graphql.js implementations)
@@ -46,7 +46,9 @@ trait Renderer {
     fn render(&self, ctx: &mut RenderContext) -> String;
 }
 
-struct RenderContext {
+struct RenderContext<'a> {
+    query_schema: &'a QuerySchema,
+
     /// Output queue for all (top level) elements that need to be rendered,
     output_queue: Vec<String>,
 
@@ -60,20 +62,15 @@ struct RenderContext {
     indent_str: &'static str,
 }
 
-impl Default for RenderContext {
-    fn default() -> Self {
-        Self {
-            output_queue: vec![],
-            rendered: HashMap::new(),
+impl<'a> RenderContext<'a> {
+    fn new(query_schema: &'a QuerySchema) -> Self {
+        RenderContext {
+            query_schema,
+            output_queue: Default::default(),
+            rendered: Default::default(),
             indent: 2,
             indent_str: " ",
         }
-    }
-}
-
-impl RenderContext {
-    fn new() -> RenderContext {
-        Self::default()
     }
 
     fn format(self) -> String {

--- a/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
@@ -28,7 +28,12 @@ fn field_ref_input_object_type(ctx: &mut BuilderContext, allow_type: InputType) 
     let object = Arc::new(object);
     ctx.cache_input_type(ident, object.clone());
 
-    object.set_fields(vec![input_field(filters::UNDERSCORE_REF, InputType::string(), None)]);
+    object.set_fields(vec![input_field(
+        ctx,
+        filters::UNDERSCORE_REF,
+        InputType::string(),
+        None,
+    )]);
 
     Arc::downgrade(&object)
 }

--- a/query-engine/schema-builder/src/input_types/objects/connect_or_create_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/connect_or_create_objects.rs
@@ -28,8 +28,8 @@ pub(crate) fn nested_connect_or_create_input_object(
             ctx.cache_input_type(ident, input_object.clone());
 
             let fields = vec![
-                input_field(args::WHERE, InputType::object(where_object), None),
-                input_field(args::CREATE, create_types, None),
+                input_field(ctx, args::WHERE, InputType::object(where_object), None),
+                input_field(ctx, args::CREATE, create_types, None),
             ];
 
             input_object.set_fields(fields);

--- a/query-engine/schema-builder/src/input_types/objects/update_many_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/update_many_objects.rs
@@ -94,8 +94,8 @@ pub(crate) fn update_many_where_combination_object(
     let update_types = update_many_input_types(ctx, &related_model, Some(parent_field));
 
     input_object.set_fields(vec![
-        input_field(args::WHERE, InputType::object(where_input_object), None),
-        input_field(args::DATA, update_types, None),
+        input_field(ctx, args::WHERE, InputType::object(where_input_object), None),
+        input_field(ctx, args::DATA, update_types, None),
     ]);
 
     Arc::downgrade(&input_object)

--- a/query-engine/schema-builder/src/input_types/objects/update_one_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/update_one_objects.rs
@@ -190,8 +190,8 @@ pub(crate) fn update_one_where_combination_object(
     ctx.cache_input_type(ident, input_object.clone());
 
     let fields = vec![
-        input_field(args::WHERE, InputType::object(where_input_object), None),
-        input_field(args::DATA, update_types, None),
+        input_field(ctx, args::WHERE, InputType::object(where_input_object), None),
+        input_field(ctx, args::DATA, update_types, None),
     ];
 
     input_object.set_fields(fields);
@@ -221,7 +221,7 @@ pub(crate) fn update_to_one_rel_where_combination_object(
 
     let fields = vec![
         arguments::where_argument(ctx, &related_model),
-        input_field(args::DATA, update_types, None),
+        input_field(ctx, args::DATA, update_types, None),
     ];
 
     input_object.set_fields(fields);

--- a/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
@@ -41,9 +41,9 @@ fn nested_upsert_list_input_object(
             ctx.cache_input_type(ident, input_object.clone());
 
             let fields = vec![
-                input_field(args::WHERE, InputType::object(where_object), None),
-                input_field(args::UPDATE, update_types, None),
-                input_field(args::CREATE, create_types, None),
+                input_field(ctx, args::WHERE, InputType::object(where_object), None),
+                input_field(ctx, args::UPDATE, update_types, None),
+                input_field(ctx, args::CREATE, create_types, None),
             ];
 
             input_object.set_fields(fields);
@@ -78,8 +78,8 @@ fn nested_upsert_nonlist_input_object(
             ctx.cache_input_type(ident, input_object.clone());
 
             let mut fields = vec![
-                input_field(args::UPDATE, update_types, None),
-                input_field(args::CREATE, create_types, None),
+                input_field(ctx, args::UPDATE, update_types, None),
+                input_field(ctx, args::CREATE, create_types, None),
             ];
 
             if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -53,6 +53,7 @@ use std::sync::Arc;
 use utils::*;
 
 pub(crate) struct BuilderContext<'a> {
+    pub(crate) input_field_types: Vec<InputType>,
     internal_data_model: &'a InternalDataModel,
     enable_raw_queries: bool,
     cache: TypeCache,
@@ -70,6 +71,7 @@ impl<'a> BuilderContext<'a> {
     ) -> Self {
         let connector = internal_data_model.schema.connector;
         Self {
+            input_field_types: Vec::with_capacity(internal_data_model.schema.db.models_count() * 5),
             internal_data_model,
             enable_raw_queries,
             cache: TypeCache::new(),
@@ -194,10 +196,12 @@ pub fn build_with_features(
     let query_type = Arc::new(query_type);
     let mutation_type = Arc::new(mutation_type);
     let capabilities = ctx.connector.capabilities().to_owned();
+    let input_field_types = ctx.input_field_types;
 
     QuerySchema::new(
         query_type,
         mutation_type,
+        input_field_types,
         input_objects,
         output_objects,
         enum_types,

--- a/query-engine/schema-builder/src/mutations/create_many.rs
+++ b/query-engine/schema-builder/src/mutations/create_many.rs
@@ -38,10 +38,10 @@ pub(crate) fn create_many(ctx: &mut BuilderContext, model: &ModelRef) -> Option<
 /// Builds "skip_duplicates" and "data" arguments intended for the create many field.
 pub(crate) fn create_many_arguments(ctx: &mut BuilderContext, model: &ModelRef) -> Vec<InputField> {
     let create_many_type = InputType::object(create_many_object_type(ctx, model, None));
-    let data_arg = input_field(args::DATA, list_union_type(create_many_type, true), None);
+    let data_arg = input_field(ctx, args::DATA, list_union_type(create_many_type, true), None);
 
     if ctx.has_capability(ConnectorCapability::CreateSkipDuplicates) {
-        let skip_arg = input_field(args::SKIP_DUPLICATES, InputType::boolean(), None).optional();
+        let skip_arg = input_field(ctx, args::SKIP_DUPLICATES, InputType::boolean(), None).optional();
 
         vec![data_arg, skip_arg]
     } else {

--- a/query-engine/schema-builder/src/mutations/create_one.rs
+++ b/query-engine/schema-builder/src/mutations/create_one.rs
@@ -37,7 +37,9 @@ pub(crate) fn create_one_arguments(ctx: &mut BuilderContext, model: &ModelRef) -
     if all_empty {
         None
     } else {
-        Some(vec![input_field(args::DATA, create_types, None).optional_if(any_empty)])
+        Some(vec![
+            input_field(ctx, args::DATA, create_types, None).optional_if(any_empty)
+        ])
     }
 }
 

--- a/query-engine/schema-builder/src/output_types/mutation_type.rs
+++ b/query-engine/schema-builder/src/output_types/mutation_type.rs
@@ -32,12 +32,12 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
     create_nested_inputs(ctx);
 
     if ctx.enable_raw_queries && ctx.has_capability(ConnectorCapability::SqlQueryRaw) {
-        fields.push(create_execute_raw_field());
-        fields.push(create_query_raw_field());
+        fields.push(create_execute_raw_field(ctx));
+        fields.push(create_query_raw_field(ctx));
     }
 
     if ctx.enable_raw_queries && ctx.has_capability(ConnectorCapability::MongoDbQueryRaw) {
-        fields.push(create_mongodb_run_command_raw());
+        fields.push(create_mongodb_run_command_raw(ctx));
     }
 
     let ident = Identifier::new_prisma("Mutation".to_owned());
@@ -97,12 +97,13 @@ fn create_nested_inputs(ctx: &mut BuilderContext) {
     }
 }
 
-fn create_execute_raw_field() -> OutputField {
+fn create_execute_raw_field(ctx: &mut BuilderContext) -> OutputField {
     field(
         "executeRaw",
         vec![
-            input_field("query", InputType::string(), None),
+            input_field(ctx, "query", InputType::string(), None),
             input_field(
+                ctx,
                 "parameters",
                 InputType::json_list(),
                 Some(dml::DefaultKind::Single(PrismaValue::String("[]".into()))),
@@ -117,12 +118,13 @@ fn create_execute_raw_field() -> OutputField {
     )
 }
 
-fn create_query_raw_field() -> OutputField {
+fn create_query_raw_field(ctx: &mut BuilderContext) -> OutputField {
     field(
         "queryRaw",
         vec![
-            input_field("query", InputType::string(), None),
+            input_field(ctx, "query", InputType::string(), None),
             input_field(
+                ctx,
                 "parameters",
                 InputType::json_list(),
                 Some(dml::DefaultKind::Single(PrismaValue::String("[]".into()))),
@@ -137,10 +139,10 @@ fn create_query_raw_field() -> OutputField {
     )
 }
 
-fn create_mongodb_run_command_raw() -> OutputField {
+fn create_mongodb_run_command_raw(ctx: &mut BuilderContext) -> OutputField {
     field(
         "runCommandRaw",
-        vec![input_field("command", InputType::json(), None)],
+        vec![input_field(ctx, "command", InputType::json(), None)],
         OutputType::json(),
         Some(QueryInfo {
             tag: QueryTag::RunCommandRaw,

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -19,8 +19,8 @@ pub(crate) fn build(ctx: &mut BuilderContext) -> (OutputType, ObjectTypeStrongRe
             append_opt(&mut vec, find_unique_or_throw_field(ctx, &model));
 
             if ctx.enable_raw_queries && ctx.has_capability(ConnectorCapability::MongoDbQueryRaw) {
-                vec.push(mongo_find_raw_field(&model));
-                vec.push(mongo_aggregate_raw_field(&model));
+                vec.push(mongo_find_raw_field(ctx, &model));
+                vec.push(mongo_aggregate_raw_field(ctx, &model));
             }
 
             vec
@@ -151,14 +151,14 @@ fn group_by_aggregation_field(ctx: &mut BuilderContext, model: &ModelRef) -> Out
     )
 }
 
-fn mongo_aggregate_raw_field(model: &ModelRef) -> OutputField {
+fn mongo_aggregate_raw_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     let field_name = format!("aggregate{}Raw", model.name());
 
     field(
         field_name,
         vec![
-            input_field("pipeline", InputType::list(InputType::json()), None).optional(),
-            input_field("options", InputType::json(), None).optional(),
+            input_field(ctx, "pipeline", InputType::list(InputType::json()), None).optional(),
+            input_field(ctx, "options", InputType::json(), None).optional(),
         ],
         OutputType::json(),
         Some(QueryInfo {
@@ -168,14 +168,14 @@ fn mongo_aggregate_raw_field(model: &ModelRef) -> OutputField {
     )
 }
 
-fn mongo_find_raw_field(model: &ModelRef) -> OutputField {
+fn mongo_find_raw_field(ctx: &mut BuilderContext, model: &ModelRef) -> OutputField {
     let field_name = format!("find{}Raw", model.name());
 
     field(
         field_name,
         vec![
-            input_field("filter", InputType::json(), None).optional(),
-            input_field("options", InputType::json(), None).optional(),
+            input_field(ctx, "filter", InputType::json(), None).optional(),
+            input_field(ctx, "options", InputType::json(), None).optional(),
         ],
         OutputType::json(),
         Some(QueryInfo {

--- a/query-engine/schema-builder/src/utils.rs
+++ b/query-engine/schema-builder/src/utils.rs
@@ -51,18 +51,21 @@ where
 }
 
 /// Field convenience wrapper function.
-pub fn input_field<T, S>(name: T, field_types: S, default_value: Option<dml::DefaultKind>) -> InputField
+pub(crate) fn input_field<T, S>(
+    ctx: &mut BuilderContext,
+    name: T,
+    field_types: S,
+    default_value: Option<dml::DefaultKind>,
+) -> InputField
 where
     T: Into<String>,
-    S: Into<Vec<InputType>>,
+    S: IntoIterator<Item = InputType>,
 {
-    InputField {
-        name: name.into(),
-        field_types: field_types.into(),
-        default_value,
-        is_required: true,
-        deprecation: None,
+    let mut input_field = InputField::new(name.into(), default_value, true);
+    for field_type in field_types {
+        input_field.push_type(field_type, &mut ctx.input_field_types);
     }
+    input_field
 }
 
 /// Capitalizes first character.

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -34,6 +34,10 @@ pub struct QuerySchema {
     /// Information about the connector this schema was build for.
     pub context: ConnectorContext,
 
+    /// Possible types for input fields. This is an internal implementation detail, it should stay
+    /// private.
+    pub(crate) input_field_types: Vec<InputType>,
+
     // Indexes query fields by their own query info for easier access.
     query_map: HashMap<QueryInfo, OutputFieldRef>,
 
@@ -82,6 +86,7 @@ impl QuerySchema {
     pub fn new(
         query: OutputTypeRef,
         mutation: OutputTypeRef,
+        input_field_types: Vec<InputType>,
         _input_object_types: Vec<InputObjectTypeStrongRef>,
         _output_object_types: Vec<ObjectTypeStrongRef>,
         _enum_types: Vec<EnumTypeRef>,
@@ -110,6 +115,7 @@ impl QuerySchema {
             mutation,
             query_map,
             mutation_map,
+            input_field_types,
             _input_object_types,
             _output_object_types,
             _enum_types,


### PR DESCRIPTION
Before this commit, InputField contains a `Vec<FieldType>`. This means a required heap allocation for every InputField, and likely a lot of heap fragmentation.

This commit changes that to two integers that define a slice in a `Vec<FieldType>` that contains all input field field types for a schema. We now have one big allocation for the whole schema.

Comparison to current main (510ac61c038f11fb8394dd4bb2e40e6e679bcb30):

schema_builder::build (small)
                        time:   [2.1996 ms 2.2057 ms 2.2120 ms]
                        change: [-5.6115% -5.1022% -4.6109%] (p = 0.00 < 0.05)
                        Performance has improved.

schema_builder::build (medium)
                        time:   [19.135 ms 19.328 ms 19.538 ms]
                        change: [-6.4815% -5.2219% -3.9380%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

Benchmarking schema_builder::build (large): Warming up for 3.0000 s Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 43.8s, or reduce sample count to 10. schema_builder::build (large)
                        time:   [423.98 ms 425.56 ms 427.25 ms]
                        change: [-12.800% -12.375% -11.951%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe