### PR TITLE
docs: fix cargo docs

### DIFF
--- a/libs/sql-schema-describer/src/postgres.rs
+++ b/libs/sql-schema-describer/src/postgres.rs
@@ -22,7 +22,7 @@ use std::{any::type_name, collections::BTreeMap, convert::TryInto};
 use tracing::trace;
 
 /// A PostgreSQL sequence.
-/// https://www.postgresql.org/docs/current/view-pg-sequences.html
+/// <https://www.postgresql.org/docs/current/view-pg-sequences.html>
 #[derive(Debug)]
 pub struct Sequence {
     /// Sequence name

--- a/libs/sql-schema-describer/src/postgres/default/c_style_scalar_lists.rs
+++ b/libs/sql-schema-describer/src/postgres/default/c_style_scalar_lists.rs
@@ -1,5 +1,5 @@
 //! Scalar list defaults of the form `'{}'`.
-//! Reference: https://www.postgresql.org/docs/current/arrays.html
+//! Reference: <https://www.postgresql.org/docs/current/arrays.html>
 
 use super::{tokenize, Parser, Token};
 use crate::{ColumnType, ColumnTypeFamily};

--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -38,7 +38,7 @@ pub enum ValidationErrorKind {
     TooManyFieldsGiven,
     /// See [`ValidationError::selection_set_on_scalar`]
     SelectionSetOnScalar,
-    /// See [`ValidationError::required_value_not_set`]
+    /// See [`ValidationError::required_argument_missing`]
     RequiredArgumentMissing,
     /// See [`ValidationError::union`]
     Union,
@@ -438,7 +438,7 @@ impl ValidationError {
         }
     }
 
-    /// Creates an [`ValidationErrorKind::ValueTooBig`] kind of error, which happens when the value
+    /// Creates an [`ValidationErrorKind::ValueTooLarge`] kind of error, which happens when the value
     /// for a float or integer coming from the JS client is larger than what can fit in an i64
     /// (2^64 - 1 = 18446744073709550000)
     ///
@@ -459,8 +459,6 @@ impl ValidationError {
     ///     }
     /// }
     ///
-    /// TODO: should this be a https://www.prisma.io/docs/reference/api-reference/error-reference#p2033 instead?
-    /// See: libs/user-facing-errors/src/query_engine/mod.rs:312
     pub fn value_too_large(selection_path: Vec<String>, argument_path: Vec<String>, value: String) -> Self {
         let argument_name = argument_path.last().expect("Argument path cannot not be empty");
         let message = format!(

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -121,7 +121,7 @@ pub enum AggregationSelection {
 }
 
 impl AggregationSelection {
-    /// Returns (<field db name>, TypeIdentifier, FieldArity)
+    /// Returns (field_db_name, TypeIdentifier, FieldArity)
     pub fn identifiers(&self) -> Vec<(String, TypeIdentifier, FieldArity)> {
         match self {
             AggregationSelection::Field(field) => {


### PR DESCRIPTION
After merging https://github.com/prisma/prisma-engines/pull/3784 cargo docs task started failing. This PR fixes the causes.

<img width="443" alt="Screenshot 2023-03-23 at 14 30 02" src="https://user-images.githubusercontent.com/210307/227219296-54f3c998-8f0f-4973-b7c1-6450185c08ab.png">
