### PR TITLE
qe/schema-builder: make capitalize() helper allocation-free

### DIFF
--- a/query-engine/schema-builder/src/input_types/mod.rs
+++ b/query-engine/schema-builder/src/input_types/mod.rs
@@ -53,8 +53,11 @@ pub(crate) fn list_union_type(input_type: InputType, as_list: bool) -> Vec<Input
 }
 
 fn compound_object_name(alias: Option<&str>, from_fields: &[ScalarFieldRef]) -> String {
-    alias.map(capitalize).unwrap_or_else(|| {
-        let field_names: Vec<String> = from_fields.iter().map(|field| capitalize(field.name())).collect();
+    alias.map(|a| capitalize(a).to_string()).unwrap_or_else(|| {
+        let field_names: Vec<String> = from_fields
+            .iter()
+            .map(|field| capitalize(field.name()).to_string())
+            .collect();
         field_names.join("")
     })
 }


### PR DESCRIPTION
Just use a Display impl instead.

Measured improvement locally: around 7-9% on the larger schemas. The point of comparison is 66ab7364fa0aeeaee8862de04d2b58ca37a1575f.

     Running benches/schema_builder_bench.rs (target/release/deps/schema_builder_bench-32b88211dc650df7)
schema_builder::build (small)
                        time:   [2.0748 ms 2.0784 ms 2.0823 ms]
                        change: [-4.2700% -4.0470% -3.8118%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  6 (6.00%) high mild
  2 (2.00%) high severe

schema_builder::build (medium)
                        time:   [17.075 ms 17.138 ms 17.213 ms]
                        change: [-8.0693% -7.5553% -7.0378%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe

Benchmarking schema_builder::build (large): Warming up for 3.0000 s Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 37.2s, or reduce sample count to 10. schema_builder::build (large)
                        time:   [367.53 ms 367.97 ms 368.43 ms]
                        change: [-8.9165% -8.7522% -8.5797%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild