### PR TITLE
CI: Cancel builds in progress if pushing more commits

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,6 +12,10 @@ on:
       - 'renovate.json'
       - 'introspection-engine/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   benchmark:
     name: "Run benchmarks on Linux"

--- a/.github/workflows/cargo-doc.yml
+++ b/.github/workflows/cargo-doc.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches:
       - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
       
 jobs:
   generate-cargo-docs:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -8,6 +8,10 @@ on:
       - 'CODEOWNERS'
       - 'renovate.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-crate-compilation:
     name: "Compile top level crates on Linux"

--- a/.github/workflows/engine-size.yml
+++ b/.github/workflows/engine-size.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-engine-size:
     name: "Check and publish Query Engine size"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -11,6 +11,10 @@ on:
       - 'CODEOWNERS'
       - 'renovate.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/migration-engine.yml
+++ b/.github/workflows/migration-engine.yml
@@ -14,6 +14,10 @@ on:
       # Specific
       - 'query-engine/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-mongodb-introspection-and-migration-connector:
     name: "Test ${{ matrix.database.name }} on Linux"

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -12,6 +12,10 @@ on:
       - 'renovate.json'
       - 'introspection-engine/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rust-vitess-tests:
     name: "Rust test suite: ${{ matrix.database.name }} (${{ matrix.engine_protocol }}) on Linux"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,6 +11,10 @@ on:
       - 'CODEOWNERS'
       - 'renovate.json'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Workspace unit tests


### PR DESCRIPTION
Per branch. This saves resources in the action runners.