### PR TITLE
fix: compacted queries with bigints

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -159,7 +159,7 @@ impl Runner {
                 .into_iter()
                 .map(|q| serde_json::from_str::<JsonSingleQuery>(&q).unwrap())
                 .collect(),
-            transaction: transaction.then(|| BatchTransactionOption { isolation_level }),
+            transaction: transaction.then_some(BatchTransactionOption { isolation_level }),
         }));
 
         let res = handler.handle(body, self.current_tx_id.clone(), None).await;


### PR DESCRIPTION
## Overview

- fix https://github.com/prisma/prisma/issues/18096

This regression was introduced by this PR https://github.com/prisma/prisma-engines/pull/3610.

Specifically, the removal of this `From` impl. When converting `PrismaValue` (response data) into `QueryValue` so that response values and user-inputted values could be compared, we used to convert `BigInt` values into `Int`. The guilty PR removed that subtle conversion.

<img width="826" alt="image" src="https://user-images.githubusercontent.com/25233379/227957975-03f161ec-0854-4204-bac5-a771bf47e819.png">

This PR does _not_ bring back this conversion but ensures both types (`Int` & `BigInt`) can be compared when unfolding compacted queries.

It is critical we do it this way because the JSON protocol now does different coercions than GraphQL at the protocol adapter level. Indeed, with the support of "custom types", `BigInt` values are now immediately parsed as `BigInt` at the protocol adapter level for JSON (unlike GraphQL). Bringing back this subtle coercion would fix GraphQL but break JSON:

- GraphQL: User-inputted value: `Int` / Response value: `BigInt` coerced as `Int` / Comparison: `Int` == `Int`
- Json: User-inputted value: `BigInt` / Response value: `BigInt` coerced as `Int` Comparison: `BigInt` != `Int`

For these reasons, the added regression test makes sure we separately test JSON & GraphQL so that we can test the JSON protocol with a proper `BigInt` custom type as input.
