### PR TITLE
qe/schema-builder: remove Arc indirection for Input, Output, Enum types

### DIFF
--- a/query-engine/core/src/executor/pipeline.rs
+++ b/query-engine/core/src/executor/pipeline.rs
@@ -1,4 +1,5 @@
 use crate::{Env, Expressionista, IrSerializer, QueryGraph, QueryInterpreter, ResponseData};
+use schema::QuerySchema;
 use tracing::Instrument;
 
 #[derive(Debug)]
@@ -17,7 +18,11 @@ impl<'conn> QueryPipeline<'conn> {
         }
     }
 
-    pub async fn execute(mut self, trace_id: Option<String>) -> crate::Result<ResponseData> {
+    pub async fn execute(
+        mut self,
+        query_schema: &QuerySchema,
+        trace_id: Option<String>,
+    ) -> crate::Result<ResponseData> {
         let serializer = self.serializer;
         let expr = Expressionista::translate(self.graph)?;
 
@@ -30,6 +35,6 @@ impl<'conn> QueryPipeline<'conn> {
             .await;
 
         trace!("{}", self.interpreter.log_output());
-        serializer.serialize(result?)
+        serializer.serialize(result?, query_schema)
     }
 }

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -28,15 +28,15 @@ impl QueryGraphBuilder {
     pub fn build(self, operation: Operation) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         let _span = info_span!("prisma:engine:build_graph");
         match operation {
-            Operation::Read(selection) => self.build_internal(selection, &self.query_schema.query()),
-            Operation::Write(selection) => self.build_internal(selection, &self.query_schema.mutation()),
+            Operation::Read(selection) => self.build_internal(selection, self.query_schema.query()),
+            Operation::Write(selection) => self.build_internal(selection, self.query_schema.mutation()),
         }
     }
 
     fn build_internal(
         &self,
         selection: Selection,
-        root_object: &ObjectTypeStrongRef, // Either the query or mutation object.
+        root_object: &ObjectType, // Either the query or mutation object.
     ) -> QueryGraphBuilderResult<(QueryGraph, IrSerializer)> {
         let mut selections = vec![selection];
         let mut parsed_object = QueryDocumentParser::new(crate::executor::get_request_now()).parse(

--- a/query-engine/core/src/response_ir/ir_serializer.rs
+++ b/query-engine/core/src/response_ir/ir_serializer.rs
@@ -1,7 +1,7 @@
 use super::{internal::serialize_internal, response::*, *};
 use crate::{CoreError, ExpressionResult, QueryResult};
 use prisma_models::PrismaValue;
-use schema::{OutputFieldRef, OutputType};
+use schema::{OutputFieldRef, OutputType, QuerySchema};
 use std::borrow::Borrow;
 
 #[derive(Debug)]
@@ -15,7 +15,11 @@ pub struct IrSerializer {
 }
 
 impl IrSerializer {
-    pub(crate) fn serialize(&self, result: ExpressionResult) -> crate::Result<ResponseData> {
+    pub(crate) fn serialize(
+        &self,
+        result: ExpressionResult,
+        query_schema: &QuerySchema,
+    ) -> crate::Result<ResponseData> {
         let _span = info_span!("prisma:engine:serialize", user_facing = true);
         match result {
             ExpressionResult::Query(QueryResult::Json(json)) => {
@@ -23,7 +27,7 @@ impl IrSerializer {
             }
 
             ExpressionResult::Query(r) => {
-                let serialized = serialize_internal(r, &self.output_field, false)?;
+                let serialized = serialize_internal(r, &self.output_field, false, query_schema)?;
 
                 // On the top level, each result boils down to a exactly a single serialized result.
                 // All checks for lists and optionals have already been performed during the recursion,

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
@@ -2,9 +2,9 @@ use super::{
     type_renderer::{render_input_types, render_output_type},
     DmmfInputField, DmmfOutputField, RenderContext,
 };
-use schema::{InputFieldRef, InputType, OutputFieldRef, ScalarType};
+use schema::{InputField, InputType, OutputFieldRef, ScalarType};
 
-pub(super) fn render_input_field(input_field: &InputFieldRef, ctx: &mut RenderContext) -> DmmfInputField {
+pub(super) fn render_input_field(input_field: &InputField, ctx: &mut RenderContext) -> DmmfInputField {
     let type_references = render_input_types(input_field.field_types(ctx.query_schema), ctx);
     let nullable = input_field
         .field_types(ctx.query_schema)

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/mod.rs
@@ -11,10 +11,7 @@ use indexmap::map::Entry;
 use object_renderer::*;
 use schema::*;
 use schema_renderer::*;
-use std::{
-    collections::HashSet,
-    sync::{Arc, Weak},
-};
+use std::{collections::HashSet, sync::Arc};
 use type_renderer::*;
 
 pub(crate) fn render(query_schema: QuerySchemaRef) -> (DmmfSchema, DmmfOperationMappings) {
@@ -194,22 +191,22 @@ impl<'a> IntoRenderer for &'a EnumType {
     }
 }
 
-impl IntoRenderer for InputObjectTypeWeakRef {
+impl IntoRenderer for InputObjectTypeId {
     fn into_renderer(&self) -> Box<dyn Renderer> {
-        Box::new(DmmfObjectRenderer::Input(Weak::clone(self)))
+        Box::new(DmmfObjectRenderer::Input(*self))
     }
 
     fn is_already_rendered(&self, ctx: &RenderContext) -> bool {
-        ctx.already_rendered(&self.into_arc().identifier)
+        ctx.already_rendered(&ctx.query_schema.db[*self].identifier)
     }
 }
 
-impl IntoRenderer for ObjectTypeWeakRef {
+impl IntoRenderer for OutputObjectTypeId {
     fn into_renderer(&self) -> Box<dyn Renderer> {
-        Box::new(DmmfObjectRenderer::Output(Weak::clone(self)))
+        Box::new(DmmfObjectRenderer::Output(*self))
     }
 
     fn is_already_rendered(&self, ctx: &RenderContext) -> bool {
-        ctx.already_rendered(&self.into_arc().identifier)
+        ctx.already_rendered(&ctx.query_schema.db[*self].identifier)
     }
 }

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/object_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/object_renderer.rs
@@ -2,28 +2,28 @@ use super::*;
 
 #[derive(Debug)]
 pub enum DmmfObjectRenderer {
-    Input(InputObjectTypeWeakRef),
-    Output(ObjectTypeWeakRef),
+    Input(InputObjectTypeId),
+    Output(OutputObjectTypeId),
 }
 
 impl Renderer for DmmfObjectRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         match &self {
             DmmfObjectRenderer::Input(input) => {
-                let input_object = input.into_arc();
+                let input_object = &ctx.query_schema.db[*input];
 
                 match &input_object.tag {
                     Some(ObjectTag::FieldRefType(_)) => self.render_field_ref_type(input_object, ctx),
                     _ => self.render_input_object(input_object, ctx),
                 }
             }
-            DmmfObjectRenderer::Output(output) => self.render_output_object(output, ctx),
+            DmmfObjectRenderer::Output(output) => self.render_output_object(&ctx.query_schema.db[*output], ctx),
         }
     }
 }
 
 impl DmmfObjectRenderer {
-    fn render_input_object(&self, input_object: InputObjectTypeStrongRef, ctx: &mut RenderContext) {
+    fn render_input_object(&self, input_object: &InputObjectType, ctx: &mut RenderContext) {
         if ctx.already_rendered(&input_object.identifier) {
             return;
         }
@@ -59,7 +59,7 @@ impl DmmfObjectRenderer {
         ctx.add_input_type(input_object.identifier.clone(), input_type);
     }
 
-    fn render_field_ref_type(&self, input_object: InputObjectTypeStrongRef, ctx: &mut RenderContext) {
+    fn render_field_ref_type(&self, input_object: &InputObjectType, ctx: &mut RenderContext) {
         if ctx.already_rendered(&input_object.identifier) {
             return;
         }
@@ -88,9 +88,7 @@ impl DmmfObjectRenderer {
         ctx.add_field_ref_type(input_object.identifier.clone(), field_ref_type);
     }
 
-    fn render_output_object(&self, output_object: &ObjectTypeWeakRef, ctx: &mut RenderContext) {
-        let output_object = output_object.into_arc();
-
+    fn render_output_object(&self, output_object: &ObjectType, ctx: &mut RenderContext) {
         if ctx.already_rendered(&output_object.identifier) {
             return;
         }

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/schema_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/schema_renderer.rs
@@ -8,8 +8,8 @@ impl Renderer for DmmfSchemaRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         // This ensures that all enums are rendered, even if not reached by the output and input types.
         render_enum_types(ctx, self.query_schema.enum_types());
-        render_output_type(&self.query_schema.query, ctx);
-        render_output_type(&self.query_schema.mutation, ctx);
+        render_output_type(&OutputType::Object(self.query_schema.query), ctx);
+        render_output_type(&OutputType::Object(self.query_schema.mutation), ctx);
     }
 }
 

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
@@ -1,12 +1,12 @@
 use super::{DmmfTypeReference, RenderContext, TypeLocation};
-use schema::{InputType, IntoArc, ObjectTag, OutputType, ScalarType};
+use schema::{InputType, ObjectTag, OutputType, ScalarType};
 
 pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderContext) -> DmmfTypeReference {
     match output_type {
         OutputType::Object(ref obj) => {
             ctx.mark_to_be_rendered(obj);
+            let obj = &ctx.query_schema.db[*obj];
 
-            let obj = obj.into_arc();
             let type_reference = DmmfTypeReference {
                 typ: obj.identifier.name(),
                 namespace: Some(obj.identifier.namespace().to_string()),
@@ -18,8 +18,8 @@ pub(super) fn render_output_type(output_type: &OutputType, ctx: &mut RenderConte
         }
 
         OutputType::Enum(et) => {
-            let et = et.into_arc();
-            ctx.mark_to_be_rendered(&et.as_ref());
+            let et = &ctx.query_schema.db[*et];
+            ctx.mark_to_be_rendered(&et);
 
             let ident = et.identifier();
             let type_reference = DmmfTypeReference {
@@ -76,8 +76,7 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
     match input_type {
         InputType::Object(ref obj) => {
             ctx.mark_to_be_rendered(obj);
-
-            let obj = obj.into_arc();
+            let obj = &ctx.query_schema.db[*obj];
 
             let location = match &obj.tag {
                 Some(ObjectTag::FieldRefType(_)) => TypeLocation::FieldRefTypes,
@@ -95,8 +94,8 @@ pub(super) fn render_input_type(input_type: &InputType, ctx: &mut RenderContext)
         }
 
         InputType::Enum(et) => {
-            let et = et.into_arc();
-            ctx.mark_to_be_rendered(&et.as_ref());
+            let et = &ctx.query_schema.db[*et];
+            ctx.mark_to_be_rendered(&et);
 
             let ident = et.identifier();
             let type_reference = DmmfTypeReference {

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
@@ -1,22 +1,22 @@
 use super::*;
 
 #[derive(Debug)]
-pub(crate) enum GqlFieldRenderer {
-    Input(InputFieldRef),
+pub(crate) enum GqlFieldRenderer<'a> {
+    Input(&'a InputField),
     Output(OutputFieldRef),
 }
 
-impl Renderer for GqlFieldRenderer {
+impl Renderer for GqlFieldRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
-            GqlFieldRenderer::Input(input) => self.render_input_field(Arc::clone(input), ctx),
+            GqlFieldRenderer::Input(input) => self.render_input_field(input, ctx),
             GqlFieldRenderer::Output(output) => self.render_output_field(Arc::clone(output), ctx),
         }
     }
 }
 
-impl GqlFieldRenderer {
-    fn render_input_field(&self, input_field: InputFieldRef, ctx: &mut RenderContext) -> String {
+impl GqlFieldRenderer<'_> {
+    fn render_input_field(&self, input_field: &InputField, ctx: &mut RenderContext) -> String {
         let rendered_type = pick_input_type(input_field.field_types(ctx.query_schema))
             .into_renderer()
             .render(ctx);
@@ -50,7 +50,7 @@ impl GqlFieldRenderer {
         format!("{}{}: {}{}", field.name, rendered_args, rendered_type, bang)
     }
 
-    fn render_arguments(&self, args: &[InputFieldRef], ctx: &mut RenderContext) -> Vec<String> {
+    fn render_arguments(&self, args: &[InputField], ctx: &mut RenderContext) -> Vec<String> {
         let mut output = Vec::with_capacity(args.len());
 
         for arg in args {
@@ -60,7 +60,7 @@ impl GqlFieldRenderer {
         output
     }
 
-    fn render_argument(&self, arg: &InputFieldRef, ctx: &mut RenderContext) -> String {
+    fn render_argument(&self, arg: &InputField, ctx: &mut RenderContext) -> String {
         let rendered_type = pick_input_type(arg.field_types(ctx.query_schema))
             .into_renderer()
             .render(ctx);

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
@@ -7,10 +7,7 @@ use enum_renderer::*;
 use field_renderer::*;
 use object_renderer::*;
 use query_core::schema::*;
-use std::{
-    collections::HashMap,
-    sync::{Arc, Weak},
-};
+use std::{collections::HashMap, sync::Arc};
 use type_renderer::*;
 
 /// Top level GraphQL schema renderer.
@@ -103,7 +100,7 @@ enum GqlRenderer<'a> {
     Schema(GqlSchemaRenderer),
     Object(GqlObjectRenderer),
     Type(GqlTypeRenderer<'a>),
-    Field(GqlFieldRenderer),
+    Field(GqlFieldRenderer<'a>),
     Enum(GqlEnumRenderer<'a>),
 }
 
@@ -145,10 +142,10 @@ impl<'a> IntoRenderer<'a> for OutputType {
     }
 }
 
-impl<'a> IntoRenderer<'a> for InputFieldRef {
+impl<'a> IntoRenderer<'a> for InputField {
     #[allow(clippy::wrong_self_convention)]
-    fn into_renderer(&self) -> GqlRenderer<'a> {
-        GqlRenderer::Field(GqlFieldRenderer::Input(Arc::clone(self)))
+    fn into_renderer(&'a self) -> GqlRenderer<'a> {
+        GqlRenderer::Field(GqlFieldRenderer::Input(self))
     }
 }
 
@@ -166,16 +163,16 @@ impl<'a> IntoRenderer<'a> for EnumType {
     }
 }
 
-impl<'a> IntoRenderer<'a> for &'a InputObjectTypeWeakRef {
+impl<'a> IntoRenderer<'a> for InputObjectTypeId {
     #[allow(clippy::wrong_self_convention)]
     fn into_renderer(&self) -> GqlRenderer<'a> {
-        GqlRenderer::Object(GqlObjectRenderer::Input(Weak::clone(self)))
+        GqlRenderer::Object(GqlObjectRenderer::Input(*self))
     }
 }
 
-impl<'a> IntoRenderer<'a> for &'a ObjectTypeWeakRef {
+impl<'a> IntoRenderer<'a> for OutputObjectTypeId {
     #[allow(clippy::wrong_self_convention)]
     fn into_renderer(&self) -> GqlRenderer<'a> {
-        GqlRenderer::Object(GqlObjectRenderer::Output(Weak::clone(self)))
+        GqlRenderer::Object(GqlObjectRenderer::Output(*self))
     }
 }

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/object_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/object_renderer.rs
@@ -2,23 +2,22 @@ use super::*;
 
 #[derive(Debug)]
 pub enum GqlObjectRenderer {
-    Input(InputObjectTypeWeakRef),
-    Output(ObjectTypeWeakRef),
+    Input(InputObjectTypeId),
+    Output(OutputObjectTypeId),
 }
 
 impl Renderer for GqlObjectRenderer {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match &self {
-            GqlObjectRenderer::Input(input) => self.render_input_object(input, ctx),
-            GqlObjectRenderer::Output(output) => self.render_output_object(output, ctx),
+            GqlObjectRenderer::Input(input) => self.render_input_object(*input, ctx),
+            GqlObjectRenderer::Output(output) => self.render_output_object(&ctx.query_schema.db[*output], ctx),
         }
     }
 }
 
 impl GqlObjectRenderer {
-    fn render_input_object(&self, input_object: &InputObjectTypeWeakRef, ctx: &mut RenderContext) -> String {
-        let input_object = input_object.into_arc();
-
+    fn render_input_object(&self, input_object: InputObjectTypeId, ctx: &mut RenderContext) -> String {
+        let input_object = &ctx.query_schema.db[input_object];
         if ctx.already_rendered(&input_object.identifier.name()) {
             return "".into();
         } else {
@@ -49,9 +48,7 @@ impl GqlObjectRenderer {
         rendered
     }
 
-    fn render_output_object(&self, output_object: &ObjectTypeWeakRef, ctx: &mut RenderContext) -> String {
-        let output_object = output_object.into_arc();
-
+    fn render_output_object(&self, output_object: &ObjectType, ctx: &mut RenderContext) -> String {
         if ctx.already_rendered(&output_object.identifier.name()) {
             return "".into();
         } else {

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/type_renderer.rs
@@ -21,11 +21,11 @@ impl<'a> GqlTypeRenderer<'a> {
         match i {
             InputType::Object(ref obj) => {
                 let _ = obj.into_renderer().render(ctx);
-                obj.into_arc().identifier.name()
+                ctx.query_schema.db[*obj].identifier.name()
             }
 
             InputType::Enum(et) => {
-                let et = et.into_arc();
+                let et = &ctx.query_schema.db[*et];
                 et.into_renderer().render(ctx);
                 et.identifier().name()
             }
@@ -61,11 +61,11 @@ impl<'a> GqlTypeRenderer<'a> {
         match o {
             OutputType::Object(obj) => {
                 let _ = obj.into_renderer().render(ctx);
-                obj.into_arc().identifier.name()
+                ctx.query_schema.db[*obj].identifier.name()
             }
 
             OutputType::Enum(et) => {
-                let et = et.into_arc();
+                let et = &ctx.query_schema.db[*et];
                 et.into_renderer().render(ctx);
                 et.identifier().name()
             }

--- a/query-engine/schema-builder/src/cache.rs
+++ b/query-engine/schema-builder/src/cache.rs
@@ -1,63 +1,40 @@
-//! Every builder is required to cache input and output type refs that are created inside
-//! of them, e.g. as soon as the builder produces a ref, it must be retrievable later,
-//! without leaking memory due to Arcs pointing to each other.
+//! Every builder is required to cache input and output type ids that are created inside
+//! of them, e.g. as soon as the builder produces a type, it must be retrievable later.
 //!
 //! The cache has two purposes:
 //! - First, break circular dependencies, as they can happen in recursive input / output types.
 //! - Second, it serves as a central list of build types of that builder, which are used later to
 //!   collect all types of the query schema.
-//!
-//! The cached types are stored as Arcs, and the cache owns these (strong) Arcs,
-//! while the cache will only hand out weak arcs. Not only does this simplify the builder architecture,
-//! but also prevents issues with memory leaks in the schema, as well as issues that when all strong
-//! arcs are dropped due to visitor operations, the schema can't be traversed anymore due to invalid references.
-use super::*;
-use std::{collections::HashMap, fmt::Debug, sync::Weak};
 
-/// Cache wrapper over Arc<T>.
-/// Caches keys at most once, and errors on repeated insertion of the same key
-/// to uphold schema building consistency guarantees.
+use super::Identifier;
+use std::{collections::HashMap, fmt::Debug};
+
+/// HashMap wrapper. Caches keys at most once, and errors on repeated insertion of the same key to
+/// uphold schema building consistency guarantees.
 #[derive(Debug, Default)]
 pub(crate) struct TypeRefCache<T> {
-    cache: HashMap<Identifier, usize>,
-    storage: Vec<Arc<T>>,
+    cache: HashMap<Identifier, T>,
 }
 
-impl<T: Debug> TypeRefCache<T> {
+impl<T: Copy + Debug> TypeRefCache<T> {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         TypeRefCache {
             cache: HashMap::with_capacity(capacity),
-            storage: Vec::with_capacity(capacity),
         }
     }
 
-    // Retrieves a cached Arc if present, and hands out a weak reference to the contents.
-    pub(crate) fn get(&self, ident: &Identifier) -> Option<Weak<T>> {
-        self.cache.get(ident).map(|idx| Arc::downgrade(&self.storage[*idx]))
+    pub(crate) fn get(&self, ident: &Identifier) -> Option<T> {
+        self.cache.get(ident).copied()
     }
 
     /// Caches given value with given identifier. Panics if the cache key already exists.
-    /// The reason is that for the query schema to work, we need weak references to be valid,
-    /// which might be violated if we insert a new arc into the cache that replaces the old one,
-    /// as it invalidates all weak refs pointing to the replaced arc, assuming that the contents
-    /// changed as well. While this restriction could be lifted by comparing the contents, it is
-    /// not required in the context of the schema builders.
-    pub(crate) fn insert(&mut self, ident: Identifier, value: Arc<T>) {
-        let idx = self.storage.len();
-        self.storage.push(value);
-        if let Some(old) = self.cache.insert(ident, idx) {
-            panic!(
-                "Invariant violation: Inserted identifier twice, this is a bug and invalidates weak arc references. {old:?}"
-            )
+    /// The reason is that for the query schema to work, we need identifiers to be valid.
+    /// If we insert a new object into the cache that replaces the old one, the reference would be
+    /// broken.
+    pub(crate) fn insert(&mut self, ident: Identifier, value: T) {
+        if let Some(old) = self.cache.insert(ident, value) {
+            panic!("Invariant violation: Inserted identifier twice, this is a bug. {old:?}")
         }
-    }
-}
-
-/// Consumes the cache and returns all contents as vector of the cached values.
-#[allow(clippy::from_over_into)]
-impl<T> Into<Vec<Arc<T>>> for TypeRefCache<T> {
-    fn into(self) -> Vec<Arc<T>> {
-        self.storage
     }
 }
 

--- a/query-engine/schema-builder/src/enum_types.rs
+++ b/query-engine/schema-builder/src/enum_types.rs
@@ -1,48 +1,40 @@
 use super::*;
 use crate::constants::{filters, itx, json_null, ordering};
 use prisma_models::prelude::ParentContainer;
-use schema::EnumType;
+use schema::{EnumType, EnumTypeId};
 
-pub(crate) fn sort_order_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeWeakRef {
+pub(crate) fn sort_order_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeId {
     let ident = Identifier::new_prisma(ordering::SORT_ORDER);
     return_cached_enum!(ctx, &ident);
 
-    let typ = Arc::new(EnumType::string(
-        ident.clone(),
-        vec![ordering::ASC.to_owned(), ordering::DESC.to_owned()],
-    ));
+    let typ = EnumType::string(ident.clone(), vec![ordering::ASC.to_owned(), ordering::DESC.to_owned()]);
 
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn nulls_order_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeWeakRef {
+pub(crate) fn nulls_order_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeId {
     let ident = Identifier::new_prisma(ordering::NULLS_ORDER);
     return_cached_enum!(ctx, &ident);
 
-    let typ = Arc::new(EnumType::string(
+    let typ = EnumType::string(
         ident.clone(),
         vec![ordering::FIRST.to_owned(), ordering::LAST.to_owned()],
-    ));
+    );
 
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn map_schema_enum_type(ctx: &mut BuilderContext<'_>, enum_id: ast::EnumId) -> EnumTypeWeakRef {
+pub(crate) fn map_schema_enum_type(ctx: &mut BuilderContext<'_>, enum_id: ast::EnumId) -> EnumTypeId {
     let ident = Identifier::new_model(IdentifierType::Enum(ctx.internal_data_model.clone().zip(enum_id)));
     return_cached_enum!(ctx, &ident);
 
     let schema_enum = ctx.internal_data_model.clone().zip(enum_id);
-    let typ = Arc::new(EnumType::database(ident.clone(), schema_enum));
-
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    let typ = EnumType::database(ident.clone(), schema_enum);
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn model_field_enum(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> EnumTypeWeakRef {
+pub(crate) fn model_field_enum(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> EnumTypeId {
     let ident = Identifier::new_prisma(IdentifierType::ScalarFieldEnum(model.clone()));
-
     return_cached_enum!(ctx, &ident);
 
     let values = model
@@ -52,30 +44,27 @@ pub(crate) fn model_field_enum(ctx: &mut BuilderContext<'_>, model: &ModelRef) -
         .map(|field| (field.name().to_owned(), field))
         .collect();
 
-    let typ = Arc::new(EnumType::field_ref(ident.clone(), values));
-
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    let typ = EnumType::field_ref(ident.clone(), values);
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn json_null_filter_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeWeakRef {
+pub(crate) fn json_null_filter_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeId {
     let ident = Identifier::new_prisma(json_null::FILTER_ENUM_NAME);
     return_cached_enum!(ctx, &ident);
 
-    let typ = Arc::new(EnumType::string(
+    let typ = EnumType::string(
         ident.clone(),
         vec![
             json_null::DB_NULL.to_owned(),
             json_null::JSON_NULL.to_owned(),
             json_null::ANY_NULL.to_owned(),
         ],
-    ));
+    );
 
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn json_null_input_enum(ctx: &mut BuilderContext<'_>, nullable: bool) -> EnumTypeWeakRef {
+pub(crate) fn json_null_input_enum(ctx: &mut BuilderContext<'_>, nullable: bool) -> EnumTypeId {
     let ident = if nullable {
         Identifier::new_prisma(json_null::NULLABLE_INPUT_ENUM_NAME)
     } else {
@@ -85,47 +74,43 @@ pub(crate) fn json_null_input_enum(ctx: &mut BuilderContext<'_>, nullable: bool)
     return_cached_enum!(ctx, &ident);
 
     let typ = if nullable {
-        Arc::new(EnumType::string(
+        EnumType::string(
             ident.clone(),
             vec![json_null::DB_NULL.to_owned(), json_null::JSON_NULL.to_owned()],
-        ))
+        )
     } else {
-        Arc::new(EnumType::string(ident.clone(), vec![json_null::JSON_NULL.to_owned()]))
+        EnumType::string(ident.clone(), vec![json_null::JSON_NULL.to_owned()])
     };
 
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    ctx.cache_enum_type(ident, typ)
 }
 
 pub(crate) fn order_by_relevance_enum(
     ctx: &mut BuilderContext<'_>,
     container: &ParentContainer,
     values: Vec<String>,
-) -> EnumTypeWeakRef {
+) -> EnumTypeId {
     let ident = Identifier::new_prisma(IdentifierType::OrderByRelevanceFieldEnum(container.clone()));
-
     return_cached_enum!(ctx, &ident);
 
-    let typ = Arc::new(EnumType::string(ident.clone(), values));
+    let typ = EnumType::string(ident.clone(), values);
 
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn query_mode_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeWeakRef {
+pub(crate) fn query_mode_enum(ctx: &mut BuilderContext<'_>) -> EnumTypeId {
     let ident = Identifier::new_prisma("QueryMode");
     return_cached_enum!(ctx, &ident);
 
-    let typ = Arc::new(EnumType::string(
+    let typ = EnumType::string(
         ident.clone(),
         vec![filters::DEFAULT.to_owned(), filters::INSENSITIVE.to_owned()],
-    ));
+    );
 
-    ctx.cache_enum_type(ident, typ.clone());
-    Arc::downgrade(&typ)
+    ctx.cache_enum_type(ident, typ)
 }
 
-pub(crate) fn itx_isolation_levels(ctx: &mut BuilderContext<'_>) -> Option<EnumTypeWeakRef> {
+pub(crate) fn itx_isolation_levels(ctx: &mut BuilderContext<'_>) -> Option<EnumTypeId> {
     let ident = Identifier::new_prisma(IdentifierType::TransactionIsolationLevel);
     if let e @ Some(_) = ctx.get_enum_type(&ident) {
         return e;
@@ -157,8 +142,6 @@ pub(crate) fn itx_isolation_levels(ctx: &mut BuilderContext<'_>) -> Option<EnumT
         return None;
     }
 
-    let typ = Arc::new(EnumType::string(ident.clone(), values));
-    ctx.cache_enum_type(ident, typ.clone());
-
-    Some(Arc::downgrade(&typ))
+    let typ = EnumType::string(ident.clone(), values);
+    Some(ctx.cache_enum_type(ident, typ))
 }

--- a/query-engine/schema-builder/src/input_types/fields/arguments.rs
+++ b/query-engine/schema-builder/src/input_types/fields/arguments.rs
@@ -16,7 +16,7 @@ pub(crate) fn where_argument(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> 
 pub(crate) fn where_unique_argument(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> Option<InputField> {
     let input_object_type = filter_objects::where_unique_object_type(ctx, model);
 
-    if input_object_type.into_arc().is_empty() {
+    if ctx.db[input_object_type].is_empty() {
         None
     } else {
         Some(input_field(
@@ -48,7 +48,8 @@ pub(crate) fn upsert_arguments(ctx: &mut BuilderContext<'_>, model: &ModelRef) -
         let update_types = update_one_objects::update_one_input_types(ctx, model, None);
         let create_types = create_one::create_one_input_types(ctx, model, None);
 
-        if update_types.iter().all(|typ| typ.is_empty()) || create_types.iter().all(|typ| typ.is_empty()) {
+        if update_types.iter().all(|typ| typ.is_empty(&ctx.db)) || create_types.iter().all(|typ| typ.is_empty(&ctx.db))
+        {
             None
         } else {
             Some(vec![

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
@@ -56,9 +56,7 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
                 let types = vec![map_scalar_input_type_for_field(ctx, sf), base_update_type];
 
                 let input_field = input_field(ctx, sf.name(), types, None);
-                input_field
-                    .optional()
-                    .nullable_if(!sf.is_required(), &mut ctx.input_field_types)
+                input_field.optional().nullable_if(!sf.is_required(), &mut ctx.db)
             }
         }
     }
@@ -84,10 +82,7 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
                 let mut input_object = input_object_type(ident.clone(), object_fields);
                 input_object.require_exactly_one_field();
 
-                let input_object = Arc::new(input_object);
-                ctx.cache_input_type(ident, input_object.clone());
-
-                Arc::downgrade(&input_object)
+                ctx.cache_input_type(ident, input_object)
             }
         };
 
@@ -105,17 +100,15 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
         let input_object = match ctx.get_input_type(&ident) {
             Some(t) => t,
             None => {
-                let input_object = Arc::new(init_input_object_type(ident.clone()));
-                ctx.cache_input_type(ident, input_object.clone());
+                let input_object = init_input_object_type(ident.clone());
+                let id = ctx.cache_input_type(ident, input_object);
 
                 // Enqueue the nested update input for its fields to be
                 // created at a later point, to avoid recursing too deep
                 // (that has caused stack overflows on large schemas in
                 // the past).
-                ctx.nested_update_inputs_queue
-                    .push((Arc::clone(&input_object), rf.clone()));
-
-                Arc::downgrade(&input_object)
+                ctx.nested_update_inputs_queue.push((id, rf.clone()));
+                id
             }
         };
 
@@ -136,7 +129,7 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
         }
 
         input_field(ctx, cf.name(), input_types, None)
-            .nullable_if(cf.is_optional() && !cf.is_list(), &mut ctx.input_field_types)
+            .nullable_if(cf.is_optional() && !cf.is_list(), &mut ctx.db)
             .optional()
     }
 }
@@ -146,7 +139,7 @@ fn update_operations_object_type(
     prefix: &str,
     sf: &ScalarFieldRef,
     with_number_operators: bool,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::FieldUpdateOperationsInput(
         !sf.is_required(),
         prefix.to_owned(),
@@ -155,14 +148,12 @@ fn update_operations_object_type(
 
     let mut obj = init_input_object_type(ident.clone());
     obj.require_exactly_one_field();
-
-    let obj = Arc::new(obj);
-    ctx.cache_input_type(ident, obj.clone());
+    let id = ctx.cache_input_type(ident, obj);
 
     let typ = map_scalar_input_type_for_field(ctx, sf);
     let mut fields = vec![input_field(ctx, operations::SET, typ.clone(), None)
         .optional()
-        .nullable_if(!sf.is_required(), &mut ctx.input_field_types)];
+        .nullable_if(!sf.is_required(), &mut ctx.db)];
 
     if with_number_operators {
         fields.push(input_field(ctx, operations::INCREMENT, typ.clone(), None).optional());
@@ -175,9 +166,8 @@ fn update_operations_object_type(
         fields.push(input_field(ctx, operations::UNSET, InputType::boolean(), None).optional());
     }
 
-    obj.set_fields(fields);
-
-    Arc::downgrade(&obj)
+    ctx.db[id].set_fields(fields);
+    id
 }
 
 /// Build an operation envelope object type for composite updates.
@@ -189,10 +179,7 @@ fn update_operations_object_type(
 ///   ... more ops ...
 /// }
 /// ```
-fn composite_update_envelope_object_type(
-    ctx: &mut BuilderContext<'_>,
-    cf: &CompositeFieldRef,
-) -> InputObjectTypeWeakRef {
+fn composite_update_envelope_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpdateEnvelopeInput(cf.typ(), cf.arity()));
 
     return_cached_input!(ctx, &ident);
@@ -200,9 +187,7 @@ fn composite_update_envelope_object_type(
     let mut input_object = init_input_object_type(ident.clone());
     input_object.require_exactly_one_field();
     input_object.set_tag(ObjectTag::CompositeEnvelope);
-
-    let input_object = Arc::new(input_object);
-    ctx.cache_input_type(ident, input_object.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let mut fields = vec![composite_set_update_input_field(ctx, cf)];
 
@@ -213,30 +198,26 @@ fn composite_update_envelope_object_type(
     append_opt(&mut fields, composite_delete_many_update_input_field(ctx, cf));
     append_opt(&mut fields, composite_unset_update_input_field(ctx, cf));
 
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }
 
 /// Builds the `update` input object type. Should be used in the envelope type.
-fn composite_update_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
+fn composite_update_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpdateInput(cf.typ()));
 
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.set_min_fields(1);
-
-    let input_object = Arc::new(input_object);
-    ctx.cache_input_type(ident, input_object.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let mapper = UpdateDataInputFieldMapper::new_checked();
     let fields = cf.typ().fields().collect::<Vec<_>>();
     let fields = mapper.map_all(ctx, &fields);
 
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }
 
 // Builds an `update` input field. Should only be used in the envelope type.
@@ -270,7 +251,7 @@ fn composite_set_update_input_field(ctx: &mut BuilderContext<'_>, cf: &Composite
     }
 
     input_field(ctx, operations::SET, input_types, None)
-        .nullable_if(!cf.is_required() && !cf.is_list(), &mut ctx.input_field_types)
+        .nullable_if(!cf.is_required() && !cf.is_list(), &mut ctx.db)
         .optional()
 }
 
@@ -287,17 +268,14 @@ fn composite_push_update_input_field(ctx: &mut BuilderContext<'_>, cf: &Composit
 }
 
 /// Builds the `upsert` input object type. Should only be used in the envelope type.
-fn composite_upsert_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
+fn composite_upsert_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpsertObjectInput(cf.typ()));
 
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.set_tag(ObjectTag::CompositeEnvelope);
-
-    let input_object = Arc::new(input_object);
-
-    ctx.cache_input_type(ident, input_object.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let update_object_type = composite_update_object_type(ctx, cf);
     let update_field = input_field(ctx, operations::UPDATE, InputType::Object(update_object_type), None);
@@ -305,9 +283,8 @@ fn composite_upsert_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFiel
 
     let fields = vec![set_field, update_field];
 
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }
 
 // Builds an `upsert` input field. Should only be used in the envelope type.
@@ -321,17 +298,14 @@ fn composite_upsert_update_input_field(ctx: &mut BuilderContext<'_>, cf: &Compos
     }
 }
 
-fn composite_update_many_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
+fn composite_update_many_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpdateManyInput(cf.typ()));
 
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.set_tag(ObjectTag::CompositeEnvelope);
-
-    let input_object = Arc::new(input_object);
-
-    ctx.cache_input_type(ident, input_object.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let where_object_type = objects::filter_objects::where_object_type(ctx, cf.typ());
     let where_field = input_field(ctx, args::WHERE, InputType::object(where_object_type), None);
@@ -341,31 +315,24 @@ fn composite_update_many_object_type(ctx: &mut BuilderContext<'_>, cf: &Composit
 
     let fields = vec![where_field, data_field];
 
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }
 
-fn composite_delete_many_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeWeakRef {
+fn composite_delete_many_object_type(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::CompositeDeleteManyInput(cf.typ()));
 
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.set_tag(ObjectTag::CompositeEnvelope);
-
-    let input_object = Arc::new(input_object);
-
-    ctx.cache_input_type(ident, input_object.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let where_object_type = objects::filter_objects::where_object_type(ctx, cf.typ());
     let where_field = input_field(ctx, args::WHERE, InputType::object(where_object_type), None);
 
-    let fields = vec![where_field];
-
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(vec![where_field]);
+    id
 }
 
 // Builds an `updateMany` input field. Should only be used in the envelope type.

--- a/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
@@ -17,35 +17,28 @@ impl WithFieldRefInputExt for InputType {
     }
 }
 
-fn field_ref_input_object_type(ctx: &mut BuilderContext<'_>, allow_type: InputType) -> InputObjectTypeWeakRef {
-    let ident = Identifier::new_prisma(field_ref_input_type_name(&allow_type));
+fn field_ref_input_object_type(ctx: &mut BuilderContext<'_>, allow_type: InputType) -> InputObjectTypeId {
+    let ident = Identifier::new_prisma(field_ref_input_type_name(&allow_type, ctx));
 
     return_cached_input!(ctx, &ident);
 
     let mut object = init_input_object_type(ident.clone());
     object.set_tag(ObjectTag::FieldRefType(allow_type));
+    let id = ctx.cache_input_type(ident, object);
 
-    let object = Arc::new(object);
-    ctx.cache_input_type(ident, object.clone());
-
-    object.set_fields(vec![input_field(
-        ctx,
-        filters::UNDERSCORE_REF,
-        InputType::string(),
-        None,
-    )]);
-
-    Arc::downgrade(&object)
+    let fields = vec![input_field(ctx, filters::UNDERSCORE_REF, InputType::string(), None)];
+    ctx.db[id].set_fields(fields);
+    id
 }
 
-fn field_ref_input_type_name(allow_type: &InputType) -> String {
+fn field_ref_input_type_name(allow_type: &InputType, ctx: &mut BuilderContext<'_>) -> String {
     let typ_str = match allow_type {
         InputType::Scalar(scalar) => match scalar {
             ScalarType::Null => unreachable!("ScalarType::Null should never reach that code path"),
             _ => scalar.to_string(),
         },
-        InputType::Enum(e) => format!("Enum{}", e.into_arc().name()),
-        InputType::List(inner) => return format!("List{}", field_ref_input_type_name(inner)),
+        InputType::Enum(e) => format!("Enum{}", ctx.db[*e].name()),
+        InputType::List(inner) => return format!("List{}", field_ref_input_type_name(inner, ctx)),
         _ => unreachable!("input ref type only support scalar or enums"),
     };
 

--- a/query-engine/schema-builder/src/input_types/mod.rs
+++ b/query-engine/schema-builder/src/input_types/mod.rs
@@ -37,7 +37,7 @@ fn map_scalar_input_type(ctx: &mut BuilderContext<'_>, typ: &TypeIdentifier, lis
 
 /// Convenience function to return [object_type, list_object_type]
 /// (shorthand + full type) if the field is a list.
-pub(crate) fn list_union_object_type(input: InputObjectTypeWeakRef, as_list: bool) -> Vec<InputType> {
+pub(crate) fn list_union_object_type(input: InputObjectTypeId, as_list: bool) -> Vec<InputType> {
     let input_type = InputType::object(input);
     list_union_type(input_type, as_list)
 }

--- a/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/filter_objects.rs
@@ -1,24 +1,20 @@
 use super::*;
 use constants::filters;
 use prisma_models::{prelude::ParentContainer, CompositeFieldRef};
-use std::sync::Arc;
 
 pub(crate) fn scalar_filter_object_type(
     ctx: &mut BuilderContext<'_>,
     model: &ModelRef,
     include_aggregates: bool,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::ScalarFilterInput(model.clone(), include_aggregates));
     return_cached_input!(ctx, &ident);
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.set_tag(ObjectTag::WhereInputType(ParentContainer::Model(model.clone())));
 
-    let input_object = Arc::new(input_object);
-    ctx.cache_input_type(ident, input_object.clone());
-
-    let weak_ref = Arc::downgrade(&input_object);
-    let object_type = InputType::object(weak_ref.clone());
+    let id = ctx.cache_input_type(ident, input_object);
+    let object_type = InputType::object(id);
 
     let mut input_fields = vec![
         input_field(
@@ -44,11 +40,11 @@ pub(crate) fn scalar_filter_object_type(
         ModelField::Composite(_) => None, // [Composites] todo
     }));
 
-    input_object.set_fields(input_fields);
-    weak_ref
+    ctx.db[id].set_fields(input_fields);
+    id
 }
 
-pub(crate) fn where_object_type<T>(ctx: &mut BuilderContext<'_>, container: T) -> InputObjectTypeWeakRef
+pub(crate) fn where_object_type<T>(ctx: &mut BuilderContext<'_>, container: T) -> InputObjectTypeId
 where
     T: Into<ParentContainer>,
 {
@@ -58,12 +54,8 @@ where
 
     let mut input_object = init_input_object_type(ident.clone());
     input_object.set_tag(ObjectTag::WhereInputType(container.clone()));
-
-    let input_object = Arc::new(input_object);
-    ctx.cache_input_type(ident, input_object.clone());
-
-    let weak_ref = Arc::downgrade(&input_object);
-    let object_type = InputType::object(weak_ref.clone());
+    let id = ctx.cache_input_type(ident, input_object);
+    let object_type = InputType::object(id);
 
     let mut fields = vec![
         input_field(
@@ -90,13 +82,12 @@ where
 
     fields.extend(input_fields);
 
-    input_object.set_fields(fields);
-    weak_ref
+    ctx.db[id].set_fields(fields);
+    id
 }
 
-pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> InputObjectTypeWeakRef {
+pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::WhereUniqueInput(model.clone()));
-
     return_cached_input!(ctx, &ident);
 
     // Split unique & ID fields vs all the other fields
@@ -145,17 +136,16 @@ pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext<'_>, model: &Mod
             .collect()
     };
 
-    let mut x = init_input_object_type(ident.clone());
+    let mut input_object = init_input_object_type(ident.clone());
 
     if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
-        x.require_at_least_one_field();
-        x.apply_constraints_on_fields(constrained_fields);
+        input_object.require_at_least_one_field();
+        input_object.apply_constraints_on_fields(constrained_fields);
     } else {
-        x.require_exactly_one_field();
+        input_object.require_exactly_one_field();
     }
 
-    let input_object = Arc::new(x);
-    ctx.cache_input_type(ident, input_object.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let mut fields: Vec<InputField> = unique_fields
         .into_iter()
@@ -211,9 +201,8 @@ pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext<'_>, model: &Mod
         fields.extend(rest_fields);
     }
 
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }
 
 /// Generates and caches an input object type for a compound field.
@@ -222,7 +211,7 @@ fn compound_field_unique_object_type(
     model: &ModelRef,
     alias: Option<&str>,
     from_fields: Vec<ScalarFieldRef>,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(format!(
         "{}{}CompoundUniqueInput",
         model.name(),
@@ -231,8 +220,8 @@ fn compound_field_unique_object_type(
 
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let object_fields = from_fields
         .into_iter()
@@ -244,22 +233,18 @@ fn compound_field_unique_object_type(
         })
         .collect();
 
-    input_object.set_fields(object_fields);
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(object_fields);
+    id
 }
 
 /// Object used for full composite equality, e.g. `{ field: "value", field2: 123 } == { field: "value" }`.
 /// If the composite is a list, only lists are allowed for comparison, no shorthands are used.
-pub(crate) fn composite_equality_object(
-    ctx: &mut BuilderContext<'_>,
-    cf: &CompositeFieldRef,
-) -> InputObjectTypeWeakRef {
+pub(crate) fn composite_equality_object(ctx: &mut BuilderContext<'_>, cf: &CompositeFieldRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(format!("{}ObjectEqualityInput", cf.typ().name()));
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
-
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
     let mut fields = vec![];
 
     let composite_type = cf.typ();
@@ -268,7 +253,7 @@ pub(crate) fn composite_equality_object(
             let map_scalar_input_type_for_field = map_scalar_input_type_for_field(ctx, &sf);
             input_field(ctx, sf.name(), map_scalar_input_type_for_field, None)
                 .optional_if(!sf.is_required())
-                .nullable_if(!sf.is_required() && !sf.is_list(), &mut ctx.input_field_types)
+                .nullable_if(!sf.is_required() && !sf.is_list(), &mut ctx.db)
         }
 
         ModelField::Composite(cf) => {
@@ -282,14 +267,13 @@ pub(crate) fn composite_equality_object(
 
             input_field(ctx, cf.name(), types, None)
                 .optional_if(!cf.is_required())
-                .nullable_if(!cf.is_required() && !cf.is_list(), &mut ctx.input_field_types)
+                .nullable_if(!cf.is_required() && !cf.is_list(), &mut ctx.db)
         }
 
         ModelField::Relation(_) => unimplemented!(),
     });
 
     fields.extend(input_fields);
-    input_object.set_fields(fields);
-
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }

--- a/query-engine/schema-builder/src/input_types/objects/update_many_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/update_many_objects.rs
@@ -19,13 +19,13 @@ pub(crate) fn update_many_input_types(
 }
 
 /// Builds "<x>UpdateManyMutationInput" input object type.
-pub(crate) fn checked_update_many_input_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> InputObjectTypeWeakRef {
+pub(crate) fn checked_update_many_input_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::CheckedUpdateManyInput(model.clone()));
 
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let filtered_fields: Vec<_> = update_one_objects::filter_checked_update_fields(ctx, model, None)
         .into_iter()
@@ -34,9 +34,8 @@ pub(crate) fn checked_update_many_input_type(ctx: &mut BuilderContext<'_>, model
 
     let field_mapper = UpdateDataInputFieldMapper::new_checked();
     let input_fields = field_mapper.map_all(ctx, &filtered_fields);
-
-    input_object.set_fields(input_fields);
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(input_fields);
+    id
 }
 
 /// Builds "<x>UncheckedUpdateManyWithout<y>MutationInput" input object type
@@ -44,7 +43,7 @@ pub(crate) fn unchecked_update_many_input_type(
     ctx: &mut BuilderContext<'_>,
     model: &ModelRef,
     parent_field: Option<&RelationFieldRef>,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     // TODO: This leads to conflicting type names.
     // TODO: See https://github.com/prisma/prisma/issues/18534 for further details.
     let name = match parent_field {
@@ -60,8 +59,8 @@ pub(crate) fn unchecked_update_many_input_type(
 
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let filtered_fields: Vec<_> = update_one_objects::filter_unchecked_update_fields(ctx, model, parent_field)
         .into_iter()
@@ -70,9 +69,8 @@ pub(crate) fn unchecked_update_many_input_type(
 
     let field_mapper = UpdateDataInputFieldMapper::new_unchecked();
     let input_fields = field_mapper.map_all(ctx, &filtered_fields);
-
-    input_object.set_fields(input_fields);
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(input_fields);
+    id
 }
 
 /// Builds "<x>UpdateManyWithWhereWithout<y>Input" input object type.
@@ -80,24 +78,25 @@ pub(crate) fn unchecked_update_many_input_type(
 pub(crate) fn update_many_where_combination_object(
     ctx: &mut BuilderContext<'_>,
     parent_field: &RelationFieldRef,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     let ident = Identifier::new_prisma(IdentifierType::UpdateManyWhereCombinationInput(
         parent_field.related_field(),
     ));
 
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let related_model = parent_field.related_model();
     let where_input_object = filter_objects::scalar_filter_object_type(ctx, &related_model, false);
     let update_types = update_many_input_types(ctx, &related_model, Some(parent_field));
 
-    input_object.set_fields(vec![
+    let fields = vec![
         input_field(ctx, args::WHERE, InputType::object(where_input_object), None),
         input_field(ctx, args::DATA, update_types, None),
-    ]);
+    ];
 
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(fields);
+    id
 }

--- a/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
@@ -7,7 +7,7 @@ use super::*;
 pub(crate) fn nested_upsert_input_object(
     ctx: &mut BuilderContext<'_>,
     parent_field: &RelationFieldRef,
-) -> Option<InputObjectTypeWeakRef> {
+) -> Option<InputObjectTypeId> {
     if parent_field.is_list() {
         nested_upsert_list_input_object(ctx, parent_field)
     } else {
@@ -19,13 +19,13 @@ pub(crate) fn nested_upsert_input_object(
 fn nested_upsert_list_input_object(
     ctx: &mut BuilderContext<'_>,
     parent_field: &RelationFieldRef,
-) -> Option<InputObjectTypeWeakRef> {
+) -> Option<InputObjectTypeId> {
     let related_model = parent_field.related_model();
     let where_object = filter_objects::where_unique_object_type(ctx, &related_model);
     let create_types = create_one::create_one_input_types(ctx, &related_model, Some(parent_field));
     let update_types = update_one_objects::update_one_input_types(ctx, &related_model, Some(parent_field));
 
-    if where_object.into_arc().is_empty() || create_types.iter().all(|typ| typ.is_empty()) {
+    if ctx.db[where_object].is_empty() || create_types.iter().all(|typ| typ.is_empty(&ctx.db)) {
         return None;
     }
 
@@ -33,8 +33,8 @@ fn nested_upsert_list_input_object(
 
     match ctx.get_input_type(&ident) {
         None => {
-            let input_object = Arc::new(init_input_object_type(ident.clone()));
-            ctx.cache_input_type(ident, input_object.clone());
+            let input_object = init_input_object_type(ident.clone());
+            let id = ctx.cache_input_type(ident, input_object);
 
             let fields = vec![
                 input_field(ctx, args::WHERE, InputType::object(where_object), None),
@@ -42,8 +42,8 @@ fn nested_upsert_list_input_object(
                 input_field(ctx, args::CREATE, create_types, None),
             ];
 
-            input_object.set_fields(fields);
-            Some(Arc::downgrade(&input_object))
+            ctx.db[id].set_fields(fields);
+            Some(id)
         }
         x => x,
     }
@@ -53,12 +53,12 @@ fn nested_upsert_list_input_object(
 fn nested_upsert_nonlist_input_object(
     ctx: &mut BuilderContext<'_>,
     parent_field: &RelationFieldRef,
-) -> Option<InputObjectTypeWeakRef> {
+) -> Option<InputObjectTypeId> {
     let related_model = parent_field.related_model();
     let create_types = create_one::create_one_input_types(ctx, &related_model, Some(parent_field));
     let update_types = update_one_objects::update_one_input_types(ctx, &related_model, Some(parent_field));
 
-    if create_types.iter().all(|typ| typ.is_empty()) {
+    if create_types.iter().all(|typ| typ.is_empty(&ctx.db)) {
         return None;
     }
 
@@ -66,8 +66,8 @@ fn nested_upsert_nonlist_input_object(
 
     match ctx.get_input_type(&ident) {
         None => {
-            let input_object = Arc::new(init_input_object_type(ident.clone()));
-            ctx.cache_input_type(ident, input_object.clone());
+            let input_object = init_input_object_type(ident.clone());
+            let id = ctx.cache_input_type(ident, input_object);
 
             let mut fields = vec![
                 input_field(ctx, args::UPDATE, update_types, None),
@@ -78,8 +78,8 @@ fn nested_upsert_nonlist_input_object(
                 fields.push(where_argument(ctx, &related_model));
             }
 
-            input_object.set_fields(fields);
-            Some(Arc::downgrade(&input_object))
+            ctx.db[id].set_fields(fields);
+            Some(id)
         }
         x => x,
     }

--- a/query-engine/schema-builder/src/mutations/create_one.rs
+++ b/query-engine/schema-builder/src/mutations/create_one.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use crate::{
     constants::args,
     field, init_input_object_type, input_field,
@@ -9,8 +7,7 @@ use crate::{
 };
 use prisma_models::{ModelRef, RelationFieldRef};
 use schema::{
-    Identifier, IdentifierType, InputField, InputObjectTypeWeakRef, InputType, OutputField, OutputType, QueryInfo,
-    QueryTag,
+    Identifier, IdentifierType, InputField, InputObjectTypeId, InputType, OutputField, OutputType, QueryInfo, QueryTag,
 };
 
 /// Builds a create mutation field (e.g. createUser) for given model.
@@ -33,8 +30,8 @@ pub(crate) fn create_one(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> Outp
 /// The data argument is not present if no data can be created.
 pub(crate) fn create_one_arguments(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> Option<Vec<InputField>> {
     let create_types = create_one_input_types(ctx, model, None);
-    let any_empty = create_types.iter().any(|typ| typ.is_empty());
-    let all_empty = create_types.iter().all(|typ| typ.is_empty());
+    let any_empty = create_types.iter().any(|typ| typ.is_empty(&ctx.db));
+    let all_empty = create_types.iter().all(|typ| typ.is_empty(&ctx.db));
 
     if all_empty {
         None
@@ -69,7 +66,7 @@ fn checked_create_input_type(
     ctx: &mut BuilderContext<'_>,
     model: &ModelRef,
     parent_field: Option<&RelationFieldRef>,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     // We allow creation from both sides of the relation - which would lead to an endless loop of input types
     // if we would allow to create the parent from a child create that is already a nested create.
     // To solve it, we remove the parent relation from the input ("Without<Parent>").
@@ -80,15 +77,15 @@ fn checked_create_input_type(
 
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let filtered_fields = filter_checked_create_fields(model, parent_field);
     let field_mapper = CreateDataInputFieldMapper::new_checked();
     let input_fields = field_mapper.map_all(ctx, &filtered_fields);
 
-    input_object.set_fields(input_fields);
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(input_fields);
+    id
 }
 
 /// Builds the create input type (<x>UncheckedCreateInput / <x>UncheckedCreateWithout<y>Input)
@@ -99,7 +96,7 @@ fn unchecked_create_input_type(
     ctx: &mut BuilderContext<'_>,
     model: &ModelRef,
     parent_field: Option<&RelationFieldRef>,
-) -> InputObjectTypeWeakRef {
+) -> InputObjectTypeId {
     // We allow creation from both sides of the relation - which would lead to an endless loop of input types
     // if we would allow to create the parent from a child create that is already a nested create.
     // To solve it, we remove the parent relation from the input ("Without<Parent>").
@@ -110,15 +107,15 @@ fn unchecked_create_input_type(
 
     return_cached_input!(ctx, &ident);
 
-    let input_object = Arc::new(init_input_object_type(ident.clone()));
-    ctx.cache_input_type(ident, input_object.clone());
+    let input_object = init_input_object_type(ident.clone());
+    let id = ctx.cache_input_type(ident, input_object);
 
     let filtered_fields = filter_unchecked_create_fields(model, parent_field);
     let field_mapper = CreateDataInputFieldMapper::new_unchecked();
     let input_fields = field_mapper.map_all(ctx, &filtered_fields);
 
-    input_object.set_fields(input_fields);
-    Arc::downgrade(&input_object)
+    ctx.db[id].set_fields(input_fields);
+    id
 }
 
 /// Filters the given model's fields down to the allowed ones for checked create.

--- a/query-engine/schema-builder/src/output_types/aggregation/group_by.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/group_by.rs
@@ -3,11 +3,11 @@ use crate::constants::aggregations::*;
 use std::convert::identity;
 
 /// Builds group by aggregation object type for given model (e.g. GroupByUserOutputType).
-pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> ObjectTypeWeakRef {
+pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> OutputObjectTypeId {
     let ident = Identifier::new_prisma(format!("{}GroupByOutputType", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
-    let object = Arc::new(ObjectType::new(ident.clone(), Some(model.id)));
+    let object = ObjectType::new(ident.clone(), Some(model.id));
 
     // Model fields that can be grouped by value.
     let mut object_fields = scalar_output_fields(ctx, model);
@@ -86,9 +86,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext<'_>, model: &
     );
 
     object.set_fields(object_fields);
-    ctx.cache_output_type(ident, ObjectTypeStrongRef::clone(&object));
-
-    ObjectTypeStrongRef::downgrade(&object)
+    ctx.cache_output_type(ident, object)
 }
 
 fn scalar_output_fields(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> Vec<OutputField> {

--- a/query-engine/schema-builder/src/output_types/aggregation/mod.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/mod.rs
@@ -75,7 +75,7 @@ fn map_field_aggregation_object<F, G>(
     type_mapper: F,
     object_mapper: G,
     is_count: bool,
-) -> ObjectTypeWeakRef
+) -> OutputObjectTypeId
 where
     F: Fn(&mut BuilderContext<'_>, &ScalarFieldRef) -> OutputType,
     G: Fn(ObjectType) -> ObjectType,
@@ -95,9 +95,6 @@ where
         .collect();
 
     let object = object_mapper(object_type(ident.clone(), fields, None));
-    let object = Arc::new(object);
 
-    ctx.cache_output_type(ident, object.clone());
-
-    Arc::downgrade(&object)
+    ctx.cache_output_type(ident, object)
 }

--- a/query-engine/schema-builder/src/output_types/aggregation/plain.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/plain.rs
@@ -1,14 +1,13 @@
-use crate::constants::aggregations::*;
-
 use super::*;
+use crate::constants::aggregations::*;
 use std::convert::identity;
 
 /// Builds plain aggregation object type for given model (e.g. AggregateUser).
-pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> ObjectTypeWeakRef {
+pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> OutputObjectTypeId {
     let ident = Identifier::new_prisma(format!("Aggregate{}", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
-    let object = ObjectTypeStrongRef::new(ObjectType::new(ident.clone(), Some(model.id)));
+    let object = ObjectType::new(ident.clone(), Some(model.id));
     let mut object_fields = vec![];
 
     let non_list_nor_json_fields = collect_non_list_nor_json_fields(&model.into());
@@ -84,7 +83,5 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext<'_>, model: &Mode
     );
 
     object.set_fields(object_fields);
-    ctx.cache_output_type(ident, ObjectTypeStrongRef::clone(&object));
-
-    ObjectTypeStrongRef::downgrade(&object)
+    ctx.cache_output_type(ident, object)
 }

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -106,7 +106,7 @@ fn map_field_aggration_relation<F, G>(
     fields: &[RelationFieldRef],
     type_mapper: F,
     object_mapper: G,
-) -> ObjectTypeWeakRef
+) -> OutputObjectTypeId
 where
     F: Fn(&mut BuilderContext<'_>, &RelationFieldRef) -> OutputType,
     G: Fn(ObjectType) -> ObjectType,
@@ -128,9 +128,5 @@ where
         .collect();
 
     let object = object_mapper(object_type(ident.clone(), fields, None));
-    let object = Arc::new(object);
-
-    ctx.cache_output_type(ident, object.clone());
-
-    Arc::downgrade(&object)
+    ctx.cache_output_type(ident, object)
 }

--- a/query-engine/schema-builder/src/output_types/objects/composite.rs
+++ b/query-engine/schema-builder/src/output_types/objects/composite.rs
@@ -8,7 +8,7 @@ use prisma_models::CompositeType;
 pub(crate) fn initialize_cache(ctx: &mut BuilderContext<'_>) {
     for composite in ctx.internal_data_model.composite_types() {
         let ident = Identifier::new_model(composite.name().to_owned());
-        ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, None)));
+        ctx.cache_output_type(ident.clone(), ObjectType::new(ident, None));
     }
 }
 
@@ -16,13 +16,12 @@ pub(crate) fn initialize_cache(ctx: &mut BuilderContext<'_>) {
 pub(crate) fn initialize_fields(ctx: &mut BuilderContext<'_>) {
     for composite in ctx.internal_data_model.composite_types() {
         let fields = compute_composite_object_type_fields(ctx, &composite);
-        let obj: ObjectTypeWeakRef = map_type(ctx, &composite);
-
-        obj.into_arc().set_fields(fields);
+        let obj = map_type(ctx, &composite);
+        ctx.db[obj].set_fields(fields);
     }
 }
 
-pub(crate) fn map_type(ctx: &mut BuilderContext<'_>, ct: &CompositeType) -> ObjectTypeWeakRef {
+pub(crate) fn map_type(ctx: &mut BuilderContext<'_>, ct: &CompositeType) -> OutputObjectTypeId {
     let ident = Identifier::new_model(ct.name().to_owned());
     ctx.get_output_type(&ident)
         .expect("Invariant violation: Initialized output object type for each composite.")

--- a/query-engine/schema-builder/src/output_types/objects/mod.rs
+++ b/query-engine/schema-builder/src/output_types/objects/mod.rs
@@ -16,16 +16,15 @@ pub(crate) fn initialize_caches(ctx: &mut BuilderContext<'_>) {
     composite::initialize_fields(ctx);
 }
 
-pub(crate) fn affected_records_object_type(ctx: &mut BuilderContext<'_>) -> ObjectTypeWeakRef {
+pub(crate) fn affected_records_object_type(ctx: &mut BuilderContext<'_>) -> OutputObjectTypeId {
     let ident = Identifier::new_prisma("AffectedRowsOutput".to_owned());
     return_cached_output!(ctx, &ident);
 
-    let object_type = Arc::new(object_type(
+    let object_type = object_type(
         ident.clone(),
         vec![field(AFFECTED_COUNT, vec![], OutputType::int(), None)],
         None,
-    ));
+    );
 
-    ctx.cache_output_type(ident, object_type.clone());
-    Arc::downgrade(&object_type)
+    ctx.cache_output_type(ident, object_type)
 }

--- a/query-engine/schema-builder/src/output_types/objects/model.rs
+++ b/query-engine/schema-builder/src/output_types/objects/model.rs
@@ -10,14 +10,14 @@ pub(crate) fn initialize_cache(ctx: &mut BuilderContext<'_>) {
     for model in ctx.internal_data_model.models() {
         let ident = Identifier::new_model(IdentifierType::Model(model.clone()));
 
-        ctx.cache_output_type(ident.clone(), Arc::new(ObjectType::new(ident, Some(model.id))));
+        ctx.cache_output_type(ident.clone(), ObjectType::new(ident, Some(model.id)));
     }
 }
 
 // Compute fields on all cached model object types.
 pub(crate) fn initialize_fields(ctx: &mut BuilderContext<'_>) {
     for model in ctx.internal_data_model.models() {
-        let obj: ObjectTypeWeakRef = map_type(ctx, &model);
+        let obj = map_type(ctx, &model);
         let mut fields = compute_model_object_type_fields(ctx, &model);
 
         // Add _count field. Only include to-many fields.
@@ -35,15 +35,14 @@ pub(crate) fn initialize_fields(ctx: &mut BuilderContext<'_>) {
             ),
         );
 
-        obj.into_arc().set_fields(fields);
+        ctx.db[obj].set_fields(fields);
     }
 }
 
 /// Returns an output object type for the given model.
 /// Relies on the output type cache being initalized.
-pub(crate) fn map_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> ObjectTypeWeakRef {
+pub(crate) fn map_type(ctx: &mut BuilderContext<'_>, model: &ModelRef) -> OutputObjectTypeId {
     let ident = Identifier::new_model(IdentifierType::Model(model.clone()));
-
     ctx.get_output_type(&ident)
         .expect("Invariant violation: Initialized output object type for each model.")
 }

--- a/query-engine/schema-builder/src/output_types/query_type.rs
+++ b/query-engine/schema-builder/src/output_types/query_type.rs
@@ -2,7 +2,7 @@ use super::*;
 use input_types::fields::arguments;
 
 /// Builds the root `Query` type.
-pub(crate) fn build(ctx: &mut BuilderContext<'_>) -> (OutputType, ObjectTypeStrongRef) {
+pub(crate) fn build(ctx: &mut BuilderContext<'_>) -> OutputObjectTypeId {
     let fields: Vec<_> = ctx
         .internal_data_model
         .models()
@@ -28,9 +28,7 @@ pub(crate) fn build(ctx: &mut BuilderContext<'_>) -> (OutputType, ObjectTypeStro
         .collect();
 
     let ident = Identifier::new_prisma("Query");
-    let strong_ref = Arc::new(object_type(ident, fields, None));
-
-    (OutputType::Object(Arc::downgrade(&strong_ref)), strong_ref)
+    ctx.db.push_output_object_type(object_type(ident, fields, None))
 }
 
 /// Builds a "single" query arity item field (e.g. "user", "post" ...) for given model.

--- a/query-engine/schema-builder/src/utils.rs
+++ b/query-engine/schema-builder/src/utils.rs
@@ -1,9 +1,6 @@
 use super::*;
 use once_cell::sync::OnceCell;
-use prisma_models::{
-    ast, dml,
-    walkers::{self, PrimaryKeyWalker},
-};
+use prisma_models::{ast, dml, walkers};
 use std::sync::Arc;
 
 /// Object type convenience wrapper function.
@@ -44,7 +41,7 @@ where
 {
     OutputField {
         name: name.into(),
-        arguments: arguments.into_iter().map(Arc::new).collect(),
+        arguments,
         field_type: Arc::new(field_type),
         query_info,
         is_nullable: false,
@@ -65,7 +62,7 @@ where
 {
     let mut input_field = InputField::new(name.into(), default_value, true);
     for field_type in field_types {
-        input_field.push_type(field_type, &mut ctx.input_field_types);
+        input_field.push_type(field_type, &mut ctx.db);
     }
     input_field
 }
@@ -85,7 +82,7 @@ pub fn compound_index_field_name(index: &walkers::IndexWalker<'_>) -> String {
 }
 
 /// Computes a compound field name based on a multi-field id.
-pub fn compound_id_field_name(pk: PrimaryKeyWalker<'_>) -> String {
+pub fn compound_id_field_name(pk: walkers::PrimaryKeyWalker<'_>) -> String {
     pk.name()
         .map(ToOwned::to_owned)
         .unwrap_or_else(|| pk.fields().map(|sf| sf.name()).collect::<Vec<_>>().join("_"))

--- a/query-engine/schema/src/db.rs
+++ b/query-engine/schema/src/db.rs
@@ -1,0 +1,72 @@
+use crate::{EnumType, InputObjectType, InputType, ObjectType};
+use std::ops;
+
+/// Internal data structure for QuerySchema. It manages the normalized data about input, output
+/// and enum types.
+#[derive(Default, Debug)]
+pub struct QuerySchemaDatabase {
+    input_object_types: Vec<InputObjectType>,
+    output_object_types: Vec<ObjectType>,
+    enum_types: Vec<EnumType>,
+
+    /// Possible types for input fields. This is an internal implementation detail, it should stay
+    /// private.
+    pub input_field_types: Vec<InputType>,
+}
+
+impl QuerySchemaDatabase {
+    pub(crate) fn iter_enum_types(&self) -> impl Iterator<Item = &EnumType> {
+        self.enum_types.iter()
+    }
+
+    pub fn push_input_object_type(&mut self, ty: InputObjectType) -> InputObjectTypeId {
+        let id = InputObjectTypeId(self.input_object_types.len());
+        self.input_object_types.push(ty);
+        id
+    }
+
+    pub fn push_output_object_type(&mut self, ty: ObjectType) -> OutputObjectTypeId {
+        let id = OutputObjectTypeId(self.output_object_types.len());
+        self.output_object_types.push(ty);
+        id
+    }
+
+    pub fn push_enum_type(&mut self, ty: EnumType) -> EnumTypeId {
+        let id = EnumTypeId(self.enum_types.len());
+        self.enum_types.push(ty);
+        id
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InputObjectTypeId(usize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct OutputObjectTypeId(usize);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct EnumTypeId(usize);
+
+impl ops::Index<InputObjectTypeId> for QuerySchemaDatabase {
+    type Output = InputObjectType;
+
+    fn index(&self, index: InputObjectTypeId) -> &Self::Output {
+        &self.input_object_types[index.0]
+    }
+}
+
+impl ops::Index<OutputObjectTypeId> for QuerySchemaDatabase {
+    type Output = ObjectType;
+
+    fn index(&self, index: OutputObjectTypeId) -> &Self::Output {
+        &self.output_object_types[index.0]
+    }
+}
+
+impl ops::Index<EnumTypeId> for QuerySchemaDatabase {
+    type Output = EnumType;
+
+    fn index(&self, index: EnumTypeId) -> &Self::Output {
+        &self.enum_types[index.0]
+    }
+}

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(rust_2018_idioms, unsafe_code)]
 
+mod db;
 mod enum_type;
 mod identifier_type;
 mod input_types;
@@ -7,6 +8,7 @@ mod output_types;
 mod query_schema;
 mod utils;
 
+pub use db::*;
 pub use enum_type::*;
 pub use identifier_type::*;
 pub use input_types::*;
@@ -14,34 +16,11 @@ pub use output_types::*;
 pub use query_schema::*;
 pub use utils::*;
 
-use std::sync::{Arc, Weak};
-
-pub type ObjectTypeStrongRef = Arc<ObjectType>;
-pub type ObjectTypeWeakRef = Weak<ObjectType>;
-
-pub type InputObjectTypeStrongRef = Arc<InputObjectType>;
-pub type InputObjectTypeWeakRef = Weak<InputObjectType>;
+use std::sync::Arc;
 
 pub type QuerySchemaRef = Arc<QuerySchema>;
 pub type OutputTypeRef = Arc<OutputType>;
 pub type OutputFieldRef = Arc<OutputField>;
-pub type InputFieldRef = Arc<InputField>;
-
-pub type EnumTypeRef = Arc<EnumType>;
-pub type EnumTypeWeakRef = Weak<EnumType>;
-
-/// Since we have the invariant that the weak refs that are used throughout the query
-/// schema have to be always valid, we use this simple trait to keep the code clutter low.
-pub trait IntoArc<T> {
-    #[allow(clippy::wrong_self_convention)]
-    fn into_arc(&self) -> Arc<T>;
-}
-
-impl<T> IntoArc<T> for Weak<T> {
-    fn into_arc(&self) -> Arc<T> {
-        self.upgrade().expect("Expected weak reference to be valid.")
-    }
-}
 
 #[derive(Debug, PartialEq)]
 pub struct Deprecation {

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -6,9 +6,9 @@ use std::{fmt, sync::Arc};
 
 #[derive(Debug, Clone)]
 pub enum OutputType {
-    Enum(EnumTypeWeakRef),
+    Enum(EnumTypeId),
     List(OutputTypeRef),
-    Object(ObjectTypeWeakRef),
+    Object(OutputObjectTypeId),
     Scalar(ScalarType),
 }
 
@@ -17,7 +17,7 @@ impl OutputType {
         OutputType::List(Arc::new(containing))
     }
 
-    pub fn object(containing: ObjectTypeWeakRef) -> OutputType {
+    pub fn object(containing: OutputObjectTypeId) -> OutputType {
         OutputType::Object(containing)
     }
 
@@ -45,7 +45,7 @@ impl OutputType {
         OutputType::Scalar(ScalarType::Boolean)
     }
 
-    pub fn enum_type(containing: EnumTypeWeakRef) -> OutputType {
+    pub fn enum_type(containing: EnumTypeId) -> OutputType {
         OutputType::Enum(containing)
     }
 
@@ -71,11 +71,11 @@ impl OutputType {
 
     /// Attempts to recurse through the type until an object type is found.
     /// Returns Some(ObjectTypeStrongRef) if ab object type is found, None otherwise.
-    pub fn as_object_type(&self) -> Option<ObjectTypeStrongRef> {
+    pub fn as_object_type<'a>(&self, db: &'a QuerySchemaDatabase) -> Option<&'a ObjectType> {
         match self {
             OutputType::Enum(_) => None,
-            OutputType::List(inner) => inner.as_object_type(),
-            OutputType::Object(obj) => Some(obj.into_arc()),
+            OutputType::List(inner) => inner.as_object_type(db),
+            OutputType::Object(obj) => Some(&db[*obj]),
             OutputType::Scalar(_) => None,
         }
     }
@@ -172,7 +172,7 @@ pub struct OutputField {
 
     /// Arguments are input fields, but positioned in context of an output field
     /// instead of being attached to an input object.
-    pub arguments: Vec<InputFieldRef>,
+    pub arguments: Vec<InputField>,
 
     /// Indicates the presence of the field on the higher output objects.
     /// States whether or not the field can be null.
@@ -228,8 +228,8 @@ impl OutputField {
 
     // Is relation determines whether the given output field maps to a a relation, i.e.
     // is an object and that object is backed by a model, meaning that it is not an scalar list
-    pub fn maps_to_relation(&self) -> bool {
-        let o = self.field_type.as_object_type();
+    pub fn maps_to_relation(&self, query_schema: &QuerySchema) -> bool {
+        let o = self.field_type.as_object_type(&query_schema.db);
         o.is_some() && o.unwrap().model.is_some()
     }
 }


### PR DESCRIPTION
...and input fields.

Instead of storing and caching `Arc`'ed versions of the types, we have a system similar to the PSL system with a single type (QuerySchemaDatabase) holding all the data, and we reference this data with typed integer identifiers.

That also means we have to pass the QuerySchema in more places in query-core. That is unavoidable if we want to move from a reference counted object graph to a more compact, data-oriented-design-ish representation.

Memory profiling schema builder with the odoo schema with DHAT shows a very noticeable drop in memory usage:

in branch

==1699== Total:     377,673,908 bytes in 3,498,476 blocks
==1699== At t-gmax: 136,875,443 bytes in 608,763 blocks
==1699== At t-end:  0 bytes in 0 blocks
==1699== Reads:     1,071,822,256 bytes
==1699== Writes:    366,576,402 bytes

on main (5ebd3e81411f77ba6842831187db14b6fada02f1)

==1699== Total:     471,456,919 bytes in 3,994,731 blocks
==1699== At t-gmax: 145,464,526 bytes in 1,086,900 blocks
==1699== At t-end:  0 bytes in 0 blocks
==1699== Reads:     1,208,299,978 bytes
==1699== Writes:    476,604,670 bytes

The first two lines in each block are the interesting ones: "Total" is how much memory was allocated during the whole execution, and "t-gmax" is the high watermark memory usage. We see a noticeable drop in both.

Below, the results of the schema-builder benchmarks. The baseline is current `main` (5ebd3e81411f77ba6842831187db14b6fada02f1).

schema_builder::build (small)
                        time:   [1.8168 ms 1.8254 ms 1.8344 ms]
                        change: [-13.144% -12.142% -11.014%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  3 (3.00%) high mild
  4 (4.00%) high severe

schema_builder::build (medium)
                        time:   [15.253 ms 15.336 ms 15.424 ms]
                        change: [-17.328% -15.968% -14.675%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

Benchmarking schema_builder::build (large): Warming up for 3.0000 s Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 33.6s, or reduce sample count to 10. schema_builder::build (large)
                        time:   [333.33 ms 335.23 ms 337.25 ms]
                        change: [-8.5819% -7.5964% -6.7264%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild