### PR TITLE
qe/dmmf: use patience algorithm for diffing DMMF snapshots

### DIFF
--- a/query-engine/dmmf/src/tests/setup.rs
+++ b/query-engine/dmmf/src/tests/setup.rs
@@ -56,7 +56,8 @@ impl std::fmt::Display for Line {
 }
 
 fn format_diff(old: &str, new: &str) -> String {
-    let diff = TextDiff::from_lines(old, new);
+    let mut differ = TextDiffConfig::default();
+    let diff = differ.algorithm(Algorithm::Patience).diff_lines(old, new);
     let mut buf = String::new();
 
     for (idx, group) in diff.grouped_ops(2).iter().enumerate() {


### PR DESCRIPTION
Diffing takes time, on account of the DMMF JSON blobs being ginormous.

I just tried a different algorithm from `similar`, and it seems way faster. Ideally we should measure but there's no time now.