### PR TITLE
qe/schema-builder: use a faster hasher for the type caches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.2.7",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +281,7 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d76085681585d39016f4d3841eb019201fc54d2dd0d92ad1e4fab3bfb32754"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "base64 0.13.1",
  "chrono",
  "hex",
@@ -1350,7 +1362,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1359,7 +1371,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -1943,7 +1955,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e52eb6380b6d2a10eb3434aec0885374490f5b82c8aaf5cd487a183c98be834"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "metrics-macros",
 ]
 
@@ -1953,7 +1965,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "142c53885123b68d94108295a09d4afe1a1388ed95b54d5dacd9a454753030f2"
 dependencies = [
- "ahash",
+ "ahash 0.7.6",
  "metrics-macros",
 ]
 
@@ -3911,6 +3923,7 @@ dependencies = [
 name = "schema-builder"
 version = "0.1.0"
 dependencies = [
+ "ahash 0.8.3",
  "codspeed-criterion-compat",
  "once_cell",
  "prisma-models",

--- a/query-engine/schema-builder/Cargo.toml
+++ b/query-engine/schema-builder/Cargo.toml
@@ -8,6 +8,7 @@ psl.workspace = true
 schema = { path = "../schema" }
 prisma-models = { path = "../prisma-models" }
 once_cell = "1.3"
+ahash = "0.8.3"
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/query-engine/schema-builder/src/cache.rs
+++ b/query-engine/schema-builder/src/cache.rs
@@ -13,13 +13,13 @@ use std::{collections::HashMap, fmt::Debug};
 /// uphold schema building consistency guarantees.
 #[derive(Debug, Default)]
 pub(crate) struct TypeRefCache<T> {
-    cache: HashMap<Identifier, T>,
+    cache: HashMap<Identifier, T, ahash::RandomState>,
 }
 
 impl<T: Copy + Debug> TypeRefCache<T> {
     pub(crate) fn with_capacity(capacity: usize) -> Self {
         TypeRefCache {
-            cache: HashMap::with_capacity(capacity),
+            cache: HashMap::with_capacity_and_hasher(capacity, ahash::RandomState::new()),
         }
     }
 


### PR DESCRIPTION
Local benchmark runs show a pretty consistent ~8% performance improvement.