### PR TITLE
qe/query-core: replace unsafe block with safe code

### DIFF
--- a/query-engine/core/src/executor/interpreting_executor.rs
+++ b/query-engine/core/src/executor/interpreting_executor.rs
@@ -1,7 +1,7 @@
 use super::execute_operation::{execute_many_operations, execute_many_self_contained, execute_single_self_contained};
 use super::request_context;
 use crate::{
-    protocol::EngineProtocol, BatchDocumentTransaction, CoreError, OpenTx, Operation, QueryExecutor, ResponseData,
+    protocol::EngineProtocol, BatchDocumentTransaction, CoreError, Operation, QueryExecutor, ResponseData,
     TransactionActorManager, TransactionError, TransactionManager, TransactionOptions, TxId,
 };
 
@@ -170,17 +170,17 @@ where
             .await;
 
             let conn = conn.map_err(|_| TransactionError::AcquisitionTimeout)??;
-            let c_tx = OpenTx::start(conn, isolation_level).await?;
 
             self.itx_manager
                 .create_tx(
                     query_schema.clone(),
                     id.clone(),
-                    c_tx,
+                    conn,
+                    isolation_level,
                     Duration::from_millis(valid_for_millis),
                     engine_protocol,
                 )
-                .await;
+                .await?;
 
             debug!("[{}] Started.", id);
             Ok(id)

--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -1,8 +1,9 @@
 use super::{CachedTx, TransactionError, TxOpRequest, TxOpRequestMsg, TxOpResponse};
 use crate::{
     execute_many_operations, execute_single_operation, protocol::EngineProtocol,
-    telemetry::helpers::set_span_link_from_traceparent, ClosedTx, OpenTx, Operation, ResponseData, TxId,
+    telemetry::helpers::set_span_link_from_traceparent, ClosedTx, Operation, ResponseData, TxId,
 };
+use connector::Connection;
 use schema::QuerySchemaRef;
 use std::{collections::HashMap, sync::Arc};
 use tokio::{
@@ -23,18 +24,18 @@ enum RunState {
     Finished,
 }
 
-pub struct ITXServer {
+pub struct ITXServer<'a> {
     id: TxId,
-    pub cached_tx: CachedTx,
+    pub cached_tx: CachedTx<'a>,
     pub timeout: Duration,
     receive: Receiver<TxOpRequest>,
     query_schema: QuerySchemaRef,
 }
 
-impl ITXServer {
+impl<'a> ITXServer<'a> {
     pub fn new(
         id: TxId,
-        tx: CachedTx,
+        tx: CachedTx<'a>,
         timeout: Duration,
         receive: Receiver<TxOpRequest>,
         query_schema: QuerySchemaRef,
@@ -115,7 +116,7 @@ impl ITXServer {
         if let CachedTx::Open(_) = self.cached_tx {
             let open_tx = self.cached_tx.as_open()?;
             trace!("[{}] committing.", self.id.to_string());
-            open_tx.tx.commit().await?;
+            open_tx.commit().await?;
             self.cached_tx = CachedTx::Committed;
         }
 
@@ -126,7 +127,7 @@ impl ITXServer {
         debug!("[{}] rolling back, was timed out = {was_timeout}", self.name());
         if let CachedTx::Open(_) = self.cached_tx {
             let open_tx = self.cached_tx.as_open()?;
-            open_tx.tx.rollback().await?;
+            open_tx.rollback().await?;
             if was_timeout {
                 trace!("[{}] Expired Rolling back", self.id.to_string());
                 self.cached_tx = CachedTx::Expired;
@@ -243,37 +244,53 @@ impl ITXClient {
     }
 }
 
-pub fn spawn_itx_actor(
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn spawn_itx_actor(
     query_schema: QuerySchemaRef,
     tx_id: TxId,
-    value: OpenTx,
+    mut conn: Box<dyn Connection + Send + Sync>,
+    isolation_level: Option<String>,
     timeout: Duration,
     channel_size: usize,
     send_done: Sender<(TxId, Option<ClosedTx>)>,
     engine_protocol: EngineProtocol,
-) -> ITXClient {
-    let (tx_to_server, rx_from_client) = channel::<TxOpRequest>(channel_size);
+) -> crate::Result<ITXClient> {
+    let span = Span::current();
+    let tx_id_str = tx_id.to_string();
+    span.record("itx_id", tx_id_str.as_str());
+    let dispatcher = crate::get_current_dispatcher();
 
+    let (tx_to_server, rx_from_client) = channel::<TxOpRequest>(channel_size);
     let client = ITXClient {
         send: tx_to_server,
         tx_id: tx_id.clone(),
     };
-
-    let mut server = ITXServer::new(
-        tx_id.clone(),
-        CachedTx::Open(value),
-        timeout,
-        rx_from_client,
-        query_schema,
-    );
-    let dispatcher = crate::get_current_dispatcher();
-    let span = Span::current();
-
-    let tx_id_str = tx_id.to_string();
-    span.record("itx_id", tx_id_str.as_str());
+    let (open_transaction_send, open_transaction_rcv) = oneshot::channel();
 
     tokio::task::spawn(
         crate::executor::with_request_context(engine_protocol, async move {
+            // We match on the result in order to send the error to the parent task and abort this
+            // task, on error. This is a separate task (actor), not a function where we can just bubble up the
+            // result.
+            let c_tx = match conn.start_transaction(isolation_level).await {
+                Ok(c_tx) => {
+                    open_transaction_send.send(Ok(())).unwrap();
+                    c_tx
+                }
+                Err(err) => {
+                    open_transaction_send.send(Err(err)).unwrap();
+                    return;
+                }
+            };
+
+            let mut server = ITXServer::new(
+                tx_id.clone(),
+                CachedTx::Open(c_tx),
+                timeout,
+                rx_from_client,
+                query_schema,
+            );
+
             let start_time = Instant::now();
             let sleep = time::sleep(timeout);
             tokio::pin!(sleep);
@@ -312,7 +329,9 @@ pub fn spawn_itx_actor(
         .with_subscriber(dispatcher),
     );
 
-    client
+    open_transaction_rcv.await.unwrap()?;
+
+    Ok(client)
 }
 
 /// Spawn the client list clear actor
@@ -356,7 +375,7 @@ pub fn spawn_itx_actor(
         }
    ```
 */
-pub fn spawn_client_list_clear_actor(
+pub(crate) fn spawn_client_list_clear_actor(
     clients: Arc<RwLock<HashMap<TxId, ITXClient>>>,
     closed_txs: Arc<RwLock<lru::LruCache<TxId, Option<ClosedTx>>>>,
     mut rx: Receiver<(TxId, Option<ClosedTx>)>,

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -1,10 +1,7 @@
 use crate::CoreError;
-use connector::{Connection, ConnectionLike, Transaction};
+use connector::Transaction;
 use std::fmt::Display;
-use tokio::{
-    task::JoinHandle,
-    time::{Duration, Instant},
-};
+use tokio::time::{Duration, Instant};
 
 mod actor_manager;
 mod actors;
@@ -72,31 +69,31 @@ where
 
 impl Display for TxId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        Display::fmt(&self.0, f)
     }
 }
 
-pub enum CachedTx {
-    Open(OpenTx),
+pub enum CachedTx<'a> {
+    Open(Box<dyn Transaction + 'a>),
     Committed,
     RolledBack,
     Expired,
 }
 
-impl Display for CachedTx {
+impl Display for CachedTx<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            CachedTx::Open(_) => write!(f, "Open"),
-            CachedTx::Committed => write!(f, "Committed"),
-            CachedTx::RolledBack => write!(f, "Rolled back"),
-            CachedTx::Expired => write!(f, "Expired"),
+            CachedTx::Open(_) => f.write_str("Open"),
+            CachedTx::Committed => f.write_str("Committed"),
+            CachedTx::RolledBack => f.write_str("Rolled back"),
+            CachedTx::Expired => f.write_str("Expired"),
         }
     }
 }
 
-impl CachedTx {
+impl<'a> CachedTx<'a> {
     /// Requires this cached TX to be `Open`, else an error will be raised that it is no longer valid.
-    pub fn as_open(&mut self) -> crate::Result<&mut OpenTx> {
+    pub(crate) fn as_open(&mut self) -> crate::Result<&mut Box<dyn Transaction + 'a>> {
         if let Self::Open(ref mut otx) = self {
             Ok(otx)
         } else {
@@ -105,7 +102,7 @@ impl CachedTx {
         }
     }
 
-    pub fn to_closed(&self, start_time: Instant, timeout: Duration) -> Option<ClosedTx> {
+    pub(crate) fn to_closed(&self, start_time: Instant, timeout: Duration) -> Option<ClosedTx> {
         match self {
             CachedTx::Open(_) => None,
             CachedTx::Committed => Some(ClosedTx::Committed),
@@ -115,39 +112,7 @@ impl CachedTx {
     }
 }
 
-pub struct OpenTx {
-    pub conn: Box<dyn Connection>,
-    pub tx: Box<dyn Transaction + 'static>,
-    pub expiration_timer: Option<JoinHandle<()>>,
-}
-
-impl OpenTx {
-    pub async fn start(mut conn: Box<dyn Connection>, isolation_level: Option<String>) -> crate::Result<Self> {
-        // Forces static lifetime for the transaction, disabling the lifetime checks for `tx`.
-        // Why is this okay? We store the connection the tx depends on with its lifetime next to
-        // the tx in the struct. Neither the connection nor the tx are moved out of this struct.
-        // The `OpenTx` struct is dropped as a unit.
-        let transaction: Box<dyn Transaction + '_> = conn.start_transaction(isolation_level).await?;
-        let tx = unsafe {
-            let tx: Box<dyn Transaction + 'static> = std::mem::transmute(transaction);
-            tx
-        };
-
-        let c_tx = OpenTx {
-            conn,
-            tx,
-            expiration_timer: None,
-        };
-
-        Ok(c_tx)
-    }
-
-    pub fn as_connection_like(&mut self) -> &mut dyn ConnectionLike {
-        self.tx.as_mut().as_connection_like()
-    }
-}
-
-pub enum ClosedTx {
+pub(crate) enum ClosedTx {
     Committed,
     RolledBack,
     Expired { start_time: Instant, timeout: Duration },

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(rust_2018_idioms)]
+#![deny(unsafe_code, rust_2018_idioms)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
And forbid unsafe code in the future.

The problem here is a self-borrowing problem: OpenTx contains a
connection, and a transaction that is initialized (in an async, fallible
way) from that connection. They are then both stored in the same struct.
That is unsafe for the usual reasons for self-borrowing: it doesn't
account for moves, that can invalidate pointers — that violates memory
safety. The comment by Dom justifying the unsafe block does _not_
address. We have to fix this situation.

The fix is simple: move the connection.start_transaction() call inside
the transaction actor. That way, the transaction can be borrowed by the
ITXServer while the connection is in scope (the actor's top-level is
basically an event loop). That required moving some code, changing some
signatures and passing potential transaction opening errors through a
new channel.

The behaviour should be identical.

closes https://github.com/prisma/client-planning/issues/288