### PR TITLE
fix(schema-engine): disable no nulls first/last on CockroachDB due to leaking warnings in prisma/prisma

### DIFF
--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -1213,7 +1213,8 @@ impl<'a> SqlSchemaDescriber<'a> {
 
             pg_ext.indexes.push((index_id, algorithm));
 
-            if algorithm == SqlIndexAlgorithm::BTree && !is_primary_key {
+            // only enable nulls first/last on Postgres
+            if !self.is_cockroach() && algorithm == SqlIndexAlgorithm::BTree && !is_primary_key {
                 let nulls_first = row.get_expect_bool("nulls_first");
 
                 let position = if nulls_first {


### PR DESCRIPTION
Note: this PR unlocks the TS pipeline in the `prisma/prisma` repo.
- [TS integration before this PR](https://github.com/prisma/prisma/pull/18655)
- [TS integration after this PR](https://github.com/prisma/prisma/pull/18689)