### PR TITLE
query-core: replace lock-free queue dependency with simple vec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3169,7 +3169,6 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "crossbeam-channel",
- "crossbeam-queue",
  "cuid",
  "enumflags2",
  "futures",

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -9,7 +9,6 @@ base64 = "0.12"
 bigdecimal = "0.3"
 chrono = "0.4"
 connector = { path = "../connectors/query-connector", package = "query-connector" }
-crossbeam-queue = "0.3.5"
 crossbeam-channel = "0.5.6"
 psl.workspace = true
 futures = "0.3"

--- a/query-engine/core/src/executor/pipeline.rs
+++ b/query-engine/core/src/executor/pipeline.rs
@@ -3,14 +3,14 @@ use schema::QuerySchema;
 use tracing::Instrument;
 
 #[derive(Debug)]
-pub struct QueryPipeline<'conn> {
+pub(crate) struct QueryPipeline<'conn> {
     graph: QueryGraph,
     interpreter: QueryInterpreter<'conn>,
     serializer: IrSerializer,
 }
 
 impl<'conn> QueryPipeline<'conn> {
-    pub fn new(graph: QueryGraph, interpreter: QueryInterpreter<'conn>, serializer: IrSerializer) -> Self {
+    pub(crate) fn new(graph: QueryGraph, interpreter: QueryInterpreter<'conn>, serializer: IrSerializer) -> Self {
         Self {
             graph,
             interpreter,
@@ -18,7 +18,7 @@ impl<'conn> QueryPipeline<'conn> {
         }
     }
 
-    pub async fn execute(
+    pub(crate) async fn execute(
         mut self,
         query_schema: &QuerySchema,
         trace_id: Option<String>,

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -5,7 +5,6 @@ use super::{
 };
 use crate::{Query, QueryResult};
 use connector::ConnectionLike;
-use crossbeam_queue::SegQueue;
 use futures::future::BoxFuture;
 use prisma_models::prelude::*;
 use std::{collections::HashMap, fmt};
@@ -140,9 +139,9 @@ impl Env {
     }
 }
 
-pub struct QueryInterpreter<'conn> {
+pub(crate) struct QueryInterpreter<'conn> {
     pub(crate) conn: &'conn mut dyn ConnectionLike,
-    log: SegQueue<String>,
+    log: Vec<String>,
 }
 
 impl<'conn> fmt::Debug for QueryInterpreter<'conn> {
@@ -156,8 +155,8 @@ impl<'conn> QueryInterpreter<'conn> {
         tracing::level_filters::STATIC_MAX_LEVEL == tracing::level_filters::LevelFilter::TRACE
     }
 
-    pub fn new(conn: &'conn mut dyn ConnectionLike) -> QueryInterpreter<'_> {
-        let log = SegQueue::new();
+    pub(crate) fn new(conn: &'conn mut dyn ConnectionLike) -> QueryInterpreter<'_> {
+        let mut log = Vec::new();
 
         if Self::log_enabled() {
             log.push("\n".to_string());
@@ -287,17 +286,17 @@ impl<'conn> QueryInterpreter<'conn> {
         }
     }
 
-    pub fn log_output(&self) -> String {
+    pub(crate) fn log_output(&self) -> String {
         let mut output = String::with_capacity(self.log.len() * 30);
 
-        while let Some(s) = self.log.pop() {
-            output.push_str(&s);
+        for s in self.log.iter().rev() {
+            output.push_str(s)
         }
 
         output
     }
 
-    fn log_line<F, S>(&self, level: usize, f: F)
+    fn log_line<F, S>(&mut self, level: usize, f: F)
     where
         S: AsRef<str>,
         F: FnOnce() -> S,


### PR DESCRIPTION
The QueryInterpreter uses a lock-free concurrent datastructure for its log messages, where it can get away with a regular Vec without logging.

Swapping the concurrent queue with a vanilla vector is:

- Simpler. We now use a ubiquitous data structure from the standard library instead of a third-party library (as awesome as crossbeam is). The API is more familiar, and it does not suggest that anything advanced or tricky is happening. It uses up less complexity budget.
- Very likely faster. The big caveat is that I haven't measured, but we go from a data structure relying on atomics and fragmented allocations to something atomics-free, lock-free and single-allocation. It ought to perform better, and lead to less memory fragmentation.