### PR TITLE
      qe/schema-builder: remove Arc indirection on output object fields 

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
@@ -3,7 +3,7 @@ use itertools::Itertools;
 use prisma_models::PrismaValue;
 use query_core::{
     constants::custom_types,
-    schema::{InputField, InputObjectType, InputType, OutputFieldRef, QuerySchema, QuerySchemaRef},
+    schema::{InputField, InputObjectType, InputType, OutputField, QuerySchema, QuerySchemaRef},
     schema_builder::constants::{self, json_null},
     ArgumentValue, ArgumentValueObject, Selection,
 };
@@ -29,7 +29,7 @@ impl JsonRequest {
         let output = JsonSingleQuery {
             model_name,
             action: Action::new(query_tag),
-            query: graphql_selection_to_json_field_query(selection, &schema_field, query_schema.as_ref()),
+            query: graphql_selection_to_json_field_query(selection, schema_field, query_schema.as_ref()),
         };
 
         Ok(output)
@@ -38,7 +38,7 @@ impl JsonRequest {
 
 fn graphql_selection_to_json_field_query(
     mut selection: Selection,
-    schema_field: &OutputFieldRef,
+    schema_field: &OutputField,
     query_schema: &QuerySchema,
 ) -> FieldQuery {
     FieldQuery {
@@ -128,7 +128,7 @@ fn arg_value_to_json(value: ArgumentValue, typ: InferredType, query_schema: &Que
 
 fn graphql_selection_to_json_selection(
     selection: Selection,
-    schema_field: &OutputFieldRef,
+    schema_field: &OutputField,
     query_schema: &QuerySchema,
 ) -> SelectionSet {
     let mut res: IndexMap<String, SelectionSetValue> = IndexMap::new();
@@ -141,16 +141,17 @@ fn graphql_selection_to_json_selection(
         if no_args && no_nested_selection {
             res.insert(selection_name, SelectionSetValue::Shorthand(true));
         } else {
-            let nested_field = schema_field
+            let (_, nested_field) = schema_field
                 .field_type
                 .as_object_type(&query_schema.db)
                 .unwrap()
+                .1
                 .find_field(&selection_name)
                 .unwrap();
 
             let nested = SelectionSetValue::Nested(graphql_selection_to_json_field_query(
                 nested_selection,
-                &nested_field,
+                nested_field,
                 query_schema,
             ));
 

--- a/query-engine/core/src/query_document/parse_ast.rs
+++ b/query-engine/core/src/query_document/parse_ast.rs
@@ -1,11 +1,10 @@
 //! Parsed query document tree. Naming is WIP.
 //! Structures represent parsed and validated parts of the query document, used by the query builders.
+use crate::QueryParserResult;
 use indexmap::IndexMap;
 use prisma_models::{OrderBy, PrismaValue, ScalarFieldRef};
-use schema::{ObjectTag, OutputFieldRef};
+use schema::{ObjectTag, OutputFieldId};
 use std::ops::{Deref, DerefMut};
-
-use crate::QueryParserResult;
 
 pub(crate) type ParsedInputList = Vec<ParsedInputValue>;
 
@@ -86,7 +85,7 @@ pub struct FieldPair {
     pub parsed_field: ParsedField,
 
     /// The schema field that the parsed field corresponds to.
-    pub schema_field: OutputFieldRef,
+    pub schema_field: OutputFieldId,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -36,7 +36,7 @@ type UncheckedItemsWithParents = IndexMap<Option<SelectionResult>, Vec<Item>>;
 /// Returns a map of pairs of (parent ID, response)
 pub(crate) fn serialize_internal(
     result: QueryResult,
-    field: &OutputFieldRef,
+    field: &OutputField,
     is_list: bool,
     query_schema: &QuerySchema,
 ) -> crate::Result<CheckedItemsWithParents> {
@@ -62,7 +62,7 @@ pub(crate) fn serialize_internal(
 }
 
 fn serialize_aggregations(
-    output_field: &OutputFieldRef,
+    output_field: &OutputField,
     record_aggregations: RecordAggregations,
     query_schema: &QuerySchema,
 ) -> crate::Result<CheckedItemsWithParents> {
@@ -80,7 +80,7 @@ fn serialize_aggregations(
                     let output_field = aggregate_object_type.find_field(field.name()).unwrap();
                     flattened.insert(
                         field.name().to_owned(),
-                        serialize_scalar(&output_field, value, query_schema)?,
+                        serialize_scalar(output_field.1, value, query_schema)?,
                     );
                 }
 
@@ -101,7 +101,7 @@ fn serialize_aggregations(
                     );
                     flattened.insert(
                         format!("_avg_{}", field.name()),
-                        serialize_scalar(&output_field, value, query_schema)?,
+                        serialize_scalar(output_field, value, query_schema)?,
                     );
                 }
 
@@ -114,7 +114,7 @@ fn serialize_aggregations(
                     );
                     flattened.insert(
                         format!("_sum_{}", field.name()),
-                        serialize_scalar(&output_field, value, query_schema)?,
+                        serialize_scalar(output_field, value, query_schema)?,
                     );
                 }
 
@@ -128,7 +128,7 @@ fn serialize_aggregations(
                     flattened.insert(
                         format!("_min_{}", field.name()),
                         serialize_scalar(
-                            &output_field,
+                            output_field,
                             coerce_non_numeric(value, &output_field.field_type),
                             query_schema,
                         )?,
@@ -145,7 +145,7 @@ fn serialize_aggregations(
                     flattened.insert(
                         format!("_max_{}", field.name()),
                         serialize_scalar(
-                            &output_field,
+                            output_field,
                             coerce_non_numeric(value, &output_field.field_type),
                             query_schema,
                         )?,
@@ -228,19 +228,19 @@ fn extract_aggregate_object_type<'a>(output_type: &OutputType, query_schema: &'a
 }
 
 // Workaround until we streamline serialization.
-fn find_nested_aggregate_output_field(
+fn find_nested_aggregate_output_field<'a>(
     object_type: &ObjectType,
     nested_obj_name: &str,
     nested_field_name: &str,
-    query_schema: &QuerySchema,
-) -> OutputFieldRef {
-    let nested_field = object_type.find_field(nested_obj_name).unwrap();
+    query_schema: &'a QuerySchema,
+) -> &'a OutputField {
+    let (_, nested_field) = object_type.find_field(nested_obj_name).unwrap();
     let nested_object_type = match nested_field.field_type.borrow() {
         OutputType::Object(obj) => &query_schema.db[*obj],
         _ => unreachable!("{} output must be an object.", nested_obj_name),
     };
 
-    nested_object_type.find_field(nested_field_name).unwrap()
+    nested_object_type.find_field(nested_field_name).unwrap().1
 }
 
 fn coerce_non_numeric(value: PrismaValue, output: &OutputType) -> PrismaValue {
@@ -252,8 +252,8 @@ fn coerce_non_numeric(value: PrismaValue, output: &OutputType) -> PrismaValue {
 
 fn serialize_record_selection(
     record_selection: RecordSelection,
-    field: &OutputFieldRef,
-    typ: &OutputTypeRef, // We additionally pass the type to allow recursing into nested type definitions of a field.
+    field: &OutputField,
+    typ: &OutputType, // We additionally pass the type to allow recursing into nested type definitions of a field.
     is_list: bool,
     query_schema: &QuerySchema,
 ) -> crate::Result<CheckedItemsWithParents> {
@@ -356,21 +356,18 @@ fn serialize_objects(
         let mut object = HashMap::with_capacity(values.len());
 
         for (val, field) in values.into_iter().zip(fields.iter()) {
-            let out_field = typ.find_field(field.name()).unwrap();
+            let (_, out_field) = typ.find_field(field.name()).unwrap();
 
             match field {
                 Field::Composite(cf) => {
                     object.insert(
                         field.name().to_owned(),
-                        serialize_composite(cf, &out_field, val, query_schema)?,
+                        serialize_composite(cf, out_field, val, query_schema)?,
                     );
                 }
 
                 _ if !out_field.field_type.is_object() => {
-                    object.insert(
-                        field.name().to_owned(),
-                        serialize_scalar(&out_field, val, query_schema)?,
-                    );
+                    object.insert(field.name().to_owned(), serialize_scalar(out_field, val, query_schema)?);
                 }
 
                 _ => (),
@@ -438,7 +435,7 @@ fn write_nested_items(
             }
 
             None => {
-                let field = enclosing_type.find_field(field_name).unwrap();
+                let (_, field) = enclosing_type.find_field(field_name).unwrap();
                 let default = match field.field_type.borrow() {
                     OutputType::List(_) => Item::list(Vec::new()),
                     _ if field.is_nullable => Item::Value(PrismaValue::Null),
@@ -469,8 +466,8 @@ fn process_nested_results(
         // todo Workaround, tb changed with flat reads.
         if let QueryResult::RecordSelection(ref rs) = nested_result {
             let name = rs.name.clone();
-            let field = enclosing_type.find_field(&name).unwrap();
-            let result = serialize_internal(nested_result, &field, false, query_schema)?;
+            let (_, field) = enclosing_type.find_field(&name).unwrap();
+            let result = serialize_internal(nested_result, field, false, query_schema)?;
 
             nested_mapping.insert(name, result);
         }
@@ -482,7 +479,7 @@ fn process_nested_results(
 // Problem: order of selections
 fn serialize_composite(
     cf: &CompositeFieldRef,
-    out_field: &OutputFieldRef,
+    out_field: &OutputField,
     value: PrismaValue,
     query_schema: &QuerySchema,
 ) -> crate::Result<Item> {
@@ -500,7 +497,7 @@ fn serialize_composite(
 
         PrismaValue::Object(pairs) => {
             let mut map = Map::new();
-            let object_type = out_field
+            let (_, object_type) = out_field
                 .field_type
                 .as_object_type(&query_schema.db)
                 .expect("Composite output field is not an object.");
@@ -516,20 +513,20 @@ fn serialize_composite(
                     .unwrap();
 
                 // The field on the output object type. Used for the actual serialization process.
-                let inner_out_field = object_type.find_field(inner_field.name()).unwrap();
+                let (_, inner_out_field) = object_type.find_field(inner_field.name()).unwrap();
 
                 match &inner_field {
                     Field::Composite(cf) => {
                         map.insert(
                             inner_field.name().to_owned(),
-                            serialize_composite(cf, &inner_out_field, value, query_schema)?,
+                            serialize_composite(cf, inner_out_field, value, query_schema)?,
                         );
                     }
 
                     _ if !inner_out_field.field_type.is_object() => {
                         map.insert(
                             inner_field.name().to_owned(),
-                            serialize_scalar(&inner_out_field, value, query_schema)?,
+                            serialize_scalar(inner_out_field, value, query_schema)?,
                         );
                     }
 
@@ -549,8 +546,8 @@ fn serialize_composite(
     }
 }
 
-fn serialize_scalar(field: &OutputFieldRef, value: PrismaValue, schema: &QuerySchema) -> crate::Result<Item> {
-    match (&value, field.field_type.as_ref()) {
+fn serialize_scalar(field: &OutputField, value: PrismaValue, schema: &QuerySchema) -> crate::Result<Item> {
+    match (&value, &field.field_type) {
         (PrismaValue::Null, _) if field.is_nullable => Ok(Item::Value(PrismaValue::Null)),
         (_, OutputType::Enum(et)) => match &schema.db[*et] {
             EnumType::Database(ref db) => convert_enum(value, db),
@@ -588,7 +585,7 @@ fn serialize_scalar(field: &OutputFieldRef, value: PrismaValue, schema: &QuerySc
     }
 }
 
-fn convert_prisma_value(field: &OutputFieldRef, value: PrismaValue, st: &ScalarType) -> crate::Result<PrismaValue> {
+fn convert_prisma_value(field: &OutputField, value: PrismaValue, st: &ScalarType) -> crate::Result<PrismaValue> {
     match crate::executor::get_engine_protocol() {
         EngineProtocol::Graphql => convert_prisma_value_graphql_protocol(field, value, st),
         EngineProtocol::Json => convert_prisma_value_json_protocol(field, value, st),
@@ -596,7 +593,7 @@ fn convert_prisma_value(field: &OutputFieldRef, value: PrismaValue, st: &ScalarT
 }
 
 fn convert_prisma_value_graphql_protocol(
-    field: &OutputFieldRef,
+    field: &OutputField,
     value: PrismaValue,
     st: &ScalarType,
 ) -> crate::Result<PrismaValue> {
@@ -636,7 +633,7 @@ fn convert_prisma_value_graphql_protocol(
 /// Since the JSON protocol is "schema-less" by design, clients require type information for them to
 /// properly deserialize special values such as bytes, decimal, datetime, etc.
 fn convert_prisma_value_json_protocol(
-    field: &OutputFieldRef,
+    field: &OutputField,
     value: PrismaValue,
     st: &ScalarType,
 ) -> crate::Result<PrismaValue> {

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
@@ -2,7 +2,7 @@ use super::{
     type_renderer::{render_input_types, render_output_type},
     DmmfInputField, DmmfOutputField, RenderContext,
 };
-use schema::{InputField, InputType, OutputFieldRef, ScalarType};
+use schema::{InputField, InputType, OutputField, ScalarType};
 
 pub(super) fn render_input_field(input_field: &InputField, ctx: &mut RenderContext) -> DmmfInputField {
     let type_references = render_input_types(input_field.field_types(ctx.query_schema), ctx);
@@ -22,7 +22,7 @@ pub(super) fn render_input_field(input_field: &InputField, ctx: &mut RenderConte
     field
 }
 
-pub(super) fn render_output_field(field: &OutputFieldRef, ctx: &mut RenderContext) -> DmmfOutputField {
+pub(super) fn render_output_field(field: &OutputField, ctx: &mut RenderContext) -> DmmfOutputField {
     let rendered_inputs = field.arguments.iter().map(|arg| render_input_field(arg, ctx)).collect();
     let output_type = render_output_type(&field.field_type, ctx);
 

--- a/query-engine/dmmf/src/tests/setup.rs
+++ b/query-engine/dmmf/src/tests/setup.rs
@@ -8,7 +8,7 @@ use std::{
     io::{Read, Write},
 };
 
-pub(crate) fn write_compressed_snapshot(dmmf: &DataModelMetaFormat, path: &str) -> () {
+pub(crate) fn write_compressed_snapshot(dmmf: &DataModelMetaFormat, path: &str) {
     let mut encoder = write::GzEncoder::new(File::create(path).unwrap(), Compression::best());
     let json = serde_json::to_vec(dmmf).unwrap();
 

--- a/query-engine/dmmf/src/tests/tests.rs
+++ b/query-engine/dmmf/src/tests/tests.rs
@@ -1,5 +1,4 @@
 use crate::{dmmf_from_schema, tests::setup::*};
-use serde_json;
 
 #[test]
 fn sqlite_ignore() {

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
@@ -3,14 +3,14 @@ use super::*;
 #[derive(Debug)]
 pub(crate) enum GqlFieldRenderer<'a> {
     Input(&'a InputField),
-    Output(OutputFieldRef),
+    Output(&'a OutputField),
 }
 
 impl Renderer for GqlFieldRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
             GqlFieldRenderer::Input(input) => self.render_input_field(input, ctx),
-            GqlFieldRenderer::Output(output) => self.render_output_field(Arc::clone(output), ctx),
+            GqlFieldRenderer::Output(output) => self.render_output_field(output, ctx),
         }
     }
 }
@@ -25,7 +25,7 @@ impl GqlFieldRenderer<'_> {
         format!("{}: {}{}", input_field.name, rendered_type, required)
     }
 
-    fn render_output_field(&self, field: OutputFieldRef, ctx: &mut RenderContext) -> String {
+    fn render_output_field(&self, field: &OutputField, ctx: &mut RenderContext) -> String {
         let rendered_args = self.render_arguments(&field.arguments, ctx);
         let rendered_args = if rendered_args.is_empty() {
             "".into()

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
@@ -149,10 +149,10 @@ impl<'a> IntoRenderer<'a> for InputField {
     }
 }
 
-impl<'a> IntoRenderer<'a> for OutputFieldRef {
+impl<'a> IntoRenderer<'a> for OutputField {
     #[allow(clippy::wrong_self_convention)]
-    fn into_renderer(&self) -> GqlRenderer<'a> {
-        GqlRenderer::Field(GqlFieldRenderer::Output(Arc::clone(self)))
+    fn into_renderer(&'a self) -> GqlRenderer<'a> {
+        GqlRenderer::Field(GqlFieldRenderer::Output(self))
     }
 }
 

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use prisma_models::{decode_bytes, parse_datetime, prelude::ParentContainer, Field};
 use query_core::{
     constants::custom_types,
-    schema::{ObjectType, OutputFieldRef, QuerySchema, QuerySchemaRef},
+    schema::{ObjectType, OutputField, QuerySchema, QuerySchemaRef},
     ArgumentValue, Operation, Selection,
 };
 use serde_json::Value as JsonValue;
@@ -37,7 +37,7 @@ impl JsonProtocolAdapter {
     }
 
     fn convert_selection(
-        field: &OutputFieldRef,
+        field: &OutputField,
         container: Option<&ParentContainer>,
         query: FieldQuery,
         query_schema: &QuerySchemaRef,
@@ -63,13 +63,13 @@ impl JsonProtocolAdapter {
             match selected {
                 // $scalars: true
                 crate::SelectionSetValue::Shorthand(true) if SelectionSet::is_all_scalars(&selection_name) => {
-                    if let Some(schema_object) = field.field_type.as_object_type(&query_schema.db) {
+                    if let Some((_, schema_object)) = field.field_type.as_object_type(&query_schema.db) {
                         Self::default_scalar_selection(schema_object, &mut selection);
                     }
                 }
                 // $composites: true
                 crate::SelectionSetValue::Shorthand(true) if SelectionSet::is_all_composites(&selection_name) => {
-                    if let Some(schema_object) = field.field_type.as_object_type(&query_schema.db) {
+                    if let Some((_, schema_object)) = field.field_type.as_object_type(&query_schema.db) {
                         if let Some(container) = container {
                             Self::default_composite_selection(
                                 &mut selection,
@@ -95,8 +95,8 @@ impl JsonProtocolAdapter {
                 crate::SelectionSetValue::Shorthand(false) => (),
                 // <field_name>: { selection: { ... }, arguments: { ... } }
                 crate::SelectionSetValue::Nested(nested_query) => {
-                    if let Some(schema_object) = field.field_type.as_object_type(&query_schema.db) {
-                        let schema_field = schema_object.find_field(&selection_name).ok_or_else(|| {
+                    if let Some((_, schema_object)) = field.field_type.as_object_type(&query_schema.db) {
+                        let (_, schema_field) = schema_object.find_field(&selection_name).ok_or_else(|| {
                             HandlerError::query_conversion(format!(
                                 "Unknown nested field '{}' for operation {} does not match any query.",
                                 selection_name, &field.name
@@ -118,7 +118,7 @@ impl JsonProtocolAdapter {
                         }
 
                         selection.push_nested_selection(Self::convert_selection(
-                            &schema_field,
+                            schema_field,
                             nested_container.as_ref(),
                             nested_query,
                             query_schema,
@@ -271,13 +271,13 @@ impl JsonProtocolAdapter {
                 for cf in model.fields().composite() {
                     let schema_field = schema_object.find_field(cf.name());
 
-                    if let Some(schema_field) = schema_field {
+                    if let Some((_, schema_field)) = schema_field {
                         let mut nested_selection = Selection::with_name(cf.name());
 
                         Self::default_composite_selection(
                             &mut nested_selection,
                             &ParentContainer::from(cf.typ()),
-                            schema_field.field_type.as_object_type(&query_schema.db).unwrap(),
+                            schema_field.field_type.as_object_type(&query_schema.db).unwrap().1,
                             walked_types,
                             query_schema,
                         )?;
@@ -298,7 +298,7 @@ impl JsonProtocolAdapter {
                 for f in ct.fields() {
                     let schema_field = schema_object.find_field(f.name());
 
-                    if let Some(schema_field) = schema_field {
+                    if let Some((_, schema_field)) = schema_field {
                         match f {
                             Field::Scalar(s) => {
                                 selection.push_nested_selection(Selection::with_name(s.name().to_owned()))
@@ -309,7 +309,7 @@ impl JsonProtocolAdapter {
                                 Self::default_composite_selection(
                                     &mut nested_selection,
                                     &ParentContainer::from(cf.typ()),
-                                    schema_field.field_type.as_object_type(&query_schema.db).unwrap(),
+                                    schema_field.field_type.as_object_type(&query_schema.db).unwrap().1,
                                     walked_types,
                                     query_schema,
                                 )?;
@@ -330,7 +330,7 @@ impl JsonProtocolAdapter {
         query_schema: &QuerySchemaRef,
         model_name: Option<String>,
         action: crate::Action,
-    ) -> crate::Result<(OperationType, &OutputFieldRef)> {
+    ) -> crate::Result<(OperationType, &OutputField)> {
         if let Some(field) = query_schema.find_query_field_by_model_and_action(model_name.as_deref(), action.value()) {
             return Ok((OperationType::Read, field));
         };

--- a/query-engine/schema-builder/examples/schema_builder_build_odoo.rs
+++ b/query-engine/schema-builder/examples/schema_builder_build_odoo.rs
@@ -5,7 +5,7 @@ fn main() {
     let idm = prisma_models::convert(validated_schema);
 
     let now = std::time::Instant::now();
-    let _ = schema_builder::build(idm.clone(), true);
+    let _ = schema_builder::build(idm, true);
     let elapsed = now.elapsed();
 
     println!("Elapsed: {:.2?}", elapsed);

--- a/query-engine/schema-builder/src/utils.rs
+++ b/query-engine/schema-builder/src/utils.rs
@@ -1,7 +1,6 @@
 use super::*;
 use once_cell::sync::OnceCell;
 use prisma_models::{ast, dml, walkers};
-use std::sync::Arc;
 
 /// Object type convenience wrapper function.
 pub fn object_type(ident: Identifier, fields: Vec<OutputField>, model: Option<ast::ModelId>) -> ObjectType {
@@ -42,7 +41,7 @@ where
     OutputField {
         name: name.into(),
         arguments,
-        field_type: Arc::new(field_type),
+        field_type,
         query_info,
         is_nullable: false,
         deprecation: None,
@@ -68,7 +67,7 @@ where
 }
 
 /// Appends an option of type T to a vector over T if the option is Some.
-pub fn append_opt<T>(vec: &mut Vec<T>, opt: Option<T>) {
+pub(crate) fn append_opt<T>(vec: &mut Vec<T>, opt: Option<T>) {
     vec.extend(opt.into_iter())
 }
 

--- a/query-engine/schema/src/db.rs
+++ b/query-engine/schema/src/db.rs
@@ -47,6 +47,8 @@ pub struct OutputObjectTypeId(usize);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EnumTypeId(usize);
 
+pub type OutputFieldId = (OutputObjectTypeId, usize);
+
 impl ops::Index<InputObjectTypeId> for QuerySchemaDatabase {
     type Output = InputObjectType;
 

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -19,8 +19,6 @@ pub use utils::*;
 use std::sync::Arc;
 
 pub type QuerySchemaRef = Arc<QuerySchema>;
-pub type OutputTypeRef = Arc<OutputType>;
-pub type OutputFieldRef = Arc<OutputField>;
 
 #[derive(Debug, PartialEq)]
 pub struct Deprecation {


### PR DESCRIPTION
This is the continuation of https://github.com/prisma/prisma-engines/commit/d4bbf03913365f897c8f7fe4b372a6bd6d7a2489,
and more generally of the typed identifiers saga
(https://github.com/prisma/client-planning/issues/265).

In (DHAT) memory profiles, we see fewer transient allocations:

On main

Elapsed: 15.16s
==1705==
==1705== Total:     262,418,444 bytes in 1,584,058 blocks
==1705== At t-gmax: 136,291,685 bytes in 584,343 blocks
==1705== At t-end:  0 bytes in 0 blocks
==1705== Reads:     796,287,555 bytes
==1705== Writes:    270,849,236 bytes

On this branch

Elapsed: 14.46s
==1705==
==1705== Total:     259,296,684 bytes in 1,551,005 blocks
==1705== At t-gmax: 136,304,087 bytes in 553,047 blocks
==1705== At t-end:  0 bytes in 0 blocks
==1705== Reads:     791,872,216 bytes
==1705== Writes:    267,000,724 bytes