### PR TITLE
bugfix: Surface errors when a json query arrives at a qe configured to use the graphQL protocol

### DIFF
--- a/.github/workflows/query-engine-black-box.yml
+++ b/.github/workflows/query-engine-black-box.yml
@@ -16,42 +16,17 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  rust-query-engine-tests:
-    name: "Test ${{ matrix.database.name }} (${{ matrix.engine_protocol }}) on Linux"
+  rust-tests:
+    name: "Test query-engine as a black-box"
 
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: "vitess_5_7"
-            single_threaded: true
-            connector: "vitess"
-            version: "5.7"
-          - name: "vitess_8_0"
-            single_threaded: true
-            connector: "vitess"
-            version: "8.0"
           - name: "postgres15"
             single_threaded: false
             connector: "postgres"
-            version: "15"
-          - name: "mssql_2022"
-            single_threaded: false
-            connector: "sqlserver"
-            version: "2022"
-          - name: "mongodb_4_2"
-            single_threaded: true
-            connector: "mongodb"
-            version: "4.2"
-          - name: "cockroach_22_2"
-            single_threaded: false
-            connector: "cockroachdb"
-            version: "22.2"
-          - name: "cockroach_22_1_0"
-            single_threaded: false
-            connector: "cockroachdb"
-            version: "22.1"
-        engine_protocol: [graphql, json]
+            version: "15"        
 
     env:
       LOG_LEVEL: "info"
@@ -65,7 +40,6 @@ jobs:
       TEST_RUNNER: "direct"
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
-      PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
 
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
@@ -86,12 +60,10 @@ jobs:
           toolchain: stable
           default: true
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
-        if: ${{ matrix.database.single_threaded }}
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo build --package query-engine      
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=8
-        if: ${{ !matrix.database.single_threaded }}
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package black-box-tests -- --test-threads=1      
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,6 +34,7 @@ jobs:
       - run: |
             cargo test --workspace \
                   --exclude=query-engine \
+                  --exclude=black-box-tests \
                   --exclude=query-engine-tests \
                   --exclude=sql-migration-tests \
                   --exclude=schema-engine-cli \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,6 +192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +255,21 @@ dependencies = [
  "radium",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "black-box-tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "indoc",
+ "insta",
+ "query-engine-tests",
+ "query-tests-setup",
+ "reqwest",
+ "serde_json",
+ "tokio",
+ "user-facing-errors",
 ]
 
 [[package]]
@@ -954,6 +975,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1541,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1585,7 +1628,7 @@ dependencies = [
  "socket2",
  "widestring",
  "winapi",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -1994,6 +2037,12 @@ dependencies = [
  "quanta",
  "sketches-ddsketch",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -3568,6 +3617,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3955,6 +4041,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.99",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -5260,6 +5358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,6 +5595,15 @@ name = "winreg"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "query-engine/connector-test-kit-rs/query-tests-setup",
   "query-engine/core",
   "query-engine/core-tests",
+  "query-engine/black-box-tests",
   "query-engine/dmmf",
   "query-engine/metrics",
   "query-engine/prisma-models",

--- a/query-engine/black-box-tests/Cargo.toml
+++ b/query-engine/black-box-tests/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "black-box-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+query-engine-tests = { path = "../connector-test-kit-rs/query-engine-tests" }
+query-tests-setup = { path = "../connector-test-kit-rs/query-tests-setup" }
+reqwest = "0.11"
+anyhow = "1.0"
+serde_json = "1.0"
+indoc.workspace = true
+tokio.workspace = true
+user-facing-errors.workspace = true
+insta = "1.7.1"

--- a/query-engine/black-box-tests/README.md
+++ b/query-engine/black-box-tests/README.md
@@ -1,0 +1,4 @@
+This crate is for testing end-to-end query-engine interfaces's
+    - metrics
+    - logging
+    - tracing

--- a/query-engine/black-box-tests/tests/black_box_tests.rs
+++ b/query-engine/black-box-tests/tests/black_box_tests.rs
@@ -1,0 +1,3 @@
+mod helpers;
+
+mod protocols;

--- a/query-engine/black-box-tests/tests/helpers.rs
+++ b/query-engine/black-box-tests/tests/helpers.rs
@@ -1,0 +1,66 @@
+use std::{env, path, process};
+
+use query_engine_tests::TestResult;
+
+/// Runs the command in the background and performs the future given, then kills the process
+pub(crate) async fn with_child_process<F>(command: &mut process::Command, f: F) -> TestResult<()>
+where
+    F: std::future::Future<Output = ()>,
+{
+    struct Cleaner<'a> {
+        p: &'a mut std::process::Child,
+    }
+    impl<'a> Drop for Cleaner<'a> {
+        fn drop(&mut self) {
+            self.p.kill().expect("Failed to kill process");
+        }
+    }
+
+    let mut child = command
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // wait for the process to start. FIXME: process INFO message from STDOUT
+    // to start
+    std::thread::sleep(std::time::Duration::from_secs(1));
+
+    // cleaner will kill the process when the the function is done
+    let _cleaner = Cleaner { p: &mut child };
+
+    f.await;
+
+    Ok(())
+}
+
+/// Configures the query-engine binary to listen in given port and using the
+/// given dml string as the schema.
+pub(crate) fn query_engine_cmd(dml: &str, port: &str) -> process::Command {
+    let mut cmd = std::process::Command::new(query_engine_bin_path());
+    cmd.env("PRISMA_DML", dml).arg("--port").arg(port).arg("-g");
+    cmd
+}
+
+/// Returns the path of the query-engine binary
+pub(crate) fn query_engine_bin_path() -> path::PathBuf {
+    let name = "query-engine";
+    let env_var = format!("CARGO_BIN_EXE_{}", name);
+    std::env::var_os(&env_var)
+        .map(|p| p.into())
+        .unwrap_or_else(|| target_dir().join(format!("{}{}", name, env::consts::EXE_SUFFIX)))
+}
+
+fn target_dir() -> path::PathBuf {
+    env::current_exe()
+        .ok()
+        .map(|mut path| {
+            path.pop();
+            if path.ends_with("deps") {
+                path.pop();
+            }
+            path
+        })
+        .unwrap()
+}

--- a/query-engine/black-box-tests/tests/protocols/mismatched.rs
+++ b/query-engine/black-box-tests/tests/protocols/mismatched.rs
@@ -1,0 +1,95 @@
+use crate::helpers::*;
+use query_engine_tests::*;
+
+const JSON_QUERY: &'static str = r###"
+{
+    "action": "findMany",
+    "modelName": "Person",
+    "query": {
+        "arguments": {
+        },
+        "selection": {
+            "$scalars": true
+        }
+    }
+}
+"###;
+
+const GRAPHQL_QUERY: &'static str = r###"
+{
+  "operationName": null,
+  "variables": {},
+  "query": "{\n  findManyPerson {\n    id\n  }\n}\n"
+}
+"###;
+
+#[test_suite(schema(schema))]
+mod mismatched {
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model Person {
+              #id(id, Int, @id)
+             }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn json_query_over_json_protocol_engine(r: Runner) -> TestResult<()> {
+        let mut qe_cmd = query_engine_cmd(r.prisma_dml(), "57582");
+        qe_cmd.env("PRISMA_ENGINE_PROTOCOL", "json");
+
+        with_child_process(&mut qe_cmd, async move {
+            let client = reqwest::Client::new();
+            let res = client
+                .post("http://0.0.0.0:57582/")
+                .body(JSON_QUERY)
+                .send()
+                .await
+                .unwrap();
+            insta::assert_snapshot!(res.text().await.unwrap(), @r###"{"data":{"findManyPerson":[]}}"###);
+        })
+        .await
+    }
+
+    #[connector_test]
+    async fn graphql_query_over_json_protocol_engine(r: Runner) -> TestResult<()> {
+        let mut qe_cmd = query_engine_cmd(r.prisma_dml(), "57582");
+        qe_cmd.env("PRISMA_ENGINE_PROTOCOL", "json");
+
+        with_child_process(&mut qe_cmd, async move {
+            let client = reqwest::Client::new();
+            let res = client
+                .post("http://0.0.0.0:57582/")
+                .body(GRAPHQL_QUERY)
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(res.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+            insta::assert_snapshot!(res.text().await.unwrap(), @r###"{"is_panic":false,"message":"Error parsing Json query. data did not match any variant of untagged enum JsonBody","backtrace":null}"###);
+        })
+        .await
+    }
+
+    #[connector_test]
+    async fn json_query_over_graphql_protocol_engine(r: Runner) -> TestResult<()> {
+        let mut qe_cmd = query_engine_cmd(r.prisma_dml(), "57582");
+        qe_cmd.env("PRISMA_ENGINE_PROTOCOL", "graphql");
+
+        with_child_process(&mut qe_cmd, async move {
+            let client = reqwest::Client::new();
+            let res = client
+                .post("http://0.0.0.0:57582/")
+                .body(JSON_QUERY)
+                .send()
+                .await
+                .unwrap();
+
+            assert_eq!(res.status(), reqwest::StatusCode::UNPROCESSABLE_ENTITY);
+            insta::assert_snapshot!(res.text().await.unwrap(), @r###"{"is_panic":false,"message":"Error parsing Graphql query. data did not match any variant of untagged enum GraphqlBody","backtrace":null}"###);
+        })
+        .await
+    }
+}

--- a/query-engine/black-box-tests/tests/protocols/mod.rs
+++ b/query-engine/black-box-tests/tests/protocols/mod.rs
@@ -1,0 +1,1 @@
+mod mismatched;

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -33,6 +33,10 @@ pub struct Runner {
 }
 
 impl Runner {
+    pub fn prisma_dml(&self) -> &str {
+        self.query_schema.internal_data_model.schema.db.source()
+    }
+
     pub async fn load(
         datamodel: String,
         connector_tag: ConnectorTag,
@@ -40,7 +44,7 @@ impl Runner {
         log_capture: TestLogCapture,
     ) -> TestResult<Self> {
         let protocol = EngineProtocol::from(&ENGINE_PROTOCOL.to_string());
-        let schema = psl::parse_schema(datamodel).unwrap();
+        let schema = psl::parse_schema(datamodel.clone()).unwrap();
         let data_source = schema.configuration.datasources.first().unwrap();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
         let executor = load_executor(data_source, schema.configuration.preview_features(), &url).await?;

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -198,10 +198,20 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
 
                 Ok(res)
             }
-            Err(_e) => {
+            Err(e) => {
+                let ufe: user_facing_errors::Error = request_handlers::HandlerError::query_conversion(format!(
+                    "Error parsing {:?} query. {}",
+                    cx.engine_protocol(),
+                    e
+                ))
+                .into();
+
+                let result_bytes = serde_json::to_vec(&ufe).unwrap();
+
                 let res = Response::builder()
-                    .status(StatusCode::BAD_REQUEST)
-                    .body(Body::empty())
+                    .status(StatusCode::UNPROCESSABLE_ENTITY) // 422
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(result_bytes))
                     .unwrap();
 
                 Ok(res)


### PR DESCRIPTION
This PR handles parsing errors gracefully when a JSON query is received by a query engine that is configured with the GraphQL protocol.