### PR TITLE
qe: relation selection shorthand for JSON protocol

### DIFF
--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -6,7 +6,7 @@ pub use composite::*;
 pub use relation::*;
 pub use scalar::*;
 
-use crate::{ast, ModelRef};
+use crate::{ast, parent_container::ParentContainer, ModelRef};
 use psl::parser_database::{walkers, ScalarType};
 use std::{borrow::Cow, hash::Hash};
 
@@ -121,6 +121,14 @@ impl Field {
             Some(v)
         } else {
             None
+        }
+    }
+
+    pub fn nested_container(&self) -> ParentContainer {
+        match self {
+            Field::Relation(rf) => ParentContainer::from(rf.related_model()),
+            Field::Scalar(sf) => sf.container(),
+            Field::Composite(cf) => ParentContainer::from(cf.typ()),
         }
     }
 }

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -124,7 +124,7 @@ impl Field {
         }
     }
 
-    pub fn nested_container(&self) -> ParentContainer {
+    pub fn related_container(&self) -> ParentContainer {
         match self {
             Field::Relation(rf) => ParentContainer::from(rf.related_model()),
             Field::Scalar(sf) => sf.container(),

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -105,7 +105,7 @@ impl JsonProtocolAdapter {
 
                         let field = container.and_then(|container| container.find_field(&schema_field.name));
                         let is_composite_field = field.as_ref().map(|f| f.is_composite()).unwrap_or(false);
-                        let nested_container = field.map(|f| f.nested_container());
+                        let nested_container = field.map(|f| f.related_container());
 
                         if is_composite_field && all_composites_set {
                             return Err(HandlerError::query_conversion(format!(
@@ -263,7 +263,7 @@ impl JsonProtocolAdapter {
             let mut nested_selection = Selection::new(nested_field_name, None, vec![], vec![]);
             let nested_container = container
                 .and_then(|c| c.find_field(nested_field_name))
-                .map(|f| f.nested_container());
+                .map(|f| f.related_container());
 
             Self::default_scalar_and_composite_selection(
                 &mut nested_selection,


### PR DESCRIPTION
Within JSON protocol, treat nested `{ "relation": true }` the same way
as `{ "relation": { "$scalars": true, "$composites": true }}`. This is
needed, because on the client we do not always have enough information
to supply explicit nested selection. One example of such case are
virtual fields, not present in the schema files (`_count`).

Fix prisma/prisma#18598
