### PR TITLE
Stopgap: Database comments

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/enumerator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/enumerator.rs
@@ -62,6 +62,11 @@ impl<'a> EnumPair<'a> {
         self.previous.is_none() && !self.context.name_is_unique(self.next.name())
     }
 
+    /// The COMMENT of the enum.
+    pub(crate) fn description(self) -> Option<&'a str> {
+        self.next.description()
+    }
+
     /// Iterates all of the variants that are part of the enum.
     pub(crate) fn variants(self) -> impl ExactSizeIterator<Item = EnumVariantPair<'a>> + 'a {
         self.next.variants().map(move |next| {

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/enumerator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/enumerator.rs
@@ -67,6 +67,11 @@ impl<'a> EnumPair<'a> {
         self.next.description()
     }
 
+    /// True if we have a new enum and it has a comment.
+    pub(crate) fn adds_a_description(self) -> bool {
+        self.previous.is_none() && self.description().is_some()
+    }
+
     /// Iterates all of the variants that are part of the enum.
     pub(crate) fn variants(self) -> impl ExactSizeIterator<Item = EnumVariantPair<'a>> + 'a {
         self.next.variants().map(move |next| {

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -227,4 +227,9 @@ impl<'a> ModelPair<'a> {
                 (!pair.defined_in_a_field()).then_some(pair)
             })
     }
+
+    /// The COMMENT of the model.
+    pub(crate) fn description(self) -> Option<&'a str> {
+        self.next.description()
+    }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -232,4 +232,9 @@ impl<'a> ModelPair<'a> {
     pub(crate) fn description(self) -> Option<&'a str> {
         self.next.description()
     }
+
+    /// True if we have a new model and it has a comment.
+    pub(crate) fn adds_a_description(self) -> bool {
+        self.previous.is_none() && self.description().is_some()
+    }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/scalar_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/scalar_field.rs
@@ -205,7 +205,7 @@ impl<'a> ScalarFieldPair<'a> {
         IntrospectionPair::new(self.context, previous, self.next)
     }
 
-    /// The COMMENT of the enum.
+    /// The COMMENT of the field.
     pub(crate) fn description(self) -> Option<&'a str> {
         self.next.description()
     }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/scalar_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/scalar_field.rs
@@ -205,6 +205,11 @@ impl<'a> ScalarFieldPair<'a> {
         IntrospectionPair::new(self.context, previous, self.next)
     }
 
+    /// The COMMENT of the enum.
+    pub(crate) fn description(self) -> Option<&'a str> {
+        self.next.description()
+    }
+
     fn column_type_family(self) -> &'a sql::ColumnTypeFamily {
         self.next.column_type_family()
     }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/scalar_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/scalar_field.rs
@@ -210,6 +210,11 @@ impl<'a> ScalarFieldPair<'a> {
         self.next.description()
     }
 
+    /// True if we have a new field and it has a comment.
+    pub(crate) fn adds_a_description(self) -> bool {
+        self.previous.is_none() && self.description().is_some()
+    }
+
     fn column_type_family(self) -> &'a sql::ColumnTypeFamily {
         self.next.column_type_family()
     }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/view.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/view.rs
@@ -179,4 +179,10 @@ impl<'a> ViewPair<'a> {
     pub(crate) fn description(self) -> Option<&'a str> {
         self.next.description()
     }
+
+    /// True if we introspect the view for the first time, and it has a comment
+    /// in the database.
+    pub(crate) fn adds_a_description(self) -> bool {
+        self.previous.is_none() && self.description().is_some()
+    }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/view.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/view.rs
@@ -174,4 +174,9 @@ impl<'a> ViewPair<'a> {
             .definition()
             .map(|s| self.context.flavour.format_view_definition(s))
     }
+
+    /// The COMMENT of the view.
+    pub(crate) fn description(self) -> Option<&'a str> {
+        self.next.description()
+    }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/enums.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/enums.rs
@@ -46,6 +46,11 @@ fn render_enum(r#enum: EnumPair<'_>) -> renderer::Enum<'_> {
         rendered_enum.documentation(docs);
     }
 
+    if r#enum.adds_a_description() {
+        let docs = "This enum is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments";
+        rendered_enum.documentation(docs);
+    }
+
     for variant in r#enum.variants() {
         let mut rendered_variant = renderer::EnumVariant::new(variant.name());
 

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
@@ -86,6 +86,11 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
         rendered.documentation(docs);
     }
 
+    if model.adds_a_description() {
+        let docs = "This model is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments";
+        rendered.documentation(docs);
+    }
+
     for field in model.scalar_fields() {
         rendered.push_field(scalar_field::render(field));
     }

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/scalar_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/scalar_field.rs
@@ -60,6 +60,11 @@ pub(crate) fn render(field: ScalarFieldPair<'_>) -> renderer::Field<'_> {
         rendered.commented_out();
     }
 
+    if field.adds_a_description() {
+        let docs = "This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments";
+        rendered.documentation(docs);
+    }
+
     rendered
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/views.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/views.rs
@@ -79,6 +79,11 @@ fn render_view(view: ViewPair<'_>) -> renderer::View<'_> {
         rendered.documentation(docs);
     }
 
+    if view.adds_a_description() {
+        let docs = "This view is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments";
+        rendered.documentation(docs);
+    }
+
     for field in view.scalar_fields() {
         rendered.push_field(scalar_field::render(field));
     }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -60,7 +60,7 @@ fn push_model_tables(ctx: &mut Context<'_>) {
         let table_id = ctx
             .schema
             .describer_schema
-            .push_table(model.database_name().to_owned(), namespace_id);
+            .push_table(model.database_name().to_owned(), namespace_id, None);
         ctx.model_id_to_table_id.insert(model.model_id(), table_id);
 
         for field in model.scalar_fields() {
@@ -219,7 +219,10 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
         };
 
         let namespace_id = ctx.walk(model_a_table_id).namespace_id(); // we put the join table in the schema of table A.
-        let table_id = ctx.schema.describer_schema.push_table(table_name.clone(), namespace_id);
+        let table_id = ctx
+            .schema
+            .describer_schema
+            .push_table(table_name.clone(), namespace_id, None);
         let column_a_type = ctx
             .walk(model_a_table_id)
             .primary_key_columns()
@@ -245,6 +248,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
                 name: model_a_column.into(),
                 tpe: column_a_type,
                 auto_increment: false,
+                description: None,
             },
         );
         let column_b_id = ctx.schema.describer_schema.push_table_column(
@@ -253,6 +257,7 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
                 name: model_b_column.into(),
                 tpe: column_b_type,
                 auto_increment: false,
+                description: None,
             },
         );
 
@@ -398,6 +403,7 @@ fn push_column_for_model_enum_scalar_field(
             column_arity(field.ast_field().arity),
         ),
         auto_increment: false,
+        description: None,
     };
 
     ctx.schema.describer_schema.push_table_column(table_id, column);
@@ -432,6 +438,7 @@ fn push_column_for_model_unsupported_scalar_field(
             field.ast_field().field_type.as_unsupported().unwrap().0.to_owned(),
         ),
         auto_increment: false,
+        description: None,
     };
 
     ctx.schema.describer_schema.push_table_column(table_id, column);
@@ -517,6 +524,7 @@ fn push_column_for_builtin_scalar_type(
             native_type: Some(native_type),
         },
         auto_increment: field.is_autoincrement() || ctx.flavour.field_is_implicit_autoincrement_primary_key(field),
+        description: None,
     };
 
     let column_id = ctx.schema.describer_schema.push_table_column(table_id, column);

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/mysql.rs
@@ -16,7 +16,7 @@ impl SqlSchemaCalculatorFlavour for MysqlFlavour {
                 model_name = field.model().database_name(),
                 field_name = field.database_name()
             );
-            let sql_enum_id = ctx.schema.describer_schema.push_enum(Default::default(), name);
+            let sql_enum_id = ctx.schema.describer_schema.push_enum(Default::default(), name, None);
             ctx.enum_ids.insert(enum_tpe.id, sql_enum_id);
             for variant in enum_tpe.values().map(|v| v.database_name().to_owned()) {
                 ctx.schema.describer_schema.push_enum_variant(sql_enum_id, variant);

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator/sql_schema_calculator_flavour/postgres.rs
@@ -16,10 +16,10 @@ impl SqlSchemaCalculatorFlavour for PostgresFlavour {
                 .schema()
                 .and_then(|(name, _)| ctx.schemas.get(name).cloned())
                 .unwrap_or_default();
-            let sql_enum_id = ctx
-                .schema
-                .describer_schema
-                .push_enum(sql_namespace_id, prisma_enum.database_name().to_owned());
+            let sql_enum_id =
+                ctx.schema
+                    .describer_schema
+                    .push_enum(sql_namespace_id, prisma_enum.database_name().to_owned(), None);
             ctx.enum_ids.insert(prisma_enum.id, sql_enum_id);
 
             for value in prisma_enum.values() {

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/enum.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/enum.rs
@@ -13,7 +13,14 @@ pub(super) fn generate_warnings(r#enum: EnumPair<'_>, warnings: &mut Warnings) {
         warnings.duplicate_names.push(generators::TopLevelItem {
             r#type: generators::TopLevelType::Enum,
             name: r#enum.name().to_string(),
-        })
+        });
+    }
+
+    if r#enum.description().is_some() {
+        warnings.commented_objects.push(generators::Object {
+            r#type: "enum",
+            name: r#enum.name().to_string(),
+        });
     }
 
     for variant in r#enum.variants() {

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/enum.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/enum.rs
@@ -17,7 +17,7 @@ pub(super) fn generate_warnings(r#enum: EnumPair<'_>, warnings: &mut Warnings) {
     }
 
     if r#enum.description().is_some() {
-        warnings.commented_objects.push(generators::Object {
+        warnings.objects_with_comments.push(generators::Object {
             r#type: "enum",
             name: r#enum.name().to_string(),
         });

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/generators.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/generators.rs
@@ -62,7 +62,7 @@ pub(crate) struct Warnings {
     /// Warn about non-default unique deferring setup
     pub(crate) non_default_deferring: Vec<ModelAndConstraint>,
     /// Warn about comments
-    pub(crate) commented_objects: Vec<Object>,
+    pub(crate) objects_with_comments: Vec<Object>,
 }
 
 impl Warnings {
@@ -220,7 +220,7 @@ impl Warnings {
 
         maybe_warn(&self.row_level_ttl, row_level_ttl_in_tables, &mut self.warnings);
         maybe_warn(&self.non_default_deferring, non_default_deferring, &mut self.warnings);
-        maybe_warn(&self.commented_objects, commented_objects, &mut self.warnings);
+        maybe_warn(&self.objects_with_comments, commented_objects, &mut self.warnings);
 
         self.warnings
     }

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/generators.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/generators.rs
@@ -61,6 +61,8 @@ pub(crate) struct Warnings {
     pub(crate) row_level_ttl: Vec<Model>,
     /// Warn about non-default unique deferring setup
     pub(crate) non_default_deferring: Vec<ModelAndConstraint>,
+    /// Warn about comments
+    pub(crate) commented_objects: Vec<Object>,
 }
 
 impl Warnings {
@@ -217,8 +219,8 @@ impl Warnings {
         );
 
         maybe_warn(&self.row_level_ttl, row_level_ttl_in_tables, &mut self.warnings);
-
         maybe_warn(&self.non_default_deferring, non_default_deferring, &mut self.warnings);
+        maybe_warn(&self.commented_objects, commented_objects, &mut self.warnings);
 
         self.warnings
     }
@@ -336,6 +338,12 @@ pub(crate) struct TopLevelItem {
     /// The name of the top-level type
     pub(crate) r#type: TopLevelType,
     /// The name of the object
+    pub(crate) name: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub(crate) struct Object {
+    pub(crate) r#type: &'static str,
     pub(crate) name: String,
 }
 
@@ -597,6 +605,16 @@ pub(crate) fn non_default_deferring(affected: &[ModelAndConstraint]) -> Warning 
 
     Warning {
         code: 35,
+        message: message.into(),
+        affected: serde_json::to_value(affected).unwrap(),
+    }
+}
+
+pub(crate) fn commented_objects(affected: &[Object]) -> Warning {
+    let message = "These objects have comments defined in the database, which is not yet fully supported. Read more: https://pris.ly/d/database-comments";
+
+    Warning {
+        code: 36,
         message: message.into(),
         affected: serde_json::to_value(affected).unwrap(),
     }

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/model.rs
@@ -51,6 +51,13 @@ pub(super) fn generate_warnings(model: ModelPair<'_>, warnings: &mut Warnings) {
         });
     }
 
+    if model.description().is_some() {
+        warnings.commented_objects.push(generators::Object {
+            r#type: "model",
+            name: model.name().to_string(),
+        })
+    }
+
     for field in model.scalar_fields() {
         if let Some(DefaultKind::Prisma1Uuid) = field.default().kind() {
             let warn = generators::ModelAndField {
@@ -96,6 +103,13 @@ pub(super) fn generate_warnings(model: ModelPair<'_>, warnings: &mut Warnings) {
             };
 
             warnings.fields_with_empty_names_in_model.push(mf);
+        }
+
+        if field.description().is_some() {
+            warnings.commented_objects.push(generators::Object {
+                r#type: "field",
+                name: format!("{}.{}", model.name(), field.name()),
+            })
         }
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/model.rs
@@ -52,7 +52,7 @@ pub(super) fn generate_warnings(model: ModelPair<'_>, warnings: &mut Warnings) {
     }
 
     if model.description().is_some() {
-        warnings.commented_objects.push(generators::Object {
+        warnings.objects_with_comments.push(generators::Object {
             r#type: "model",
             name: model.name().to_string(),
         })
@@ -106,7 +106,7 @@ pub(super) fn generate_warnings(model: ModelPair<'_>, warnings: &mut Warnings) {
         }
 
         if field.description().is_some() {
-            warnings.commented_objects.push(generators::Object {
+            warnings.objects_with_comments.push(generators::Object {
                 r#type: "field",
                 name: format!("{}.{}", model.name(), field.name()),
             })

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/view.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/view.rs
@@ -30,7 +30,7 @@ pub(super) fn generate_warnings(view: ViewPair<'_>, warnings: &mut Warnings) {
     }
 
     if view.description().is_some() {
-        warnings.commented_objects.push(generators::Object {
+        warnings.objects_with_comments.push(generators::Object {
             r#type: "view",
             name: view.name().to_string(),
         })
@@ -66,7 +66,7 @@ pub(super) fn generate_warnings(view: ViewPair<'_>, warnings: &mut Warnings) {
         }
 
         if field.description().is_some() {
-            warnings.commented_objects.push(generators::Object {
+            warnings.objects_with_comments.push(generators::Object {
                 r#type: "field",
                 name: format!("{}.{}", view.name(), field.name()),
             })

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/view.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/view.rs
@@ -29,6 +29,13 @@ pub(super) fn generate_warnings(view: ViewPair<'_>, warnings: &mut Warnings) {
         });
     }
 
+    if view.description().is_some() {
+        warnings.commented_objects.push(generators::Object {
+            r#type: "view",
+            name: view.name().to_string(),
+        })
+    }
+
     for field in view.scalar_fields() {
         if field.remapped_name_from_psl() {
             let mf = generators::ViewAndField {
@@ -56,6 +63,13 @@ pub(super) fn generate_warnings(view: ViewPair<'_>, warnings: &mut Warnings) {
             };
 
             warnings.fields_with_empty_names_in_view.push(mf);
+        }
+
+        if field.description().is_some() {
+            warnings.commented_objects.push(generators::Object {
+                r#type: "field",
+                name: format!("{}.{}", view.name(), field.name()),
+            })
         }
     }
 

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
@@ -407,8 +407,10 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         model a {
           id  Int     @id
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
           val String? @db.String(20)
         }
     "#]];

--- a/schema-engine/sql-introspection-tests/tests/commenting_out/postgres.rs
+++ b/schema-engine/sql-introspection-tests/tests/commenting_out/postgres.rs
@@ -184,7 +184,7 @@ async fn a_table_with_only_an_unsupported_id(api: &mut TestApi) -> TestResult {
     "#};
 
     let result = api.introspect().await?;
-    api.assert_eq_datamodels(&dm, &result);
+    api.assert_eq_datamodels(dm, &result);
 
     Ok(())
 }

--- a/schema-engine/sql-introspection-tests/tests/enums/cockroachdb.rs
+++ b/schema-engine/sql-introspection-tests/tests/enums/cockroachdb.rs
@@ -47,7 +47,7 @@ async fn a_table_with_enums(api: &mut TestApi) -> TestResult {
 
     for _ in 0..4 {
         let result = api.introspect().await?;
-        api.assert_eq_datamodels(&dm, &result);
+        api.assert_eq_datamodels(dm, &result);
     }
 
     Ok(())

--- a/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
@@ -344,18 +344,23 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         model a {
           id  Int     @id
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
           val String? @db.VarChar(20)
         }
 
         /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        /// This view is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         view b {
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
           val String? @db.VarChar(20)
 
           @@ignore
         }
 
+        /// This enum is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         enum c {
           a
           b

--- a/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
@@ -328,6 +328,7 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
         COMMENT ON COLUMN a.val IS 'meow';
         COMMENT ON VIEW b IS 'purr';
         COMMENT ON TYPE c IS 'hiss';
+        COMMENT ON COLUMN b.val IS 'miu';
     "#};
 
     api.raw_cmd(schema).await;
@@ -389,6 +390,14 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
               {
                 "type": "field",
                 "name": "a.val"
+              },
+              {
+                "type": "view",
+                "name": "b"
+              },
+              {
+                "type": "field",
+                "name": "b.val"
               }
             ]
           }

--- a/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
@@ -463,7 +463,7 @@ async fn manually_remapped_enum_value_name(api: &mut TestApi) -> TestResult {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await?;
+    let result = api.re_introspect(input_dm).await?;
     api.assert_eq_datamodels(final_dm, &result);
 
     let expected = json!([{
@@ -530,7 +530,7 @@ async fn manually_re_mapped_enum_name(api: &mut TestApi) -> TestResult {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await?;
+    let result = api.re_introspect(input_dm).await?;
     api.assert_eq_datamodels(final_dm, &result);
 
     let expected = json!([{
@@ -591,7 +591,7 @@ async fn manually_re_mapped_invalid_enum_values(api: &mut TestApi) -> TestResult
         }
     "#;
 
-    let result = api.re_introspect(&input_dm).await?;
+    let result = api.re_introspect(input_dm).await?;
     api.assert_eq_datamodels(final_dm, &result);
 
     let expected = json!([{
@@ -822,7 +822,7 @@ async fn custom_model_order(api: &mut TestApi) -> TestResult {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await?;
+    let result = api.re_introspect(input_dm).await?;
     api.assert_eq_datamodels(final_dm, &result);
 
     Ok(())
@@ -901,7 +901,7 @@ async fn custom_enum_order(api: &mut TestApi) -> TestResult {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await?;
+    let result = api.re_introspect(input_dm).await?;
     api.assert_eq_datamodels(final_dm, &result);
 
     Ok(())
@@ -1033,7 +1033,7 @@ async fn virtual_cuid_default(api: &mut TestApi) {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await.unwrap();
+    let result = api.re_introspect(input_dm).await.unwrap();
     api.assert_eq_datamodels(final_dm, &result);
 }
 
@@ -1083,7 +1083,7 @@ async fn virtual_cuid_default_cockroach(api: &mut TestApi) {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await.unwrap();
+    let result = api.re_introspect(input_dm).await.unwrap();
     api.assert_eq_datamodels(final_dm, &result);
 }
 
@@ -1321,7 +1321,7 @@ async fn re_introspecting_mysql_enum_names(api: &mut TestApi) -> TestResult {
             }
         "#;
 
-    let result = api.re_introspect(&input_dm).await.unwrap();
+    let result = api.re_introspect(input_dm).await.unwrap();
     api.assert_eq_datamodels(final_dm, &result);
 
     assert_eq_json!(
@@ -1496,7 +1496,7 @@ async fn re_introspecting_ignore(api: &mut TestApi) -> TestResult {
         }
     "#};
 
-    let result = api.re_introspect(&input_dm).await.unwrap();
+    let result = api.re_introspect(input_dm).await.unwrap();
     api.assert_eq_datamodels(final_dm, &result);
 
     Ok(())
@@ -1594,7 +1594,7 @@ async fn re_introspecting_custom_compound_unique_upgrade(api: &mut TestApi) -> T
          }
      "#};
 
-    let result = api.re_introspect(&input_dm).await?;
+    let result = api.re_introspect(input_dm).await?;
     api.assert_eq_datamodels(final_dm, &result);
 
     Ok(())

--- a/schema-engine/sql-introspection-tests/tests/simple.rs
+++ b/schema-engine/sql-introspection-tests/tests/simple.rs
@@ -136,7 +136,7 @@ source .test_database_urls/mysql_5_6
     tok(conn.raw_cmd(&text)).unwrap();
 
     let params = ConnectorParams {
-        connection_string: database_url.to_owned(),
+        connection_string: database_url,
         preview_features,
         shadow_database_connection_string: None,
     };

--- a/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
+++ b/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
@@ -849,6 +849,10 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
               {
                 "type": "model",
                 "name": "a"
+              },
+              {
+                "type": "field",
+                "name": "a.a"
               }
             ]
           }

--- a/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
+++ b/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
@@ -832,8 +832,10 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         model a {
           id Int  @id @default(autoincrement())
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
           a  Int?
         }
     "#]];

--- a/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
+++ b/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
@@ -808,3 +808,53 @@ async fn northwind(api: TestApi) {
     "#]];
     api.expect_datamodel(&expectation).await;
 }
+
+#[test_connector(tags(Mysql8), exclude(Vitess))]
+async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
+    // https://www.notion.so/prismaio/Comments-ac89f872098e463183fd668a643f3ab8
+
+    let schema = indoc! {r#"
+        CREATE TABLE a (
+            id INT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+            a INT COMMENT 'meow'
+        ) comment 'purr';
+    "#};
+
+    api.raw_cmd(schema).await;
+
+    let expectation = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "mysql"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model a {
+          id Int  @id @default(autoincrement())
+          a  Int?
+        }
+    "#]];
+
+    api.expect_datamodel(&expectation).await;
+
+    let expectation = expect![[r#"
+        [
+          {
+            "code": 36,
+            "message": "These objects have comments defined in the database, which is not yet fully supported. Read more: https://pris.ly/d/database-comments",
+            "affected": [
+              {
+                "type": "model",
+                "name": "a"
+              }
+            ]
+          }
+        ]"#]];
+
+    api.expect_warnings(&expectation).await;
+
+    Ok(())
+}

--- a/schema-engine/sql-schema-describer/src/lib.rs
+++ b/schema-engine/sql-schema-describer/src/lib.rs
@@ -220,12 +220,15 @@ impl SqlSchema {
     }
 
     /// Add an enum to the schema.
-    pub fn push_enum(&mut self, namespace_id: NamespaceId, enum_name: String) -> EnumId {
+    pub fn push_enum(&mut self, namespace_id: NamespaceId, enum_name: String, description: Option<String>) -> EnumId {
         let id = EnumId(self.enums.len() as u32);
+
         self.enums.push(Enum {
             namespace_id,
             name: enum_name,
+            description,
         });
+
         id
     }
 
@@ -335,23 +338,35 @@ impl SqlSchema {
         id
     }
 
-    pub fn push_table(&mut self, name: String, namespace_id: NamespaceId) -> TableId {
+    pub fn push_table(&mut self, name: String, namespace_id: NamespaceId, description: Option<String>) -> TableId {
         let id = TableId(self.tables.len() as u32);
+
         self.tables.push(Table {
             namespace_id,
             name,
             properties: TableProperties::empty(),
+            description,
         });
+
         id
     }
 
-    pub fn push_view(&mut self, name: String, namespace_id: NamespaceId, definition: Option<String>) -> ViewId {
+    pub fn push_view(
+        &mut self,
+        name: String,
+        namespace_id: NamespaceId,
+        definition: Option<String>,
+        description: Option<String>,
+    ) -> ViewId {
         let id = ViewId(self.views.len() as u32);
+
         self.views.push(View {
             namespace_id,
             name,
             definition,
+            description,
         });
+
         id
     }
 
@@ -360,13 +375,17 @@ impl SqlSchema {
         name: String,
         namespace_id: NamespaceId,
         properties: BitFlags<TableProperties>,
+        description: Option<String>,
     ) -> TableId {
         let id = TableId(self.tables.len() as u32);
+
         self.tables.push(Table {
             namespace_id,
             name,
             properties,
+            description,
         });
+
         id
     }
 
@@ -483,6 +502,7 @@ pub struct Table {
     namespace_id: NamespaceId,
     name: String,
     properties: BitFlags<TableProperties>,
+    description: Option<String>,
 }
 
 /// The type of an index.
@@ -572,6 +592,8 @@ pub struct Column {
     pub tpe: ColumnType,
     /// Is the column auto-incrementing?
     pub auto_increment: bool,
+    /// The comment in the database
+    pub description: Option<String>,
 }
 
 /// The type of a column.
@@ -758,6 +780,7 @@ struct Enum {
     /// The namespace the enum type belongs to, if applicable.
     namespace_id: NamespaceId,
     name: String,
+    description: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -775,6 +798,8 @@ pub struct View {
     pub name: String,
     /// The SQL definition of the view.
     pub definition: Option<String>,
+    /// The comment in the database
+    pub description: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]

--- a/schema-engine/sql-schema-describer/src/mssql.rs
+++ b/schema-engine/sql-schema-describer/src/mssql.rs
@@ -226,7 +226,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             };
 
             let cloned_name = table_name.clone();
-            let id = sql_schema.push_table(table_name, namespace_id);
+            let id = sql_schema.push_table(table_name, namespace_id, None);
             map.insert((namespace, cloned_name), id);
         }
 
@@ -395,6 +395,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 name,
                 tpe,
                 auto_increment,
+                description: None,
             };
 
             match container_id {
@@ -578,6 +579,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 namespace_id,
                 name: row.get_expect_string("view_name"),
                 definition: row.get_string("view_sql"),
+                description: None,
             })
         }
 

--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -236,6 +236,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 namespace_id: NamespaceId(0),
                 name: row.get_expect_string("view_name"),
                 definition: row.get_string("view_sql"),
+                description: None,
             })
         }
 
@@ -303,9 +304,10 @@ impl<'a> SqlSchemaDescriber<'a> {
                     name,
                     Default::default(),
                     Into::into(TableProperties::IsPartition),
+                    None,
                 )
             } else {
-                sql_schema.push_table(name, Default::default())
+                sql_schema.push_table(name, Default::default(), None)
             };
             map.insert(cloned_name, id);
         }
@@ -534,6 +536,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 name,
                 tpe,
                 auto_increment,
+                description: None,
             };
 
             match container_id {
@@ -645,7 +648,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             "longtext" => (ColumnTypeFamily::String, Some(MySqlType::LongText)),
             "enum" => {
                 let enum_name = format!("{table}_{column_name}");
-                let enum_id = sql_schema.push_enum(Default::default(), enum_name);
+                let enum_id = sql_schema.push_enum(Default::default(), enum_name, None);
                 push_enum_variants(full_data_type, enum_id, sql_schema);
                 (ColumnTypeFamily::Enum(enum_id), None)
             }

--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -293,7 +293,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             (
                 row.get_expect_string("table_name"),
                 row.get_expect_string("create_options") == "partitioned",
-                row.get_string("table_comment").filter(|c| c != ""),
+                row.get_string("table_comment").filter(|c| !c.is_empty()),
             )
         });
 

--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -278,7 +278,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             SELECT DISTINCT
               BINARY table_info.table_name AS table_name,
               table_info.create_options AS create_options,
-              IF(table_info.table_comment = '', NULL, table_info.table_comment) AS table_comment
+              table_info.table_comment AS table_comment
             FROM information_schema.tables AS table_info
             JOIN information_schema.columns AS column_info
                 ON BINARY column_info.table_name = BINARY table_info.table_name
@@ -293,7 +293,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             (
                 row.get_expect_string("table_name"),
                 row.get_expect_string("create_options") == "partitioned",
-                row.get_string("table_comment"),
+                row.get_string("table_comment").filter(|c| c != ""),
             )
         });
 
@@ -535,7 +535,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 }
             }
 
-            let description = col.get_string("table_comment");
+            let description = col.get_string("column_comment");
 
             let col = Column {
                 name,

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -729,6 +729,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 row.get_expect_bool("is_partition"),
                 row.get_expect_bool("has_subclass"),
                 row.get_expect_bool("has_row_level_security"),
+                row.get_string("description"),
             ));
 
             pg_ext.table_options.push(options);
@@ -736,7 +737,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
         let mut map = IndexMap::default();
 
-        for (table_name, namespace, is_partition, has_subclass, has_row_level_security) in names {
+        for (table_name, namespace, is_partition, has_subclass, has_row_level_security, description) in names {
             let cloned_name = table_name.clone();
 
             let partition = if is_partition {
@@ -760,6 +761,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 table_name,
                 sql_schema.get_namespace_id(&namespace).unwrap(),
                 partition | subclass | row_level_security,
+                description,
             );
 
             map.insert((namespace, cloned_name), id);
@@ -788,8 +790,15 @@ impl<'a> SqlSchemaDescriber<'a> {
     async fn get_views(&self, sql_schema: &mut SqlSchema) -> DescriberResult<()> {
         let namespaces = &sql_schema.namespaces;
         let sql = indoc! {r#"
-            SELECT viewname AS view_name, definition AS view_sql, schemaname as namespace
-            FROM pg_catalog.pg_views
+            SELECT
+                views.viewname AS view_name,
+                views.definition AS view_sql,
+                views.schemaname AS namespace,
+                description.description AS description
+            FROM pg_catalog.pg_views views
+            INNER JOIN pg_catalog.pg_namespace ns ON views.schemaname = ns.nspname
+            INNER JOIN pg_catalog.pg_class class ON class.relnamespace = ns.oid AND class.relname = views.viewname
+            LEFT JOIN pg_catalog.pg_description description ON description.objoid = class.oid
             WHERE schemaname = ANY ( $1 )
         "#};
 
@@ -800,19 +809,18 @@ impl<'a> SqlSchemaDescriber<'a> {
                 &[Array(Some(namespaces.iter().map(|v| v.as_str().into()).collect()))],
             )
             .await?;
-        let mut views = Vec::with_capacity(result_set.len());
 
         for row in result_set.into_iter() {
-            views.push(View {
-                namespace_id: sql_schema
-                    .get_namespace_id(&row.get_expect_string("namespace"))
-                    .unwrap(),
-                name: row.get_expect_string("view_name"),
-                definition: row.get_string("view_sql"),
-            })
-        }
+            let name = row.get_expect_string("view_name");
+            let definition = row.get_string("view_sql");
+            let description = row.get_string("description");
 
-        sql_schema.views = views;
+            let namespace_id = sql_schema
+                .get_namespace_id(&row.get_expect_string("namespace"))
+                .unwrap();
+
+            sql_schema.push_view(name, namespace_id, definition, description);
+        }
 
         Ok(())
     }
@@ -845,7 +853,8 @@ impl<'a> SqlSchemaDescriber<'a> {
                 pg_get_expr(attdef.adbin, attdef.adrelid) AS column_default,
                 info.is_nullable,
                 info.is_identity,
-                info.character_maximum_length
+                info.character_maximum_length,
+                description.description
             FROM information_schema.columns info
             JOIN pg_attribute att ON att.attname = info.column_name
             JOIN (
@@ -857,6 +866,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                   AND relname = info.table_name
                   AND namespace = info.table_schema
             LEFT OUTER JOIN pg_attrdef attdef ON attdef.adrelid = att.attrelid AND attdef.adnum = att.attnum AND table_schema = namespace
+            LEFT OUTER JOIN pg_description description ON description.objoid = att.attrelid AND description.objsubid = ordinal_position
             WHERE table_schema = ANY ( $1 ) {is_visible_clause}
             ORDER BY namespace, table_name, ordinal_position;
         "#
@@ -907,6 +917,8 @@ impl<'a> SqlSchemaDescriber<'a> {
                 .and_then(|raw_default_value| raw_default_value.to_string())
                 .and_then(|raw_default_value| get_default_value(&raw_default_value, &tpe));
 
+            let description = col.get_string("description");
+
             let auto_increment = is_identity
                 || matches!(default.as_ref().map(|d| &d.kind), Some(DefaultKind::Sequence(_)))
                 || (self.is_cockroach()
@@ -928,6 +940,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                 name,
                 tpe,
                 auto_increment,
+                description,
             };
 
             match container_id {
@@ -1405,10 +1418,11 @@ impl<'a> SqlSchemaDescriber<'a> {
         let namespaces = &sql_schema.namespaces;
 
         let sql = "
-            SELECT t.typname as name, e.enumlabel as value, n.nspname as namespace
+            SELECT t.typname as name, e.enumlabel as value, n.nspname as namespace, d.description
             FROM pg_type t
             JOIN pg_enum e ON t.oid = e.enumtypid
             JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+            LEFT OUTER JOIN pg_description d ON d.objoid = t.oid
             WHERE n.nspname = ANY ( $1 )
             ORDER BY e.enumsortorder";
 
@@ -1419,19 +1433,25 @@ impl<'a> SqlSchemaDescriber<'a> {
                 &[Array(Some(namespaces.iter().map(|v| v.as_str().into()).collect()))],
             )
             .await?;
-        let mut enum_values: BTreeMap<(NamespaceId, String), Vec<String>> = BTreeMap::new();
+        let mut enum_values: BTreeMap<(NamespaceId, String, Option<String>), Vec<String>> = BTreeMap::new();
 
         for row in rows.into_iter() {
             let name = row.get_expect_string("name");
             let value = row.get_expect_string("value");
             let namespace = row.get_expect_string("namespace");
+            let description = row.get_string("description");
             let namespace_id = sql_schema.get_namespace_id(&namespace).unwrap();
-            let values = enum_values.entry((namespace_id, name)).or_insert_with(Vec::new);
+
+            let values = enum_values
+                .entry((namespace_id, name, description))
+                .or_insert_with(Vec::new);
+
             values.push(value);
         }
 
-        for ((namespace_id, enum_name), variants) in enum_values {
-            let enum_id = sql_schema.push_enum(namespace_id, enum_name);
+        for ((namespace_id, enum_name, description), variants) in enum_values {
+            let enum_id = sql_schema.push_enum(namespace_id, enum_name, description);
+
             for variant in variants {
                 sql_schema.push_enum_variant(enum_id, variant);
             }

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -798,7 +798,7 @@ impl<'a> SqlSchemaDescriber<'a> {
             FROM pg_catalog.pg_views views
             INNER JOIN pg_catalog.pg_namespace ns ON views.schemaname = ns.nspname
             INNER JOIN pg_catalog.pg_class class ON class.relnamespace = ns.oid AND class.relname = views.viewname
-            LEFT JOIN pg_catalog.pg_description description ON description.objoid = class.oid
+            LEFT JOIN pg_catalog.pg_description description ON description.objoid = class.oid AND description.objsubid = 0
             WHERE schemaname = ANY ( $1 )
         "#};
 

--- a/schema-engine/sql-schema-describer/src/postgres/tables_query.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/tables_query.sql
@@ -4,9 +4,11 @@ SELECT
   (tbl.relhassubclass and tbl.relkind = 'p') as is_partition,
   (tbl.relhassubclass and tbl.relkind = 'r') as has_subclass,
   tbl.relrowsecurity as has_row_level_security,
-  reloptions
+  reloptions,
+  pd.description as description
 FROM pg_class AS tbl
 INNER JOIN pg_namespace AS namespace ON namespace.oid = tbl.relnamespace
+LEFT JOIN pg_description pd ON pd.objoid = tbl.oid AND pd.objsubid = 0
 WHERE
   ( -- (relkind = 'r' and relispartition = 't') matches partition table "duplicates"
     (tbl.relkind = 'r' AND tbl.relispartition = 'f')

--- a/schema-engine/sql-schema-describer/src/postgres/tables_query_simple.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/tables_query_simple.sql
@@ -4,9 +4,11 @@ SELECT
   false as is_partition,
   false as has_subclass,
   false as has_row_level_security,
-  reloptions
+  reloptions,
+  pd.description as description
 FROM pg_class AS tbl
 INNER JOIN pg_namespace AS namespace ON namespace.oid = tbl.relnamespace
+LEFT JOIN pg_description pd ON pd.objoid = tbl.oid AND pd.objsubid = 0
 WHERE
     tbl.relkind = 'r' AND namespace.nspname = ANY ( $1 )
 ORDER BY namespace, table_name;

--- a/schema-engine/sql-schema-describer/src/sqlite.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite.rs
@@ -171,11 +171,11 @@ impl<'a> SqlSchemaDescriber<'a> {
 
             match r#type.as_str() {
                 "table" => {
-                    let id = schema.push_table(name, Default::default());
+                    let id = schema.push_table(name, Default::default(), None);
                     map.insert(cloned_name, Either::Left(id));
                 }
                 "view" => {
-                    let id = schema.push_view(name, Default::default(), definition);
+                    let id = schema.push_view(name, Default::default(), definition, None);
                     map.insert(cloned_name, Either::Right(id));
                 }
                 _ => unreachable!(),
@@ -400,6 +400,7 @@ async fn push_columns(
             name: row.get_expect_string("name"),
             tpe,
             auto_increment: false,
+            description: None,
         };
 
         match container_id {

--- a/schema-engine/sql-schema-describer/src/walkers/column.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/column.rs
@@ -111,6 +111,11 @@ impl<'a> ColumnWalker<'a> {
         self.id.is_right()
     }
 
+    /// Description (comment) of the column.
+    pub fn description(self) -> Option<&'a str> {
+        self.get().description.as_deref()
+    }
+
     fn get(self) -> &'a Column {
         match self.id {
             Either::Left(table_column_id) => &self.schema.table_columns[table_column_id.0 as usize].1,

--- a/schema-engine/sql-schema-describer/src/walkers/enum.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/enum.rs
@@ -35,6 +35,11 @@ impl<'a> EnumWalker<'a> {
         super::range_for_key(&self.schema.enum_variants, self.id, |variant| variant.enum_id)
             .map(move |idx| self.schema.enum_variants[idx].variant_name.as_str())
     }
+
+    /// Description (comment) of the enum.
+    pub fn description(self) -> Option<&'a str> {
+        self.get().description.as_deref()
+    }
 }
 
 impl<'a> EnumVariantWalker<'a> {

--- a/schema-engine/sql-schema-describer/src/walkers/table.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/table.rs
@@ -115,6 +115,11 @@ impl<'a> TableWalker<'a> {
         self.table().properties.contains(TableProperties::HasRowLevelSecurity)
     }
 
+    /// Description (comment) of the table.
+    pub fn description(self) -> Option<&'a str> {
+        self.table().description.as_deref()
+    }
+
     /// Reference to the underlying `Table` struct.
     fn table(self) -> &'a Table {
         &self.schema.tables[self.id.0 as usize]

--- a/schema-engine/sql-schema-describer/src/walkers/view.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/view.rs
@@ -29,6 +29,11 @@ impl<'a> ViewWalker<'a> {
         self.columns_range().map(move |idx| self.walk(ViewColumnId(idx as u32)))
     }
 
+    /// Description (comment) of the view.
+    pub fn description(self) -> Option<&'a str> {
+        self.get().description.as_deref()
+    }
+
     fn columns_range(self) -> Range<usize> {
         super::range_for_key(&self.schema.view_columns, self.id, |(tid, _)| *tid)
     }

--- a/schema-engine/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -139,6 +139,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -159,6 +160,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -176,6 +178,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -193,6 +196,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -210,6 +214,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -227,6 +232,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -244,6 +250,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -261,6 +268,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -278,6 +286,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -295,6 +304,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -312,6 +322,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -329,6 +340,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -346,6 +358,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -363,6 +376,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -380,6 +394,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -397,6 +412,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -414,6 +430,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -431,6 +448,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -448,6 +466,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -465,6 +484,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -482,6 +502,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -499,6 +520,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -516,6 +538,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -533,6 +556,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -550,6 +574,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -567,6 +592,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -584,6 +610,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -601,6 +628,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -618,6 +646,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -635,6 +664,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -819,6 +849,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -828,6 +859,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -848,6 +880,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -865,6 +898,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -882,6 +916,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -899,6 +934,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -996,6 +1032,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -1005,6 +1042,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -1014,6 +1052,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -1023,6 +1062,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -1032,6 +1072,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -1052,6 +1093,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1069,6 +1111,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1086,6 +1129,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1103,6 +1147,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1120,6 +1165,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1137,6 +1183,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1154,6 +1201,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1171,6 +1219,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1188,6 +1237,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],

--- a/schema-engine/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -99,6 +99,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [
@@ -107,6 +108,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                         0,
                     ),
                     name: "User_enum_col",
+                    description: None,
                 },
             ],
             enum_variants: [
@@ -139,6 +141,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -156,6 +159,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -173,6 +177,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -190,6 +195,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -207,6 +213,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -224,6 +231,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -241,6 +249,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -258,6 +267,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -275,6 +285,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -292,6 +303,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -309,6 +321,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -326,6 +339,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -343,6 +357,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -360,6 +375,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -377,6 +393,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -394,6 +411,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -411,6 +429,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -428,6 +447,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -445,6 +465,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -462,6 +483,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -479,6 +501,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -496,6 +519,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -515,6 +539,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -530,6 +555,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -547,6 +573,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -564,6 +591,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -581,6 +609,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -598,6 +627,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -615,6 +645,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -632,6 +663,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -649,6 +681,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -666,6 +699,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -683,6 +717,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -700,6 +735,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -717,6 +753,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -734,6 +771,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -751,6 +789,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -768,6 +807,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -785,6 +825,7 @@ fn all_mysql_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -893,6 +934,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [
@@ -901,6 +943,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                         0,
                     ),
                     name: "User_enum_col",
+                    description: None,
                 },
             ],
             enum_variants: [
@@ -933,6 +976,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -950,6 +994,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -967,6 +1012,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -984,6 +1030,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1001,6 +1048,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1018,6 +1066,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1035,6 +1084,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1052,6 +1102,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1069,6 +1120,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1086,6 +1138,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1103,6 +1156,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1120,6 +1174,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1137,6 +1192,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1154,6 +1210,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1171,6 +1228,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1188,6 +1246,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1205,6 +1264,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1222,6 +1282,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1239,6 +1300,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1256,6 +1318,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1273,6 +1336,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1290,6 +1354,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1309,6 +1374,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1324,6 +1390,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1341,6 +1408,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1358,6 +1426,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1375,6 +1444,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1392,6 +1462,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1409,6 +1480,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1426,6 +1498,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1443,6 +1516,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1460,6 +1534,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1477,6 +1552,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1494,6 +1570,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1511,6 +1588,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1528,6 +1606,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1545,6 +1624,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1562,6 +1642,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1579,6 +1660,7 @@ fn all_mariadb_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -1680,6 +1762,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [
@@ -1688,6 +1771,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                         0,
                     ),
                     name: "User_enum_col",
+                    description: None,
                 },
             ],
             enum_variants: [
@@ -1720,6 +1804,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1737,6 +1822,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1754,6 +1840,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1771,6 +1858,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1788,6 +1876,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1805,6 +1894,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1822,6 +1912,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1839,6 +1930,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1856,6 +1948,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1873,6 +1966,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1890,6 +1984,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1907,6 +2002,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1924,6 +2020,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1941,6 +2038,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1958,6 +2056,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1975,6 +2074,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1992,6 +2092,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2009,6 +2110,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2026,6 +2128,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2043,6 +2146,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2060,6 +2164,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2077,6 +2182,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2096,6 +2202,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2111,6 +2218,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2128,6 +2236,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2145,6 +2254,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2162,6 +2272,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2179,6 +2290,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2196,6 +2308,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2213,6 +2326,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2230,6 +2344,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2247,6 +2362,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2264,6 +2380,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2281,6 +2398,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2298,6 +2416,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2315,6 +2434,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2332,6 +2452,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2349,6 +2470,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2366,6 +2488,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -2531,6 +2654,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -2540,6 +2664,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -2560,6 +2685,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2577,6 +2703,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2594,6 +2721,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -2719,6 +2847,7 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -2739,6 +2868,7 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -2794,6 +2924,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -2814,6 +2945,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2831,6 +2963,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -2899,6 +3032,7 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -2919,6 +3053,7 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -2985,6 +3120,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [
@@ -2993,6 +3129,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                         0,
                     ),
                     name: "game_enum_col",
+                    description: None,
                 },
             ],
             enum_variants: [
@@ -3019,6 +3156,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3036,6 +3174,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3053,6 +3192,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3070,6 +3210,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3087,6 +3228,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3104,6 +3246,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3121,6 +3264,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3138,6 +3282,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3155,6 +3300,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3172,6 +3318,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3191,6 +3338,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -3206,6 +3354,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -142,6 +142,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -162,6 +163,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -179,6 +181,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -196,6 +199,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -213,6 +217,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -230,6 +235,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -247,6 +253,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -264,6 +271,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -281,6 +289,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -298,6 +307,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -315,6 +325,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -332,6 +343,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -349,6 +361,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -366,6 +379,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -383,6 +397,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -400,6 +415,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -417,6 +433,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -434,6 +451,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -451,6 +469,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -468,6 +487,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -485,6 +505,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -502,6 +523,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -519,6 +541,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -536,6 +559,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -553,6 +577,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -570,6 +595,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -587,6 +613,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -604,6 +631,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -621,6 +649,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -638,6 +667,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -655,6 +685,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -672,6 +703,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -689,6 +721,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -706,6 +739,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -723,6 +757,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -740,6 +775,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -757,6 +793,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -774,6 +811,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -791,6 +829,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -808,6 +847,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -825,6 +865,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -842,6 +883,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -859,6 +901,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -876,6 +919,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -1270,6 +1314,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -1290,6 +1335,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1307,6 +1353,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1324,6 +1371,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1341,6 +1389,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -1445,6 +1494,7 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -1465,6 +1515,7 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -1802,6 +1853,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -1811,6 +1863,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -1831,6 +1884,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1848,6 +1902,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -1865,6 +1920,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -1882,6 +1938,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -2026,6 +2083,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -2035,6 +2093,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -2044,6 +2103,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -2053,6 +2113,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -2062,6 +2123,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -2082,6 +2144,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2099,6 +2162,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -2116,6 +2180,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -2133,6 +2198,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2150,6 +2216,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -2167,6 +2234,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -2184,6 +2252,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -2201,6 +2270,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -2218,6 +2288,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -240,6 +240,7 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -260,6 +261,7 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -277,6 +279,7 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -294,6 +297,7 @@ fn multi_field_indexes_must_be_inferred_in_the_right_order(api: TestApi) {
                             ),
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],

--- a/schema-engine/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -72,6 +72,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -90,6 +91,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -105,6 +107,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -120,6 +123,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -135,6 +139,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -150,6 +155,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -165,6 +171,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -281,6 +288,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -299,6 +307,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -314,6 +323,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -382,6 +392,7 @@ fn backslashes_in_string_literals(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -400,6 +411,7 @@ fn backslashes_in_string_literals(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
             ],
@@ -467,6 +479,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
                 Table {
                     namespace_id: NamespaceId(
@@ -476,6 +489,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                     properties: BitFlags<TableProperties> {
                         bits: 0b0,
                     },
+                    description: None,
                 },
             ],
             enums: [],
@@ -494,6 +508,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
                 (
@@ -509,6 +524,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -524,6 +540,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -539,6 +556,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: false,
+                        description: None,
                     },
                 ),
                 (
@@ -554,6 +572,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
                             native_type: None,
                         },
                         auto_increment: true,
+                        description: None,
                     },
                 ),
             ],


### PR DESCRIPTION
Part of: https://github.com/prisma/schema-team/issues/388

Implements comment stopgap on databases with specced and standardized comments: PostgreSQL (tables, views, columns, enums), CockroachDB (tables, columns) and MySQL (tables, columns).