### PR TITLE
Add comments to PSL for stopgaps (that are missing)

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour.rs
@@ -3,6 +3,7 @@ mod postgresql;
 mod sqlite;
 mod sqlserver;
 
+use sql::TableWalker;
 use sql_schema_describer as sql;
 
 pub(super) use mysql::MysqlIntrospectionFlavour;
@@ -32,4 +33,8 @@ pub(crate) trait IntrospectionFlavour {
     }
 
     fn generate_warnings(&self, _ctx: &DatamodelCalculatorContext<'_>, _warnings: &mut Warnings) {}
+
+    fn uses_row_level_ttl(&self, _ctx: &DatamodelCalculatorContext<'_>, _table: TableWalker<'_>) -> bool {
+        false
+    }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour.rs
@@ -3,7 +3,7 @@ mod postgresql;
 mod sqlite;
 mod sqlserver;
 
-use sql::{ForeignKeyWalker, IndexWalker, TableWalker};
+use sql::{ForeignKeyWalker, IndexColumnWalker, IndexWalker, TableWalker};
 use sql_schema_describer as sql;
 
 pub(super) use mysql::MysqlIntrospectionFlavour;
@@ -46,6 +46,14 @@ pub(crate) trait IntrospectionFlavour {
         &self,
         _ctx: &DatamodelCalculatorContext<'_>,
         _foreign_key: ForeignKeyWalker<'_>,
+    ) -> bool {
+        false
+    }
+
+    fn uses_non_default_null_position(
+        &self,
+        _ctx: &DatamodelCalculatorContext<'_>,
+        _column: IndexColumnWalker<'_>,
     ) -> bool {
         false
     }

--- a/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour.rs
@@ -3,7 +3,7 @@ mod postgresql;
 mod sqlite;
 mod sqlserver;
 
-use sql::TableWalker;
+use sql::{ForeignKeyWalker, IndexWalker, TableWalker};
 use sql_schema_describer as sql;
 
 pub(super) use mysql::MysqlIntrospectionFlavour;
@@ -35,6 +35,18 @@ pub(crate) trait IntrospectionFlavour {
     fn generate_warnings(&self, _ctx: &DatamodelCalculatorContext<'_>, _warnings: &mut Warnings) {}
 
     fn uses_row_level_ttl(&self, _ctx: &DatamodelCalculatorContext<'_>, _table: TableWalker<'_>) -> bool {
+        false
+    }
+
+    fn uses_non_default_index_deferring(&self, _ctx: &DatamodelCalculatorContext<'_>, _index: IndexWalker<'_>) -> bool {
+        false
+    }
+
+    fn uses_non_default_foreign_key_deferring(
+        &self,
+        _ctx: &DatamodelCalculatorContext<'_>,
+        _foreign_key: ForeignKeyWalker<'_>,
+    ) -> bool {
         false
     }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour/cockroachdb.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour/cockroachdb.rs
@@ -1,3 +1,0 @@
-pub(crate) struct CockroachDbIntrospectionFlavour;
-
-impl super::IntrospectionFlavour for CockroachDbIntrospectionFlavour {}

--- a/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour/postgresql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/datamodel_calculator/context/flavour/postgresql.rs
@@ -1,4 +1,4 @@
-use sql::postgres::PostgresSchemaExt;
+use sql::{postgres::PostgresSchemaExt, TableWalker};
 use sql_schema_describer as sql;
 
 use crate::{
@@ -43,11 +43,17 @@ impl super::IntrospectionFlavour for PostgresIntrospectionFlavour {
                 }
             }
 
-            if pg_ext.uses_row_level_ttl(table.id) && ctx.is_cockroach() {
+            if self.uses_row_level_ttl(ctx, table) {
                 warnings.row_level_ttl.push(Model {
                     model: ctx.table_prisma_name(table.id).prisma_name().to_string(),
                 });
             }
         }
+    }
+
+    fn uses_row_level_ttl(&self, ctx: &DatamodelCalculatorContext<'_>, table: TableWalker<'_>) -> bool {
+        let pg_ext: &PostgresSchemaExt = ctx.sql_schema.downcast_connector_data();
+
+        ctx.is_cockroach() && pg_ext.uses_row_level_ttl(table.id)
     }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/index.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/index.rs
@@ -160,6 +160,21 @@ impl<'a> IndexPair<'a> {
         self.defined_in_a_field().then(|| self.fields().next().unwrap())
     }
 
+    /// True, if we add a new index that has non-default deferring.
+    pub(crate) fn adds_a_non_default_deferring(self) -> bool {
+        if self.previous.is_none() {
+            return false;
+        }
+
+        if let Some(index) = self.next {
+            self.context
+                .flavour
+                .uses_non_default_index_deferring(self.context, index)
+        } else {
+            false
+        }
+    }
+
     fn defined_in_a_field(self) -> bool {
         if !matches!(self.index_type(), sql::IndexType::Unique) {
             return false;

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/index.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/index.rs
@@ -162,16 +162,12 @@ impl<'a> IndexPair<'a> {
 
     /// True, if we add a new index that has non-default deferring.
     pub(crate) fn adds_a_non_default_deferring(self) -> bool {
-        if self.previous.is_none() {
-            return false;
-        }
-
-        if let Some(index) = self.next {
-            self.context
+        match (self.previous, self.next) {
+            (None, Some(next)) => self
+                .context
                 .flavour
-                .uses_non_default_index_deferring(self.context, index)
-        } else {
-            false
+                .uses_non_default_index_deferring(self.context, next),
+            _ => false,
         }
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/index_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/index_field.rs
@@ -46,6 +46,18 @@ impl<'a> IndexFieldPair<'a> {
         self.next.and_then(|next| next.length())
     }
 
+    /// True, if we _add_ an index with non-default null position.
+    pub(crate) fn adds_non_default_null_position(self) -> bool {
+        if self.previous.is_some() {
+            return false;
+        }
+
+        match self.next {
+            Some(next) => self.context.flavour.uses_non_default_null_position(self.context, next),
+            None => false,
+        }
+    }
+
     /// A PostgreSQL specific operator class for the indexed column.
     pub(crate) fn opclass(self) -> Option<IndexOps<'a>> {
         if !self.context.sql_family.is_postgres() {

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -175,12 +175,13 @@ impl<'a> ModelPair<'a> {
     /// deferring.
     pub(crate) fn adds_non_default_deferring(self) -> bool {
         let from_index = self.all_indexes().any(|i| i.adds_a_non_default_deferring());
+
         let from_fk = self
             .relation_fields()
             .filter(|rf| rf.fields().is_some())
             .any(|rf| rf.adds_non_default_deferring());
 
-        from_index || from_fk
+        self.previous.is_none() && (from_index || from_fk)
     }
 
     /// A model must have either a primary key, or at least one unique

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -144,6 +144,11 @@ impl<'a> ModelPair<'a> {
         self.previous.filter(|m| m.mapped_name().is_some()).is_some()
     }
 
+    /// True, if we have a new model that uses row level TTL.
+    pub(crate) fn adds_a_row_level_ttl(self) -> bool {
+        self.previous.is_none() && self.context.flavour.uses_row_level_ttl(self.context, self.next)
+    }
+
     /// A model must have either a primary key, or at least one unique
     /// index defined that consists of columns that are all supported by
     /// prisma and not null.

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -37,9 +37,19 @@ impl<'a> ModelPair<'a> {
         self.next.is_partition()
     }
 
+    /// True, if we add a new model with a partition.
+    pub(crate) fn new_with_partition(self) -> bool {
+        self.previous.is_none() && self.is_partition()
+    }
+
     /// Whether the model has subclass tables or not.
     pub(crate) fn has_subclass(self) -> bool {
         self.next.has_subclass()
+    }
+
+    /// True, if we add a new model with a subclass.
+    pub(crate) fn new_with_subclass(self) -> bool {
+        self.previous.is_none() && self.has_subclass()
     }
 
     /// Whether the model has row level security enabled.

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -52,6 +52,13 @@ impl<'a> ModelPair<'a> {
         self.previous.is_none() && self.has_row_level_security()
     }
 
+    /// True, if we add an index with non-default null position.
+    pub(crate) fn adds_non_default_null_position(self) -> bool {
+        self.all_indexes()
+            .flat_map(|i| i.fields())
+            .any(|f| f.adds_non_default_null_position())
+    }
+
     /// Name of the model in the PSL. The value can be sanitized if it
     /// contains characters that are not allowed in the PSL
     /// definition.

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/model.rs
@@ -47,6 +47,11 @@ impl<'a> ModelPair<'a> {
         self.next.has_row_level_security()
     }
 
+    /// True, if we add a new model with row level security enabled.
+    pub(crate) fn adds_row_level_security(self) -> bool {
+        self.previous.is_none() && self.has_row_level_security()
+    }
+
     /// Name of the model in the PSL. The value can be sanitized if it
     /// contains characters that are not allowed in the PSL
     /// definition.
@@ -151,7 +156,7 @@ impl<'a> ModelPair<'a> {
 
     /// True, if we _add_ a new constraint with a non-default
     /// deferring.
-    pub(crate) fn uses_non_default_deferring(self) -> bool {
+    pub(crate) fn adds_non_default_deferring(self) -> bool {
         let from_index = self.all_indexes().any(|i| i.adds_a_non_default_deferring());
         let from_fk = self
             .relation_fields()

--- a/schema-engine/connectors/sql-schema-connector/src/introspection_pair/relation_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection_pair/relation_field.rs
@@ -356,6 +356,21 @@ impl<'a> RelationFieldPair<'a> {
         }
     }
 
+    /// True, if we add a new constraint with non-default deferring.
+    pub(crate) fn adds_non_default_deferring(self) -> bool {
+        match self.relation_type {
+            RelationType::Inline(field) => {
+                field.previous.is_none()
+                    && self
+                        .context
+                        .flavour
+                        .uses_non_default_foreign_key_deferring(self.context, field.next)
+            }
+            RelationType::Many2Many(_) => false,
+            RelationType::Emulated(_) => false,
+        }
+    }
+
     /// If the relation is completely taken from the PSL.
     pub(crate) fn reintrospected_relation(self) -> bool {
         matches!(self.relation_type, RelationType::Emulated(_))

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
@@ -104,9 +104,15 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
     }
 
     if model.adds_row_level_security() {
-        let docs= "This model contains row level security and requires additional setup for migrations. Visit https://prisl.y/d/row-level-security for more info.";
+        let docs= "This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.";
 
-        rendered.documentation(docs)
+        rendered.documentation(docs);
+    }
+
+    if model.adds_non_default_null_position() {
+        let docs = "This model contains an index with non-default null sort order and requires additional setup for migrations. Visit https://pris.ly/d/default-index-null-ordering for more info.";
+
+        rendered.documentation(docs);
     }
 
     for field in model.scalar_fields() {

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
@@ -46,13 +46,13 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
         }
     }
 
-    if model.is_partition() {
+    if model.new_with_partition() {
         let docs = "This table is a partition table and requires additional setup for migrations. Visit https://pris.ly/d/partition-tables for more info.";
 
         rendered.documentation(docs);
     }
 
-    if model.has_subclass() {
+    if model.new_with_subclass() {
         let docs = "This table has subclasses and requires additional setup for migrations. Visit https://pris.ly/d/table-inheritance for more info.";
 
         rendered.documentation(docs);

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
@@ -97,10 +97,16 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
         rendered.documentation(docs);
     }
 
-    if model.uses_non_default_deferring() {
+    if model.adds_non_default_deferring() {
         let docs = "This model has constraints using non-default deferring rules and requires additional setup for migrations. Visit https://pris.ly/d/constraint-deferring for more info.";
 
         rendered.documentation(docs);
+    }
+
+    if model.adds_row_level_security() {
+        let docs= "This model contains row level security and requires additional setup for migrations. Visit https://prisl.y/d/row-level-security for more info.";
+
+        rendered.documentation(docs)
     }
 
     for field in model.scalar_fields() {

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
@@ -97,6 +97,12 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
         rendered.documentation(docs);
     }
 
+    if model.uses_non_default_deferring() {
+        let docs = "This model has constraints using non-default deferring rules and requires additional setup for migrations. Visit https://pris.ly/d/constraint-deferring for more info.";
+
+        rendered.documentation(docs);
+    }
+
     for field in model.scalar_fields() {
         rendered.push_field(scalar_field::render(field));
     }

--- a/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/rendering/models.rs
@@ -91,6 +91,12 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
         rendered.documentation(docs);
     }
 
+    if model.adds_a_row_level_ttl() {
+        let docs = "This model is using a row level TTL in the database, and requires an additional setup in migrations. Read more: https://pris.ly/d/row-level-ttl";
+
+        rendered.documentation(docs);
+    }
+
     for field in model.scalar_fields() {
         rendered.push_field(scalar_field::render(field));
     }

--- a/schema-engine/connectors/sql-schema-connector/src/warnings/generators.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/warnings/generators.rs
@@ -581,7 +581,7 @@ pub(crate) fn non_default_index_null_sort_order(affected: &[IndexedColumn]) -> W
 }
 
 pub(super) fn row_level_security_tables_found(affected: &[Model]) -> Warning {
-    let message = "These tables contain row level security, which is not yet fully supported.";
+    let message = "These tables contain row level security, which is not yet fully supported. Read more: https://pris.ly/d/row-level-security";
 
     Warning {
         code: 30,

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
@@ -377,6 +377,24 @@ async fn row_level_ttl_stopgap(api: &mut TestApi) -> TestResult {
 
     api.expect_warnings(&expectation).await;
 
+    let input = indoc! {r#"
+        /// This model is using a row level TTL in the database, and requires an additional setup in migrations. Read more: https://pris.ly/d/row-level-ttl
+        model ttl_test {
+          id          BigInt    @id @default(autoincrement())
+          inserted_at DateTime? @default(now()) @db.Timestamp(6)
+        }
+    "#};
+
+    let expectation = expect![[r#"
+        /// This model is using a row level TTL in the database, and requires an additional setup in migrations. Read more: https://pris.ly/d/row-level-ttl
+        model ttl_test {
+          id          BigInt    @id @default(autoincrement())
+          inserted_at DateTime? @default(now()) @db.Timestamp(6)
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expectation).await;
+
     Ok(())
 }
 

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
@@ -353,6 +353,7 @@ async fn row_level_ttl_stopgap(api: &mut TestApi) -> TestResult {
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model is using a row level TTL in the database, and requires an additional setup in migrations. Read more: https://pris.ly/d/row-level-ttl
         model ttl_test {
           id          BigInt    @id @default(autoincrement())
           inserted_at DateTime? @default(now()) @db.Timestamp(6)

--- a/schema-engine/sql-introspection-tests/tests/commenting_out/postgres.rs
+++ b/schema-engine/sql-introspection-tests/tests/commenting_out/postgres.rs
@@ -507,7 +507,7 @@ ALTER TABLE foo ENABLE ROW LEVEL SECURITY; "#,
           url      = "env(TEST_DATABASE_URL)"
         }
 
-        /// This model contains row level security and requires additional setup for migrations. Visit https://prisl.y/d/row-level-security for more info.
+        /// This model contains row level security and requires additional setup for migrations. Visit https://pris.ly/d/row-level-security for more info.
         model foo {
           id    Int    @id @default(autoincrement())
           owner String @db.VarChar(30)

--- a/schema-engine/sql-introspection-tests/tests/commenting_out/postgres.rs
+++ b/schema-engine/sql-introspection-tests/tests/commenting_out/postgres.rs
@@ -487,7 +487,7 @@ ALTER TABLE foo ENABLE ROW LEVEL SECURITY; "#,
 
     let expected = json!([{
         "code": 30,
-        "message": "These tables contain row level security, which is not yet fully supported.",
+        "message": "These tables contain row level security, which is not yet fully supported. Read more: https://pris.ly/d/row-level-security",
         "affected": [
             {
                 "model": "foo"
@@ -507,6 +507,7 @@ ALTER TABLE foo ENABLE ROW LEVEL SECURITY; "#,
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model contains row level security and requires additional setup for migrations. Visit https://prisl.y/d/row-level-security for more info.
         model foo {
           id    Int    @id @default(autoincrement())
           owner String @db.VarChar(30)

--- a/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
@@ -188,6 +188,7 @@ async fn index_sort_order_stopgap(api: &mut TestApi) -> TestResult {
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model contains an index with non-default null sort order and requires additional setup for migrations. Visit https://pris.ly/d/default-index-null-ordering for more info.
         model foo {
           id Int @id
           a  Int

--- a/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
@@ -268,6 +268,7 @@ async fn deferrable_stopgap(api: &mut TestApi) -> TestResult {
           url      = "env(TEST_DATABASE_URL)"
         }
 
+        /// This model has constraints using non-default deferring rules and requires additional setup for migrations. Visit https://pris.ly/d/constraint-deferring for more info.
         model a {
           id  Int  @id(map: "foo_pkey")
           foo Int? @unique(map: "foo_key")

--- a/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
@@ -223,6 +223,36 @@ async fn index_sort_order_stopgap(api: &mut TestApi) -> TestResult {
 
     api.expect_warnings(&expectation).await;
 
+    let input = indoc! {r#"
+        /// This model contains an index with non-default null sort order and requires additional setup for migrations. Visit https://pris.ly/d/default-index-null-ordering for more info.
+        model foo {
+          id Int @id
+          a  Int
+          b  Int @unique(map: "idx_b", sort: Desc)
+          c  Int
+          d  Int @unique(map: "idx_d")
+
+          @@index([a], map: "idx_a")
+          @@index([c(sort: Desc)], map: "idx_c")
+        }
+    "#};
+
+    let expectation = expect![[r#"
+        /// This model contains an index with non-default null sort order and requires additional setup for migrations. Visit https://pris.ly/d/default-index-null-ordering for more info.
+        model foo {
+          id Int @id
+          a  Int
+          b  Int @unique(map: "idx_b", sort: Desc)
+          c  Int
+          d  Int @unique(map: "idx_d")
+
+          @@index([a], map: "idx_a")
+          @@index([c(sort: Desc)], map: "idx_c")
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expectation).await;
+
     Ok(())
 }
 
@@ -308,6 +338,38 @@ async fn deferrable_stopgap(api: &mut TestApi) -> TestResult {
         ]"#]];
 
     api.expect_warnings(&expectation).await;
+
+    let input = indoc! {r#"
+        /// This model has constraints using non-default deferring rules and requires additional setup for migrations. Visit https://pris.ly/d/constraint-deferring for more info.
+        model a {
+          id  Int  @id(map: "foo_pkey")
+          foo Int? @unique(map: "foo_key")
+          bar Int?
+          b   b?   @relation(fields: [foo], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "a_b_fk")
+        }
+
+        model b {
+          id Int @id
+          a  a?
+        }
+    "#};
+
+    let expectation = expect![[r#"
+        /// This model has constraints using non-default deferring rules and requires additional setup for migrations. Visit https://pris.ly/d/constraint-deferring for more info.
+        model a {
+          id  Int  @id(map: "foo_pkey")
+          foo Int? @unique(map: "foo_key")
+          bar Int?
+          b   b?   @relation(fields: [foo], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "a_b_fk")
+        }
+
+        model b {
+          id Int @id
+          a  a?
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expectation).await;
 
     Ok(())
 }
@@ -411,6 +473,56 @@ async fn commenting_stopgap(api: &mut TestApi) -> TestResult {
         ]"#]];
 
     api.expect_warnings(&expectation).await;
+
+    let input = indoc! {r#"
+        /// This model is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        model a {
+          id  Int     @id
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+          val String? @db.VarChar(20)
+        }
+
+        /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        /// This view is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        view b {
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+          val String? @db.VarChar(20)
+
+          @@ignore
+        }
+
+        /// This enum is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        enum c {
+          a
+          b
+        }   
+    "#};
+
+    let expectation = expect![[r#"
+        /// This model is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        model a {
+          id  Int     @id
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+          val String? @db.VarChar(20)
+        }
+
+        /// The underlying view does not contain a valid unique identifier and can therefore currently not be handled by the Prisma Client.
+        /// This view is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        view b {
+          /// This field is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+          val String? @db.VarChar(20)
+
+          @@ignore
+        }
+
+        /// This enum is commented in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        enum c {
+          a
+          b
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(input, expectation).await;
 
     Ok(())
 }


### PR DESCRIPTION
Adds PSL level comments to all of the stopgaps merged so far. Adds a few missing pris.ly links.

Adds re-introspection tests for all implemented stopgaps.

Fixes: https://github.com/prisma/prisma/issues/18103