### PR TITLE
qe: delete dead Deprecation field in InputObjectField and OutputObjectField

### DIFF
--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
@@ -11,15 +11,13 @@ pub(super) fn render_input_field(input_field: &InputField, ctx: &mut RenderConte
         .iter()
         .any(|typ| matches!(typ, InputType::Scalar(ScalarType::Null)));
 
-    let field = DmmfInputField {
+    DmmfInputField {
         name: input_field.name.clone(),
         input_types: type_references,
         is_required: input_field.is_required,
         is_nullable: nullable,
-        deprecation: input_field.deprecation.as_ref().map(Into::into),
-    };
-
-    field
+        deprecation: None,
+    }
 }
 
 pub(super) fn render_output_field(field: &OutputField, ctx: &mut RenderContext) -> DmmfOutputField {
@@ -31,7 +29,7 @@ pub(super) fn render_output_field(field: &OutputField, ctx: &mut RenderContext) 
         args: rendered_inputs,
         output_type,
         is_nullable: field.is_nullable,
-        deprecation: field.deprecation.as_ref().map(Into::into),
+        deprecation: None,
     };
 
     ctx.add_mapping(field.name.clone(), field.query_info.as_ref());

--- a/query-engine/dmmf/src/serialization_ast/schema_ast.rs
+++ b/query-engine/dmmf/src/serialization_ast/schema_ast.rs
@@ -1,5 +1,4 @@
 use indexmap::IndexMap;
-use schema::Deprecation;
 use serde::Serialize;
 
 #[derive(Debug, Serialize, Default)]
@@ -113,14 +112,4 @@ pub struct DmmfDeprecation {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub planned_removal_version: Option<String>,
-}
-
-impl From<&Deprecation> for DmmfDeprecation {
-    fn from(deprecation: &Deprecation) -> Self {
-        Self {
-            since_version: deprecation.since_version.clone(),
-            planned_removal_version: deprecation.planned_removal_version.clone(),
-            reason: deprecation.reason.clone(),
-        }
-    }
 }

--- a/query-engine/schema-builder/src/utils.rs
+++ b/query-engine/schema-builder/src/utils.rs
@@ -44,7 +44,6 @@ where
         field_type,
         query_info,
         is_nullable: false,
-        deprecation: None,
     }
 }
 

--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -111,7 +111,6 @@ impl InputObjectType {
 pub struct InputField {
     pub name: String,
     pub default_value: Option<dml::DefaultKind>,
-    pub deprecation: Option<Deprecation>,
 
     /// Possible field types, represented as a union of input types, but only one can be provided at any time.
     /// Slice expressed as (start, len).
@@ -127,7 +126,6 @@ impl InputField {
         InputField {
             name,
             default_value,
-            deprecation: None,
             field_types: None,
             is_required,
         }
@@ -189,20 +187,6 @@ impl InputField {
     /// Adds possible input type to this input field's type union.
     pub fn add_type(mut self, typ: InputType, db: &mut QuerySchemaDatabase) -> Self {
         self.push_type(typ, db);
-        self
-    }
-
-    pub fn deprecate<T, S>(mut self, reason: T, since_version: S, planned_removal_version: Option<S>) -> Self
-    where
-        T: Into<String>,
-        S: Into<String>,
-    {
-        self.deprecation = Some(Deprecation {
-            reason: reason.into(),
-            since_version: since_version.into(),
-            planned_removal_version: planned_removal_version.map(Into::into),
-        });
-
         self
     }
 }

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -19,10 +19,3 @@ pub use utils::*;
 use std::sync::Arc;
 
 pub type QuerySchemaRef = Arc<QuerySchema>;
-
-#[derive(Debug, PartialEq)]
-pub struct Deprecation {
-    pub since_version: String,
-    pub planned_removal_version: Option<String>,
-    pub reason: String,
-}

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -168,7 +168,6 @@ impl ObjectType {
 pub struct OutputField {
     pub name: String,
     pub field_type: OutputType,
-    pub deprecation: Option<Deprecation>,
 
     /// Arguments are input fields, but positioned in context of an output field
     /// instead of being attached to an input object.
@@ -194,20 +193,6 @@ impl OutputField {
         } else {
             self
         }
-    }
-
-    pub fn deprecate<T, S>(mut self, reason: T, since_version: S, planned_removal_version: Option<String>) -> Self
-    where
-        T: Into<String>,
-        S: Into<String>,
-    {
-        self.deprecation = Some(Deprecation {
-            reason: reason.into(),
-            since_version: since_version.into(),
-            planned_removal_version,
-        });
-
-        self
     }
 
     pub fn model(&self) -> Option<&ModelRef> {


### PR DESCRIPTION
This is part of de-crufting schema-builder.