### PR TITLE
ci(query-engine-black-box): Rename workflow

### DIFF
--- a/.github/workflows/query-engine-black-box.yml
+++ b/.github/workflows/query-engine-black-box.yml
@@ -1,4 +1,4 @@
-name: Query Engine
+name: Query Engine Black Box
 on:
   push:
     branches:


### PR DESCRIPTION
Otherwise GH UI shows both as `Qeery Engine` which is inconvenient.