### PR TITLE
qe: concurrently build query schema and start connection

### DIFF
--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -37,36 +37,45 @@ impl PrismaContext {
         enabled_features: EnabledFeatures,
         metrics: Option<MetricRegistry>,
     ) -> PrismaResult<PrismaContext> {
-        let config = &schema.configuration;
-        // We only support one data source at the moment, so take the first one (default not exposed yet).
-        let data_source = config
-            .datasources
-            .first()
-            .ok_or_else(|| PrismaError::ConfigurationError("No valid data source found".into()))?;
+        let arced_schema = Arc::new(schema);
+        let arced_schema_2 = Arc::clone(&arced_schema);
 
-        let url = data_source.load_url(|key| env::var(key).ok())?;
+        let query_schema_fut = tokio::runtime::Handle::current().spawn_blocking(move || {
+            // Build internal data model
+            let internal_data_model = prisma_models::convert(arced_schema);
 
-        // Load executor
-        let executor = load_executor(data_source, config.preview_features(), &url).await?;
+            // Construct query schema
+            Arc::new(schema_builder::build(
+                internal_data_model,
+                enabled_features.contains(Feature::RawQueries),
+            ))
+        });
+        let executor_fut = tokio::spawn(async move {
+            let config = &arced_schema_2.configuration;
+            let preview_features = config.preview_features();
 
-        // Build internal data model
-        let internal_data_model = prisma_models::convert(Arc::new(schema));
+            // We only support one data source at the moment, so take the first one (default not exposed yet).
+            let data_source = config
+                .datasources
+                .first()
+                .ok_or_else(|| PrismaError::ConfigurationError("No valid data source found".into()))?;
 
-        // Construct query schema
-        let query_schema: QuerySchemaRef = Arc::new(schema_builder::build(
-            internal_data_model,
-            enabled_features.contains(Feature::RawQueries),
-        ));
+            let url = data_source.load_url(|key| env::var(key).ok())?;
+            // Load executor
+            let executor = load_executor(data_source, preview_features, &url).await?;
+            executor.primary_connector().get_connection().await?;
+            PrismaResult::<_>::Ok(executor)
+        });
+
+        let (query_schema, executor) = tokio::join!(query_schema_fut, executor_fut);
 
         let context = Self {
-            query_schema,
-            executor,
+            query_schema: query_schema.unwrap(),
+            executor: executor.unwrap()?,
             metrics: metrics.unwrap_or_default(),
             engine_protocol: protocol,
             enabled_features,
         };
-
-        context.verify_connection().await?;
 
         Ok(context)
     }
@@ -85,11 +94,6 @@ impl PrismaContext {
 
     pub fn engine_protocol(&self) -> EngineProtocol {
         self.engine_protocol
-    }
-
-    async fn verify_connection(&self) -> PrismaResult<()> {
-        self.executor.primary_connector().get_connection().await?;
-        Ok(())
     }
 }
 

--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -13,7 +13,7 @@ pub async fn load(
     source: &Datasource,
     features: PreviewFeatures,
     url: &str,
-) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync>> {
+) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync + 'static>> {
     match source.active_provider {
         p if SQLITE.is_provider(p) => sqlite(source, url, features).await,
         p if MYSQL.is_provider(p) => mysql(source, url, features).await,


### PR DESCRIPTION
When constructing a query engine, this runs two tasks concurrently that we previously performed sequentially:

- Loading an executor and getting a connection out of the pool.
- schema_builder::build()

This is an attempt at improving time to first query: we measured that schema_builder::builder() still takes very significant time on startup for large Prisma schemas.