### PR TITLE
psl+qe: simplify connector capabilities representation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ name = "black-box-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "enumflags2",
  "indoc",
  "insta",
  "query-engine-tests",
@@ -3346,6 +3347,7 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "colored",
+ "enumflags2",
  "futures",
  "indoc",
  "insta",

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -7,8 +7,8 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
-        StringFilter,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        NativeTypeInstance, RelationMode, StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
     parser_database::{
@@ -26,36 +26,36 @@ use crate::completions;
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::ModelPrimaryKeyKeyIndexForeignKey];
 
-const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::AdvancedJsonNullability,
-    ConnectorCapability::AnyId,
-    ConnectorCapability::AutoIncrement,
-    ConnectorCapability::AutoIncrementAllowedOnNonId,
-    ConnectorCapability::AutoIncrementMultipleAllowed,
-    ConnectorCapability::AutoIncrementNonIndexedAllowed,
-    ConnectorCapability::CompoundIds,
-    ConnectorCapability::CreateMany,
-    ConnectorCapability::CreateManyWriteableAutoIncId,
-    ConnectorCapability::CreateSkipDuplicates,
-    ConnectorCapability::Enums,
-    ConnectorCapability::InsensitiveFilters,
-    ConnectorCapability::Json,
-    ConnectorCapability::JsonFiltering,
-    ConnectorCapability::JsonFilteringArrayPath,
-    ConnectorCapability::NamedPrimaryKeys,
-    ConnectorCapability::NamedForeignKeys,
-    ConnectorCapability::SqlQueryRaw,
-    ConnectorCapability::RelationFieldsInArbitraryOrder,
-    ConnectorCapability::ScalarLists,
-    ConnectorCapability::UpdateableId,
-    ConnectorCapability::WritableAutoincField,
-    ConnectorCapability::ImplicitManyToManyRelation,
-    ConnectorCapability::DecimalType,
-    ConnectorCapability::OrderByNullsFirstLast,
-    ConnectorCapability::SupportsTxIsolationSerializable,
-    ConnectorCapability::NativeUpsert,
-    ConnectorCapability::MultiSchema,
-];
+const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(ConnectorCapability::{
+    AdvancedJsonNullability |
+    AnyId |
+    AutoIncrement |
+    AutoIncrementAllowedOnNonId |
+    AutoIncrementMultipleAllowed |
+    AutoIncrementNonIndexedAllowed |
+    CompoundIds |
+    CreateMany |
+    CreateManyWriteableAutoIncId |
+    CreateSkipDuplicates |
+    Enums |
+    InsensitiveFilters |
+    Json |
+    JsonFiltering |
+    JsonFilteringArrayPath |
+    NamedPrimaryKeys |
+    NamedForeignKeys |
+    SqlQueryRaw |
+    RelationFieldsInArbitraryOrder |
+    ScalarLists |
+    UpdateableId |
+    WritableAutoincField |
+    ImplicitManyToManyRelation |
+    DecimalType |
+    OrderByNullsFirstLast |
+    SupportsTxIsolationSerializable |
+    NativeUpsert |
+    MultiSchema
+});
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[
     (ScalarType::Int, CockroachType::Int4),
@@ -80,7 +80,7 @@ impl Connector for CockroachDatamodelConnector {
         "CockroachDB"
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
+    fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }
 

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -7,30 +7,31 @@ use enumflags2::BitFlags;
 use mongodb_types::*;
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        NativeTypeInstance, RelationMode,
     },
     diagnostics::{Diagnostics, Span},
     parser_database::{walkers::*, ReferentialAction, ScalarType},
 };
 use std::result::Result as StdResult;
 
-const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::Json,
-    ConnectorCapability::Enums,
-    ConnectorCapability::EnumArrayPush,
-    ConnectorCapability::RelationFieldsInArbitraryOrder,
-    ConnectorCapability::CreateMany,
-    ConnectorCapability::ScalarLists,
-    ConnectorCapability::JsonLists,
-    ConnectorCapability::InsensitiveFilters,
-    ConnectorCapability::CompositeTypes,
-    ConnectorCapability::FullTextIndex,
-    ConnectorCapability::SortOrderInFullTextIndex,
-    ConnectorCapability::MongoDbQueryRaw,
-    ConnectorCapability::DefaultValueAuto,
-    ConnectorCapability::TwoWayEmbeddedManyToManyRelation,
-    ConnectorCapability::UndefinedType,
-];
+const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(ConnectorCapability::{
+    Json |
+    Enums |
+    EnumArrayPush |
+    RelationFieldsInArbitraryOrder |
+    CreateMany |
+    ScalarLists |
+    JsonLists |
+    InsensitiveFilters |
+    CompositeTypes |
+    FullTextIndex |
+    SortOrderInFullTextIndex |
+    MongoDbQueryRaw |
+    DefaultValueAuto |
+    TwoWayEmbeddedManyToManyRelation |
+    UndefinedType
+});
 
 pub(crate) struct MongoDbDatamodelConnector;
 
@@ -43,7 +44,7 @@ impl Connector for MongoDbDatamodelConnector {
         "MongoDB"
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
+    fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }
 

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -8,7 +8,8 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        NativeTypeInstance, RelationMode,
     },
     diagnostics::{Diagnostics, Span},
     parser_database::{self, ast, ParserDatabase, ReferentialAction, ScalarType},
@@ -26,32 +27,32 @@ const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
     ConstraintScope::ModelPrimaryKeyKeyIndex,
 ];
 
-const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::AnyId,
-    ConnectorCapability::AutoIncrement,
-    ConnectorCapability::AutoIncrementAllowedOnNonId,
-    ConnectorCapability::AutoIncrementMultipleAllowed,
-    ConnectorCapability::AutoIncrementNonIndexedAllowed,
-    ConnectorCapability::CompoundIds,
-    ConnectorCapability::CreateMany,
-    ConnectorCapability::MultiSchema,
-    ConnectorCapability::NamedDefaultValues,
-    ConnectorCapability::NamedForeignKeys,
-    ConnectorCapability::NamedPrimaryKeys,
-    ConnectorCapability::SqlQueryRaw,
-    ConnectorCapability::ReferenceCycleDetection,
-    ConnectorCapability::UpdateableId,
-    ConnectorCapability::PrimaryKeySortOrderDefinition,
-    ConnectorCapability::ImplicitManyToManyRelation,
-    ConnectorCapability::DecimalType,
-    ConnectorCapability::ClusteringSetting,
-    ConnectorCapability::OrderByNullsFirstLast,
-    ConnectorCapability::SupportsTxIsolationReadUncommitted,
-    ConnectorCapability::SupportsTxIsolationReadCommitted,
-    ConnectorCapability::SupportsTxIsolationRepeatableRead,
-    ConnectorCapability::SupportsTxIsolationSerializable,
-    ConnectorCapability::SupportsTxIsolationSnapshot,
-];
+const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(ConnectorCapability::{
+    AnyId |
+    AutoIncrement |
+    AutoIncrementAllowedOnNonId |
+    AutoIncrementMultipleAllowed |
+    AutoIncrementNonIndexedAllowed |
+    CompoundIds |
+    CreateMany |
+    MultiSchema |
+    NamedDefaultValues |
+    NamedForeignKeys |
+    NamedPrimaryKeys |
+    SqlQueryRaw |
+    ReferenceCycleDetection |
+    UpdateableId |
+    PrimaryKeySortOrderDefinition |
+    ImplicitManyToManyRelation |
+    DecimalType |
+    ClusteringSetting |
+    OrderByNullsFirstLast |
+    SupportsTxIsolationReadUncommitted |
+    SupportsTxIsolationReadCommitted |
+    SupportsTxIsolationRepeatableRead |
+    SupportsTxIsolationSerializable |
+    SupportsTxIsolationSnapshot
+});
 
 pub(crate) struct MsSqlDatamodelConnector;
 
@@ -82,7 +83,7 @@ impl Connector for MsSqlDatamodelConnector {
         "SQL Server"
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
+    fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }
 

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -1,21 +1,21 @@
 mod native_types;
 mod validations;
 
-use lsp_types::CompletionList;
 pub use native_types::MySqlType;
 
+use crate::completions;
 use enumflags2::BitFlags;
+use lsp_types::CompletionList;
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{walkers, ReferentialAction, ScalarType},
     PreviewFeature,
 };
 use MySqlType::*;
-
-use crate::completions;
 
 const TINY_BLOB_TYPE_NAME: &str = "TinyBlob";
 const BLOB_TYPE_NAME: &str = "Blob";
@@ -26,39 +26,39 @@ const TEXT_TYPE_NAME: &str = "Text";
 const MEDIUM_TEXT_TYPE_NAME: &str = "MediumText";
 const LONG_TEXT_TYPE_NAME: &str = "LongText";
 
-const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::Enums,
-    ConnectorCapability::EnumArrayPush,
-    ConnectorCapability::Json,
-    ConnectorCapability::AutoIncrementAllowedOnNonId,
-    ConnectorCapability::RelationFieldsInArbitraryOrder,
-    ConnectorCapability::CreateMany,
-    ConnectorCapability::WritableAutoincField,
-    ConnectorCapability::CreateSkipDuplicates,
-    ConnectorCapability::UpdateableId,
-    ConnectorCapability::JsonFiltering,
-    ConnectorCapability::JsonFilteringJsonPath,
-    ConnectorCapability::JsonFilteringAlphanumeric,
-    ConnectorCapability::CreateManyWriteableAutoIncId,
-    ConnectorCapability::AutoIncrement,
-    ConnectorCapability::CompoundIds,
-    ConnectorCapability::AnyId,
-    ConnectorCapability::SqlQueryRaw,
-    ConnectorCapability::NamedForeignKeys,
-    ConnectorCapability::AdvancedJsonNullability,
-    ConnectorCapability::IndexColumnLengthPrefixing,
-    ConnectorCapability::MultiSchema,
-    ConnectorCapability::FullTextIndex,
-    ConnectorCapability::FullTextSearchWithIndex,
-    ConnectorCapability::MultipleFullTextAttributesPerModel,
-    ConnectorCapability::ImplicitManyToManyRelation,
-    ConnectorCapability::DecimalType,
-    ConnectorCapability::OrderByNullsFirstLast,
-    ConnectorCapability::SupportsTxIsolationReadUncommitted,
-    ConnectorCapability::SupportsTxIsolationReadCommitted,
-    ConnectorCapability::SupportsTxIsolationRepeatableRead,
-    ConnectorCapability::SupportsTxIsolationSerializable,
-];
+const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(ConnectorCapability::{
+    Enums |
+    EnumArrayPush |
+    Json |
+    AutoIncrementAllowedOnNonId |
+    RelationFieldsInArbitraryOrder |
+    CreateMany |
+    WritableAutoincField |
+    CreateSkipDuplicates |
+    UpdateableId |
+    JsonFiltering |
+    JsonFilteringJsonPath |
+    JsonFilteringAlphanumeric |
+    CreateManyWriteableAutoIncId |
+    AutoIncrement |
+    CompoundIds |
+    AnyId |
+    SqlQueryRaw |
+    NamedForeignKeys |
+    AdvancedJsonNullability |
+    IndexColumnLengthPrefixing |
+    MultiSchema |
+    FullTextIndex |
+    FullTextSearchWithIndex |
+    MultipleFullTextAttributesPerModel |
+    ImplicitManyToManyRelation |
+    DecimalType |
+    OrderByNullsFirstLast |
+    SupportsTxIsolationReadUncommitted |
+    SupportsTxIsolationReadCommitted |
+    SupportsTxIsolationRepeatableRead |
+    SupportsTxIsolationSerializable
+});
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];
 
@@ -85,7 +85,7 @@ impl Connector for MySqlDatamodelConnector {
         "MySQL"
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
+    fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }
 

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -8,8 +8,8 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance, RelationMode,
-        StringFilter,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        NativeTypeInstance, RelationMode, StringFilter,
     },
     diagnostics::Diagnostics,
     parser_database::{ast, walkers, IndexAlgorithm, OperatorClass, ParserDatabase, ReferentialAction, ScalarType},
@@ -25,44 +25,44 @@ const CONSTRAINT_SCOPES: &[ConstraintScope] = &[
     ConstraintScope::ModelPrimaryKeyKeyIndexForeignKey,
 ];
 
-const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::AdvancedJsonNullability,
-    ConnectorCapability::AnyId,
-    ConnectorCapability::AutoIncrement,
-    ConnectorCapability::AutoIncrementAllowedOnNonId,
-    ConnectorCapability::AutoIncrementMultipleAllowed,
-    ConnectorCapability::AutoIncrementNonIndexedAllowed,
-    ConnectorCapability::CompoundIds,
-    ConnectorCapability::CreateMany,
-    ConnectorCapability::CreateManyWriteableAutoIncId,
-    ConnectorCapability::CreateSkipDuplicates,
-    ConnectorCapability::Enums,
-    ConnectorCapability::EnumArrayPush,
-    ConnectorCapability::FullTextSearchWithoutIndex,
-    ConnectorCapability::InsensitiveFilters,
-    ConnectorCapability::Json,
-    ConnectorCapability::JsonFiltering,
-    ConnectorCapability::JsonFilteringArrayPath,
-    ConnectorCapability::JsonFilteringAlphanumeric,
-    ConnectorCapability::JsonFilteringAlphanumericFieldRef,
-    ConnectorCapability::MultiSchema,
-    ConnectorCapability::NamedForeignKeys,
-    ConnectorCapability::NamedPrimaryKeys,
-    ConnectorCapability::SqlQueryRaw,
-    ConnectorCapability::RelationFieldsInArbitraryOrder,
-    ConnectorCapability::ScalarLists,
-    ConnectorCapability::JsonLists,
-    ConnectorCapability::UpdateableId,
-    ConnectorCapability::WritableAutoincField,
-    ConnectorCapability::ImplicitManyToManyRelation,
-    ConnectorCapability::DecimalType,
-    ConnectorCapability::OrderByNullsFirstLast,
-    ConnectorCapability::SupportsTxIsolationReadUncommitted,
-    ConnectorCapability::SupportsTxIsolationReadCommitted,
-    ConnectorCapability::SupportsTxIsolationRepeatableRead,
-    ConnectorCapability::SupportsTxIsolationSerializable,
-    ConnectorCapability::NativeUpsert,
-];
+const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(ConnectorCapability::{
+    AdvancedJsonNullability |
+    AnyId |
+    AutoIncrement |
+    AutoIncrementAllowedOnNonId |
+    AutoIncrementMultipleAllowed |
+    AutoIncrementNonIndexedAllowed |
+    CompoundIds |
+    CreateMany |
+    CreateManyWriteableAutoIncId |
+    CreateSkipDuplicates |
+    Enums |
+    EnumArrayPush |
+    FullTextSearchWithoutIndex |
+    InsensitiveFilters |
+    Json |
+    JsonFiltering |
+    JsonFilteringArrayPath |
+    JsonFilteringAlphanumeric |
+    JsonFilteringAlphanumericFieldRef |
+    MultiSchema |
+    NamedForeignKeys |
+    NamedPrimaryKeys |
+    SqlQueryRaw |
+    RelationFieldsInArbitraryOrder |
+    ScalarLists |
+    JsonLists |
+    UpdateableId |
+    WritableAutoincField |
+    ImplicitManyToManyRelation |
+    DecimalType |
+    OrderByNullsFirstLast |
+    SupportsTxIsolationReadUncommitted |
+    SupportsTxIsolationReadCommitted |
+    SupportsTxIsolationRepeatableRead |
+    SupportsTxIsolationSerializable |
+    NativeUpsert
+});
 
 pub struct PostgresDatamodelConnector;
 
@@ -251,7 +251,7 @@ impl Connector for PostgresDatamodelConnector {
         "Postgres"
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
+    fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }
 

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -1,6 +1,9 @@
 use enumflags2::BitFlags;
 use psl_core::{
-    datamodel_connector::{Connector, ConnectorCapability, ConstraintScope, NativeTypeConstructor, NativeTypeInstance},
+    datamodel_connector::{
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        NativeTypeInstance,
+    },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{ReferentialAction, ScalarType},
 };
@@ -8,20 +11,20 @@ use std::borrow::Cow;
 
 const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[];
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalKeyIndex];
-const CAPABILITIES: &[ConnectorCapability] = &[
-    ConnectorCapability::AnyId,
-    ConnectorCapability::AutoIncrement,
-    ConnectorCapability::CompoundIds,
-    ConnectorCapability::SqlQueryRaw,
-    ConnectorCapability::RelationFieldsInArbitraryOrder,
-    ConnectorCapability::UpdateableId,
-    ConnectorCapability::ImplicitManyToManyRelation,
-    ConnectorCapability::DecimalType,
-    ConnectorCapability::BackwardCompatibleQueryRaw,
-    ConnectorCapability::OrderByNullsFirstLast,
-    ConnectorCapability::SupportsTxIsolationSerializable,
-    ConnectorCapability::NativeUpsert,
-];
+const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(ConnectorCapability::{
+    AnyId |
+    AutoIncrement |
+    CompoundIds |
+    SqlQueryRaw |
+    RelationFieldsInArbitraryOrder |
+    UpdateableId |
+    ImplicitManyToManyRelation |
+    DecimalType |
+    BackwardCompatibleQueryRaw |
+    OrderByNullsFirstLast |
+    SupportsTxIsolationSerializable |
+    NativeUpsert
+});
 
 pub struct SqliteDatamodelConnector;
 
@@ -34,7 +37,7 @@ impl Connector for SqliteDatamodelConnector {
         "sqlite"
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
+    fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }
 

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -80,9 +80,7 @@ impl Datasource {
     }
 
     pub fn capabilities(&self) -> ConnectorCapabilities {
-        let capabilities = self.active_connector.capabilities().to_owned();
-
-        ConnectorCapabilities::new(capabilities)
+        self.active_connector.capabilities()
     }
 
     /// The applicable relation mode for this datasource.

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -53,11 +53,11 @@ pub trait Connector: Send + Sync {
     fn name(&self) -> &str;
 
     /// The static list of capabilities for the connector.
-    fn capabilities(&self) -> &'static [ConnectorCapability];
+    fn capabilities(&self) -> ConnectorCapabilities;
 
     /// Does the connector have this capability?
     fn has_capability(&self, capability: ConnectorCapability) -> bool {
-        self.capabilities().contains(&capability)
+        self.capabilities().contains(capability)
     }
 
     /// The maximum length of constraint names in bytes. Connectors without a

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -5,6 +5,8 @@ use std::{fmt, str::FromStr};
 macro_rules! capabilities {
     ($( $variant:ident $(,)? ),*) => {
         #[derive(Debug, Clone, Copy, PartialEq)]
+        #[enumflags2::bitflags]
+        #[repr(u64)]
         pub enum ConnectorCapability {
             $(
                 $variant,
@@ -19,7 +21,7 @@ macro_rules! capabilities {
                     )*
                 };
 
-                write!(f, "{}", name)
+                f.write_str(name)
             }
         }
 
@@ -101,69 +103,4 @@ capabilities!(
 );
 
 /// Contains all capabilities that the connector is able to serve.
-#[derive(Debug)]
-pub struct ConnectorCapabilities {
-    pub capabilities: Vec<ConnectorCapability>,
-}
-
-impl ConnectorCapabilities {
-    pub fn empty() -> Self {
-        Self { capabilities: vec![] }
-    }
-
-    pub fn new(capabilities: Vec<ConnectorCapability>) -> Self {
-        Self { capabilities }
-    }
-
-    pub fn contains(&self, capability: ConnectorCapability) -> bool {
-        self.capabilities.contains(&capability)
-    }
-
-    pub fn supports_any(&self, capabilities: &[ConnectorCapability]) -> bool {
-        self.capabilities
-            .iter()
-            .any(|connector_capability| capabilities.contains(connector_capability))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_empty_cap_does_not_contain() {
-        let cap = ConnectorCapabilities::empty();
-        assert!(!cap.supports_any(&[ConnectorCapability::JsonFilteringJsonPath]));
-    }
-
-    #[test]
-    fn test_cap_with_others_does_not_contain() {
-        let cap = ConnectorCapabilities::new(vec![
-            ConnectorCapability::PrimaryKeySortOrderDefinition,
-            ConnectorCapability::JsonFilteringArrayPath,
-        ]);
-        assert!(!cap.supports_any(&[ConnectorCapability::JsonFilteringJsonPath]));
-    }
-
-    #[test]
-    fn test_cap_with_others_does_contain() {
-        let cap = ConnectorCapabilities::new(vec![
-            ConnectorCapability::PrimaryKeySortOrderDefinition,
-            ConnectorCapability::JsonFilteringJsonPath,
-            ConnectorCapability::JsonFilteringArrayPath,
-        ]);
-        assert!(cap.supports_any(&[
-            ConnectorCapability::JsonFilteringJsonPath,
-            ConnectorCapability::JsonFilteringArrayPath,
-        ]));
-    }
-
-    #[test]
-    fn test_does_contain() {
-        let cap = ConnectorCapabilities::new(vec![
-            ConnectorCapability::PrimaryKeySortOrderDefinition,
-            ConnectorCapability::JsonFilteringArrayPath,
-        ]);
-        assert!(!cap.supports_any(&[ConnectorCapability::JsonFilteringJsonPath]));
-    }
-}
+pub type ConnectorCapabilities = enumflags2::BitFlags<ConnectorCapability>;

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -19,14 +19,14 @@ impl Connector for EmptyDatamodelConnector {
         BitFlags::all()
     }
 
-    fn capabilities(&self) -> &'static [ConnectorCapability] {
-        &[
-            ConnectorCapability::AutoIncrement,
-            ConnectorCapability::CompoundIds,
-            ConnectorCapability::Enums,
-            ConnectorCapability::Json,
-            ConnectorCapability::ImplicitManyToManyRelation,
-        ]
+    fn capabilities(&self) -> ConnectorCapabilities {
+        enumflags2::make_bitflags!(ConnectorCapability::{
+            AutoIncrement |
+            CompoundIds |
+            Enums |
+            Json |
+            ImplicitManyToManyRelation
+        })
     }
 
     fn max_identifier_length(&self) -> usize {

--- a/query-engine/black-box-tests/Cargo.toml
+++ b/query-engine/black-box-tests/Cargo.toml
@@ -13,3 +13,4 @@ indoc.workspace = true
 tokio.workspace = true
 user-facing-errors.workspace = true
 insta = "1.7.1"
+enumflags2 = "0.7"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -4,6 +4,7 @@ name = "query-engine-tests"
 version = "0.1.0"
 
 [dependencies]
+enumflags2 = "0.7"
 anyhow = "1.0"
 serde_json = "1.0"
 query-test-macros = { path = "../query-test-macros" }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/compile-bench.md
@@ -1,3 +1,3 @@
 | Command | Mean [s] | Min [s] | Max [s] | Relative |
 |:---|---:|---:|---:|---:|
-| `cargo build --tests` | 25.490 ± 0.107 | 25.369 | 25.571 | 1.00 |
+| `cargo build --tests` | 24.646 ± 0.025 | 24.624 | 24.673 | 1.00 |

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/json.rs
@@ -4,7 +4,7 @@
 #[macro_export]
 macro_rules! jNull {
     ($capabilities:expr, $s:expr) => {
-        if !$capabilities.contains(&ConnectorCapability::AdvancedJsonNullability) {
+        if !$capabilities.contains(ConnectorCapability::AdvancedJsonNullability) {
             $s.replace("DbNull", "null")
                 .replace("JsonNull", "\"null\"")
                 .replace("AnyNull", "null")

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json.rs
@@ -43,7 +43,7 @@ mod json {
         if runner
             .connector()
             .capabilities()
-            .contains(&ConnectorCapability::AdvancedJsonNullability)
+            .contains(ConnectorCapability::AdvancedJsonNullability)
         {
             insta::assert_snapshot!(
               run_query!(&runner, r#"query { findManyTestModel(where: { json: { equals: DbNull }}) { id }}"#),
@@ -85,7 +85,7 @@ mod json {
         if runner
             .connector()
             .capabilities()
-            .contains(&ConnectorCapability::AdvancedJsonNullability)
+            .contains(ConnectorCapability::AdvancedJsonNullability)
         {
             insta::assert_snapshot!(
                 run_query!(&runner, r#"query { findManyTestModel(where: { NOT: [{ json: { equals: DbNull } }]}) { id }}"#),
@@ -128,7 +128,7 @@ mod json {
         if runner
             .connector()
             .capabilities()
-            .contains(&ConnectorCapability::AdvancedJsonNullability)
+            .contains(ConnectorCapability::AdvancedJsonNullability)
         {
             runner
                 .query("mutation { createOneTestModel(data: { id: 1, json: DbNull}) { id }}")
@@ -176,7 +176,7 @@ mod json {
         if runner
             .connector()
             .capabilities()
-            .contains(&ConnectorCapability::AdvancedJsonNullability)
+            .contains(ConnectorCapability::AdvancedJsonNullability)
         {
             // Should work, but not useful with req. fields.
             insta::assert_snapshot!(

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
@@ -71,7 +71,7 @@ pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream
                 #test_database_name,
                 &[#only],
                 &[#exclude],
-                &[#(ConnectorCapability::#capabilities),*],
+                enumflags2::make_bitflags!(ConnectorCapability::{#(#capabilities)|*}),
                 &[#(#excluded_features),*],
                 #handler,
                 &[#(#db_schemas),*],

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
@@ -61,7 +61,7 @@ pub fn relation_link_test_impl(attr: TokenStream, input: TokenStream) -> TokenSt
                 #id_only,
                 &[#only],
                 &[#exclude],
-                &[#(ConnectorCapability::#required_capabilities,)*],
+                enumflags2::make_bitflags!(ConnectorCapability::{#(#required_capabilities|)*}),
                 (#suite_name, #test_name),
                 #runner_fn_ident
             )

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/cockroachdb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/cockroachdb.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::{datamodel_rendering::SqlDatamodelRenderer, TestResult};
+use psl::datamodel_connector::ConnectorCapabilities;
 
 #[derive(Debug, Default, Clone)]
 pub struct CockroachDbConnectorTag {
-    capabilities: Vec<ConnectorCapability>,
     version: Option<CockroachDbVersion>,
 }
 
@@ -87,8 +87,8 @@ impl ConnectorTagInterface for CockroachDbConnectorTag {
         }
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        psl::builtin_connectors::COCKROACH.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -109,10 +109,7 @@ impl CockroachDbConnectorTag {
             None => None,
         };
 
-        Ok(Self {
-            capabilities: cockroachdb_capabilities(),
-            version,
-        })
+        Ok(Self { version })
     }
 
     /// Returns all versions of this connector.
@@ -120,16 +117,10 @@ impl CockroachDbConnectorTag {
         vec![
             Self {
                 version: Some(CockroachDbVersion::V221),
-                capabilities: cockroachdb_capabilities(),
             },
             Self {
                 version: Some(CockroachDbVersion::V222),
-                capabilities: cockroachdb_capabilities(),
             },
         ]
     }
-}
-
-fn cockroachdb_capabilities() -> Vec<ConnectorCapability> {
-    psl::builtin_connectors::COCKROACH.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -16,7 +16,7 @@ pub use vitess::*;
 use crate::{datamodel_rendering::DatamodelRenderer, TestError, CONFIG};
 use cockroachdb::*;
 use enum_dispatch::enum_dispatch;
-use psl::datamodel_connector::ConnectorCapability;
+use psl::datamodel_connector::ConnectorCapabilities;
 use std::{convert::TryFrom, fmt};
 
 #[enum_dispatch]
@@ -42,7 +42,7 @@ pub trait ConnectorTagInterface {
     ) -> String;
 
     /// Capabilities of the implementing connector.
-    fn capabilities(&self) -> &[ConnectorCapability];
+    fn capabilities(&self) -> ConnectorCapabilities;
 
     /// Serialization of the connector. Expected to return `(tag_name, version)`.
     /// Todo: Think of something better.
@@ -162,11 +162,11 @@ impl ConnectorTag {
     pub(crate) fn should_run(
         only: &[(&str, Option<&str>)],
         exclude: &[(&str, Option<&str>)],
-        capabilities: &[ConnectorCapability],
+        capabilities: ConnectorCapabilities,
     ) -> bool {
         let connector = CONFIG.test_connector_tag().unwrap();
 
-        if !capabilities.is_empty() && !capabilities.iter().all(|cap| connector.capabilities().contains(cap)) {
+        if !capabilities.is_empty() && !connector.capabilities().contains(capabilities) {
             println!("Connector excluded. Missing required capability.");
             return false;
         }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mongodb.rs
@@ -5,7 +5,6 @@ use psl::builtin_connectors::MONGODB;
 #[derive(Debug, Default, Clone)]
 pub struct MongoDbConnectorTag {
     version: Option<MongoDbVersion>,
-    capabilities: Vec<ConnectorCapability>,
 }
 
 impl ConnectorTagInterface for MongoDbConnectorTag {
@@ -47,8 +46,8 @@ impl ConnectorTagInterface for MongoDbConnectorTag {
         }
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        MONGODB.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -79,10 +78,7 @@ impl MongoDbConnectorTag {
             None => None,
         };
 
-        Ok(Self {
-            version,
-            capabilities: mongo_capabilities(),
-        })
+        Ok(Self { version })
     }
 
     /// Returns all versions of this connector.
@@ -90,15 +86,12 @@ impl MongoDbConnectorTag {
         vec![
             Self {
                 version: Some(MongoDbVersion::V4_2),
-                capabilities: mongo_capabilities(),
             },
             Self {
                 version: Some(MongoDbVersion::V4_4),
-                capabilities: mongo_capabilities(),
             },
             Self {
                 version: Some(MongoDbVersion::V5),
-                capabilities: mongo_capabilities(),
             },
         ]
     }
@@ -142,8 +135,4 @@ impl ToString for MongoDbVersion {
         }
         .to_owned()
     }
-}
-
-fn mongo_capabilities() -> Vec<ConnectorCapability> {
-    MONGODB.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mysql.rs
@@ -4,7 +4,6 @@ use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
 #[derive(Debug, Default, Clone)]
 pub struct MySqlConnectorTag {
     version: Option<MySqlVersion>,
-    capabilities: Vec<ConnectorCapability>,
 }
 
 impl MySqlConnectorTag {
@@ -48,8 +47,8 @@ impl ConnectorTagInterface for MySqlConnectorTag {
         }
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        psl::builtin_connectors::MYSQL.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -77,32 +76,23 @@ impl MySqlConnectorTag {
             None => None,
         };
 
-        Ok(Self {
-            version,
-            capabilities: mysql_capabilities(),
-        })
+        Ok(Self { version })
     }
 
     /// Returns all versions of this connector.
     pub fn all() -> Vec<Self> {
-        let capabilities = mysql_capabilities();
-
         vec![
             Self {
                 version: Some(MySqlVersion::V5_6),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(MySqlVersion::V5_7),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(MySqlVersion::V8),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(MySqlVersion::MariaDb),
-                capabilities,
             },
         ]
     }
@@ -143,8 +133,4 @@ impl ToString for MySqlVersion {
         }
         .to_owned()
     }
-}
-
-fn mysql_capabilities() -> Vec<ConnectorCapability> {
-    psl::builtin_connectors::MYSQL.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -4,7 +4,6 @@ use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
 #[derive(Debug, Default, Clone)]
 pub struct PostgresConnectorTag {
     version: Option<PostgresVersion>,
-    capabilities: Vec<ConnectorCapability>,
 }
 
 impl ConnectorTagInterface for PostgresConnectorTag {
@@ -64,8 +63,8 @@ impl ConnectorTagInterface for PostgresConnectorTag {
         }
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        psl::builtin_connectors::POSTGRES.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -97,47 +96,35 @@ impl PostgresConnectorTag {
             None => None,
         };
 
-        Ok(Self {
-            version,
-            capabilities: postgres_capabilities(),
-        })
+        Ok(Self { version })
     }
 
     /// Returns all versions of this connector.
     pub fn all() -> Vec<Self> {
-        let capabilities = postgres_capabilities();
         vec![
             Self {
                 version: Some(PostgresVersion::V9),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::V10),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::V11),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::V12),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::V13),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::V14),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::V15),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(PostgresVersion::PgBouncer),
-                capabilities,
             },
         ]
     }
@@ -191,8 +178,4 @@ impl ToString for PostgresVersion {
         }
         .to_owned()
     }
-}
-
-fn postgres_capabilities() -> Vec<ConnectorCapability> {
-    psl::builtin_connectors::POSTGRES.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sql_server.rs
@@ -1,11 +1,9 @@
-use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
-
 use super::*;
+use crate::{datamodel_rendering::SqlDatamodelRenderer, TestError, TestResult};
 
 #[derive(Debug, Default, Clone)]
 pub struct SqlServerConnectorTag {
     version: Option<SqlServerVersion>,
-    capabilities: Vec<ConnectorCapability>,
 }
 
 impl ConnectorTagInterface for SqlServerConnectorTag {
@@ -46,8 +44,8 @@ impl ConnectorTagInterface for SqlServerConnectorTag {
         }
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        psl::builtin_connectors::MSSQL.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -74,28 +72,20 @@ impl SqlServerConnectorTag {
             None => None,
         };
 
-        Ok(Self {
-            version,
-            capabilities: sql_server_capabilities(),
-        })
+        Ok(Self { version })
     }
 
     /// Returns all versions of this connector.
     pub fn all() -> Vec<Self> {
-        let capabilities = sql_server_capabilities();
-
         vec![
             Self {
                 version: Some(SqlServerVersion::V2017),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(SqlServerVersion::V2019),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(SqlServerVersion::V2022),
-                capabilities,
             },
         ]
     }
@@ -139,8 +129,4 @@ impl ToString for SqlServerVersion {
         }
         .to_owned()
     }
-}
-
-fn sql_server_capabilities() -> Vec<ConnectorCapability> {
-    psl::builtin_connectors::MSSQL.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/sqlite.rs
@@ -2,9 +2,7 @@ use super::*;
 use crate::SqlDatamodelRenderer;
 
 #[derive(Debug, Default, Clone, PartialEq)]
-pub struct SqliteConnectorTag {
-    capabilities: Vec<ConnectorCapability>,
-}
+pub struct SqliteConnectorTag;
 
 impl ConnectorTagInterface for SqliteConnectorTag {
     fn datamodel_provider(&self) -> &'static str {
@@ -30,8 +28,8 @@ impl ConnectorTagInterface for SqliteConnectorTag {
         format!("file://{workspace_root}/db/{database}.db")
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        psl::builtin_connectors::SQLITE.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -45,17 +43,11 @@ impl ConnectorTagInterface for SqliteConnectorTag {
 
 impl SqliteConnectorTag {
     pub fn new() -> Self {
-        Self {
-            capabilities: sqlite_capabilities(),
-        }
+        Self
     }
 
     /// Returns all versions of this connector.
     pub fn all() -> Vec<Self> {
         vec![Self::new()]
     }
-}
-
-fn sqlite_capabilities() -> Vec<ConnectorCapability> {
-    psl::builtin_connectors::SQLITE.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -4,7 +4,6 @@ use std::{fmt::Display, str::FromStr};
 
 #[derive(Debug, Default, Clone)]
 pub struct VitessConnectorTag {
-    capabilities: Vec<ConnectorCapability>,
     version: Option<VitessVersion>,
 }
 
@@ -31,8 +30,8 @@ impl ConnectorTagInterface for VitessConnectorTag {
         }
     }
 
-    fn capabilities(&self) -> &[ConnectorCapability] {
-        &self.capabilities
+    fn capabilities(&self) -> ConnectorCapabilities {
+        psl::builtin_connectors::MYSQL.capabilities()
     }
 
     fn as_parse_pair(&self) -> (String, Option<String>) {
@@ -62,24 +61,17 @@ impl VitessConnectorTag {
             None => None,
         };
 
-        Ok(Self {
-            version,
-            capabilities: vitess_capabilities(),
-        })
+        Ok(Self { version })
     }
 
     /// Returns all versions of this connector.
     pub fn all() -> Vec<Self> {
-        let capabilities = vitess_capabilities();
-
         vec![
             Self {
                 version: Some(VitessVersion::V5_7),
-                capabilities: capabilities.clone(),
             },
             Self {
                 version: Some(VitessVersion::V8_0),
-                capabilities,
             },
         ]
     }
@@ -120,8 +112,4 @@ impl Display for VitessVersion {
             Self::V8_0 => write!(f, "8.0"),
         }
     }
-}
-
-fn vitess_capabilities() -> Vec<ConnectorCapability> {
-    psl::builtin_connectors::MYSQL.capabilities().to_owned()
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/schema_with_relation.rs
@@ -1,5 +1,5 @@
 use super::*;
-use psl::datamodel_connector::ConnectorCapability;
+use psl::datamodel_connector::{ConnectorCapabilities, ConnectorCapability};
 use serde::{Deserialize, Serialize};
 use std::{convert::TryFrom, str::FromStr};
 
@@ -43,7 +43,7 @@ impl TryFrom<DatamodelWithParams> for String {
     }
 }
 
-pub type DatamodelsAndCapabilities = (Vec<DatamodelWithParams>, Vec<Vec<ConnectorCapability>>);
+pub type DatamodelsAndCapabilities = (Vec<DatamodelWithParams>, Vec<ConnectorCapabilities>);
 
 pub(crate) fn schema_with_relation(
     on_parent: &RelationField,
@@ -120,7 +120,7 @@ pub(crate) fn schema_with_relation(
     // Reduces the amount of generated tests when `true`
     let simple_test_mode = std::env::var("SIMPLE_TEST_MODE").is_ok();
     let mut datamodels: Vec<DatamodelWithParams> = vec![];
-    let mut required_capabilities: Vec<Vec<ConnectorCapability>> = vec![];
+    let mut required_capabilities: Vec<ConnectorCapabilities> = vec![];
 
     for parent_id in id_options.iter() {
         for child_id in id_options.iter() {
@@ -188,14 +188,14 @@ pub(crate) fn schema_with_relation(
                                 }}
                             "};
 
-                            let mut required_capabilities_for_dm = vec![];
+                            let mut required_capabilities_for_dm = ConnectorCapabilities::default();
 
                             match (parent_id, child_id) {
                                 (Identifier::Compound, _) | (_, Identifier::Compound) => {
-                                    required_capabilities_for_dm.push(ConnectorCapability::CompoundIds)
+                                    required_capabilities_for_dm |= ConnectorCapability::CompoundIds;
                                 }
                                 (Identifier::None, _) | (_, Identifier::None) => {
-                                    required_capabilities_for_dm.push(ConnectorCapability::AnyId)
+                                    required_capabilities_for_dm |= ConnectorCapability::AnyId;
                                 }
                                 _ => (),
                             }

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,7 +1,7 @@
 use crate::{EnumType, IdentifierType, ObjectType, OutputField, OutputObjectTypeId, QuerySchemaDatabase};
 use prisma_models::{InternalDataModelRef, ModelRef};
 use psl::{
-    datamodel_connector::{ConnectorCapability, RelationMode},
+    datamodel_connector::{ConnectorCapabilities, ConnectorCapability, RelationMode},
     PreviewFeatures,
 };
 use std::{collections::HashMap, fmt};
@@ -39,7 +39,7 @@ pub struct QuerySchema {
 #[derive(Debug)]
 pub struct ConnectorContext {
     /// Capabilities of the provider.
-    pub capabilities: Vec<ConnectorCapability>,
+    pub capabilities: ConnectorCapabilities,
 
     /// Enabled preview features.
     pub features: PreviewFeatures,
@@ -49,7 +49,7 @@ pub struct ConnectorContext {
 }
 
 impl ConnectorContext {
-    pub fn new(capabilities: Vec<ConnectorCapability>, features: PreviewFeatures, relation_mode: RelationMode) -> Self {
+    pub fn new(capabilities: ConnectorCapabilities, features: PreviewFeatures, relation_mode: RelationMode) -> Self {
         Self {
             capabilities,
             features,
@@ -58,7 +58,7 @@ impl ConnectorContext {
     }
 
     pub fn can_native_upsert(&self) -> bool {
-        self.capabilities.contains(&ConnectorCapability::NativeUpsert)
+        self.capabilities.contains(ConnectorCapability::NativeUpsert)
     }
 }
 
@@ -69,7 +69,7 @@ impl QuerySchema {
         mutation: OutputObjectTypeId,
         db: QuerySchemaDatabase,
         internal_data_model: InternalDataModelRef,
-        capabilities: Vec<ConnectorCapability>,
+        capabilities: ConnectorCapabilities,
     ) -> Self {
         let features = internal_data_model.schema.configuration.preview_features();
         let relation_mode = internal_data_model.schema.relation_mode();


### PR DESCRIPTION
By going from a Vec<ConnectorCapability> to a bitflag-based representation:

- Handling is generally simplified (intersections, etc.) and uses a standard data structure (preview features already have that shape for example).
- We can pass around capabilities easier (bitflags are `Copy`)
- Memory usage is lower.
- We avoid allocations and copies for each test and in schema building.
- Compile times for the QE test suite get slightly faster (see committed benchmark results in the diff).