### PR TITLE
query-core: depend on prisma-value through prisma-models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3236,7 +3236,6 @@ dependencies = [
  "opentelemetry",
  "petgraph 0.4.13",
  "prisma-models",
- "prisma-value",
  "psl",
  "query-connector",
  "query-engine-metrics",

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -18,7 +18,6 @@ itertools = "0.10"
 once_cell = "1"
 petgraph = "0.4"
 prisma-models = { path = "../prisma-models", features = ["default_generators"] }
-prisma-value = { path = "../../libs/prisma-value" }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
 query-engine-metrics = {path = "../metrics"}
 serde.workspace = true

--- a/query-engine/core/src/executor/request_context.rs
+++ b/query-engine/core/src/executor/request_context.rs
@@ -1,8 +1,9 @@
 use crate::protocol::EngineProtocol;
+use prisma_models::PrismaValue;
 
 #[derive(Debug)]
 struct RequestContext {
-    request_now: prisma_value::PrismaValue,
+    request_now: PrismaValue,
     engine_protocol: EngineProtocol,
 }
 
@@ -16,13 +17,13 @@ tokio::task_local! {
 /// That panics if REQUEST_CONTEXT has not been set with with_request_context().
 ///
 /// If we had a query context we carry for the entire lifetime of the query, it would belong there.
-pub(crate) fn get_request_now() -> prisma_value::PrismaValue {
+pub(crate) fn get_request_now() -> PrismaValue {
     // FIXME: we want to bypass task locals if this code is executed outside of a tokio context. As
     // of this writing, it happens only in the query validation test suite.
     //
     // Eventually, this will go away when we have a plain query context reference we pass around.
     if tokio::runtime::Handle::try_current().is_err() {
-        return prisma_value::PrismaValue::DateTime(chrono::Utc::now().into());
+        return PrismaValue::DateTime(chrono::Utc::now().into());
     }
     REQUEST_CONTEXT.with(|rc| rc.request_now.clone())
 }
@@ -56,7 +57,7 @@ where
         // the database persisted.
         let dt = chrono::Utc::now().duration_round(timestamp_precision).unwrap();
         let ctx = RequestContext {
-            request_now: prisma_value::PrismaValue::DateTime(dt.into()),
+            request_now: PrismaValue::DateTime(dt.into()),
             engine_protocol,
         };
 

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -4,8 +4,7 @@ use connector::{
     self, filter::Filter, ConditionListValue, ConnectionLike, QueryArguments, RelAggregationRow,
     RelAggregationSelection, ScalarCompare,
 };
-use prisma_models::{FieldSelection, ManyRecords, Record, RelationFieldRef, SelectionResult};
-use prisma_value::PrismaValue;
+use prisma_models::{FieldSelection, ManyRecords, PrismaValue, Record, RelationFieldRef, SelectionResult};
 use std::collections::HashMap;
 
 pub(crate) async fn m2m(

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -4,8 +4,7 @@ use bigdecimal::{BigDecimal, ToPrimitive};
 use chrono::prelude::*;
 use core::fmt;
 use indexmap::IndexSet;
-use prisma_models::{DefaultKind, ValueGeneratorFn};
-use prisma_value::PrismaValue;
+use prisma_models::{DefaultKind, PrismaValue, ValueGeneratorFn};
 use std::{convert::TryFrom, str::FromStr};
 use user_facing_errors::query_engine::validation::ValidationError;
 use uuid::Uuid;
@@ -433,7 +432,7 @@ impl QueryDocumentParser {
         argument_path: &Path,
         s: &str,
     ) -> QueryParserResult<DateTime<FixedOffset>> {
-        prisma_value::parse_datetime(s).map_err(|err| {
+        prisma_models::parse_datetime(s).map_err(|err| {
             ValidationError::invalid_argument_value(
                 selection_path.segments(),
                 argument_path.segments(),
@@ -445,7 +444,7 @@ impl QueryDocumentParser {
     }
 
     fn parse_bytes(&self, selection_path: &Path, argument_path: &Path, s: String) -> QueryParserResult<PrismaValue> {
-        prisma_value::decode_bytes(&s).map(PrismaValue::Bytes).map_err(|err| {
+        prisma_models::decode_bytes(&s).map(PrismaValue::Bytes).map_err(|err| {
             ValidationError::invalid_argument_value(
                 selection_path.segments(),
                 argument_path.segments(),

--- a/query-engine/core/src/query_graph_builder/write/raw.rs
+++ b/query-engine/core/src/query_graph_builder/write/raw.rs
@@ -1,17 +1,16 @@
 use super::*;
 use crate::{query_ast::*, query_graph::QueryGraph, ParsedField};
-use prisma_models::ModelRef;
-use prisma_value::PrismaValue;
+use prisma_models::{ModelRef, PrismaValue};
 use std::{collections::HashMap, convert::TryInto};
 
-pub fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuilderResult<()> {
+pub(crate) fn execute_raw(graph: &mut QueryGraph, field: ParsedField) -> QueryGraphBuilderResult<()> {
     let raw_query = Query::Write(WriteQuery::ExecuteRaw(raw_query(None, None, field)?));
 
     graph.create_node(raw_query);
     Ok(())
 }
 
-pub fn query_raw(
+pub(crate) fn query_raw(
     graph: &mut QueryGraph,
     model: Option<ModelRef>,
     query_type: Option<String>,


### PR DESCRIPTION
That way, there is only one import path for PrismaValue. For readability and to keep dependencies tidy.