### PR TITLE
query-core: drop base64 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,7 @@ dependencies = [
 name = "prisma-value"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.3",
+ "base64 0.13.1",
  "bigdecimal",
  "chrono",
  "once_cell",
@@ -3221,7 +3221,6 @@ name = "query-core"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.12.3",
  "bigdecimal",
  "chrono",
  "connection-string",
@@ -3260,7 +3259,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64 0.12.3",
+ "base64 0.13.1",
  "connection-string",
  "enumflags2",
  "graphql-parser",

--- a/libs/prisma-value/Cargo.toml
+++ b/libs/prisma-value/Cargo.toml
@@ -4,7 +4,7 @@ name = "prisma-value"
 version = "0.1.0"
 
 [dependencies]
-base64 = "0.12"
+base64 = "0.13"
 chrono = { version = "0.4", features = ["serde"] }
 once_cell = "1.3"
 regex = "1.2"

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -5,7 +5,6 @@ version = "0.1.0"
 
 [dependencies]
 async-trait = "0.1"
-base64 = "0.12"
 bigdecimal = "0.3"
 chrono = "0.4"
 connection-string.workspace = true 

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -13,7 +13,7 @@ vendored-openssl = ["quaint/vendored-openssl"]
 tokio.workspace = true
 anyhow = "1.0"
 async-trait = "0.1"
-base64 = "0.12"
+base64 = "0.13"
 connection-string.workspace = true
 connector = { path = "../connectors/query-connector", package = "query-connector" }
 enumflags2 = { version = "0.7"}


### PR DESCRIPTION
In fact, it is not used.