### PR TITLE
qe/schema-builder: make imports more uniform

### DIFF
--- a/query-engine/schema-builder/src/enum_types.rs
+++ b/query-engine/schema-builder/src/enum_types.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::{filters, itx, json_null, ordering};
+use constants::{filters, itx, json_null, ordering};
 use prisma_models::prelude::ParentContainer;
 use schema::{EnumType, EnumTypeId};
 

--- a/query-engine/schema-builder/src/input_types/fields/arguments.rs
+++ b/query-engine/schema-builder/src/input_types/fields/arguments.rs
@@ -1,7 +1,7 @@
 use super::*;
-use crate::input_types::objects::order_by_objects::OrderByOptions;
-use crate::mutations::create_one;
 use constants::args;
+use input_types::objects::order_by_objects::OrderByOptions;
+use mutations::create_one;
 use objects::*;
 use prisma_models::{prelude::ParentContainer, CompositeFieldRef};
 

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/create.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::*;
+use constants::*;
 use prisma_models::CompositeFieldRef;
 
 pub(crate) struct CreateDataInputFieldMapper {

--- a/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema-builder/src/input_types/fields/data_input_mapper/update.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::{constants::*, enum_types::*};
+use constants::*;
 use prisma_models::CompositeFieldRef;
 
 pub(crate) struct UpdateDataInputFieldMapper {

--- a/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
+++ b/query-engine/schema-builder/src/input_types/fields/field_ref_type.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::filters;
+use constants::filters;
 
 pub(crate) trait WithFieldRefInputExt {
     fn with_field_ref_input(self, ctx: &mut BuilderContext<'_>) -> Vec<InputType>;

--- a/query-engine/schema-builder/src/input_types/fields/input_fields.rs
+++ b/query-engine/schema-builder/src/input_types/fields/input_fields.rs
@@ -1,7 +1,7 @@
-use super::objects::*;
 use super::*;
-use crate::mutations::{create_many, create_one};
 use constants::{args, operations};
+use mutations::{create_many, create_one};
+use objects::*;
 use psl::datamodel_connector::ConnectorCapability;
 
 pub(crate) fn filter_input_field(

--- a/query-engine/schema-builder/src/input_types/mod.rs
+++ b/query-engine/schema-builder/src/input_types/mod.rs
@@ -2,7 +2,6 @@ pub(crate) mod fields;
 pub(crate) mod objects;
 
 use super::*;
-use crate::enum_types::*;
 use fields::*;
 use prisma_models::ScalarFieldRef;
 use schema::*;

--- a/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema-builder/src/input_types/objects/upsert_objects.rs
@@ -1,8 +1,7 @@
-use crate::constants::args;
-use crate::input_types::fields::arguments::where_argument;
-use crate::mutations::create_one;
-
 use super::*;
+use constants::args;
+use input_types::fields::arguments::where_argument;
+use mutations::create_one;
 
 pub(crate) fn nested_upsert_input_object(
     ctx: &mut BuilderContext<'_>,

--- a/query-engine/schema-builder/src/lib.rs
+++ b/query-engine/schema-builder/src/lib.rs
@@ -36,6 +36,7 @@ mod utils;
 
 pub use self::utils::{compound_id_field_name, compound_index_field_name};
 
+use self::{enum_types::*, utils::*};
 use cache::TypeRefCache;
 use prisma_models::{ast, Field as ModelField, InternalDataModel, ModelRef, RelationFieldRef, TypeIdentifier};
 use psl::{
@@ -43,7 +44,6 @@ use psl::{
     PreviewFeature, PreviewFeatures,
 };
 use schema::*;
-use utils::*;
 
 pub(crate) struct BuilderContext<'a> {
     internal_data_model: &'a InternalDataModel,

--- a/query-engine/schema-builder/src/mutations/create_many.rs
+++ b/query-engine/schema-builder/src/mutations/create_many.rs
@@ -1,13 +1,7 @@
-use crate::{
-    constants::args,
-    field, init_input_object_type, input_field,
-    input_types::{
-        fields::data_input_mapper::{CreateDataInputFieldMapper, DataInputFieldMapper},
-        list_union_type,
-    },
-    output_types::objects,
-    BuilderContext, ModelField,
-};
+use super::*;
+use constants::*;
+use input_types::{fields::data_input_mapper::*, list_union_type};
+use output_types::objects;
 use prisma_models::{ModelRef, RelationFieldRef};
 use psl::datamodel_connector::ConnectorCapability;
 use schema::{

--- a/query-engine/schema-builder/src/mutations/create_one.rs
+++ b/query-engine/schema-builder/src/mutations/create_one.rs
@@ -1,10 +1,7 @@
-use crate::{
-    constants::args,
-    field, init_input_object_type, input_field,
-    input_types::fields::data_input_mapper::{CreateDataInputFieldMapper, DataInputFieldMapper},
-    output_types::objects,
-    BuilderContext, ModelField,
-};
+use super::*;
+use constants::*;
+use input_types::fields::data_input_mapper::*;
+use output_types::objects;
 use prisma_models::{ModelRef, RelationFieldRef};
 use schema::{
     Identifier, IdentifierType, InputField, InputObjectTypeId, InputType, OutputField, OutputType, QueryInfo, QueryTag,

--- a/query-engine/schema-builder/src/mutations/mod.rs
+++ b/query-engine/schema-builder/src/mutations/mod.rs
@@ -3,3 +3,5 @@ pub(crate) mod create_one;
 
 pub(crate) use create_many::create_many;
 pub(crate) use create_one::create_one;
+
+use super::*;

--- a/query-engine/schema-builder/src/output_types/aggregation/group_by.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/group_by.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::aggregations::*;
+use constants::aggregations::*;
 use std::convert::identity;
 
 /// Builds group by aggregation object type for given model (e.g. GroupByUserOutputType).

--- a/query-engine/schema-builder/src/output_types/aggregation/plain.rs
+++ b/query-engine/schema-builder/src/output_types/aggregation/plain.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::constants::aggregations::*;
+use constants::aggregations::*;
 use std::convert::identity;
 
 /// Builds plain aggregation object type for given model (e.g. AggregateUser).

--- a/query-engine/schema-builder/src/output_types/field.rs
+++ b/query-engine/schema-builder/src/output_types/field.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::enum_types::*;
 use input_types::fields::arguments;
 use prisma_models::{CompositeFieldRef, ScalarFieldRef};
 

--- a/query-engine/schema-builder/src/output_types/mutation_type.rs
+++ b/query-engine/schema-builder/src/output_types/mutation_type.rs
@@ -1,6 +1,6 @@
 use super::*;
-use crate::mutations::{create_many, create_one};
 use input_types::fields::{arguments, input_fields};
+use mutations::{create_many, create_one};
 use prisma_models::{DefaultKind, PrismaValue};
 use psl::datamodel_connector::ConnectorCapability;
 

--- a/query-engine/schema-builder/src/output_types/objects/mod.rs
+++ b/query-engine/schema-builder/src/output_types/objects/mod.rs
@@ -2,7 +2,7 @@ pub mod composite;
 pub mod model;
 
 use super::*;
-use crate::constants::output_fields::*;
+use constants::output_fields::*;
 
 /// Initializes output object type caches on the context.
 /// This is a critical first step to ensure that all model and composite output

--- a/query-engine/schema-builder/src/output_types/objects/model.rs
+++ b/query-engine/schema-builder/src/output_types/objects/model.rs
@@ -1,7 +1,5 @@
-#![allow(clippy::unnecessary_to_owned)]
-
 use super::*;
-use crate::constants::aggregations::*;
+use constants::aggregations::*;
 use std::convert::identity;
 
 /// Compute initial model cache. No fields are computed because we first


### PR DESCRIPTION
Standardize on the `use super::*` pattern. It tends to put way too much into scope, compared to the approach we take elsewhere, but it standardizes the pattern in schema-builder.

This makes it easier to experiment with merging the `schema` and `schema-builder` crates.