### PR TITLE
qe: Add extra tracing spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,6 +3859,7 @@ dependencies = [
  "prisma-models",
  "psl",
  "rustc-hash",
+ "tracing",
 ]
 
 [[package]]

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -257,7 +257,13 @@ impl QueryEngine {
                     let executor = load_executor(data_source, preview_features, &url).await?;
                     let connector = executor.primary_connector();
 
-                    connector.get_connection().await?;
+                    let conn_span = tracing::info_span!(
+                        "prisma:engine:connection",
+                        user_facing = true,
+                        "db.type" = connector.name(),
+                    );
+
+                    connector.get_connection().instrument(conn_span).await?;
 
                     crate::Result::<_>::Ok(executor)
                 };
@@ -409,13 +415,27 @@ impl QueryEngine {
     }
 
     #[napi]
-    pub async fn dmmf(&self) -> napi::Result<String> {
+    pub async fn dmmf(&self, trace: String) -> napi::Result<String> {
         async_panic_to_js_error(async {
             let inner = self.inner.read().await;
             let engine = inner.as_engine()?;
-            let dmmf = dmmf::render_dmmf(&engine.query_schema);
 
-            Ok(serde_json::to_string(&dmmf)?)
+            let dispatcher = self.logger.dispatcher();
+
+            tracing::dispatcher::with_default(&dispatcher, || {
+                let span = tracing::info_span!("prisma:engine:dmmf");
+                let _ = telemetry::helpers::set_parent_context_from_json_str(&span, &trace);
+                let _guard = span.enter();
+                let dmmf = dmmf::render_dmmf(&engine.query_schema);
+
+                let json = {
+                    let span = tracing::info_span!("prisma:engine:dmmf_to_json");
+                    let _guard = span.enter();
+                    serde_json::to_string(&dmmf)?
+                };
+
+                Ok(json)
+            })
         })
         .await
     }

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -429,8 +429,7 @@ impl QueryEngine {
                 let dmmf = dmmf::render_dmmf(&engine.query_schema);
 
                 let json = {
-                    let span = tracing::info_span!("prisma:engine:dmmf_to_json");
-                    let _guard = span.enter();
+                    let _span = tracing::info_span!("prisma:engine:dmmf_to_json").entered();
                     serde_json::to_string(&dmmf)?
                 };
 

--- a/query-engine/request-handlers/src/dmmf/mod.rs
+++ b/query-engine/request-handlers/src/dmmf/mod.rs
@@ -1,6 +1,7 @@
 use dmmf_crate::DataModelMetaFormat;
 use query_core::schema::QuerySchema;
 
+#[tracing::instrument(name = "prisma:engine:render_dmmf")]
 pub fn render_dmmf(query_schema: &QuerySchema) -> DataModelMetaFormat {
     dmmf_crate::from_precomputed_parts(query_schema)
 }

--- a/query-engine/request-handlers/src/protocols/graphql/body.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/body.rs
@@ -2,6 +2,7 @@ use super::GraphQLProtocolAdapter;
 use query_core::{BatchDocument, BatchDocumentTransaction, Operation, QueryDocument};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tracing::info_span;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", untagged)]
@@ -55,6 +56,7 @@ impl From<&str> for SingleQuery {
 impl GraphqlBody {
     /// Convert a `GraphQlBody` into a `QueryDocument`.
     pub fn into_doc(self) -> crate::Result<QueryDocument> {
+        let _span = info_span!("prisma:engine:into_doc").entered();
         match self {
             GraphqlBody::Single(body) => {
                 let operation = GraphQLProtocolAdapter::convert_query_to_operation(&body.query, body.operation_name)?;

--- a/query-engine/request-handlers/src/protocols/json/body.rs
+++ b/query-engine/request-handlers/src/protocols/json/body.rs
@@ -4,6 +4,7 @@ use query_core::{
     BatchDocument, BatchDocumentTransaction, Operation, QueryDocument,
 };
 use serde::{Deserialize, Serialize};
+use tracing::info_span;
 
 use super::protocol_adapter::JsonProtocolAdapter;
 
@@ -17,6 +18,7 @@ pub enum JsonBody {
 impl JsonBody {
     /// Convert a `JsonBody` into a `QueryDocument`.
     pub fn into_doc(self, query_schema: &QuerySchemaRef) -> crate::Result<QueryDocument> {
+        let _span = info_span!("prisma:engine:into_doc").entered();
         match self {
             JsonBody::Single(query) => {
                 let operation = JsonProtocolAdapter::convert_single(query, query_schema)?;

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -8,6 +8,7 @@ prisma-models = { path = "../prisma-models" }
 once_cell = "1.3"
 psl.workspace = true
 rustc-hash = "1.1.0"
+tracing = "0.1"
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/query-engine/schema/src/build.rs
+++ b/query-engine/schema/src/build.rs
@@ -138,6 +138,7 @@ impl<'a> BuilderContext<'a> {
 }
 
 pub fn build(schema: Arc<psl::ValidatedSchema>, enable_raw_queries: bool) -> QuerySchema {
+    let _span = tracing::info_span!("prisma:engine:schema").entered();
     let preview_features = schema.configuration.preview_features();
     build_with_features(schema, preview_features, enable_raw_queries)
 }


### PR DESCRIPTION
These internal spans are used for performance inventory. At some point we already had them merged (#3729) and reverted them because of the broken tests  on the client side (#3741). Test in question is broken and the functionality it tests does not actually work, so I think we should be fine with merging this now.