### PR TITLE
ci: switch from actions-rs/toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/build-apple-intel.yml
+++ b/.github/workflows/build-apple-intel.yml
@@ -26,10 +26,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/build-apple-silicon.yml
+++ b/.github/workflows/build-apple-silicon.yml
@@ -23,10 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Install aarch64 toolchain
         run: rustup target add aarch64-apple-darwin

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,10 +23,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.commit }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/cache@v3
         with:
@@ -36,10 +33,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
+      - run: cargo build --release
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -21,10 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - run: "cargo clean && cargo build --release -p schema-engine-cli"
         name: "Compile Migration Engine"

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -22,26 +22,18 @@ jobs:
       RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            components: clippy
-            override: true
+          components: clippy
+      - run: cargo clippy --all-features
 
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
   format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
           components: rustfmt
-          override: true
       - name: Check formatting
         run: cargo fmt -- --check
   shellcheck:

--- a/.github/workflows/quaint.yml
+++ b/.github/workflows/quaint.yml
@@ -14,11 +14,10 @@ jobs:
       RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-            components: clippy
-            override: true
-            toolchain: stable
+          components: clippy
+
       - name: Install dependencies
         run: sudo apt install -y openssl libkrb5-dev
       - uses: actions-rs/clippy-check@v1

--- a/.github/workflows/query-engine-black-box.yml
+++ b/.github/workflows/query-engine-black-box.yml
@@ -55,10 +55,7 @@ jobs:
       - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
         run: make start-${{ matrix.database.name }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - run: export WORKSPACE_ROOT=$(pwd) && cargo build --package query-engine      
         env:

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -81,10 +81,7 @@ jobs:
       - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
         run: make start-${{ matrix.database.name }}
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
         if: ${{ matrix.database.single_threaded }}

--- a/.github/workflows/schema-engine.yml
+++ b/.github/workflows/schema-engine.yml
@@ -34,6 +34,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -44,11 +45,6 @@ jobs:
 
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}-single
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
 
       - run: cargo test -p mongodb-schema-connector
         env:
@@ -108,6 +104,7 @@ jobs:
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -118,11 +115,6 @@ jobs:
 
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
 
       - run: cargo test -p sql-introspection-tests
         if: ${{ !matrix.database.single_threaded }}
@@ -216,10 +208,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{matrix.rust}}
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,11 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - run: |
             cargo test --workspace \


### PR DESCRIPTION
As the GitHub Action to download a run toolchain. The main reason is that https://github.com/actions-rs/toolchain is unmaintained. dtolnay/rust-toolchain is more stable, more lightweight, more self-contained, does not depend on an application runtime beyond bash.

Previous internal discussion: https://prisma-company.slack.com/archives/C4GCG53BP/p1669891725070999