### PR TITLE
query-engine/schema: shrink public API

### DIFF
--- a/query-engine/schema/src/build.rs
+++ b/query-engine/schema/src/build.rs
@@ -33,7 +33,7 @@ mod utils;
 pub use self::utils::{compound_id_field_name, compound_index_field_name};
 
 use self::{enum_types::*, utils::*};
-use crate::*;
+use crate::{db::QuerySchemaDatabase, *};
 use cache::TypeRefCache;
 use prisma_models::{ast, Field as ModelField, InternalDataModel, ModelRef, RelationFieldRef, TypeIdentifier};
 use psl::{

--- a/query-engine/schema/src/lib.rs
+++ b/query-engine/schema/src/lib.rs
@@ -11,15 +11,21 @@ mod output_types;
 mod query_schema;
 mod utils;
 
-pub use self::build::{build, build_with_features, compound_id_field_name, compound_index_field_name};
-pub use db::*;
-pub use enum_type::*;
-pub use identifier_type::*;
-pub use input_types::*;
-pub use output_types::*;
-pub use query_schema::*;
-pub use utils::*;
+pub use self::{
+    build::{build, build_with_features, compound_id_field_name, compound_index_field_name},
+    db::{InputObjectTypeId, OutputFieldId, OutputObjectTypeId},
+    enum_type::{DatabaseEnumType, EnumType},
+    input_types::{InputField, InputObjectType, InputType, ObjectTag},
+    output_types::{ObjectType, OutputField, OutputType},
+    query_schema::{ConnectorContext, Identifier, QueryInfo, QuerySchema, QueryTag, ScalarType},
+    utils::{capitalize, scalar_filter_name},
+};
 
+use self::{
+    db::{EnumTypeId, QuerySchemaDatabase},
+    identifier_type::IdentifierType,
+    input_types::InputObjectTypeConstraints,
+};
 use std::sync::Arc;
 
 pub type QuerySchemaRef = Arc<QuerySchema>;

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -130,7 +130,7 @@ impl Debug for ObjectType {
 }
 
 impl ObjectType {
-    pub fn new(ident: Identifier, model: Option<ModelId>) -> Self {
+    pub(crate) fn new(ident: Identifier, model: Option<ModelId>) -> Self {
         Self {
             identifier: ident,
             fields: OnceCell::new(),
@@ -142,7 +142,7 @@ impl ObjectType {
         &self.identifier
     }
 
-    pub fn add_field(&mut self, field: OutputField) {
+    pub(crate) fn add_field(&mut self, field: OutputField) {
         self.fields.get_mut().unwrap().push(field)
     }
 
@@ -150,17 +150,12 @@ impl ObjectType {
         self.fields.get().unwrap()
     }
 
-    pub fn set_fields(&self, fields: Vec<OutputField>) {
+    pub(crate) fn set_fields(&self, fields: Vec<OutputField>) {
         self.fields.set(fields).unwrap();
     }
 
     pub fn find_field<'a>(&'a self, name: &str) -> Option<(usize, &'a OutputField)> {
         self.get_fields().iter().enumerate().find(|(_, f)| f.name == name)
-    }
-
-    /// True if fields are empty, false otherwise.
-    pub fn is_empty(&self) -> bool {
-        self.get_fields().is_empty()
     }
 }
 
@@ -182,12 +177,12 @@ pub struct OutputField {
 }
 
 impl OutputField {
-    pub fn nullable(mut self) -> Self {
+    pub(crate) fn nullable(mut self) -> Self {
         self.is_nullable = true;
         self
     }
 
-    pub fn nullable_if(self, condition: bool) -> Self {
+    pub(crate) fn nullable_if(self, condition: bool) -> Self {
         if condition {
             self.nullable()
         } else {
@@ -203,7 +198,7 @@ impl OutputField {
         matches!(self.query_tag(), Some(&QueryTag::FindUnique))
     }
 
-    pub fn query_info(&self) -> Option<&QueryInfo> {
+    pub(crate) fn query_info(&self) -> Option<&QueryInfo> {
         self.query_info.as_ref()
     }
 

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,4 +1,4 @@
-use crate::{EnumType, IdentifierType, ObjectType, OutputField, OutputObjectTypeId, QuerySchemaDatabase};
+use crate::{db::QuerySchemaDatabase, EnumType, IdentifierType, ObjectType, OutputField, OutputObjectTypeId};
 use prisma_models::{InternalDataModelRef, ModelRef};
 use psl::{
     datamodel_connector::{ConnectorCapabilities, ConnectorCapability, RelationMode},
@@ -64,7 +64,7 @@ impl ConnectorContext {
 
 impl QuerySchema {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub(crate) fn new(
         query: OutputObjectTypeId,
         mutation: OutputObjectTypeId,
         db: QuerySchemaDatabase,


### PR DESCRIPTION
This is a first step in https://github.com/prisma/client-planning/issues/349

The next step will be figuring out the lazy API we need, and adapt the current API. We will then be free to make the internals lazy.