### PR TITLE
Make EngineState public

### DIFF
--- a/schema-engine/core/src/lib.rs
+++ b/schema-engine/core/src/lib.rs
@@ -16,7 +16,7 @@ mod rpc;
 mod state;
 mod timings;
 
-pub use self::{api::GenericApi, core_error::*, rpc::rpc_api, timings::TimingsLayer};
+pub use self::{api::GenericApi, core_error::*, rpc::rpc_api, state::EngineState, timings::TimingsLayer};
 pub use schema_connector;
 
 use enumflags2::BitFlags;

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -41,7 +41,7 @@ type ErasedConnectorRequest = Box<
 >;
 
 impl EngineState {
-    pub(crate) fn new(initial_datamodel: Option<String>, host: Option<Arc<dyn ConnectorHost>>) -> Self {
+    pub fn new(initial_datamodel: Option<String>, host: Option<Arc<dyn ConnectorHost>>) -> Self {
         EngineState {
             initial_datamodel: initial_datamodel.map(|s| psl::validate(s.into())),
             host: host.unwrap_or_else(|| Arc::new(schema_connector::EmptyHost)),

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -113,7 +113,12 @@ impl EngineState {
         response_receiver.await.expect("receiver boomed")
     }
 
-    async fn with_connector_for_url<O: Send + 'static>(&self, url: String, f: ConnectorRequest<O>) -> CoreResult<O> {
+    /// Executes a request with a custom connector URL
+    pub async fn with_connector_for_url<O: Send + 'static>(
+        &self,
+        url: String,
+        f: ConnectorRequest<O>,
+    ) -> CoreResult<O> {
         let (response_sender, response_receiver) = tokio::sync::oneshot::channel::<CoreResult<O>>();
         let erased: ErasedConnectorRequest = Box::new(move |connector| {
             Box::pin(async move {

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -18,7 +18,7 @@ use tracing_futures::Instrument;
 /// `connectors`. Each connector has its own async task, and communicates with the core through
 /// channels. That ensures that each connector is handling requests one at a time to avoid
 /// synchronization issues. You can think of it in terms of the actor model.
-pub(crate) struct EngineState {
+pub struct EngineState {
     initial_datamodel: Option<psl::ValidatedSchema>,
     host: Arc<dyn ConnectorHost>,
     // A map from either:


### PR DESCRIPTION
Prisma Client Rust uses `EngineState` to do migrations with custom URLs. This requires using `EngineState` itself rather than `GenericApi` so that `with_connector_for_url` can be used.
This probably belongs on my own fork but it'd be nice to have here.