### PR TITLE
qe: delete calls to prisma_models::convert()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,6 @@ name = "core-tests"
 version = "0.1.0"
 dependencies = [
  "dissimilar",
- "prisma-models",
  "psl",
  "query-core",
  "request-handlers",
@@ -3306,7 +3305,6 @@ dependencies = [
  "mongodb-query-connector",
  "opentelemetry",
  "opentelemetry-otlp",
- "prisma-models",
  "psl",
  "quaint",
  "query-connector",

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -49,9 +49,7 @@ impl Runner {
         let data_source = schema.configuration.datasources.first().unwrap();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
         let executor = load_executor(data_source, schema.configuration.preview_features(), &url).await?;
-        let internal_data_model = prisma_models::convert(Arc::new(schema));
-
-        let query_schema: QuerySchemaRef = Arc::new(schema::build(internal_data_model, true));
+        let query_schema: QuerySchemaRef = Arc::new(schema::build(Arc::new(schema), true));
 
         Ok(Self {
             executor,

--- a/query-engine/core-tests/Cargo.toml
+++ b/query-engine/core-tests/Cargo.toml
@@ -11,6 +11,5 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 request-handlers = { path = "../request-handlers" }
 query-core = { path = "../core" }
 schema = { path = "../schema" }
-prisma-models = { path = "../prisma-models" }
 psl.workspace = true
 serde_json.workspace = true

--- a/query-engine/core-tests/tests/query_validation_tests.rs
+++ b/query-engine/core-tests/tests/query_validation_tests.rs
@@ -19,8 +19,7 @@ fn run_query_validation_test(query_file_path: &str) {
         .chain(ALL_PREVIEW_FEATURES.hidden_features())
         .collect();
     let parsed_schema = psl::parse_schema(schema).unwrap();
-    let prisma_models_schema = prisma_models::convert(Arc::new(parsed_schema));
-    let schema = Arc::new(schema::build_with_features(prisma_models_schema, all_features, true));
+    let schema = Arc::new(schema::build_with_features(Arc::new(parsed_schema), all_features, true));
 
     let err_string = match validate(&query, schema) {
         Ok(()) => panic!("these tests are only for errors, the query should fail to validate, but it did not"),

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -17,8 +17,7 @@ pub fn dmmf_json_from_schema(schema: &str) -> String {
 
 pub fn dmmf_from_schema(schema: &str) -> DataModelMetaFormat {
     let schema = Arc::new(psl::parse_schema(schema).unwrap());
-    let internal_data_model = prisma_models::convert(schema);
-    from_precomputed_parts(&schema::build(internal_data_model, true))
+    from_precomputed_parts(&schema::build(schema, true))
 }
 
 pub fn from_precomputed_parts(query_schema: &QuerySchema) -> DataModelMetaFormat {

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -263,11 +263,8 @@ impl QueryEngine {
                 };
 
                 let query_schema_fut = tokio::runtime::Handle::current().spawn_blocking(move || {
-                    // Build internal data model
-                    let internal_data_model = prisma_models::convert(arced_schema_2);
-
                     let enable_raw_queries = true;
-                    schema::build(internal_data_model, enable_raw_queries)
+                    schema::build(arced_schema_2, enable_raw_queries)
                 });
 
                 let (query_schema, executor) = tokio::join!(query_schema_fut, executor_fut);

--- a/query-engine/query-engine-node-api/src/functions.rs
+++ b/query-engine/query-engine-node-api/src/functions.rs
@@ -27,8 +27,7 @@ pub fn dmmf(datamodel_string: String) -> napi::Result<String> {
         .to_result()
         .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
 
-    let internal_data_model = prisma_models::convert(Arc::new(schema));
-    let query_schema = query_core::schema::build(internal_data_model, true);
+    let query_schema = query_core::schema::build(Arc::new(schema), true);
     let dmmf = dmmf::render_dmmf(&query_schema);
 
     Ok(serde_json::to_string(&dmmf)?)

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -20,7 +20,6 @@ enumflags2 = { version = "0.7"}
 psl.workspace = true
 graphql-parser = { git = "https://github.com/prisma/graphql-parser" }
 mongodb-connector = { path = "../connectors/mongodb-query-connector", optional = true, package = "mongodb-query-connector" }
-prisma-models = { path = "../prisma-models" }
 query-core = { path = "../core" }
 request-handlers = { path = "../request-handlers" }
 serde.workspace = true

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -89,8 +89,7 @@ impl CliCommand {
     }
 
     async fn dmmf(request: DmmfRequest) -> PrismaResult<()> {
-        let internal_data_model = prisma_models::convert(Arc::new(request.schema));
-        let query_schema = schema::build(internal_data_model, request.enable_raw_queries);
+        let query_schema = schema::build(Arc::new(request.schema), request.enable_raw_queries);
         let dmmf = dmmf::render_dmmf(&query_schema);
         let serialized = serde_json::to_string_pretty(&dmmf)?;
 

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -45,12 +45,9 @@ impl PrismaContext {
         let arced_schema_2 = Arc::clone(&arced_schema);
 
         let query_schema_fut = tokio::runtime::Handle::current().spawn_blocking(move || {
-            // Build internal data model
-            let internal_data_model = prisma_models::convert(arced_schema);
-
             // Construct query schema
             Arc::new(schema::build(
-                internal_data_model,
+                arced_schema,
                 enabled_features.contains(Feature::RawQueries),
             ))
         });

--- a/query-engine/query-engine/src/tests/dmmf.rs
+++ b/query-engine/query-engine/src/tests/dmmf.rs
@@ -9,8 +9,7 @@ use std::sync::Arc;
 
 pub fn get_query_schema(datamodel_string: &str) -> QuerySchema {
     let dm = psl::parse_schema(datamodel_string).unwrap();
-    let internal_ref = prisma_models::convert(Arc::new(dm));
-    schema::build(internal_ref, false)
+    schema::build(Arc::new(dm), false)
 }
 
 // Tests in this file run serially because the function `get_query_schema` depends on setting an env var.

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -457,9 +457,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        let internal_data_model = prisma_models::convert(Arc::new(schema));
-
-        Arc::new(schema::build(internal_data_model, true))
+        Arc::new(schema::build(Arc::new(schema), true))
     }
 
     #[test]
@@ -1446,9 +1444,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        let internal_data_model = prisma_models::convert(Arc::new(schema));
-
-        Arc::new(schema::build(internal_data_model, true))
+        Arc::new(schema::build(Arc::new(schema), true))
     }
 
     #[test]
@@ -1580,9 +1576,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        let internal_data_model = prisma_models::convert(Arc::new(schema));
-
-        Arc::new(schema::build(internal_data_model, true))
+        Arc::new(schema::build(Arc::new(schema), true))
     }
 
     #[test]
@@ -1639,9 +1633,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        let internal_data_model = prisma_models::convert(Arc::new(schema));
-
-        Arc::new(schema::build(internal_data_model, true))
+        Arc::new(schema::build(Arc::new(schema), true))
     }
 
     #[test]

--- a/query-engine/schema/benches/schema_builder_bench.rs
+++ b/query-engine/schema/benches/schema_builder_bench.rs
@@ -13,10 +13,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         });
 
         let validated_schema = std::sync::Arc::new(psl::validate(source_file));
-        let idm = prisma_models::convert(validated_schema);
 
         c.bench_function(&format!("schema_builder::build ({name})"), |b| {
-            b.iter(|| black_box(schema::build(idm.clone(), true)));
+            b.iter(|| black_box(schema::build(validated_schema.clone(), true)));
         });
     }
 }

--- a/query-engine/schema/examples/schema_builder_build_odoo.rs
+++ b/query-engine/schema/examples/schema_builder_build_odoo.rs
@@ -2,10 +2,9 @@ fn main() {
     let prisma_schema = include_str!("../test-schemas/odoo.prisma");
     let source_file: psl::SourceFile = prisma_schema.into();
     let validated_schema = std::sync::Arc::new(psl::validate(source_file));
-    let idm = prisma_models::convert(validated_schema);
 
     let now = std::time::Instant::now();
-    let _ = schema::build(idm, true);
+    let _ = schema::build(validated_schema, true);
     let elapsed = now.elapsed();
 
     println!("Elapsed: {:.2?}", elapsed);

--- a/query-engine/schema/src/build.rs
+++ b/query-engine/schema/src/build.rs
@@ -137,16 +137,17 @@ impl<'a> BuilderContext<'a> {
     }
 }
 
-pub fn build(internal_data_model: InternalDataModel, enable_raw_queries: bool) -> QuerySchema {
-    let preview_features = internal_data_model.schema.configuration.preview_features();
-    build_with_features(internal_data_model, preview_features, enable_raw_queries)
+pub fn build(schema: Arc<psl::ValidatedSchema>, enable_raw_queries: bool) -> QuerySchema {
+    let preview_features = schema.configuration.preview_features();
+    build_with_features(schema, preview_features, enable_raw_queries)
 }
 
 pub fn build_with_features(
-    internal_data_model: InternalDataModel,
+    schema: Arc<psl::ValidatedSchema>,
     preview_features: PreviewFeatures,
     enable_raw_queries: bool,
 ) -> QuerySchema {
+    let internal_data_model = prisma_models::convert(schema);
     let mut ctx = BuilderContext::new(&internal_data_model, enable_raw_queries, preview_features);
 
     output_types::objects::initialize_caches(&mut ctx);


### PR DESCRIPTION
It is now only ever used before schema::build(). This commit makes it part of schema::build(). This does not change the behaviour of schema::build(), since prisma_models::convert() does not work and should have absolutely no impact.