### PR TITLE
qe: fix vendored-openssl feature on query-engine binary

### DIFF
--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 default = ["sql", "mongodb"]
 mongodb = ["mongodb-connector"]
 sql = ["sql-connector"]
-vendored-openssl = ["quaint/vendored-openssl"]
+vendored-openssl = ["sql-connector/vendored-openssl"]
 
 [dependencies]
 tokio.workspace = true


### PR DESCRIPTION
It did not work because quaint is a dev dependency on that crate. The
fix is to align the way we turn on the feature with
query-engine-node-api and schema-engine: use the `vendored-openssl`
feature on `sql-query-connector`.

The buggy behaviour and the fix were confirmed with `ldd`. We will
automate these checks, see
https://github.com/prisma/client-planning/issues/370