### PR TITLE
qe/connector-test-kit-rs: avoid writing schema to disk before each test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3172,11 +3172,10 @@ dependencies = [
  "mongodb",
  "mongodb-client",
  "once_cell",
- "parking_lot 0.12.1",
  "psl",
  "quaint",
  "schema-core",
- "tempfile",
+ "sql-schema-connector",
  "test-setup",
  "url",
 ]

--- a/query-engine/connector-test-kit-rs/qe-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/qe-setup/Cargo.toml
@@ -8,12 +8,11 @@ psl.workspace = true
 quaint.workspace = true
 mongodb-client = { path = "../../../libs/mongodb-client" }
 schema-core = { path = "../../../schema-engine/core" }
+sql-schema-connector = { path = "../../../schema-engine/connectors/sql-schema-connector" }
 test-setup = { path = "../../../libs/test-setup" }
 
-parking_lot = { version = "0.12", features = ["send_guard"] }
 connection-string = "*"
 enumflags2 = "*"
 mongodb = "2.3.0"
-tempfile = "3.3.0"
 url = "2"
 once_cell = "1.17.0"

--- a/query-engine/connector-test-kit-rs/qe-setup/src/cockroachdb.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/cockroachdb.rs
@@ -4,12 +4,12 @@ use schema_core::schema_connector::{ConnectorError, ConnectorResult};
 use url::Url;
 
 pub(crate) async fn cockroach_setup(url: String, prisma_schema: &str) -> ConnectorResult<()> {
-    let mut url = Url::parse(&url).map_err(ConnectorError::url_parse_error)?;
-    let mut quaint_url = quaint::connector::PostgresUrl::new(url.clone()).unwrap();
+    let mut parsed_url = Url::parse(&url).map_err(ConnectorError::url_parse_error)?;
+    let mut quaint_url = quaint::connector::PostgresUrl::new(parsed_url.clone()).unwrap();
     quaint_url.set_flavour(PostgresFlavour::Cockroach);
 
     let db_name = quaint_url.dbname();
-    let conn = create_admin_conn(&mut url).await?;
+    let conn = create_admin_conn(&mut parsed_url).await?;
 
     let query = format!(
         r#"
@@ -20,11 +20,9 @@ pub(crate) async fn cockroach_setup(url: String, prisma_schema: &str) -> Connect
 
     conn.raw_cmd(&query).await.unwrap();
 
-    crate::diff_and_apply(prisma_schema).await;
-
-    drop_db_when_thread_exits(url, db_name);
-
-    Ok(())
+    drop_db_when_thread_exits(parsed_url, db_name);
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_cockroach();
+    crate::diff_and_apply(prisma_schema, url, &mut connector).await
 }
 
 async fn create_admin_conn(url: &mut Url) -> ConnectorResult<Quaint> {

--- a/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
@@ -13,11 +13,8 @@ pub use schema_core::schema_connector::ConnectorError;
 use self::{cockroachdb::*, mongodb::*, mssql::*, mysql::*, postgres::*};
 use enumflags2::BitFlags;
 use psl::{builtin_connectors::*, Datasource};
-use schema_core::{
-    json_rpc::types::*,
-    schema_connector::{BoxFuture, ConnectorResult},
-};
-use std::{env, sync::Arc};
+use schema_core::schema_connector::{ConnectorResult, DiffTarget, SchemaConnector};
+use std::env;
 
 fn parse_configuration(datamodel: &str) -> ConnectorResult<(Datasource, String, BitFlags<psl::PreviewFeature>)> {
     let config = psl::parse_configuration(datamodel)
@@ -44,25 +41,25 @@ pub async fn setup(prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResult<
 
     match &source.active_provider {
         provider if [POSTGRES.provider_name()].contains(provider) => {
-            postgres_setup(url, prisma_schema, db_schemas).await?
+            postgres_setup(url, prisma_schema, db_schemas).await
         }
-        provider if COCKROACH.is_provider(provider) => cockroach_setup(url, prisma_schema).await?,
-        provider if MSSQL.is_provider(provider) => mssql_setup(url, prisma_schema, db_schemas).await?,
+        provider if COCKROACH.is_provider(provider) => cockroach_setup(url, prisma_schema).await,
+        provider if MSSQL.is_provider(provider) => mssql_setup(url, prisma_schema, db_schemas).await,
         provider if MYSQL.is_provider(provider) => {
             mysql_reset(&url).await?;
-            diff_and_apply(prisma_schema).await;
+            let mut connector = sql_schema_connector::SqlSchemaConnector::new_mysql();
+            diff_and_apply(prisma_schema, url, &mut connector).await
         }
         provider if SQLITE.is_provider(provider) => {
             std::fs::remove_file(source.url.as_literal().unwrap().trim_start_matches("file:")).ok();
-            diff_and_apply(prisma_schema).await;
+            let mut connector = sql_schema_connector::SqlSchemaConnector::new_sqlite();
+            diff_and_apply(prisma_schema, url, &mut connector).await
         }
 
-        provider if MONGODB.is_provider(provider) => mongo_setup(prisma_schema, &url).await?,
+        provider if MONGODB.is_provider(provider) => mongo_setup(prisma_schema, &url).await,
 
         x => unimplemented!("Connector {} is not supported yet", x),
-    };
-
-    Ok(())
+    }
 }
 
 /// Database teardown for connector-test-kit-rs.
@@ -90,48 +87,19 @@ pub async fn teardown(prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResu
     Ok(())
 }
 
-#[derive(Default)]
-struct LoggingHost {
-    printed: parking_lot::Mutex<Vec<String>>,
-}
-
-impl schema_core::schema_connector::ConnectorHost for LoggingHost {
-    fn print(&self, text: &str) -> BoxFuture<'_, ConnectorResult<()>> {
-        let mut msgs = self.printed.lock();
-        msgs.push(text.to_owned());
-        Box::pin(std::future::ready(Ok(())))
-    }
-}
-
-async fn diff_and_apply(schema: &str) {
-    let tmpdir = tempfile::tempdir().unwrap();
-    let host = Arc::new(LoggingHost::default());
-    let api = schema_core::schema_api(Some(schema.to_owned()), Some(host.clone())).unwrap();
-    let schema_file_path = tmpdir.path().join("schema.prisma");
-    std::fs::write(&schema_file_path, schema).unwrap();
-
-    // 2. create the database schema for given Prisma schema
-    api.diff(DiffParams {
-        exit_code: None,
-        from: DiffTarget::Empty,
-        to: DiffTarget::SchemaDatamodel(SchemaContainer {
-            schema: schema_file_path.to_string_lossy().into(),
-        }),
-        script: true,
-        shadow_database_url: None,
-    })
-    .await
-    .unwrap();
-    let migrations = host.printed.lock();
-    let migration = migrations[0].clone();
-    drop(migrations);
-
-    api.db_execute(DbExecuteParams {
-        datasource_type: DbExecuteDatasourceType::Schema(SchemaContainer {
-            schema: schema_file_path.to_string_lossy().into(),
-        }),
-        script: migration,
-    })
-    .await
-    .unwrap();
+async fn diff_and_apply(schema: &str, url: String, connector: &mut dyn SchemaConnector) -> ConnectorResult<()> {
+    connector.set_params(schema_core::schema_connector::ConnectorParams {
+        connection_string: url,
+        preview_features: Default::default(),
+        shadow_database_connection_string: None,
+    })?;
+    let from = connector
+        .database_schema_from_diff_target(DiffTarget::Empty, None, None)
+        .await?;
+    let to = connector
+        .database_schema_from_diff_target(DiffTarget::Datamodel(schema.into()), None, None)
+        .await?;
+    let migration = connector.diff(from, to);
+    let script = connector.render_script(&migration, &Default::default()).unwrap();
+    connector.db_execute(script).await
 }

--- a/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
@@ -19,7 +19,6 @@ pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[
             "#
         );
         conn.raw_cmd(&sql).await.unwrap();
-        conn.raw_cmd(&format!("USE [{db_name}];")).await.unwrap();
     } else {
         let api = schema_core::schema_api(Some(prisma_schema.to_owned()), None)?;
         api.reset().await.ok();
@@ -40,7 +39,6 @@ pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[
             .unwrap();
     }
 
-    // 2. create the database schema for given Prisma schema
-    crate::diff_and_apply(prisma_schema).await;
-    Ok(())
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_mssql();
+    crate::diff_and_apply(prisma_schema, url, &mut connector).await
 }

--- a/query-engine/connector-test-kit-rs/qe-setup/src/postgres.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/postgres.rs
@@ -4,15 +4,15 @@ use std::collections::HashMap;
 use url::Url;
 
 pub(crate) async fn postgres_setup(url: String, prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResult<()> {
-    let mut url = Url::parse(&url).map_err(ConnectorError::url_parse_error)?;
-    let mut quaint_url = quaint::connector::PostgresUrl::new(url.clone()).unwrap();
+    let mut parsed_url = Url::parse(&url).map_err(ConnectorError::url_parse_error)?;
+    let mut quaint_url = quaint::connector::PostgresUrl::new(parsed_url.clone()).unwrap();
     quaint_url.set_flavour(PostgresFlavour::Postgres);
 
     let (db_name, schema) = (quaint_url.dbname(), quaint_url.schema());
 
     if !db_schemas.is_empty() {
-        strip_schema_param_from_url(&mut url);
-        let conn = create_postgres_admin_conn(url.clone()).await?;
+        strip_schema_param_from_url(&mut parsed_url);
+        let conn = create_postgres_admin_conn(parsed_url.clone()).await?;
 
         let query = format!("DROP DATABASE \"{db_name}\"");
         conn.raw_cmd(&query).await.ok();
@@ -20,16 +20,16 @@ pub(crate) async fn postgres_setup(url: String, prisma_schema: &str, db_schemas:
         let query = format!("CREATE DATABASE \"{db_name}\"");
         conn.raw_cmd(&query).await.ok();
     } else {
-        strip_schema_param_from_url(&mut url);
-        let conn = create_postgres_admin_conn(url.clone()).await?;
+        strip_schema_param_from_url(&mut parsed_url);
+        let conn = create_postgres_admin_conn(parsed_url.clone()).await?;
 
         let query = format!("CREATE DATABASE \"{db_name}\"");
         conn.raw_cmd(&query).await.ok();
 
         // Now create the schema
-        url.set_path(&format!("/{db_name}"));
+        parsed_url.set_path(&format!("/{db_name}"));
 
-        let conn = Quaint::new(url.as_ref()).await.unwrap();
+        let conn = Quaint::new(parsed_url.as_ref()).await.unwrap();
 
         let drop_and_recreate_schema =
             format!("DROP SCHEMA IF EXISTS \"{schema}\" CASCADE;\nCREATE SCHEMA \"{schema}\";");
@@ -38,8 +38,8 @@ pub(crate) async fn postgres_setup(url: String, prisma_schema: &str, db_schemas:
             .map_err(|e| ConnectorError::from_source(e, ""))?;
     }
 
-    crate::diff_and_apply(prisma_schema).await;
-    Ok(())
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_postgres();
+    crate::diff_and_apply(prisma_schema, url, &mut connector).await
 }
 
 pub(crate) async fn postgres_teardown(url: &str, db_schemas: &[&str]) -> ConnectorResult<()> {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -28,12 +28,12 @@ mod metrics {
 
         match runner.connector_version() {
             Sqlite => assert_eq!(total_queries, 9),
-            SqlServer(_) => assert_eq!(total_queries, 15),
+            SqlServer(_) => assert_eq!(total_queries, 17),
             MongoDb(_) => assert_eq!(total_queries, 5),
-            CockroachDb => assert_eq!(total_queries, 10),
-            MySql(_) => assert_eq!(total_queries, 9),
+            CockroachDb => (), // not deterministic
+            MySql(_) => assert_eq!(total_queries, 12),
             Vitess(_) => assert_eq!(total_queries, 11),
-            _ => assert_eq!(total_queries, 11),
+            Postgres(_) => assert_eq!(total_queries, 14),
         }
 
         assert_eq!(total_operations, 2);

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15607.rs
@@ -5,9 +5,8 @@
 
 use indoc::indoc;
 use query_engine_tests::{
-    query_core::TxId, render_test_datamodel, setup_metrics, setup_project, test_tracing_subscriber, ConnectorTag,
-    LogEmit, QueryResult, Runner, TestError, TestLogCapture, TestResult, TryFrom, WithSubscriber, CONFIG,
-    ENV_LOG_LEVEL,
+    query_core::TxId, render_test_datamodel, setup_metrics, test_tracing_subscriber, ConnectorTag, LogEmit,
+    QueryResult, Runner, TestError, TestLogCapture, TestResult, TryFrom, WithSubscriber, CONFIG, ENV_LOG_LEVEL,
 };
 use std::future::Future;
 use tokio::sync::mpsc;
@@ -74,9 +73,7 @@ impl Actor {
             Some("READ COMMITTED"),
         );
 
-        setup_project(&datamodel, &[]).await?;
-
-        let mut runner = Runner::load(datamodel, tag, setup_metrics(), log_capture).await?;
+        let mut runner = Runner::load(datamodel, &[], tag, setup_metrics(), log_capture).await?;
 
         tokio::spawn(async move {
             while let Some(message) = query_receiver.recv().await {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -42,18 +42,13 @@ pub static ENV_LOG_LEVEL: Lazy<String> = Lazy::new(|| std::env::var("LOG_LEVEL")
 pub static ENGINE_PROTOCOL: Lazy<String> =
     Lazy::new(|| std::env::var("PRISMA_ENGINE_PROTOCOL").unwrap_or_else(|_| "graphql".to_owned()));
 
-/// Setup of everything as defined in the passed datamodel.
-pub async fn setup_project(datamodel: &str, db_schemas: &[&str]) -> TestResult<()> {
-    Ok(qe_setup::setup(datamodel, db_schemas).await?)
-}
-
 /// Teardown of a test setup.
-pub async fn teardown_project(datamodel: &str, db_schemas: &[&str]) -> TestResult<()> {
+async fn teardown_project(datamodel: &str, db_schemas: &[&str]) -> TestResult<()> {
     Ok(qe_setup::teardown(datamodel, db_schemas).await?)
 }
 
 /// Helper method to allow a sync shell function to run the async test blocks.
-pub fn run_with_tokio<O, F: std::future::Future<Output = O>>(fut: F) -> O {
+fn run_with_tokio<O, F: std::future::Future<Output = O>>(fut: F) -> O {
     Builder::new_current_thread()
         .enable_all()
         .build()
@@ -165,10 +160,8 @@ fn run_relation_link_test_impl(
 
         run_with_tokio(
             async move {
-                println!("Used datamodel:\n {}", datamodel.clone().yellow());
-                setup_project(&datamodel, Default::default()).await.unwrap();
-
-                let runner = Runner::load(datamodel.clone(), connector, metrics, log_capture)
+                println!("Used datamodel:\n {}", datamodel.yellow());
+                let runner = Runner::load(datamodel.clone(), &[], connector, metrics, log_capture)
                     .await
                     .unwrap();
 
@@ -271,10 +264,8 @@ fn run_connector_test_impl(
 
     crate::run_with_tokio(
         async {
-            println!("Used datamodel:\n {}", datamodel.clone().yellow());
-            crate::setup_project(&datamodel, db_schemas).await.unwrap();
-
-            let runner = Runner::load(datamodel.clone(), connector, metrics, log_capture)
+            println!("Used datamodel:\n {}", datamodel.yellow());
+            let runner = Runner::load(datamodel.clone(), db_schemas, connector, metrics, log_capture)
                 .await
                 .unwrap();
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -40,12 +40,15 @@ impl Runner {
 
     pub async fn load(
         datamodel: String,
+        db_schemas: &[&str],
         connector_tag: ConnectorTag,
         metrics: MetricRegistry,
         log_capture: TestLogCapture,
     ) -> TestResult<Self> {
+        qe_setup::setup(&datamodel, db_schemas).await?;
+
         let protocol = EngineProtocol::from(&ENGINE_PROTOCOL.to_string());
-        let schema = psl::parse_schema(datamodel.clone()).unwrap();
+        let schema = psl::parse_schema(datamodel).unwrap();
         let data_source = schema.configuration.datasources.first().unwrap();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
         let executor = load_executor(data_source, schema.configuration.preview_features(), &url).await?;


### PR DESCRIPTION
qe-setup used the migration engine in a way that forced us to write the Prisma schema for each test to disk before running the test. In this PR, we avoid this, keeping the schema in memory.

This should make test runs faster, but there is so much variability, even with few tests, that I haven't been able to get a usable measurement of the impact.