### PR TITLE
qe: allow binding to a free port automatically

### DIFF
--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -29,7 +29,14 @@ pub async fn listen(cx: Arc<PrismaContext>, opts: &PrismaOpt) -> PrismaResult<()
 
     let server = Server::bind(&addr).tcp_nodelay(true).serve(query_engine);
 
-    info!("Started query engine http server on http://{}", addr);
+    // Note: we call `server.local_addr()` instead of reusing original `addr` because it may contain port 0 to request
+    // the OS to assign a free port automatically, and we want to print the address which is actually in use.
+    info!(
+        ip = %server.local_addr().ip(),
+        port = %server.local_addr().port(),
+        "Started query engine http server on http://{}",
+        server.local_addr()
+    );
 
     if let Err(e) = server.await {
         eprintln!("server error: {e}");


### PR DESCRIPTION
Currently the BinaryEngine class in the client, as well as the
mini-proxy, contain the code to find a free port, and then spawn the
Query Engine server on that port. The problem is that in environments
where lots of servers are frequently spawned, as in CI, it's far from
rare that something else grabs that port between the time the port is
found on the JavaScript side and the the time the QE server is
started. This is one of recurring sources of flakiness in our tests.

Some examples:
- https://github.com/prisma/prisma/actions/runs/4760387369/jobs/8461995272?pr=18859#step:11:6485
- https://github.com/prisma/prisma/actions/runs/4760387369/jobs/8461995272?pr=18859#step:11:6485
- and so on

To fix this, QE server should request an available port from the
operating system itself instead of relying on the client to pass a
free port via CLI arguments. This is already possible by passing
`--port 0`, as it's functionality provided "for free" by the `bind`
system call itself, however currently when doing that there's no way
for the client to learn which port was assigned by the kernel.

This PR changes the log message to print the real port the server was
bound to, as well as adds `ip` and `port` fields for the client to be
able to read them easily and not rely on parsing the string.

Before:

```
{"timestamp":"2023-04-28T15:31:18.964323Z","level":"INFO","fields":{"message":"Started
query engine http server on http://127.0.0.1:0"},"target":"query_engine::server"}
```

After:

```
{"timestamp":"2023-04-28T15:37:24.830553Z","level":"INFO","fields":{"message":"Started
query engine http server on http://127.0.0.1:64816","ip":"127.0.0.1","port":"64816"},
"target":"query_engine::server"}
```
