### PR TITLE
feat(query-engine): ensure argument path is mentioned in `UnknownInputField` error

### DIFF
--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -355,8 +355,9 @@ impl ValidationError {
         input_type_description: InputTypeDescription,
     ) -> Self {
         let message = format!(
-            "`{}`: Field does not exist in enclosing type.",
-            selection_path.join(".")
+            "`{}.{}`: Field does not exist in enclosing type.",
+            selection_path.join("."),
+            argument_path.join("."),
         );
         ValidationError {
             kind: ValidationErrorKind::UnknownInputField,

--- a/query-engine/core-tests/tests/query_validation_tests/unknown_input_field.expected.json
+++ b/query-engine/core-tests/tests/query_validation_tests/unknown_input_field.expected.json
@@ -1,6 +1,6 @@
 {
   "is_panic": false,
-  "message": "`findManyUser.foo`: Field does not exist in enclosing type.",
+  "message": "`findManyUser.where.foo`: Field does not exist in enclosing type.",
   "meta": {
     "kind": "UnknownInputField",
     "inputType": {
@@ -62,8 +62,7 @@
       "foo"
     ],
     "selectionPath": [
-      "findManyUser",
-      "foo"
+      "findManyUser"
     ]
   },
   "error_code": "P2009"

--- a/query-engine/core-tests/tests/query_validation_tests/unknown_input_field.expected.json
+++ b/query-engine/core-tests/tests/query_validation_tests/unknown_input_field.expected.json
@@ -1,6 +1,6 @@
 {
   "is_panic": false,
-  "message": "`findManyUser`: Field does not exist in enclosing type.",
+  "message": "`findManyUser.foo`: Field does not exist in enclosing type.",
   "meta": {
     "kind": "UnknownInputField",
     "inputType": {
@@ -62,7 +62,8 @@
       "foo"
     ],
     "selectionPath": [
-      "findManyUser"
+      "findManyUser",
+      "foo"
     ]
   },
   "error_code": "P2009"

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -718,7 +718,7 @@ impl QueryDocumentParser {
             .map(|(field_name, value)| {
                 let field = schema_object.find_field(field_name.as_str()).ok_or_else(|| {
                     ValidationError::unknown_input_field(
-                        selection_path.add(field_name.clone()).segments(),
+                        selection_path.segments(),
                         argument_path.add(field_name.clone()).segments(),
                         conversions::schema_input_object_type_to_input_type_description(schema_object, query_schema),
                     )

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -718,7 +718,7 @@ impl QueryDocumentParser {
             .map(|(field_name, value)| {
                 let field = schema_object.find_field(field_name.as_str()).ok_or_else(|| {
                     ValidationError::unknown_input_field(
-                        selection_path.segments(),
+                        selection_path.add(field_name.clone()).segments(),
                         argument_path.add(field_name.clone()).segments(),
                         conversions::schema_input_object_type_to_input_type_description(schema_object, query_schema),
                     )


### PR DESCRIPTION
First mentioned in [Slack](https://prisma.slack.com/archives/C04JZQXUKL0/p1680686786461599).

Prisma Client Python directly uses the error message returned by the query engine in the vast majority of cases & when upgrading to the latest Prisma version I noticed that the `UnknownInputField` (any maybe more?) error doesn't actually include the name of the field that isn't found which can lead to a confusing error message.

Note that I'm not familiar with the error data-structures so this fix may not be 100% correct.