### PR TITLE
fix(schema-engine): stabilise check/exclusion constraints' ordering in introspection warnings

### DIFF
--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/constraints.rs
@@ -58,12 +58,6 @@ async fn aragon_test_cockroachdb(api: &mut TestApi) -> TestResult {
 #[test_connector(tags(CockroachDb))]
 async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
     let raw_sql = indoc! {r#"
-        CREATE TABLE todo_list (
-          tl_id BIGSERIAL PRIMARY KEY,
-          is_public CHAR(1) NOT NULL DEFAULT 'N',
-          CONSTRAINT ck_is_public CHECK (is_public = ANY ARRAY['Y':::STRING::CHAR, 'N':::STRING::CHAR]:::CHAR[])
-        );
-
         CREATE TABLE user_active_security (
             id BIGSERIAL NOT NULL,
             us_login STRING NOT NULL,
@@ -82,6 +76,12 @@ async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
           ua_id BIGSERIAL PRIMARY KEY,
           ua_right CHAR NULL,
           CONSTRAINT user_sec_action_profile_ua_right_check CHECK (ua_right = ANY ARRAY['R':::STRING::CHAR, 'W':::STRING::CHAR]:::CHAR[])
+        );
+
+        CREATE TABLE todo_list (
+          tl_id BIGSERIAL PRIMARY KEY,
+          is_public CHAR(1) NOT NULL DEFAULT 'N',
+          CONSTRAINT ck_is_public CHECK (is_public = ANY ARRAY['Y':::STRING::CHAR, 'N':::STRING::CHAR]:::CHAR[])
         );
     "#};
 

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/constraints.rs
@@ -1,0 +1,118 @@
+//! https://www.notion.so/prismaio/PostgreSQL-Exclusion-Constraints-fb2ecc44f773463f908d3d0e2d737271
+
+use indoc::indoc;
+use sql_introspection_tests::test_api::*;
+use test_macros::test_connector;
+
+#[test_connector(tags(CockroachDb))]
+async fn aragon_test_cockroachdb(api: &mut TestApi) -> TestResult {
+    let raw_sql = indoc! {r#"
+        CREATE TABLE users (
+            user_id INT8 PRIMARY KEY
+        );
+        
+        CREATE TABLE tokens (
+            token_id INT8 PRIMARY KEY,
+            token_scope STRING NULL,
+            CONSTRAINT tokens_token_scope_check CHECK (token_scope = ANY ARRAY['MAGICLINK':::STRING, 'API':::STRING]:::STRING[])
+        );
+    "#};
+
+    api.raw_cmd(raw_sql).await;
+
+    let schema = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "cockroachdb"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
+        model tokens {
+          token_id    BigInt  @id
+          token_scope String?
+        }
+
+        model users {
+          user_id BigInt @id
+        }
+    "#]];
+
+    api.expect_datamodel(&schema).await;
+
+    let expectation = expect![[r#"
+        *** WARNING ***
+
+        These constraints are not supported by the Prisma Client, because Prisma currently does not fully support check constraints. Read more: https://pris.ly/d/postgres-check-constraints
+          - Model: "tokens", constraint: "tokens_token_scope_check"
+    "#]];
+
+    api.expect_warnings(&expectation).await;
+
+    Ok(())
+}
+
+#[test_connector(tags(CockroachDb))]
+async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
+    let raw_sql = indoc! {r#"
+        CREATE SEQUENCE user_active_security_id_seq MINVALUE 1 MAXVALUE 2147483647 INCREMENT 1 START 1;
+
+        CREATE TABLE user_active_security (
+            id INT8 NOT NULL DEFAULT nextval('user_active_security_id_seq'::REGCLASS),
+            us_login STRING NOT NULL,
+            us_ledger VARCHAR(1) NOT NULL,
+            us_action VARCHAR(1) NOT NULL,
+            CONSTRAINT user_active_security_pk PRIMARY KEY (id ASC),
+            CONSTRAINT user_active_security_action_check CHECK (us_action::STRING = ANY ARRAY['Y':::STRING::VARCHAR::STRING, 'N':::STRING::VARCHAR::STRING]:::STRING[]),
+            CONSTRAINT user_active_security_ledger_check CHECK (us_ledger::STRING = ANY ARRAY['Y':::STRING::VARCHAR::STRING, 'N':::STRING::VARCHAR::STRING]:::STRING[])
+        );
+
+        COMMENT ON COLUMN user_active_security.us_login IS e'user\'s login';
+        COMMENT ON COLUMN user_active_security.us_ledger IS 'Flag Security for ledger';
+        COMMENT ON COLUMN user_active_security.us_action IS 'Security for action';
+    "#};
+
+    api.raw_cmd(raw_sql).await;
+
+    let schema = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "cockroachdb"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
+        /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        model user_active_security {
+          id        BigInt @id(map: "user_active_security_pk") @default(sequence(maxValue: 2147483647))
+          us_login  String
+          us_ledger String @db.String(1)
+          us_action String @db.String(1)
+        }
+    "#]];
+
+    api.expect_datamodel(&schema).await;
+
+    let expectation = expect![[r#"
+        *** WARNING ***
+
+        These constraints are not supported by the Prisma Client, because Prisma currently does not fully support check constraints. Read more: https://pris.ly/d/postgres-check-constraints
+          - Model: "user_active_security", constraint: "user_active_security_action_check"
+          - Model: "user_active_security", constraint: "user_active_security_ledger_check"
+
+        These objects have comments defined in the database, which is not yet fully supported. Read more: https://pris.ly/d/database-comments
+          - Type: "field", name: "user_active_security.us_login"
+          - Type: "field", name: "user_active_security.us_ledger"
+          - Type: "field", name: "user_active_security.us_action"
+    "#]];
+
+    api.expect_warnings(&expectation).await;
+
+    Ok(())
+}

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/constraints.rs
@@ -58,10 +58,14 @@ async fn aragon_test_cockroachdb(api: &mut TestApi) -> TestResult {
 #[test_connector(tags(CockroachDb))]
 async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
     let raw_sql = indoc! {r#"
-        CREATE SEQUENCE user_active_security_id_seq MINVALUE 1 MAXVALUE 2147483647 INCREMENT 1 START 1;
+        CREATE TABLE todo_list (
+          tl_id BIGSERIAL PRIMARY KEY,
+          is_public CHAR(1) NOT NULL DEFAULT 'N',
+          CONSTRAINT ck_is_public CHECK (is_public = ANY ARRAY['Y':::STRING::CHAR, 'N':::STRING::CHAR]:::CHAR[])
+        );
 
         CREATE TABLE user_active_security (
-            id INT8 NOT NULL DEFAULT nextval('user_active_security_id_seq'::REGCLASS),
+            id BIGSERIAL NOT NULL,
             us_login STRING NOT NULL,
             us_ledger VARCHAR(1) NOT NULL,
             us_action VARCHAR(1) NOT NULL,
@@ -73,6 +77,12 @@ async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
         COMMENT ON COLUMN user_active_security.us_login IS e'user\'s login';
         COMMENT ON COLUMN user_active_security.us_ledger IS 'Flag Security for ledger';
         COMMENT ON COLUMN user_active_security.us_action IS 'Security for action';
+
+        CREATE TABLE user_sec_action_profile (
+          ua_id BIGSERIAL PRIMARY KEY,
+          ua_right CHAR NULL,
+          CONSTRAINT user_sec_action_profile_ua_right_check CHECK (ua_right = ANY ARRAY['R':::STRING::CHAR, 'W':::STRING::CHAR]:::CHAR[])
+        );
     "#};
 
     api.raw_cmd(raw_sql).await;
@@ -88,12 +98,24 @@ async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
         }
 
         /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
+        model todo_list {
+          tl_id     BigInt @id @default(autoincrement())
+          is_public String @default("N") @db.Char(1)
+        }
+
+        /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
         /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         model user_active_security {
-          id        BigInt @id(map: "user_active_security_pk") @default(sequence(maxValue: 2147483647))
+          id        BigInt @id(map: "user_active_security_pk") @default(autoincrement())
           us_login  String
           us_ledger String @db.String(1)
           us_action String @db.String(1)
+        }
+
+        /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
+        model user_sec_action_profile {
+          ua_id    BigInt  @id @default(autoincrement())
+          ua_right String? @db.Char(1)
         }
     "#]];
 
@@ -103,8 +125,10 @@ async fn noalyss_folder_test_cockroachdb(api: &mut TestApi) -> TestResult {
         *** WARNING ***
 
         These constraints are not supported by the Prisma Client, because Prisma currently does not fully support check constraints. Read more: https://pris.ly/d/postgres-check-constraints
+          - Model: "todo_list", constraint: "ck_is_public"
           - Model: "user_active_security", constraint: "user_active_security_action_check"
           - Model: "user_active_security", constraint: "user_active_security_ledger_check"
+          - Model: "user_sec_action_profile", constraint: "user_sec_action_profile_ua_right_check"
 
         These objects have comments defined in the database, which is not yet fully supported. Read more: https://pris.ly/d/database-comments
           - Type: "field", name: "user_active_security.us_login"

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
@@ -1,3 +1,4 @@
+mod constraints;
 mod gin;
 
 use indoc::indoc;

--- a/schema-engine/sql-introspection-tests/tests/postgres/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/constraints.rs
@@ -55,18 +55,24 @@ async fn aragon_test_postgres(api: &mut TestApi) -> TestResult {
     Ok(())
 }
 
-#[test_connector(tags(CockroachDb))]
-async fn aragon_test_cockroachdb(api: &mut TestApi) -> TestResult {
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
     let raw_sql = indoc! {r#"
-        CREATE TABLE users (
-            user_id INT8 PRIMARY KEY
+        CREATE SEQUENCE user_active_security_id_seq MINVALUE 1 MAXVALUE 2147483647 INCREMENT 1 START 1;
+
+        CREATE TABLE user_active_security (
+            id INT8 NOT NULL DEFAULT nextval('user_active_security_id_seq'::REGCLASS),
+            us_login TEXT NOT NULL,
+            us_ledger VARCHAR(1) NOT NULL,
+            us_action VARCHAR(1) NOT NULL,
+            CONSTRAINT user_active_security_pk PRIMARY KEY (id),
+            CONSTRAINT user_active_security_action_check CHECK (us_action::TEXT = ANY (ARRAY['Y', 'N'])),
+            CONSTRAINT user_active_security_ledger_check CHECK (us_ledger::TEXT = ANY (ARRAY['Y', 'N']))
         );
-        
-        CREATE TABLE tokens (
-            token_id INT8 PRIMARY KEY,
-            token_scope STRING NULL,
-            CONSTRAINT tokens_token_scope_check CHECK (token_scope = ANY ARRAY['MAGICLINK':::STRING, 'API':::STRING]:::STRING[])
-        );
+
+        COMMENT ON COLUMN user_active_security.us_login IS e'user\'s login';
+        COMMENT ON COLUMN user_active_security.us_ledger IS 'Flag Security for ledger';
+        COMMENT ON COLUMN user_active_security.us_action IS 'Security for action';
     "#};
 
     api.raw_cmd(raw_sql).await;
@@ -77,18 +83,17 @@ async fn aragon_test_cockroachdb(api: &mut TestApi) -> TestResult {
         }
 
         datasource db {
-          provider = "cockroachdb"
+          provider = "postgresql"
           url      = "env(TEST_DATABASE_URL)"
         }
 
         /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
-        model tokens {
-          token_id    BigInt  @id
-          token_scope String?
-        }
-
-        model users {
-          user_id BigInt @id
+        /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
+        model user_active_security {
+          id        BigInt @id(map: "user_active_security_pk") @default(autoincrement())
+          us_login  String
+          us_ledger String @db.VarChar(1)
+          us_action String @db.VarChar(1)
         }
     "#]];
 
@@ -98,7 +103,13 @@ async fn aragon_test_cockroachdb(api: &mut TestApi) -> TestResult {
         *** WARNING ***
 
         These constraints are not supported by the Prisma Client, because Prisma currently does not fully support check constraints. Read more: https://pris.ly/d/postgres-check-constraints
-          - Model: "tokens", constraint: "tokens_token_scope_check"
+          - Model: "user_active_security", constraint: "user_active_security_action_check"
+          - Model: "user_active_security", constraint: "user_active_security_ledger_check"
+
+        These objects have comments defined in the database, which is not yet fully supported. Read more: https://pris.ly/d/database-comments
+          - Type: "field", name: "user_active_security.us_login"
+          - Type: "field", name: "user_active_security.us_ledger"
+          - Type: "field", name: "user_active_security.us_action"
     "#]];
 
     api.expect_warnings(&expectation).await;

--- a/schema-engine/sql-introspection-tests/tests/postgres/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/constraints.rs
@@ -58,11 +58,6 @@ async fn aragon_test_postgres(api: &mut TestApi) -> TestResult {
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
     let raw_sql = indoc! {r#"
-        CREATE TABLE todo_list (
-            tl_id BIGSERIAL PRIMARY KEY,
-            is_public CHAR(1) NOT NULL DEFAULT 'N' CHECK (is_public IN ('Y', 'N'))
-        );
-    
         CREATE TABLE user_active_security (
             id BIGSERIAL NOT NULL,
             us_login TEXT NOT NULL,
@@ -80,7 +75,12 @@ async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
         CREATE TABLE user_sec_action_profile (
           ua_id BIGSERIAL PRIMARY KEY,
           ua_right CHAR(1) CHECK (ua_right IN ('R', 'W'))
-        );        
+        );
+
+        CREATE TABLE todo_list (
+          tl_id BIGSERIAL PRIMARY KEY,
+          is_public CHAR(1) NOT NULL DEFAULT 'N' CHECK (is_public IN ('Y', 'N'))
+      );
     "#};
 
     api.raw_cmd(raw_sql).await;

--- a/schema-engine/sql-introspection-tests/tests/postgres/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/constraints.rs
@@ -58,10 +58,13 @@ async fn aragon_test_postgres(api: &mut TestApi) -> TestResult {
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
 async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
     let raw_sql = indoc! {r#"
-        CREATE SEQUENCE user_active_security_id_seq MINVALUE 1 MAXVALUE 2147483647 INCREMENT 1 START 1;
-
+        CREATE TABLE todo_list (
+            tl_id BIGSERIAL PRIMARY KEY,
+            is_public CHAR(1) NOT NULL DEFAULT 'N' CHECK (is_public IN ('Y', 'N'))
+        );
+    
         CREATE TABLE user_active_security (
-            id INT8 NOT NULL DEFAULT nextval('user_active_security_id_seq'::REGCLASS),
+            id BIGSERIAL NOT NULL,
             us_login TEXT NOT NULL,
             us_ledger VARCHAR(1) NOT NULL,
             us_action VARCHAR(1) NOT NULL,
@@ -73,6 +76,11 @@ async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
         COMMENT ON COLUMN user_active_security.us_login IS e'user\'s login';
         COMMENT ON COLUMN user_active_security.us_ledger IS 'Flag Security for ledger';
         COMMENT ON COLUMN user_active_security.us_action IS 'Security for action';
+
+        CREATE TABLE user_sec_action_profile (
+          ua_id BIGSERIAL PRIMARY KEY,
+          ua_right CHAR(1) CHECK (ua_right IN ('R', 'W'))
+        );        
     "#};
 
     api.raw_cmd(raw_sql).await;
@@ -88,12 +96,24 @@ async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
         }
 
         /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
+        model todo_list {
+          tl_id     BigInt @id @default(autoincrement())
+          is_public String @default("N") @db.Char(1)
+        }
+
+        /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
         /// This model or at least one of its fields has comments in the database, and requires an additional setup for migrations: Read more: https://pris.ly/d/database-comments
         model user_active_security {
           id        BigInt @id(map: "user_active_security_pk") @default(autoincrement())
           us_login  String
           us_ledger String @db.VarChar(1)
           us_action String @db.VarChar(1)
+        }
+
+        /// This table contains check constraints and requires additional setup for migrations. Visit https://pris.ly/d/postgres-check-constraints for more info.
+        model user_sec_action_profile {
+          ua_id    BigInt  @id @default(autoincrement())
+          ua_right String? @db.Char(1)
         }
     "#]];
 
@@ -103,8 +123,10 @@ async fn noalyss_folder_test_postgres(api: &mut TestApi) -> TestResult {
         *** WARNING ***
 
         These constraints are not supported by the Prisma Client, because Prisma currently does not fully support check constraints. Read more: https://pris.ly/d/postgres-check-constraints
+          - Model: "todo_list", constraint: "todo_list_is_public_check"
           - Model: "user_active_security", constraint: "user_active_security_action_check"
           - Model: "user_active_security", constraint: "user_active_security_ledger_check"
+          - Model: "user_sec_action_profile", constraint: "user_sec_action_profile_ua_right_check"
 
         These objects have comments defined in the database, which is not yet fully supported. Read more: https://pris.ly/d/database-comments
           - Type: "field", name: "user_active_security.us_login"

--- a/schema-engine/sql-schema-describer/src/postgres/constraints_query.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/constraints_query.sql
@@ -13,4 +13,4 @@ JOIN pg_namespace AS schemainfo
 	ON schemainfo.oid = tableinfo.relnamespace
 WHERE schemainfo.nspname = ANY ( $1 )
 	AND contype NOT IN ('p', 'u', 'f')
-ORDER BY constr.contype;
+ORDER BY namespace, table_name, constr.contype, constraint_name;


### PR DESCRIPTION
This PR:
- sorts check and exclusion constraints explicitly by model and constraint name.
- adds new tests for Postgres and CockroachDB inspired by `introspection-ci`
- fixes https://github.com/prisma/schema-team/issues/400.