### PR TITLE
fix(schema-engine): close #18776, panic on `row.get_expect_string("create_options")` using MySQL

### DIFF
--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -292,7 +292,9 @@ impl<'a> SqlSchemaDescriber<'a> {
         let names = rows.into_iter().map(|row| {
             (
                 row.get_expect_string("table_name"),
-                row.get_string("create_options").filter(|c| c == "partitioned"),
+                row.get_string("create_options")
+                    .filter(|c| c.as_str() == "partitioned")
+                    .is_some(),
                 row.get_string("table_comment").filter(|c| !c.is_empty()),
             )
         });

--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -292,7 +292,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         let names = rows.into_iter().map(|row| {
             (
                 row.get_expect_string("table_name"),
-                row.get_expect_string("create_options") == "partitioned",
+                row.get_string("create_options").filter(|c| c == "partitioned"),
                 row.get_string("table_comment").filter(|c| !c.is_empty()),
             )
         });


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma/issues/18776.

**Note**: Although I'm not able to reproduce https://github.com/prisma/prisma/issues/18776, this one-liner change should fix it.

In fact, if we take a look at the stacktrace

```
Error: Error in migration engine.
Reason: [libs/sql-schema-describer/src/mysql.rs:293:21] called `Result::unwrap()` on an `Err` value: "Getting create_options from Resultrow ResultRow { columns: [\"table_name\", \"create_options\"], values: [Bytes(Some([85, 115, 101, 114])), Text(None)] } as String failed"
```

we notice that the value of `create_options` is `Text(None)`, rather than `Text(Some("..."))`.
This implies that replacing

```rust
row.get_expect_string("create_options") == "partitioned",
```

with 

```rust
row.get_string("create_options").filter(|c| c == "partitioned"),
```

should be enough to fix the issue.