### PR TITLE
nix: remove duplicate darwin packages from shell.nix

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,9 +5,7 @@ let
 in
 {
   devShells.default = pkgs.mkShell {
-    packages = with pkgs;
-      [ devToolchain llvmPackages_latest.bintools ]
-      ++ lib.optionals stdenv.isDarwin [ darwin.apple_sdk.frameworks.Security ];
+    packages = [ devToolchain pkgs.llvmPackages_latest.bintools ];
     inputsFrom = [ self'.packages.prisma-engines ];
     shellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux
       "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";


### PR DESCRIPTION
We already inherit these packages from the `prisma-engines` package
via `inputsFrom`, there's no need to specify them twice.
