### PR TITLE
feat(quaint): add support for Value::Char in MySQL SELECT queries

### DIFF
--- a/quaint/.envrc
+++ b/quaint/.envrc
@@ -1,4 +1,4 @@
-export TEST_MYSQL="mysql://root:prisma@localhost:3306/prisma"
+export TEST_MYSQL="mysql://root:root@localhost:3306/tests"
 export TEST_MYSQL8="mysql://root:prisma@localhost:3307/prisma"
 export TEST_MYSQL_MARIADB="mysql://root:prisma@localhost:3308/prisma"
 export TEST_PSQL="postgres://postgres:prisma@localhost:5432/postgres"

--- a/quaint/src/connector/mysql/conversion.rs
+++ b/quaint/src/connector/mysql/conversion.rs
@@ -263,6 +263,7 @@ impl TakeRow for my::Row {
                     [0] => Value::boolean(false),
                     _ => Value::boolean(true),
                 },
+                my::Value::Bytes(c) if c.len() == 1 => Value::character(c[0] as char),
                 // https://dev.mysql.com/doc/internals/en/character-set.html
                 my::Value::Bytes(b) if column.character_set() == 63 => Value::bytes(b),
                 my::Value::Bytes(s) => Value::text(String::from_utf8(s)?),

--- a/quaint/src/tests/types/mysql.rs
+++ b/quaint/src/tests/types/mysql.rs
@@ -158,7 +158,13 @@ test_type!(bit64(
     Value::bytes(vec![0, 0, 0, 0, 0, 6, 107, 58])
 ));
 
-test_type!(char(mysql, "char(255)", Value::Text(None), Value::text("foobar")));
+test_type!(char(
+    mysql,
+    "char",
+    (Value::Char(None), Value::Text(None)),
+    (Value::character('c'), Value::character('c'))
+));
+test_type!(char_255(mysql, "char(255)", Value::Text(None), Value::text("foobar")));
 test_type!(float(mysql, "float", Value::Float(None), Value::float(1.12345),));
 test_type!(double(mysql, "double", Value::Double(None), Value::double(1.12314124)));
 test_type!(varchar(mysql, "varchar(255)", Value::Text(None), Value::text("foobar")));


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-engines/issues/3943.