### PR TITLE
Build Windows engines with static MSVCRT

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,8 +12,9 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
+      RUSTFLAGS: "-C target-feature=+crt-static"
     runs-on: windows-latest
-    
+
     steps:
       - name: Output link to real commit
         run: echo ${{ github.repository }}/commit/${{ github.event.inputs.commit }}


### PR DESCRIPTION
Statically link CRT on Windows. Unlike on Linux, on Windows this is possible for libraries too, so this works even for the Node-API addon.

Other projects are also doing this, for example see this VSCode PR: https://github.com/microsoft/vscode/pull/164532

This makes Prisma work out-of-the-box on a freshly installed Windows without requiring the user to manually download and install MSVCRT or rely on other software silently installing it.

AFAIK, some versions or editions of Windows might come with MSVCRT DLLs pre-installed (I think @janpio did some investigation previously) but for me the issue was immediately reproducible on the latest version (22H2) of Windows 10 Home.

The size impact for us is ranging from 126.5 KB for `query-engine.dll.node` to 130.5 KB for `migration-engine.exe`.

Fixes: https://github.com/prisma/prisma/issues/9940
Fixes: https://github.com/prisma/prisma/issues/9975
Fixes: https://github.com/prisma/prisma/issues/13648
Fixes: https://github.com/prisma/prisma/issues/17887
Closes: https://github.com/prisma/client-planning/issues/333

---

Before this change:

![Screenshot from 2023-05-03 18-00-27](https://user-images.githubusercontent.com/4923335/235974181-34423315-aab3-4e63-93d1-f1675e69f6f2.png)
![Screenshot from 2023-05-03 18-01-07](https://user-images.githubusercontent.com/4923335/235974212-5bf1ce62-2993-45ed-9a88-f1ba8721b6ef.png)

After this change:

![Screenshot from 2023-05-03 18-02-06](https://user-images.githubusercontent.com/4923335/235974255-d00f5547-8ed6-4108-aad8-674b64283770.png)

All Windows tests also passing on the client side: https://github.com/prisma/prisma/pull/19060