### PR TITLE
fix(json): support list of tagged json

### DIFF
--- a/query-engine/core/src/query_document/argument_value.rs
+++ b/query-engine/core/src/query_document/argument_value.rs
@@ -76,7 +76,7 @@ impl ArgumentValue {
     pub fn can_be_parsed_as_json(&self) -> bool {
         match self {
             ArgumentValue::Object(_) => true,
-            ArgumentValue::List(_) => true,
+            ArgumentValue::List(l) => l.iter().all(|v| v.can_be_parsed_as_json()),
             ArgumentValue::Scalar(pv) => !matches!(pv, PrismaValue::Enum(_) | PrismaValue::Json(_)),
             ArgumentValue::FieldRef(_) => false,
         }

--- a/query-engine/core/src/query_document/argument_value.rs
+++ b/query-engine/core/src/query_document/argument_value.rs
@@ -73,10 +73,10 @@ impl ArgumentValue {
         }
     }
 
-    pub fn can_be_parsed_as_json(&self) -> bool {
+    pub fn should_be_parsed_as_json(&self) -> bool {
         match self {
             ArgumentValue::Object(_) => true,
-            ArgumentValue::List(l) => l.iter().all(|v| v.can_be_parsed_as_json()),
+            ArgumentValue::List(l) => l.iter().all(|v| v.should_be_parsed_as_json()),
             ArgumentValue::Scalar(pv) => !matches!(pv, PrismaValue::Enum(_) | PrismaValue::Json(_)),
             ArgumentValue::FieldRef(_) => false,
         }

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -223,7 +223,7 @@ impl QueryDocumentParser {
                 // We do not get into this catch-all _if_ the value is already Json, if it's a FieldRef or if it's an Enum.
                 // We don't because they've already been desambiguified at the procotol adapter level.
                 (value, InputType::Scalar(ScalarType::Json))
-                    if value.can_be_parsed_as_json() && get_engine_protocol().is_json() =>
+                    if value.should_be_parsed_as_json() && get_engine_protocol().is_json() =>
                 {
                     Ok(ParsedInputValue::Single(self.to_json(
                         &selection_path,


### PR DESCRIPTION
## Overview

- Lists of tagged json used to be [caught in a catch-all](https://github.com/prisma/prisma-engines/blob/c454edf46d202669405ccad6bd071947dc58d528/query-engine/core/src/query_document/parser.rs#L220-L233) (specific to json protocol) which converted the input to JSON. This prevented `[Json(), Json()]` to be pushed as multiple json values since it was coerced to `Json([Json(), Json()])`.
- Client tests are all green too: https://github.com/prisma/prisma/pull/19058

The catch-all in question:
https://github.com/prisma/prisma-engines/blob/c454edf46d202669405ccad6bd071947dc58d528/query-engine/core/src/query_document/parser.rs#L220-L233