### PR TITLE
qe: write new benchmark suite for query validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3619,6 +3619,7 @@ name = "request-handlers"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
+ "codspeed-criterion-compat",
  "connection-string",
  "dmmf",
  "futures",

--- a/query-engine/core-tests/tests/query_validation_tests.rs
+++ b/query-engine/core-tests/tests/query_validation_tests.rs
@@ -86,7 +86,7 @@ fn format_chunks(chunks: Vec<dissimilar::Chunk<'_>>) -> String {
 fn validate(query: &str, schema: schema::QuerySchemaRef) -> Result<(), request_handlers::HandlerError> {
     let json_request: JsonSingleQuery = serde_json::from_str(query).unwrap();
     let operation = request_handlers::JsonProtocolAdapter::convert_single(json_request, &schema)?;
-    QueryGraphBuilder::new(schema)
+    QueryGraphBuilder::new(&schema)
         .build(operation)
         .map_err(query_core::CoreError::from)?;
     Ok(())

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -33,3 +33,4 @@ cuid = "1.2"
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"
+

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -9,18 +9,18 @@ pub static PRISMA_RENDER_DOT_FILE: Lazy<bool> = Lazy::new(|| match std::env::var
     Err(_) => false,
 });
 
-pub struct QueryGraphBuilder {
-    query_schema: QuerySchemaRef,
+pub struct QueryGraphBuilder<'a> {
+    query_schema: &'a QuerySchema,
 }
 
-impl fmt::Debug for QueryGraphBuilder {
+impl fmt::Debug for QueryGraphBuilder<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryGraphBuilder").finish()
     }
 }
 
-impl QueryGraphBuilder {
-    pub fn new(query_schema: QuerySchemaRef) -> Self {
+impl<'a> QueryGraphBuilder<'a> {
+    pub fn new(query_schema: &'a QuerySchema) -> Self {
         Self { query_schema }
     }
 
@@ -46,7 +46,7 @@ impl QueryGraphBuilder {
         let mut parsed_object = QueryDocumentParser::new(crate::executor::get_request_now()).parse(
             &selections,
             root_object,
-            &self.query_schema,
+            self.query_schema,
         )?;
 
         // Because we're processing root objects, there can only be one query / mutation.

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -27,8 +27,13 @@ sql-query-connector = { path = "../connectors/sql-query-connector", optional = t
 [dev-dependencies]
 insta = "1.7.1"
 schema = { path = "../schema" }
+codspeed-criterion-compat = "1.1.0"
 
 [features]
 default = ["mongodb", "sql"]
 mongodb = ["mongodb-query-connector"]
 sql = ["sql-query-connector"]
+
+[[bench]]
+name = "query_planning_bench"
+harness = false

--- a/query-engine/request-handlers/benches/deep_read_query.json
+++ b/query-engine/request-handlers/benches/deep_read_query.json
@@ -1,0 +1,61 @@
+{
+    "action": "findMany",
+    "modelName": "website",
+    "query": {
+        "selection": {
+            "id": true,
+            "base_language_install_website_rel": {
+                "selection": {
+                    "base_language_install": {
+                        "selection": {
+                            "overwrite": true,
+                            "write_uid": true,
+                            "lang": true
+                        }
+                    }
+                }
+            },
+            "website_page_website_page_website_idTowebsite": {
+                "selection": {
+                    "id": true,
+                    "res_users_website_page_create_uidTores_users": {
+                        "selection": {
+                            "id": true,
+                            "company_id": true,
+                            "create_uid": true,
+                            "res_users_log_res_users_log_create_uidTores_users": {
+                                "selection": {
+                                    "id": true
+                                }
+                            },
+                            "snailmail_letter_snailmail_letter_create_uidTores_users": {
+                                "selection": {
+                                    "id": true,
+                                    "duplex": true,
+                                    "ir_attachment": {
+                                        "selection": {
+                                            "id": true,
+                                            "res_id": true,
+                                            "type": true,
+                                            "mail_channel": {
+                                                "selection": {
+                                                    "id": true,
+                                                    "mail_moderation": {
+                                                        "selection": {
+                                                            "id": true,
+                                                            "email": true
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/query-engine/request-handlers/benches/large_read.json
+++ b/query-engine/request-handlers/benches/large_read.json
@@ -1,0 +1,60 @@
+{
+    "action": "findMany",
+    "modelName": "website",
+    "query": {
+        "selection": {
+            "id": true,
+            "name": true,
+            "company_id": true,
+            "default_lang_id": true,
+            "default_lang_code": true,
+            "social_twitter": true,
+            "auto_redirect_lang": true,
+            "social_github": true,
+            "base_language_install_website_rel": {
+                "selection": {
+                    "base_language_install": {
+                        "selection": {
+                            "overwrite": true,
+                            "state": true,
+                            "create_uid": true,
+                            "create_date": true,
+                            "write_date": true,
+                            "write_uid": true,
+                            "lang": true
+                        }
+                    }
+                }
+            },
+            "website_page_website_page_website_idTowebsite": {
+                "selection": {
+                    "id": true,
+                    "is_published": true,
+                    "url": true,
+                    "view_id": true,
+                    "website_indexed": true,
+                    "date_publish": true,
+                    "header_overlay": true,
+                    "website_id": true,
+                    "create_uid": true,
+                    "create_date": true,
+                    "theme_template_id": true,
+                    "res_users_website_page_create_uidTores_users": {
+                        "selection": {
+                            "id": true,
+                            "company_id": true,
+                            "login": true,
+                            "company_id": true,
+                            "partner_id": true,
+                            "create_date": true,
+                            "signature": true,
+                            "action_id": true,
+                            "action_id": true,
+                            "create_uid": true
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/query-engine/request-handlers/benches/mutation.json
+++ b/query-engine/request-handlers/benches/mutation.json
@@ -1,0 +1,56 @@
+{
+    "action": "updateOne",
+    "modelName": "website",
+    "query": {
+        "arguments": {
+            "where": { "id": 9999999 },
+            "data": {
+                "domain": "bad.horse",
+                "google_maps_api_key": "0000000000000000000000000000000000000000000000000",
+                "social_instagram": "@badhorse",
+                "cdn_activated": false,
+                "auth_signup_uninvited": "rude, just rude",
+                "specific_user_account": true,
+                "res_config_settings": {
+                    "update": {
+                        "where": { "id": 33 },
+                        "data": {
+                            "module_base_import": false,
+                            "module_google_calendar": true
+                        }
+                    }
+                },
+                "res_company": {
+                    "update": {
+                        "res_currency": { "create": { "name": "JPY", "symbol": "¥" } },
+                        "ir_property": {
+                            "create": []
+                        }
+                    }
+                },
+                "res_users_res_users_website_idTowebsite": {
+                    "upsert": {
+                        "where": { "id": 200},
+                        "update": {
+                            "login": "Evil Corp"
+                        },
+                        "create": {
+                            "login": "Evil Corp",
+                            "notification_type": "meowing",
+                            "odoobot_state": "it's aight",
+                            "res_company_res_users_company_idTores_company": {
+                                "connect": { "id": 210390 }
+                            },
+                            "res_partner_res_users_partner_idTores_partner": {
+                                "connect": { "id": 810390 }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "selection": {
+            "id": true
+        }
+    }
+}

--- a/query-engine/request-handlers/benches/query_planning_bench.rs
+++ b/query-engine/request-handlers/benches/query_planning_bench.rs
@@ -1,0 +1,72 @@
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Criterion};
+use query_core::{query_graph_builder::QueryGraphBuilder, *};
+use request_handlers::JsonSingleQuery;
+use schema::QuerySchema;
+use std::sync::Arc;
+
+const SCHEMA: &str = include_str!("../../schema/test-schemas/odoo.prisma");
+
+const QUERIES: &[(&str, &str)] = &[
+    (
+        "small_read",
+        r#"
+        { "action": "findMany", "modelName": "website_redirect", "query": { "selection": { "id": true } } }
+        "#,
+    ),
+    (
+        "medium_read",
+        r#"
+        {
+            "action": "findMany",
+            "modelName": "website_redirect",
+            "query": {
+                "selection": {
+                    "id": true,
+                    "create_uid": true,
+                    "create_date": true,
+                    "type": true,
+                    "active": true,
+                    "sequence": true,
+                    "url_from": true,
+                    "url_to": true,
+                    "website": {
+                        "selection": {
+                            "id": true,
+                            "name": true,
+                            "company_id": true,
+                            "default_lang_id": true,
+                            "default_lang_code": true,
+                            "social_twitter": true
+                        }
+                    }
+                }
+            }
+        }
+        "#,
+    ),
+    ("large_read", include_str!("./large_read.json")),
+    ("deep_read_query", include_str!("./deep_read_query.json")),
+    ("mutation", include_str!("./mutation.json")),
+];
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let validated_schema = psl::parse_schema(SCHEMA).unwrap();
+    let query_schema = schema::build(Arc::new(validated_schema), true);
+
+    for (name, query) in QUERIES {
+        c.bench_function(name, |b| b.iter(|| validate_and_plan(query, &query_schema)));
+    }
+}
+
+fn validate_and_plan(query: &str, schema: &QuerySchema) {
+    fn validate_and_plan_impl(query: &str, schema: &QuerySchema) {
+        let json_request: JsonSingleQuery = serde_json::from_str(query).unwrap();
+        let operation = request_handlers::JsonProtocolAdapter::convert_single(json_request, &schema).unwrap();
+        QueryGraphBuilder::new(&schema).build(operation).unwrap();
+    }
+
+    black_box(validate_and_plan_impl(query, schema))
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use prisma_models::{decode_bytes, parse_datetime, prelude::ParentContainer, Field};
 use query_core::{
     constants::custom_types,
-    schema::{ObjectType, OutputField, QuerySchema, QuerySchemaRef},
+    schema::{ObjectType, OutputField, QuerySchema},
     ArgumentValue, Operation, Selection,
 };
 use serde_json::Value as JsonValue;
@@ -18,7 +18,7 @@ enum OperationType {
 pub struct JsonProtocolAdapter;
 
 impl JsonProtocolAdapter {
-    pub fn convert_single(query: JsonSingleQuery, query_schema: &QuerySchemaRef) -> crate::Result<Operation> {
+    pub fn convert_single(query: JsonSingleQuery, query_schema: &QuerySchema) -> crate::Result<Operation> {
         let JsonSingleQuery {
             model_name,
             action,
@@ -40,7 +40,7 @@ impl JsonProtocolAdapter {
         field: &OutputField,
         container: Option<&ParentContainer>,
         query: FieldQuery,
-        query_schema: &QuerySchemaRef,
+        query_schema: &QuerySchema,
     ) -> crate::Result<Selection> {
         let FieldQuery {
             arguments,
@@ -248,7 +248,7 @@ impl JsonProtocolAdapter {
         parent_field: &OutputField,
         nested_field_name: &str,
         container: Option<&ParentContainer>,
-        query_schema: &QuerySchemaRef,
+        query_schema: &QuerySchema,
         all_scalars_set: bool,
     ) -> crate::Result<Selection> {
         let nested_object_type = parent_field
@@ -386,7 +386,7 @@ impl JsonProtocolAdapter {
     }
 
     fn find_schema_field(
-        query_schema: &QuerySchemaRef,
+        query_schema: &QuerySchema,
         model_name: Option<String>,
         action: crate::Action,
     ) -> crate::Result<(OperationType, &OutputField)> {
@@ -414,7 +414,7 @@ mod tests {
     use query_core::schema;
     use std::sync::Arc;
 
-    fn schema() -> schema::QuerySchemaRef {
+    fn schema() -> schema::QuerySchema {
         let schema_str = r#"
           generator client {
             provider        = "prisma-client-js"
@@ -457,7 +457,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        Arc::new(schema::build(Arc::new(schema), true))
+        schema::build(Arc::new(schema), true)
     }
 
     #[test]
@@ -1412,7 +1412,7 @@ mod tests {
         "###);
     }
 
-    fn composite_schema() -> schema::QuerySchemaRef {
+    fn composite_schema() -> schema::QuerySchema {
         let schema_str = r#"
           generator client {
             provider        = "prisma-client-js"
@@ -1444,7 +1444,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        Arc::new(schema::build(Arc::new(schema), true))
+        schema::build(Arc::new(schema), true)
     }
 
     #[test]
@@ -1551,7 +1551,7 @@ mod tests {
         "###);
     }
 
-    fn recursive_composite_schema() -> schema::QuerySchemaRef {
+    fn recursive_composite_schema() -> schema::QuerySchema {
         let schema_str = r#"
           generator client {
             provider        = "prisma-client-js"
@@ -1576,7 +1576,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        Arc::new(schema::build(Arc::new(schema), true))
+        schema::build(Arc::new(schema), true)
     }
 
     #[test]
@@ -1605,7 +1605,7 @@ mod tests {
         "###);
     }
 
-    fn sibling_composite_schema() -> schema::QuerySchemaRef {
+    fn sibling_composite_schema() -> schema::QuerySchema {
         let schema_str = r#"
           generator client {
             provider        = "prisma-client-js"
@@ -1633,7 +1633,7 @@ mod tests {
 
         schema.diagnostics.to_result().unwrap();
 
-        Arc::new(schema::build(Arc::new(schema), true))
+        schema::build(Arc::new(schema), true)
     }
 
     #[test]

--- a/query-engine/schema/benches/schema_builder_bench.rs
+++ b/query-engine/schema/benches/schema_builder_bench.rs
@@ -4,7 +4,7 @@ const SMALL: (&str, &str) = ("small", include_str!("../test-schemas/standupbot.p
 const MEDIUM: (&str, &str) = ("medium", include_str!("../test-schemas/noalyss_folder.prisma"));
 const LARGE: (&str, &str) = ("large", include_str!("../test-schemas/odoo.prisma"));
 
-pub fn criterion_benchmark(c: &mut Criterion) {
+fn criterion_benchmark(c: &mut Criterion) {
     for (name, prisma_schema) in [SMALL, MEDIUM, LARGE] {
         let source_file: psl::SourceFile = prisma_schema.into();
 


### PR DESCRIPTION
This fills a gap: we have no benchmark that measures the execution speed of  query validation and planning, i.e. the work that happens in the query engine between when a Prisma Client request arrives and the start of the first database request to answer that client request. The code path tested here is connector agnostic and pure (no IO), so the measurements should be relatively stable.

The main goal with this benchmarks suite is to catch potential regressions as we move more work from query engine initialization time ("schema builder") to query processing time, in an effort to improve startup times in serverless contexts.

part of https://github.com/prisma/client-planning/issues/344
closes https://github.com/prisma/client-planning/issues/345