### PR TITLE
qe/ci: run query validation benchmarks with codspped

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,14 +24,14 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: cargo bench --bench schema_builder_bench
-
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed
 
-      - name: Build the benchmark target(s)
-        run: cargo codspeed build
-        working-directory: ./query-engine/schema
+      - name: 'Build the benchmark targets: schema'
+        run: cargo codspeed build -p schema
+
+      - name: 'Build the benchmark targets: request-handlers'
+        run: cargo codspeed build -p request-handlers
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v1


### PR DESCRIPTION
For continuous monitoring and to spot performance regressions. In local bench runs, I saw more variability on these new benchmarks than on the schema-builder ones, let's see if we need to up the threshold to report perf regressions in codspeed.