### PR TITLE
qe: remove XML scalar type

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -24,7 +24,6 @@ pub enum PrismaValue {
     Uuid(Uuid),
     List(PrismaListValue),
     Json(String),
-    Xml(String),
 
     /// A collections of key-value pairs constituting an object.
     #[serde(serialize_with = "serialize_object")]
@@ -319,7 +318,6 @@ impl fmt::Display for PrismaValue {
             PrismaValue::Null => "null".fmt(f),
             PrismaValue::Uuid(x) => x.fmt(f),
             PrismaValue::Json(x) => x.fmt(f),
-            PrismaValue::Xml(x) => x.fmt(f),
             PrismaValue::BigInt(x) => x.fmt(f),
             PrismaValue::List(x) => {
                 let as_string = format!("{x:?}");

--- a/query-engine/connectors/mongodb-query-connector/src/value.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/value.rs
@@ -271,7 +271,6 @@ impl IntoBson for (&TypeIdentifier, PrismaValue) {
             ),
 
             // Unhandled mappings
-            (TypeIdentifier::Xml, _) => return Err(MongoError::Unsupported("Mongo doesn't support XML.".to_owned())),
             (TypeIdentifier::Unsupported, _) => unreachable!("Unsupported types should never hit the connector."),
 
             (ident, val) => {

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
@@ -25,7 +25,6 @@ impl ScalarFieldExt for ScalarField {
             (PrismaValue::List(l), _) => Value::Array(Some(l.into_iter().map(|x| self.value(x)).collect())),
             (PrismaValue::Json(s), _) => Value::Json(Some(serde_json::from_str::<serde_json::Value>(&s).unwrap())),
             (PrismaValue::Bytes(b), _) => Value::Bytes(Some(b.into())),
-            (PrismaValue::Xml(s), _) => Value::Xml(Some(s.into())),
             (PrismaValue::Object(_), _) => unimplemented!(),
             (PrismaValue::Null, ident) => match ident {
                 TypeIdentifier::String => Value::Text(None),
@@ -39,7 +38,6 @@ impl ScalarFieldExt for ScalarField {
                 TypeIdentifier::Int => Value::Int32(None),
                 TypeIdentifier::BigInt => Value::Int64(None),
                 TypeIdentifier::Bytes => Value::Bytes(None),
-                TypeIdentifier::Xml => Value::Xml(None),
                 TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),
             },
         }
@@ -64,7 +62,6 @@ impl ScalarFieldExt for ScalarField {
             TypeIdentifier::Enum(_) => TypeFamily::Text(Some(TypeDataLength::Constant(8000))),
             TypeIdentifier::UUID => TypeFamily::Uuid,
             TypeIdentifier::Json => TypeFamily::Text(Some(TypeDataLength::Maximum)),
-            TypeIdentifier::Xml => TypeFamily::Text(Some(TypeDataLength::Maximum)),
             TypeIdentifier::DateTime => TypeFamily::DateTime,
             TypeIdentifier::Bytes => TypeFamily::Text(parse_scalar_length(self)),
             TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),
@@ -87,7 +84,6 @@ pub fn convert_lossy<'a>(pv: PrismaValue) -> Value<'a> {
         PrismaValue::List(l) => Value::Array(Some(l.into_iter().map(convert_lossy).collect())),
         PrismaValue::Json(s) => Value::Json(serde_json::from_str(&s).unwrap()),
         PrismaValue::Bytes(b) => Value::Bytes(Some(b.into())),
-        PrismaValue::Xml(s) => Value::Xml(Some(s.into())),
         PrismaValue::Null => Value::Int32(None), // Can't tell which type the null is supposed to be.
         PrismaValue::Object(_) => unimplemented!(),
     }

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -287,12 +287,6 @@ fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result
             Value::Bytes(Some(bytes)) => PrismaValue::Bytes(bytes.into()),
             _ => return Err(create_error(&p_value)),
         },
-        TypeIdentifier::Xml => match p_value {
-            value if value.is_null() => PrismaValue::Null,
-            Value::Xml(Some(xml)) => PrismaValue::Xml(xml.to_string()),
-            Value::Text(Some(s)) => PrismaValue::Xml(s.into_owned()),
-            _ => return Err(create_error(&p_value)),
-        },
         TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),
     })
 }

--- a/query-engine/connectors/sql-query-connector/src/value.rs
+++ b/query-engine/connectors/sql-query-connector/src/value.rs
@@ -84,7 +84,9 @@ pub fn to_prisma_value(quaint_value: Value<'_>) -> crate::Result<PrismaValue> {
             .map(|b| PrismaValue::Bytes(b.into_owned()))
             .unwrap_or(PrismaValue::Null),
 
-        Value::Xml(s) => s.map(|s| PrismaValue::Xml(s.into_owned())).unwrap_or(PrismaValue::Null),
+        Value::Xml(s) => s
+            .map(|s| PrismaValue::String(s.into_owned()))
+            .unwrap_or(PrismaValue::Null),
     };
 
     Ok(val)

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -361,7 +361,6 @@ impl QueryDocumentParser {
             (PrismaValue::String(s), ScalarType::String) => Ok(PrismaValue::String(s)),
             (PrismaValue::Boolean(b), ScalarType::Boolean) => Ok(PrismaValue::Boolean(b)),
             (PrismaValue::Json(json), ScalarType::Json) => Ok(PrismaValue::Json(json)),
-            (PrismaValue::Xml(xml), ScalarType::Xml) => Ok(PrismaValue::Xml(xml)),
             (PrismaValue::Uuid(uuid), ScalarType::UUID) => Ok(PrismaValue::Uuid(uuid)),
             (PrismaValue::Bytes(bytes), ScalarType::Bytes) => Ok(PrismaValue::Bytes(bytes)),
             (PrismaValue::BigInt(b_int), ScalarType::BigInt) => Ok(PrismaValue::BigInt(b_int)),
@@ -369,7 +368,6 @@ impl QueryDocumentParser {
             (PrismaValue::Null, ScalarType::Null) => Ok(PrismaValue::Null),
 
             // String coercion matchers
-            (PrismaValue::String(s), ScalarType::Xml) => Ok(PrismaValue::Xml(s)),
             (PrismaValue::String(s), ScalarType::JsonList) => {
                 self.parse_json_list_from_str(selection_path, argument_path, &s)
             }
@@ -892,7 +890,6 @@ pub(crate) mod conversions {
                 format!("({})", itertools::join(v.iter().map(prisma_value_to_type_name), ", "))
             }
             PrismaValue::Json(_) => "JSON".to_string(),
-            PrismaValue::Xml(_) => "XML".to_string(),
             PrismaValue::Object(_) => "Object".to_string(),
             PrismaValue::Null => "Null".to_string(),
             PrismaValue::DateTime(_) => "DateTime".to_string(),

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -582,15 +582,11 @@ fn convert_prisma_value_graphql_protocol(
         (ScalarType::DateTime, PrismaValue::DateTime(dt)) => PrismaValue::DateTime(dt),
         (ScalarType::UUID, PrismaValue::Uuid(u)) => PrismaValue::Uuid(u),
         (ScalarType::Bytes, PrismaValue::Bytes(b)) => PrismaValue::Bytes(b),
-        (ScalarType::Xml, PrismaValue::Xml(b)) => PrismaValue::Xml(b),
 
         // The Decimal type doesn't have a corresponding PrismaValue variant. We need to serialize it
         // to String so that client can deserialize it as Decimal again.
         (ScalarType::Decimal, PrismaValue::Int(i)) => PrismaValue::String(i.to_string()),
         (ScalarType::Decimal, PrismaValue::Float(f)) => PrismaValue::String(f.to_string()),
-        // TODO: Remove this, it is a hack. The Xml type no longer exists as a Prisma native type.
-        // TODO: It should not exist as a ScalarType, TypeIdentifier, or PrismaValue.
-        (ScalarType::String, PrismaValue::Xml(xml)) => PrismaValue::String(xml),
 
         (st, pv) => {
             return Err(crate::FieldConversionError::create(
@@ -636,11 +632,6 @@ fn convert_prisma_value_json_protocol(
         (ScalarType::Boolean, PrismaValue::Boolean(x)) => PrismaValue::Boolean(x),
         (ScalarType::Int, PrismaValue::Int(x)) => PrismaValue::Int(x),
         (ScalarType::Float, PrismaValue::Float(x)) => PrismaValue::Float(x),
-
-        // TODO: Xml is no longer a native Prisma type. It should not exist as special PrismaValue.
-        (ScalarType::String | ScalarType::Xml, PrismaValue::Xml(xml) | PrismaValue::String(xml)) => {
-            PrismaValue::String(xml)
-        }
 
         (st, pv) => {
             return Err(crate::FieldConversionError::create(

--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -263,7 +263,6 @@ fn prisma_value_to_serde(value: &PrismaValue) -> serde_json::Value {
         PrismaValue::Null => serde_json::Value::Null,
         PrismaValue::Uuid(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::Json(val) => serde_json::Value::String(val.to_string()),
-        PrismaValue::Xml(val) => serde_json::Value::String(val.to_string()),
         PrismaValue::List(value_vec) => serde_json::Value::Array(value_vec.iter().map(prisma_value_to_serde).collect()),
         PrismaValue::Bytes(b) => serde_json::Value::String(encode_bytes(b)),
         PrismaValue::Object(pairs) => {

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
@@ -48,7 +48,6 @@ pub(super) fn render_output_type<'a>(output_type: &OutputType<'a>, ctx: &mut Ren
                 ScalarType::Json => "Json",
                 ScalarType::UUID => "UUID",
                 ScalarType::JsonList => "Json",
-                ScalarType::Xml => "Xml",
                 ScalarType::Bytes => "Bytes",
             };
 

--- a/query-engine/prisma-models/src/field/mod.rs
+++ b/query-engine/prisma-models/src/field/mod.rs
@@ -153,7 +153,6 @@ pub enum TypeIdentifier {
     Enum(ast::EnumId),
     UUID,
     Json,
-    Xml,
     DateTime,
     Bytes,
     Unsupported,
@@ -181,7 +180,6 @@ impl TypeIdentifier {
             }
             TypeIdentifier::UUID => "UUID".into(),
             TypeIdentifier::Json => "Json".into(),
-            TypeIdentifier::Xml => "Xml".into(),
             TypeIdentifier::DateTime => "DateTime".into(),
             TypeIdentifier::Bytes => "Bytes".into(),
             TypeIdentifier::Unsupported => "Unsupported".into(),

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/type_renderer.rs
@@ -46,7 +46,6 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::Json => "Json",
                     ScalarType::UUID => "UUID",
                     ScalarType::JsonList => "Json",
-                    ScalarType::Xml => "Xml",
                     ScalarType::Bytes => "Bytes",
                     ScalarType::Null => unreachable!("Null types should not be picked for GQL rendering."),
                 };
@@ -85,7 +84,6 @@ impl<'a> GqlTypeRenderer<'a> {
                     ScalarType::Json => "Json",
                     ScalarType::UUID => "UUID",
                     ScalarType::JsonList => "Json",
-                    ScalarType::Xml => "Xml",
                     ScalarType::Bytes => "Bytes",
                     ScalarType::Null => unreachable!("Null types should not be picked for GQL rendering."),
                 };

--- a/query-engine/schema/src/build/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema/src/build/input_types/fields/data_input_mapper/update.rs
@@ -43,7 +43,6 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
                 InputType::object(update_operations_object_type(ctx, "DateTime", sf.clone(), false))
             }
             TypeIdentifier::UUID => InputType::object(update_operations_object_type(ctx, "Uuid", sf.clone(), false)),
-            TypeIdentifier::Xml => InputType::object(update_operations_object_type(ctx, "Xml", sf.clone(), false)),
             TypeIdentifier::Bytes => InputType::object(update_operations_object_type(ctx, "Bytes", sf.clone(), false)),
 
             TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),

--- a/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
@@ -265,9 +265,7 @@ fn full_scalar_filter_type(
                 filters
             }
 
-            TypeIdentifier::Boolean | TypeIdentifier::Xml => {
-                equality_filters(ctx, mapped_scalar_type.clone(), nullable).collect()
-            }
+            TypeIdentifier::Boolean => equality_filters(ctx, mapped_scalar_type.clone(), nullable).collect(),
 
             TypeIdentifier::Bytes | TypeIdentifier::Enum(_) => {
                 equality_filters(ctx, mapped_scalar_type.clone(), nullable)

--- a/query-engine/schema/src/build/input_types/mod.rs
+++ b/query-engine/schema/src/build/input_types/mod.rs
@@ -21,7 +21,6 @@ fn map_scalar_input_type(ctx: &'_ QuerySchema, typ: TypeIdentifier, list: bool) 
         TypeIdentifier::DateTime => InputType::date_time(),
         TypeIdentifier::Json => InputType::json(),
         TypeIdentifier::Enum(id) => InputType::enum_type(map_schema_enum_type(ctx, id)),
-        TypeIdentifier::Xml => InputType::xml(),
         TypeIdentifier::Bytes => InputType::bytes(),
         TypeIdentifier::BigInt => InputType::bigint(),
         TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),

--- a/query-engine/schema/src/build/output_types/field.rs
+++ b/query-engine/schema/src/build/output_types/field.rs
@@ -39,7 +39,6 @@ pub(crate) fn map_scalar_output_type<'a>(ctx: &'a QuerySchema, typ: &TypeIdentif
         TypeIdentifier::DateTime => OutputType::date_time(),
         TypeIdentifier::UUID => OutputType::uuid(),
         TypeIdentifier::Int => OutputType::int(),
-        TypeIdentifier::Xml => OutputType::xml(),
         TypeIdentifier::Bytes => OutputType::bytes(),
         TypeIdentifier::BigInt => OutputType::bigint(),
         TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),

--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -259,10 +259,6 @@ impl<'a> InputType<'a> {
         InputType::Scalar(ScalarType::UUID)
     }
 
-    pub(crate) fn xml() -> InputType<'a> {
-        InputType::Scalar(ScalarType::Xml)
-    }
-
     pub(crate) fn bytes() -> InputType<'a> {
         InputType::Scalar(ScalarType::Bytes)
     }

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -72,10 +72,6 @@ impl<'a> OutputType<'a> {
         InnerOutputType::Scalar(ScalarType::UUID)
     }
 
-    pub(crate) fn xml() -> InnerOutputType<'a> {
-        InnerOutputType::Scalar(ScalarType::Xml)
-    }
-
     pub(crate) fn bytes() -> InnerOutputType<'a> {
         InnerOutputType::Scalar(ScalarType::Bytes)
     }

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -308,7 +308,6 @@ pub enum ScalarType {
     Json,
     JsonList,
     UUID,
-    Xml,
     Bytes,
 }
 
@@ -326,7 +325,6 @@ impl fmt::Display for ScalarType {
             ScalarType::Json => "Json",
             ScalarType::UUID => "UUID",
             ScalarType::JsonList => "Json",
-            ScalarType::Xml => "Xml",
             ScalarType::Bytes => "Bytes",
         };
 

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
@@ -65,7 +65,6 @@ impl<'a> DefaultValuePair<'a> {
             (Some(sql::DefaultKind::Value(PrismaValue::Null)), _) => Some(DefaultKind::Constant(&"null")),
             (Some(sql::DefaultKind::Value(PrismaValue::String(val))), _) => Some(DefaultKind::String(val)),
             (Some(sql::DefaultKind::Value(PrismaValue::Json(val))), _) => Some(DefaultKind::String(val)),
-            (Some(sql::DefaultKind::Value(PrismaValue::Xml(val))), _) => Some(DefaultKind::String(val)),
 
             (Some(sql::DefaultKind::Value(PrismaValue::Boolean(val))), _) => Some(DefaultKind::Constant(val)),
             (Some(sql::DefaultKind::Value(PrismaValue::Enum(variant))), sql::ColumnTypeFamily::Enum(enum_id)) => {
@@ -95,7 +94,7 @@ impl<'a> DefaultValuePair<'a> {
 
             (Some(sql::DefaultKind::Value(PrismaValue::List(vals))), _) => match vals.first() {
                 None => Some(DefaultKind::ConstantList(Vec::new())),
-                Some(PrismaValue::String(_) | PrismaValue::Xml(_) | PrismaValue::Json(_)) => {
+                Some(PrismaValue::String(_) | PrismaValue::Json(_)) => {
                     let vals = vals.iter().filter_map(|val| val.as_string()).collect();
                     Some(DefaultKind::StringList(vals))
                 }


### PR DESCRIPTION
There are traces of it in TypeIdentifier, ScalarType and PrismaValue, either from a deprecated Prisma 1 feature or from a feature idea that never happened. This is noise. This commit removes these enum variants.