### PR TITLE
feat(schema-engine): support circumstances in MySQL

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -96,8 +96,8 @@ impl SqlFlavour for MysqlFlavour {
     }
 
     fn describe_schema(&mut self, _namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<SqlSchema>> {
-        with_connection(&mut self.state, |params, _c, connection| async move {
-            connection.describe_schema(params).await
+        with_connection(&mut self.state, |params, circumstances, connection| async move {
+            connection.describe_schema(circumstances, params).await
         })
     }
 
@@ -427,6 +427,7 @@ impl SqlFlavour for MysqlFlavour {
 pub(crate) enum Circumstances {
     LowerCasesTableNames,
     IsMysql56,
+    IsMysql57,
     IsMariadb,
     IsVitess,
 }
@@ -538,6 +539,10 @@ where
 
                             if global_version.starts_with("5.6") {
                                 circumstances |= Circumstances::IsMysql56;
+                            }
+
+                            if global_version.starts_with("5.7") {
+                                circumstances |= Circumstances::IsMysql57;
                             }
 
                             if global_version.contains("MariaDB") {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/connection.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/connection.rs
@@ -10,7 +10,7 @@ use quaint::{
     prelude::{ConnectionInfo, Queryable},
 };
 use schema_connector::{ConnectorError, ConnectorResult};
-use sql_schema_describer::{DescriberErrorKind, SqlSchema, SqlSchemaDescriberBackend};
+use sql_schema_describer::{DescriberErrorKind, SqlSchema};
 use user_facing_errors::{
     schema_engine::DatabaseSchemaInconsistent,
     schema_engine::{ApplyMigrationError, DirectDdlNotAllowed, ForeignKeyCreationNotAllowed},
@@ -31,9 +31,28 @@ impl Connection {
         ))
     }
 
-    #[tracing::instrument(skip(self, params))]
-    pub(super) async fn describe_schema(&mut self, params: &super::Params) -> ConnectorResult<SqlSchema> {
-        let mut schema = sql_schema_describer::mysql::SqlSchemaDescriber::new(&self.0)
+    #[tracing::instrument(skip(self, circumstances, params))]
+    pub(super) async fn describe_schema(
+        &mut self,
+        circumstances: BitFlags<super::Circumstances>,
+        params: &super::Params,
+    ) -> ConnectorResult<SqlSchema> {
+        use sql_schema_describer::{mysql as describer, SqlSchemaDescriberBackend};
+        let mut describer_circumstances: BitFlags<describer::Circumstances> = Default::default();
+
+        if circumstances.contains(super::Circumstances::IsMariadb) {
+            describer_circumstances |= describer::Circumstances::MariaDb;
+        }
+
+        if circumstances.contains(super::Circumstances::IsMysql56) {
+            describer_circumstances |= describer::Circumstances::MySql56;
+        }
+
+        if circumstances.contains(super::Circumstances::IsMysql57) {
+            describer_circumstances |= describer::Circumstances::MySql57;
+        }
+
+        let mut schema = sql_schema_describer::mysql::SqlSchemaDescriber::new(&self.0, describer_circumstances)
             .describe(&[params.url.dbname()])
             .await
             .map_err(|err| match err.into_kind() {

--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -40,8 +40,19 @@ impl Flavour {
     }
 }
 
+#[enumflags2::bitflags]
+#[derive(Clone, Copy, Debug)]
+#[repr(u8)]
+pub enum Circumstances {
+    MariaDb,
+    MySql56,
+    MySql57,
+}
+
 pub struct SqlSchemaDescriber<'a> {
     conn: &'a dyn Queryable,
+    #[allow(dead_code)]
+    circumstances: BitFlags<Circumstances>,
 }
 
 #[async_trait::async_trait]
@@ -202,8 +213,8 @@ impl Parser for SqlSchemaDescriber<'_> {}
 
 impl<'a> SqlSchemaDescriber<'a> {
     /// Constructor.
-    pub fn new(conn: &'a dyn Queryable) -> SqlSchemaDescriber<'a> {
-        SqlSchemaDescriber { conn }
+    pub fn new(conn: &'a dyn Queryable, circumstances: BitFlags<Circumstances>) -> SqlSchemaDescriber<'a> {
+        SqlSchemaDescriber { conn, circumstances }
     }
 
     #[tracing::instrument(skip(self))]


### PR DESCRIPTION
This allows:
- to unlock https://github.com/prisma/prisma-engines/pull/3944, which needs conditional logic depending on the current MySQL version
- to let the `sql-schema-describer` code for MySQL resemble Postgres much more than currently