### PR TITLE
qe: filter out unique criteria containing an unsupported field

### DIFF
--- a/query-engine/connector-test-kit-rs/README.md
+++ b/query-engine/connector-test-kit-rs/README.md
@@ -3,14 +3,15 @@ The test kit is a (currently incomplete) port of the Scala test kit, located in 
 It's fully focused on integration testing the query engine through request-response assertions.
 
 ## Test organization
-The test kit is a combination of three crates, from which two are "lower level" crates that are only required to make it work, whereas only one is important if you only want to author tests. The three-crate approach is required to prevent circular dependencies between the crates (arrow = depends-on):
+
+The test kit is a combination of three crates, from which two are "lower level" crates that are only required to make it work, whereas only one is important if you only want to author tests.
 ```
                ┌────────────────────┐
            ┌───│ query-engine-tests │───┐
            │   └────────────────────┘   │
            ▼                            ▼
 ┌────────────────────┐       ┌────────────────────┐
-│ query-test-macros  │──────▶│ query-tests-setup  │
+│ query-test-macros  │       │ query-tests-setup  │
 └────────────────────┘       └────────────────────┘
 ```
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -17,6 +17,7 @@ mod prisma_15581;
 mod prisma_15607;
 mod prisma_16760;
 mod prisma_17103;
+mod prisma_18517;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_17103.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_17103.rs
@@ -1,4 +1,3 @@
-use indoc::indoc;
 use query_engine_tests::*;
 
 #[test_suite(schema(schema))]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_18517.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_18517.rs
@@ -1,0 +1,27 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(Postgres))]
+mod prisma_18517 {
+    fn schema() -> String {
+        r#"
+model Container {
+  id                    String                 @id @default(uuid()) @test.Char(20)
+  createdAt             DateTime               @default(now())
+  label                 String?
+  parent                Container?             @relation("ContainerToContainer", fields: [parentId], references: [id], onDelete: Cascade)
+  parentId              String?                @test.Char(20)
+  path                  Unsupported("money")?  @unique
+  childContainers       Container[]            @relation("ContainerToContainer")
+}
+        "#.to_owned()
+    }
+
+    #[connector_test]
+    async fn regression(runner: Runner) -> TestResult<()> {
+        run_query! {
+            &runner,
+            r#"query { findManyContainer(where: { label: "root", parentId: null }) { id }}"#
+        };
+        Ok(())
+    }
+}

--- a/query-engine/prisma-models/src/model.rs
+++ b/query-engine/prisma-models/src/model.rs
@@ -54,6 +54,9 @@ impl Model {
     }
 
     pub fn unique_indexes(&self) -> impl Iterator<Item = walkers::IndexWalker<'_>> {
-        self.walker().indexes().filter(|idx| idx.is_unique())
+        self.walker()
+            .indexes()
+            .filter(|idx| idx.is_unique())
+            .filter(|index| !index.fields().any(|f| f.is_unsupported()))
     }
 }

--- a/query-engine/prisma-models/src/projections/model_projection.rs
+++ b/query-engine/prisma-models/src/projections/model_projection.rs
@@ -74,6 +74,7 @@ impl ModelProjection {
         self.fields
             .iter()
             .flat_map(|field| match field {
+                Field::Scalar(sf) if matches!(sf.type_identifier(), TypeIdentifier::Unsupported) => Vec::new(),
                 Field::Scalar(sf) => vec![sf.clone()],
                 Field::Relation(rf) => rf.scalar_fields(),
                 Field::Composite(_) => todo!(), // [Composites] todo


### PR DESCRIPTION
They are not usable by the query engine, and currently cause crashes whenever querying the model containing them.

closes https://github.com/prisma/prisma/issues/18517