### PR TITLE
qe/schema: remove once_cell usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,7 +3856,6 @@ name = "schema"
 version = "0.1.0"
 dependencies = [
  "codspeed-criterion-compat",
- "once_cell",
  "prisma-models",
  "psl",
  "rustc-hash",

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 prisma-models = { path = "../prisma-models" }
-once_cell = "1.3"
 psl.workspace = true
 rustc-hash = "1.1.0"
 tracing = "0.1"

--- a/query-engine/schema/src/build/output_types/aggregation/group_by.rs
+++ b/query-engine/schema/src/build/output_types/aggregation/group_by.rs
@@ -7,7 +7,7 @@ pub(crate) fn group_by_output_object_type(ctx: &mut BuilderContext<'_>, model: &
     let ident = Identifier::new_prisma(format!("{}GroupByOutputType", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
-    let object = ObjectType::new(ident.clone(), Some(model.id));
+    let mut object = ObjectType::new(ident.clone(), Some(model.id));
 
     // Model fields that can be grouped by value.
     let mut object_fields = scalar_output_fields(ctx, model);

--- a/query-engine/schema/src/build/output_types/aggregation/plain.rs
+++ b/query-engine/schema/src/build/output_types/aggregation/plain.rs
@@ -7,7 +7,7 @@ pub(crate) fn aggregation_object_type(ctx: &mut BuilderContext<'_>, model: &Mode
     let ident = Identifier::new_prisma(format!("Aggregate{}", capitalize(model.name())));
     return_cached_output!(ctx, &ident);
 
-    let object = ObjectType::new(ident.clone(), Some(model.id));
+    let mut object = ObjectType::new(ident.clone(), Some(model.id));
     let mut object_fields = vec![];
 
     let non_list_nor_json_fields = collect_non_list_nor_json_fields(&model.into());

--- a/query-engine/schema/src/build/utils.rs
+++ b/query-engine/schema/src/build/utils.rs
@@ -1,35 +1,32 @@
 use super::*;
-use once_cell::sync::OnceCell;
 use prisma_models::{ast, walkers, DefaultKind};
 
 /// Object type convenience wrapper function.
 pub fn object_type(ident: Identifier, fields: Vec<OutputField>, model: Option<ast::ModelId>) -> ObjectType {
-    let object_type = ObjectType::new(ident, model);
-
+    let mut object_type = ObjectType::new(ident, model);
     object_type.set_fields(fields);
     object_type
 }
 
 /// Input object type convenience wrapper function.
-pub fn input_object_type(ident: Identifier, fields: Vec<InputField>) -> InputObjectType {
-    let object_type = init_input_object_type(ident);
-
+pub(crate) fn input_object_type(ident: Identifier, fields: Vec<InputField>) -> InputObjectType {
+    let mut object_type = init_input_object_type(ident);
     object_type.set_fields(fields);
     object_type
 }
 
 /// Input object type initializer for cases where only the name is known, and fields are computed later.
-pub fn init_input_object_type(ident: Identifier) -> InputObjectType {
+pub(crate) fn init_input_object_type(ident: Identifier) -> InputObjectType {
     InputObjectType {
         identifier: ident,
         constraints: InputObjectTypeConstraints::default(),
-        fields: OnceCell::new(),
+        fields: Vec::new(),
         tag: None,
     }
 }
 
 /// Field convenience wrapper function.
-pub fn field<T>(
+pub(crate) fn field<T>(
     name: T,
     arguments: Vec<InputField>,
     field_type: OutputType,

--- a/query-engine/schema/src/db.rs
+++ b/query-engine/schema/src/db.rs
@@ -57,11 +57,23 @@ impl ops::Index<InputObjectTypeId> for QuerySchemaDatabase {
     }
 }
 
+impl ops::IndexMut<InputObjectTypeId> for QuerySchemaDatabase {
+    fn index_mut(&mut self, index: InputObjectTypeId) -> &mut Self::Output {
+        &mut self.input_object_types[index.0]
+    }
+}
+
 impl ops::Index<OutputObjectTypeId> for QuerySchemaDatabase {
     type Output = ObjectType;
 
     fn index(&self, index: OutputObjectTypeId) -> &Self::Output {
         &self.output_object_types[index.0]
+    }
+}
+
+impl ops::IndexMut<OutputObjectTypeId> for QuerySchemaDatabase {
+    fn index_mut(&mut self, index: OutputObjectTypeId) -> &mut Self::Output {
+        &mut self.output_object_types[index.0]
     }
 }
 

--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::db::QuerySchemaDatabase;
 use fmt::Debug;
-use once_cell::sync::OnceCell;
 use prisma_models::{prelude::ParentContainer, DefaultKind};
 use std::{boxed::Box, fmt};
 
@@ -9,7 +8,7 @@ use std::{boxed::Box, fmt};
 pub struct InputObjectType {
     pub identifier: Identifier,
     pub constraints: InputObjectTypeConstraints,
-    pub(crate) fields: OnceCell<Vec<InputField>>,
+    pub(crate) fields: Vec<InputField>,
     pub tag: Option<ObjectTag>,
 }
 
@@ -50,13 +49,11 @@ impl Debug for InputObjectType {
 
 impl InputObjectType {
     pub fn get_fields(&self) -> &Vec<InputField> {
-        self.fields.get().unwrap()
+        &self.fields
     }
 
-    pub(crate) fn set_fields(&self, fields: Vec<InputField>) {
-        self.fields
-            .set(fields)
-            .unwrap_or_else(|_| panic!("Fields of {:?} are already set", self.identifier));
+    pub(crate) fn set_fields(&mut self, fields: Vec<InputField>) {
+        self.fields = fields;
     }
 
     /// True if fields are empty, false otherwise.

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -1,6 +1,5 @@
 use super::*;
 use fmt::Debug;
-use once_cell::sync::OnceCell;
 use prisma_models::{ast::ModelId, ModelRef};
 use std::fmt;
 
@@ -113,7 +112,7 @@ impl OutputType {
 
 pub struct ObjectType {
     pub identifier: Identifier,
-    fields: OnceCell<Vec<OutputField>>,
+    fields: Vec<OutputField>,
 
     // Object types can directly map to models.
     model: Option<ModelId>,
@@ -133,7 +132,7 @@ impl ObjectType {
     pub(crate) fn new(ident: Identifier, model: Option<ModelId>) -> Self {
         Self {
             identifier: ident,
-            fields: OnceCell::new(),
+            fields: Vec::new(),
             model,
         }
     }
@@ -143,15 +142,15 @@ impl ObjectType {
     }
 
     pub(crate) fn add_field(&mut self, field: OutputField) {
-        self.fields.get_mut().unwrap().push(field)
+        self.fields.push(field)
     }
 
     pub fn get_fields(&self) -> &[OutputField] {
-        self.fields.get().unwrap()
+        &self.fields
     }
 
-    pub(crate) fn set_fields(&self, fields: Vec<OutputField>) {
-        self.fields.set(fields).unwrap();
+    pub(crate) fn set_fields(&mut self, fields: Vec<OutputField>) {
+        self.fields = fields;
     }
 
     pub fn find_field<'a>(&'a self, name: &str) -> Option<(usize, &'a OutputField)> {


### PR DESCRIPTION
It is not needed anymore and just produces extra complexity that is not warranted.