### PR TITLE
Replace old broken pris.ly migrate lock link in error message

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -105,7 +105,7 @@ impl SqlFlavour for PostgresFlavour {
                         database_host: params.url.host().to_owned(),
                         database_port: params.url.port().to_string(),
                         context: format!(
-                            "Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369)). Elapsed: {}ms. See https://pris.ly/d/migrate-advisory-locking for details.", ADVISORY_LOCK_TIMEOUT.as_millis()
+                            "Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369)). Elapsed: {}ms. See https://prisma.io/docs/concepts/components/prisma-migrate/migrate-development-production#advisory-locking for details.", ADVISORY_LOCK_TIMEOUT.as_millis()
                             ),
                     })
                 })??;


### PR DESCRIPTION
The psql advisory lock error message pushes the user to a pris.ly link that redirects the user to a root doc page with an outdated anchor tag for advisory locking content no longer on that page

This PR replaces that link with an explicit link to the advisory locking section of the docs https://prisma.io/docs/concepts/components/prisma-migrate/migrate-development-production#advisory-locking, assuming no one is going to make new pris.ly links anytime soon 