### PR TITLE
Stopgap: Postgres Expression Indexes

### DIFF
--- a/schema-engine/connectors/schema-connector/src/warnings.rs
+++ b/schema-engine/connectors/schema-connector/src/warnings.rs
@@ -118,6 +118,8 @@ pub struct Warnings {
     pub row_level_ttl: Vec<Model>,
     /// Warn about non-default unique deferring setup
     pub non_default_deferring: Vec<ModelAndConstraint>,
+    /// Warning about Expression Indexes.
+    pub expression_indexes: Vec<ModelAndConstraint>,
     /// Warn about comments
     pub objects_with_comments: Vec<Object>,
     /// Warn about fields which point to an empty type.
@@ -421,6 +423,12 @@ impl fmt::Display for Warnings {
         render_warnings(
             "The following models are capped collections, which are not yet fully supported. Read more: https://pris.ly/d/mongodb-capped-collections",
             &self.capped_collection,
+            f
+        )?;
+
+        render_warnings(
+            "These indexes are not supported by the Prisma Client, because Prisma currently does not fully support expression indexes. Read more: https://pris.ly/d/expression-indexes",
+            &self.expression_indexes,
             f
         )?;
 

--- a/schema-engine/connectors/schema-connector/src/warnings.rs
+++ b/schema-engine/connectors/schema-connector/src/warnings.rs
@@ -427,7 +427,7 @@ impl fmt::Display for Warnings {
         )?;
 
         render_warnings(
-            "These indexes are not supported by the Prisma Client, because Prisma currently does not fully support expression indexes. Read more: https://pris.ly/d/expression-indexes",
+            "These indexes are not supported by Prisma Client, because Prisma currently does not fully support expression indexes. Read more: https://pris.ly/d/expression-indexes",
             &self.expression_indexes,
             f
         )?;

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/models.rs
@@ -128,7 +128,7 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
     }
 
     if model.expression_indexes().next().is_some() {
-        let docs = "This model contains an exression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.";
+        let docs = "This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.";
 
         rendered.documentation(docs);
     }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/models.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/models.rs
@@ -127,6 +127,12 @@ fn render_model(model: ModelPair<'_>, sql_family: SqlFamily) -> renderer::Model<
         rendered.documentation(docs);
     }
 
+    if model.expression_indexes().next().is_some() {
+        let docs = "This model contains an exression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.";
+
+        rendered.documentation(docs);
+    }
+
     for field in model.scalar_fields() {
         rendered.push_field(scalar_field::render(field));
     }

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/warnings/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/warnings/model.rs
@@ -64,6 +64,13 @@ pub(super) fn generate_warnings(model: ModelPair<'_>, warnings: &mut Warnings) {
         })
     }
 
+    for expr_indx in model.expression_indexes() {
+        warnings.expression_indexes.push(generators::ModelAndConstraint {
+            model: model.name().to_string(),
+            constraint: expr_indx.to_string(),
+        })
+    }
+
     for field in model.scalar_fields() {
         if let Some(DefaultKind::Prisma1Uuid) = field.default().kind() {
             let warn = generators::ModelAndField {

--- a/schema-engine/sql-introspection-tests/tests/postgres/gin.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/gin.rs
@@ -14,6 +14,7 @@ async fn full_text_functions_filtered_out(api: &mut TestApi) -> TestResult {
     api.database().raw_cmd(&create_idx).await?;
 
     let expected = expect![[r#"
+        /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
         model A {
           id   Int    @id @default(autoincrement())
           data String

--- a/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/postgres/mod.rs
@@ -90,6 +90,7 @@ async fn pg_xml_indexes_are_skipped(api: &mut TestApi) -> TestResult {
     api.database().raw_cmd(&create_primary).await?;
 
     let dm = indoc! {r#"
+        /// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
         model xml_test {
           id   Int @id @default(autoincrement())
           data String? @db.Xml

--- a/schema-engine/sql-introspection-tests/tests/simple/cockroach/index_with_expression_column.sql
+++ b/schema-engine/sql-introspection-tests/tests/simple/cockroach/index_with_expression_column.sql
@@ -31,6 +31,7 @@ datasource db {
 }
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+/// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model communication_channels {
   id                BigInt
   path              String  @db.String(255)

--- a/schema-engine/sql-introspection-tests/tests/simple/postgres/index_with_expression_column.sql
+++ b/schema-engine/sql-introspection-tests/tests/simple/postgres/index_with_expression_column.sql
@@ -20,10 +20,6 @@ CREATE INDEX index_communication_channels_on_path_and_path_type ON communication
 CREATE UNIQUE INDEX index_communication_channels_on_user_id_and_path_and_path_type ON communication_channels (user_id, lower((path)::text), path_type);
 CREATE INDEX index_communication_channels_on_confirmation_code ON communication_channels (confirmation_code);
 
-
-
-
-
 /*
 generator js {
   provider = "prisma-client-js"

--- a/schema-engine/sql-introspection-tests/tests/simple/postgres/index_with_expression_column.sql
+++ b/schema-engine/sql-introspection-tests/tests/simple/postgres/index_with_expression_column.sql
@@ -23,6 +23,7 @@ CREATE INDEX index_communication_channels_on_confirmation_code ON communication_
 
 
 
+
 /*
 generator js {
   provider = "prisma-client-js"
@@ -34,6 +35,7 @@ datasource db {
 }
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
+/// This model contains an exression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model communication_channels {
   id                BigInt
   path              String  @db.VarChar(255)

--- a/schema-engine/sql-introspection-tests/tests/simple/postgres/index_with_expression_column.sql
+++ b/schema-engine/sql-introspection-tests/tests/simple/postgres/index_with_expression_column.sql
@@ -35,7 +35,7 @@ datasource db {
 }
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
-/// This model contains an exression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
+/// This model contains an expression index which requires additional setup for migrations. Visit https://pris.ly/d/expression-indexes for more info.
 model communication_channels {
   id                BigInt
   path              String  @db.VarChar(255)

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -1521,6 +1521,7 @@ fn index_from_row(
             }
         };
 
+        // * Note: Expression Indexes can have 1 & 2
         if column_index == 0 {
             // new index!
             let index_id = if is_primary_key {

--- a/schema-engine/sql-schema-describer/src/postgres/indexes_query.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/indexes_query.sql
@@ -40,7 +40,7 @@ FROM
     INNER JOIN pg_class AS tableinfo ON tableinfo.oid = rawindex.indrelid
     INNER JOIN pg_class AS indexinfo ON indexinfo.oid = rawindex.indexrelid
     INNER JOIN pg_namespace AS schemainfo ON schemainfo.oid = tableinfo.relnamespace
-    INNER JOIN pg_attribute AS columninfo
+    LEFT JOIN pg_attribute AS columninfo
         ON columninfo.attrelid = tableinfo.oid AND columninfo.attnum = rawindex.indkeyid
     INNER JOIN pg_am AS indexaccess ON indexaccess.oid = indexinfo.relam
     LEFT JOIN pg_opclass AS opclass -- left join because crdb has no opclasses

--- a/schema-engine/sql-schema-describer/src/postgres/indexes_query.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/indexes_query.sql
@@ -11,7 +11,6 @@ WITH rawindex AS (
     FROM pg_index -- https://www.postgresql.org/docs/current/catalog-pg-index.html
     WHERE
         indpred IS NULL -- filter out partial indexes
-        AND array_position(indkey::int2[], 0::int2) IS NULL -- filter out expression indexes
         AND NOT indisexclusion -- filter out exclusion constraints
 )
 SELECT

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1022,6 +1022,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
                     BTree,
                 ),
             ],
+            expression_indexes: [],
             index_null_position: {},
             constraint_options: {
                 Index(
@@ -1206,6 +1207,7 @@ fn postgres_sequences_must_work(api: TestApi) {
         PostgresSchemaExt {
             opclasses: [],
             indexes: [],
+            expression_indexes: [],
             index_null_position: {},
             constraint_options: {},
             table_options: [],

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1806,6 +1806,7 @@ fn extensions_are_described_correctly(api: TestApi) {
         PostgresSchemaExt {
             opclasses: [],
             indexes: [],
+            expression_indexes: [],
             index_null_position: {},
             constraint_options: {},
             table_options: [],

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests/cockroach_describer_tests.rs
@@ -525,6 +525,7 @@ fn cockroachdb_22_2_sequences_must_work(api: TestApi) {
         PostgresSchemaExt {
             opclasses: [],
             indexes: [],
+            expression_indexes: [],
             index_null_position: {},
             constraint_options: {},
             table_options: [],


### PR DESCRIPTION
Refactored get_indexes to allow for reading rows that have expression indexes without actually tracking indexes in Prisma Schema.

closes https://github.com/prisma/team-orm/issues/82