### PR TITLE
(Prisma 5) feat: remove list shorthands (BREAKING)

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
@@ -32,17 +32,6 @@ mod to_many {
         );
 
         insta::assert_snapshot!(
-            run_query!(runner, r#"{
-                    findManyTestModel(where: {
-                        to_many_as: { equals: { a_1: "Test", a_2: 0 } }
-                    }) {
-                        id
-                    }
-                }"#),
-            @r###"{"data":{"findManyTestModel":[{"id":5}]}}"###
-        );
-
-        insta::assert_snapshot!(
           run_query!(runner, r#"{
                     findManyTestModel(where: {
                         NOT: [

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/composite/equals.rs
@@ -31,18 +31,6 @@ mod to_many {
           @r###"{"data":{"findManyTestModel":[{"id":5}]}}"###
         );
 
-        // Implicit equal shorthand (equivalent to the one above)
-        insta::assert_snapshot!(
-            run_query!(runner, r#"{
-                    findManyTestModel(where: {
-                        to_many_as: { a_1: "Test", a_2: 0 }
-                    }) {
-                        id
-                    }
-                }"#),
-            @r###"{"data":{"findManyTestModel":[{"id":5}]}}"###
-        );
-
         insta::assert_snapshot!(
             run_query!(runner, r#"{
                     findManyTestModel(where: {
@@ -234,81 +222,19 @@ mod to_many {
     // No object coercion
     // TODO: This test is ignored because the JSON protocol required to enable the object syntax for equality on composite lists.
     // TODO: It should be enabled again once we remove the object shorthand syntaxes.
-    // #[connector_test]
-    // async fn single_object(runner: Runner) -> TestResult<()> {
-    //     create_to_many_test_data(&runner).await?;
+    #[connector_test]
+    async fn single_object(runner: Runner) -> TestResult<()> {
+        create_to_many_test_data(&runner).await?;
 
-    //     assert_error!(
-    //         runner,
-    //         r#"{
-    //             findManyTestModel(where: { to_many_as: { equals: { a_1: "Test", a_2: 0 } }}) {
-    //                 id
-    //             }
-    //         }"#,
-    //         2009,
-    //         "Invalid argument type"
-    //     );
-
-    //     Ok(())
-    // }
-
-    fn deep_equality_schema() -> String {
-        let schema = indoc! {
-            r#"
-              model CommentRequiredList {
-                #id(id, Int, @id)
-            
-                country String?
-                contents CommentContent[]
-              }
-            
-              type CommentContent {
-                text    String
-                upvotes CommentContentUpvotes[]
-              }
-            
-              type CommentContentUpvotes {
-                vote Boolean
-                userId String
-              }"#
-        };
-
-        schema.to_owned()
-    }
-
-    #[connector_test(schema(deep_equality_schema))]
-    async fn deep_equality_shorthand_should_work(runner: Runner) -> TestResult<()> {
-        run_query!(
-            &runner,
-            r#"mutation {
-                createOneCommentRequiredList(data: {
-                    id: 1,
-                    contents: {
-                        text: "hello world",
-                        upvotes: { vote: true, userId: "10" }
-                    }
-                }) {
+        assert_error!(
+            runner,
+            r#"{
+                findManyTestModel(where: { to_many_as: { equals: { a_1: "Test", a_2: 0 } }}) {
                     id
                 }
-            }"#
-        );
-
-        insta::assert_snapshot!(
-            run_query!(&runner, r#"{
-                findManyCommentRequiredList(
-                    where: {
-                        contents: {
-                            equals: {
-                                text: "hello world",
-                                upvotes: { vote: true, userId: "10" }
-                            }
-                        }
-                    }
-                ) {
-                    id
-                }
-            }"#),
-            @r###"{"data":{"findManyCommentRequiredList":[{"id":1}]}}"###
+            }"#,
+            2009,
+            "Invalid argument type"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/filters.rs
@@ -146,16 +146,6 @@ mod filter_spec {
           @r###"{"data":{"findManyUser":[{"unique":1},{"unique":2}]}}"###
         );
 
-        insta::assert_snapshot!(
-          &user_uniques(&runner, r#"(where: { name: { in: "Bernd" }})"#).await?,
-          @r###"{"data":{"findManyUser":[{"unique":2}]}}"###
-        );
-
-        insta::assert_snapshot!(
-          &user_uniques(&runner, r#"(where: { NOT: { name: { in: "Bernd" } }})"#).await?,
-          @r###"{"data":{"findManyUser":[{"unique":1},{"unique":3},{"unique":4}]}}"###
-        );
-
         Ok(())
     }
 
@@ -166,17 +156,6 @@ mod filter_spec {
         insta::assert_snapshot!(
           &user_uniques(&runner, r#"(where: { name: { notIn: ["Bernd", "Paul"] }})"#).await?,
           @r###"{"data":{"findManyUser":[{"unique":3},{"unique":4}]}}"###
-        );
-
-        insta::assert_snapshot!(
-          &user_uniques(&runner, r#"(where: { name: { notIn: "Bernd" }})"#).await?,
-          @r###"{"data":{"findManyUser":[{"unique":1},{"unique":3},{"unique":4}]}}"###
-        );
-
-        // NOT notIn == in
-        insta::assert_snapshot!(
-          &user_uniques(&runner, r#"(where: { NOT: { name: { notIn: "Bernd" }}})"#).await?,
-          @r###"{"data":{"findManyUser":[{"unique":2}]}}"###
         );
 
         Ok(())

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -98,8 +98,7 @@ impl<'a> ScalarFilterParser<'a> {
                         PrismaValue::Null => field.equals(value),
                         PrismaValue::List(values) => field.is_in(values),
 
-                        val if self.reverse() => field.not_in(vec![val]),
-                        val => field.is_in(vec![val]),
+                        _ => unreachable!(), // Validation guarantees this.
                     },
                     ConditionValue::FieldRef(field_ref) if self.reverse() => field.not_in(field_ref),
                     ConditionValue::FieldRef(field_ref) => field.is_in(field_ref),
@@ -120,8 +119,7 @@ impl<'a> ScalarFilterParser<'a> {
                         PrismaValue::Null => field.not_equals(value),
                         PrismaValue::List(values) => field.not_in(values),
 
-                        val if self.reverse() => field.is_in(vec![val]),
-                        val => field.not_in(vec![val]),
+                        _ => unreachable!(), // Validation guarantees this.
                     },
                     ConditionValue::FieldRef(field_ref) if self.reverse() => field.is_in(field_ref),
                     ConditionValue::FieldRef(field_ref) => field.not_in(field_ref),

--- a/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
@@ -23,7 +23,7 @@ pub(crate) fn get_field_filter_types(
 
         ModelField::Composite(cf) if cf.is_list() => vec![
             InputType::object(to_many_composite_filter_object(ctx, cf.clone())),
-            InputType::list(to_one_composite_filter_shorthand_types(ctx, cf.clone())),
+            InputType::list(to_one_composite_filter_shorthand_types(ctx, cf)),
         ],
 
         ModelField::Composite(cf) => vec![

--- a/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
@@ -22,8 +22,8 @@ pub(crate) fn get_field_filter_types(
         }
 
         ModelField::Composite(cf) if cf.is_list() => vec![
-            InputType::object(to_many_composite_filter_object(ctx, cf)),
-            InputType::list(to_one_composite_filter_shorthand_types(ctx, cf)),
+            InputType::object(to_many_composite_filter_object(ctx, cf.clone())),
+            InputType::list(to_one_composite_filter_shorthand_types(ctx, cf.clone())),
         ],
 
         ModelField::Composite(cf) => vec![
@@ -147,29 +147,14 @@ fn to_many_composite_filter_object(ctx: &'_ QuerySchema, cf: CompositeFieldRef) 
         let composite_equals_object = filter_objects::composite_equality_object(ctx, cf.clone());
 
         let mut fields = vec![
-            input_field(
-                filters::EQUALS,
-                // The object (aka shorthand) syntax is only supported because the client used to expose all
-                // list input types as T | T[]. Consider removing it one day.
-                list_union_type(InputType::object(composite_equals_object), true),
-                None,
-            )
-            .optional(),
-            simple_input_field(filters::EVERY, InputType::object(composite_where_object.clone()), None).optional(),
-            simple_input_field(filters::SOME, InputType::object(composite_where_object.clone()), None).optional(),
-            simple_input_field(filters::NONE, InputType::object(composite_where_object), None).optional(),
-            simple_input_field(filters::IS_EMPTY, InputType::boolean(), None).optional(),
-        ];
-
-        let mut fields = vec![
             simple_input_field(
                 filters::EQUALS,
                 InputType::list(InputType::object(composite_equals_object)),
                 None,
             )
             .optional(),
-            simple_input_field(filters::EVERY, InputType::object(composite_where_object), None).optional(),
-            simple_input_field(filters::SOME, InputType::object(composite_where_object), None).optional(),
+            simple_input_field(filters::EVERY, InputType::object(composite_where_object.clone()), None).optional(),
+            simple_input_field(filters::SOME, InputType::object(composite_where_object.clone()), None).optional(),
             simple_input_field(filters::NONE, InputType::object(composite_where_object), None).optional(),
             simple_input_field(filters::IS_EMPTY, InputType::boolean(), None).optional(),
         ];

--- a/query-engine/schema/src/build/input_types/objects/filter_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/filter_objects.rs
@@ -248,15 +248,13 @@ pub(crate) fn composite_equality_object(ctx: &'_ QuerySchema, cf: CompositeField
             }
 
             ModelField::Composite(cf) => {
-                let types = if cf.is_list() {
-                    // The object (aka shorthand) syntax is only supported because the client used to expose all
-                    // list input types as T | T[]. Consider removing it one day.
-                    list_union_type(InputType::object(composite_equality_object(ctx, cf.clone())), true)
+                let field_type = if cf.is_list() {
+                    InputType::list(InputType::object(composite_equality_object(ctx, cf.clone())))
                 } else {
-                    vec![InputType::object(composite_equality_object(ctx, cf.clone()))]
+                    InputType::object(composite_equality_object(ctx, cf.clone()))
                 };
 
-                input_field(cf.name().to_owned(), types, None)
+                simple_input_field(cf.name().to_owned(), field_type, None)
                     .optional_if(!cf.is_required())
                     .nullable_if(!cf.is_required() && !cf.is_list())
             }


### PR DESCRIPTION
# ⚠️ DO NOT MERGE BEFORE PRISMA 5 RELEASE

## Overview

Revert recent changes that allowed shorthand syntaxes for list operations (for jsonProtocol). This touches:

- The `in` & `notIn` filter
- The `equals` filter for composite lists

Concretely, given the following datamodel:

```
model Test {
  id        Int       @id @map("_id")
  name      String
  address    Address
  addresses Address[]
}

type Address {
  street String
}
```

We have the following diffs:

```diff
input TestWhereInput {
  AND: TestWhereInput | [TestWhereInput]
  OR: [TestWhereInput]
  NOT: TestWhereInput | [TestWhereInput]
  id: IntFilter | Int
  name: StringFilter | String
  address: AddressCompositeFilter | AddressObjectEqualityInput
- addresses: AddressCompositeListFilter | [AddressObjectEqualityInput] | AddressObjectEqualityInput
+ addresses: AddressCompositeListFilter | [AddressObjectEqualityInput]
}

input TestWhereUniqueInput {
  id: Int
  AND: TestWhereInput | [TestWhereInput]
  OR: [TestWhereInput]
  NOT: TestWhereInput | [TestWhereInput]
  name: StringFilter | String
  address: AddressCompositeFilter | AddressObjectEqualityInput
- addresses: AddressCompositeListFilter | [AddressObjectEqualityInput] | AddressObjectEqualityInput
+ addresses: AddressCompositeListFilter | [AddressObjectEqualityInput]
}

input AddressCompositeListFilter {
 - equals: AddressObjectEqualityInput | [AddressObjectEqualityInput]
+ equals: [AddressObjectEqualityInput]
  every: AddressWhereInput
  some: AddressWhereInput
  none: AddressWhereInput
  isEmpty: Boolean
  isSet: Boolean
}

input <Type>Filter {
  equals: <Type> | <Type>FieldRefInput
-  in: [<Type>] | List<Type>FieldRefInput | <Type>
-  notIn: [<Type>] | List<Type>FieldRefInput | <Type>
+ in: [<Type>] | List<Type>FieldRefInput
+ notIn: [<Type>] | List<Type>FieldRefInput
  lt: <Type> | <Type>FieldRefInput
  lte: <Type> | <Type>FieldRefInput
  gt: <Type> | <Type>FieldRefInput
  gte: <Type> | <Type>FieldRefInput
  not: <Type> | Nested<Type>Filter
}
```
