### PR TITLE
(Prisma 5) fix: unchecked update many input (BREAKING)

### DIFF
--- a/query-engine/dmmf/src/tests/setup.rs
+++ b/query-engine/dmmf/src/tests/setup.rs
@@ -60,7 +60,7 @@ fn format_diff(old: &str, new: &str) -> String {
     let diff = differ.algorithm(Algorithm::Patience).diff_lines(old, new);
     let mut buf = String::new();
 
-    for (idx, group) in diff.grouped_ops(3).iter().enumerate() {
+    for (idx, group) in diff.grouped_ops(6).iter().enumerate() {
         if idx > 0 {
             buf.push_str(&format!("{:-^1$}\n", "-", 80));
         }

--- a/query-engine/schema/src/build/input_types/objects/update_many_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/update_many_objects.rs
@@ -34,18 +34,10 @@ pub(crate) fn unchecked_update_many_input_type(
     model: Model,
     parent_field: Option<RelationFieldRef>,
 ) -> InputObjectType<'_> {
-    // TODO: This leads to conflicting type names.
-    // TODO: See https://github.com/prisma/prisma/issues/18534 for further details.
-    let name = match &parent_field {
-        Some(pf) => format!(
-            "{}UncheckedUpdateManyWithout{}Input",
-            model.name(),
-            capitalize(pf.name())
-        ),
-        _ => format!("{}UncheckedUpdateManyInput", model.name()),
-    };
-
-    let ident = Identifier::new_prisma(name);
+    let ident = Identifier::new_prisma(IdentifierType::UncheckedUpdateManyInput(
+        model.clone(),
+        parent_field.clone().map(|pf| pf.related_field()),
+    ));
 
     let mut input_object = init_input_object_type(ident);
     input_object.set_fields(move || {

--- a/query-engine/schema/src/identifier_type.rs
+++ b/query-engine/schema/src/identifier_type.rs
@@ -12,6 +12,7 @@ pub enum IdentifierType {
     Mutation,
     CheckedCreateInput(Model, Option<RelationField>),
     CheckedUpdateManyInput(Model),
+    UncheckedUpdateManyInput(Model, Option<RelationField>),
     CheckedUpdateOneInput(Model, Option<RelationField>),
     CompositeCreateEnvelopeInput(CompositeType, FieldArity),
     CompositeCreateInput(CompositeType),
@@ -293,6 +294,15 @@ impl std::fmt::Display for IdentifierType {
             IdentifierType::CreateManyInput(model, related_field) => match related_field {
                 Some(ref rf) => write!(f, "{}CreateMany{}Input", model.name(), capitalize(rf.name())),
                 _ => write!(f, "{}CreateManyInput", model.name()),
+            },
+            IdentifierType::UncheckedUpdateManyInput(model, related_field) => match related_field {
+                Some(rf) => write!(
+                    f,
+                    "{}UncheckedUpdateManyWithout{}Input",
+                    model.name(),
+                    capitalize(rf.name())
+                ),
+                _ => write!(f, "{}UncheckedUpdateManyInput", model.name()),
             },
         }
     }


### PR DESCRIPTION
# ⚠️ DO NOT MERGE BEFORE PRISMA 5

## Overview

- fixes https://github.com/prisma/prisma/issues/18534

## DMMF changes

Given the following datamodel:

```prisma
model Invoice {
  InvoiceId Int @id @default(autoincrement())

  invoice_items InvoiceItem[]
}

model InvoiceItem {
  InvoiceLineId Int @id @default(autoincrement())

  InvoiceItemInvoiceId Int     @map("InvoiceId")
  invoices             Invoice @relation(fields: [InvoiceItemInvoiceId], references: [InvoiceId])

  TrackId Int
  tracks  Track @relation(fields: [TrackId], references: [TrackId])
}

model Track {
  TrackId Int    @id @default(autoincrement())
  Name    String

  invoice_items InvoiceItem[]
}
```

The following types changes:

```diff
-input InvoiceItemUncheckedUpdateManyWithoutInvoice_itemsInput {
+input InvoiceItemUncheckedUpdateManyWithoutInvoicesInput {
  InvoiceLineId: Int | IntFieldUpdateOperationsInput
  TrackId: Int | IntFieldUpdateOperationsInput
}

input InvoiceItemUpdateManyWithWhereWithoutInvoicesInput {
  where: InvoiceItemScalarWhereInput
 -data: InvoiceItemUpdateManyMutationInput | InvoiceItemUncheckedUpdateManyWithoutInvoice_itemsInput
 +data: InvoiceItemUpdateManyMutationInput | InvoiceItemUncheckedUpdateManyWithoutInvoicesInput
}

input InvoiceItemUpdateManyWithWhereWithoutTracksInput {
  where: InvoiceItemScalarWhereInput
-data: InvoiceItemUpdateManyMutationInput | InvoiceItemUncheckedUpdateManyWithoutInvoice_itemsInput
+  data: InvoiceItemUpdateManyMutationInput | InvoiceItemUncheckedUpdateManyWithoutTracksInput
}

+input InvoiceItemUncheckedUpdateManyWithoutTracksInput {
+  InvoiceLineId: Int | IntFieldUpdateOperationsInput
+  InvoiceItemInvoiceId: Int | IntFieldUpdateOperationsInput
+}
```