### PR TITLE
qe: Properly instrument schema builder span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,6 @@ dependencies = [
  "prisma-models",
  "psl",
  "rustc-hash",
- "tracing",
 ]
 
 [[package]]

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -268,10 +268,13 @@ impl QueryEngine {
                     crate::Result::<_>::Ok(executor)
                 };
 
-                let query_schema_fut = tokio::runtime::Handle::current().spawn_blocking(move || {
-                    let enable_raw_queries = true;
-                    schema::build(arced_schema_2, enable_raw_queries)
-                });
+                let query_schema_span = tracing::info_span!("prisma:engine:schema");
+                let query_schema_fut = tokio::runtime::Handle::current()
+                    .spawn_blocking(move || {
+                        let enable_raw_queries = true;
+                        schema::build(arced_schema_2, enable_raw_queries)
+                    })
+                    .instrument(query_schema_span);
 
                 let (query_schema, executor) = tokio::join!(query_schema_fut, executor_fut);
 

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 prisma-models = { path = "../prisma-models" }
 psl.workspace = true
 rustc-hash = "1.1.0"
-tracing = "0.1"
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/query-engine/schema/src/build.rs
+++ b/query-engine/schema/src/build.rs
@@ -138,7 +138,6 @@ impl<'a> BuilderContext<'a> {
 }
 
 pub fn build(schema: Arc<psl::ValidatedSchema>, enable_raw_queries: bool) -> QuerySchema {
-    let _span = tracing::info_span!("prisma:engine:schema").entered();
     let preview_features = schema.configuration.preview_features();
     build_with_features(schema, preview_features, enable_raw_queries)
 }


### PR DESCRIPTION
Since it is now done on a separate thread, `Dispatcher` is not correctly
propogated and span is not exported. We have to instrument top-level
span instead.
