### PR TITLE
(Prisma 5) fix: nullable to one relation filter input (BREAKING)

### DIFF
--- a/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
@@ -79,23 +79,23 @@ fn to_many_relation_filter_object(ctx: &'_ QuerySchema, rf: RelationFieldRef) ->
 }
 
 fn to_one_relation_filter_object(ctx: &'_ QuerySchema, rf: RelationFieldRef) -> InputObjectType<'_> {
-    // TODO: The ToOneRelationFilterInput is currently broken as it does not take nullability into account.
-    // TODO: This means that the first relation field to be traversed will set the nullability for all other relation field that points to the same related model.
-    let ident = Identifier::new_prisma(IdentifierType::ToOneRelationFilterInput(rf.related_model()));
+    let ident = Identifier::new_prisma(IdentifierType::ToOneRelationFilterInput(rf.related_model(), rf.arity()));
 
     let mut object = init_input_object_type(ident);
     object.set_tag(ObjectTag::RelationEnvelope);
     object.set_fields(move || {
         let related_input_type = filter_objects::where_object_type(ctx, rf.related_model().into());
+
         vec![
             simple_input_field(filters::IS, InputType::object(related_input_type.clone()), None)
                 .optional()
-                .nullable(),
+                .nullable_if(!rf.is_required()),
             simple_input_field(filters::IS_NOT, InputType::object(related_input_type), None)
                 .optional()
-                .nullable(),
+                .nullable_if(!rf.is_required()),
         ]
     });
+
     object
 }
 

--- a/query-engine/schema/src/identifier_type.rs
+++ b/query-engine/schema/src/identifier_type.rs
@@ -41,7 +41,7 @@ pub enum IdentifierType {
     ToManyCompositeFilterInput(CompositeType),
     ToManyRelationFilterInput(Model),
     ToOneCompositeFilterInput(CompositeType, FieldArity),
-    ToOneRelationFilterInput(Model),
+    ToOneRelationFilterInput(Model, FieldArity),
     TransactionIsolationLevel,
     UncheckedCreateInput(Model, Option<RelationField>),
     UncheckedUpdateOneInput(Model, Option<RelationField>),
@@ -180,8 +180,10 @@ impl std::fmt::Display for IdentifierType {
             IdentifierType::ToManyRelationFilterInput(related_model) => {
                 write!(f, "{}ListRelationFilter", capitalize(related_model.name()))
             }
-            IdentifierType::ToOneRelationFilterInput(related_model) => {
-                write!(f, "{}RelationFilter", capitalize(related_model.name()))
+            IdentifierType::ToOneRelationFilterInput(related_model, arity) => {
+                let nullable = if arity.is_optional() { "Nullable" } else { "" };
+
+                write!(f, "{}{}RelationFilter", capitalize(related_model.name()), nullable)
             }
             IdentifierType::ToOneCompositeFilterInput(ct, arity) => {
                 let nullable = if arity.is_optional() { "Nullable" } else { "" };


### PR DESCRIPTION
# :warning: DO NOT MERGE BEFORE PRISMA 5

## Overview

- fixes https://github.com/prisma/prisma/issues/18585

## DMMF changes

Given the following datamodel:

```prisma
model User {
  id Int @id

  addressId Int     @unique
  address   Address @relation(fields: [addressId], references: [id])

  post Post[]
}

model Address {
  id Int @id

  user User?
}

model Post {
  id Int @id

  userId Int
  user   User @relation(fields: [userId], references: [id])
}
```

It changes DMMF in the following ways:

```diff
input UserRelationFilter {
  is: UserWhereInput
  isNot: UserWhereInput
}

+input UserNullableRelationFilter {
+  is: UserWhereInput | Null
+  isNot: UserWhereInput | Null
+}

input AddressWhereInput {
  AND: AddressWhereInput | [AddressWhereInput]
  OR: [AddressWhereInput]
  NOT: AddressWhereInput | [AddressWhereInput]
  id: IntFilter | Int
- user: UserRelationFilter | UserWhereInput
+ user: UserNullableRelationFilter | UserWhereInput
}

input AddressWhereUniqueInput {
  id: Int
  AND: AddressWhereInput | [AddressWhereInput]
  OR: [AddressWhereInput]
  NOT: AddressWhereInput | [AddressWhereInput]
-  user: UserRelationFilter | UserWhereInput
+  user: UserNullableRelationFilter | UserWhereInput
}

input PostWhereInput {
  AND: PostWhereInput | [PostWhereInput]
  OR: [PostWhereInput]
  NOT: PostWhereInput | [PostWhereInput]
  id: IntFilter | Int
  userId: IntFilter | Int
  user: UserRelationFilter | UserWhereInput
}
```