### PR TITLE
sql-query-connector: use quaint versions of tokio-postgres and mysql_…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2861,20 +2861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960c214283ef8f0027974c03e9014517ced5db12f021a9abb66185a5751fab0a"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
 source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#00d4815e58859261bdfca71c75be7dc657303f7d"
@@ -2882,7 +2868,7 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tokio-postgres 0.7.7 (git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode)",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -2903,24 +2889,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres-protocol"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b7fa9f396f51dffd61546fd8573ee20592287996568e6175ceb0f8699ad75d"
-dependencies = [
- "base64 0.21.0",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "hmac",
- "md-5",
- "memchr",
- "rand 0.8.5",
- "sha2 0.10.5",
- "stringprep",
-]
-
-[[package]]
 name = "postgres-types"
 version = "0.2.4"
 source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#00d4815e58859261bdfca71c75be7dc657303f7d"
@@ -2929,21 +2897,10 @@ dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator",
- "postgres-protocol 0.6.4",
+ "postgres-protocol",
  "serde",
  "serde_json",
  "uuid 1.1.2",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f028f05971fe20f512bcc679e2c10227e57809a3af86a7606304435bc8896cd6"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "postgres-protocol 0.6.5",
 ]
 
 [[package]]
@@ -3205,14 +3162,14 @@ dependencies = [
  "num_cpus",
  "percent-encoding",
  "postgres-native-tls",
- "postgres-types 0.2.4",
+ "postgres-types",
  "rusqlite",
  "serde_json",
  "sqlformat",
  "thiserror",
  "tiberius",
  "tokio",
- "tokio-postgres 0.7.7 (git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode)",
+ "tokio-postgres",
  "tokio-util 0.6.10",
  "tracing",
  "tracing-core",
@@ -4314,10 +4271,8 @@ dependencies = [
  "cuid",
  "futures",
  "itertools",
- "mysql_async",
  "once_cell",
  "opentelemetry",
- "postgres",
  "prisma-models",
  "prisma-value",
  "psl",
@@ -4328,7 +4283,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-postgres 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -4774,30 +4728,6 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a12c1b3e0704ae7dfc25562629798b29c72e6b1d0a681b6f29ab4ae5e7f7bf"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "futures-channel",
- "futures-util",
- "log",
- "parking_lot 0.12.1",
- "percent-encoding",
- "phf",
- "pin-project-lite",
- "postgres-protocol 0.6.5",
- "postgres-types 0.2.5",
- "socket2",
- "tokio",
- "tokio-util 0.7.3",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.7.7"
 source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#00d4815e58859261bdfca71c75be7dc657303f7d"
 dependencies = [
  "async-trait",
@@ -4811,8 +4741,8 @@ dependencies = [
  "percent-encoding",
  "phf",
  "pin-project-lite",
- "postgres-protocol 0.6.4",
- "postgres-types 0.2.4",
+ "postgres-protocol",
+ "postgres-types",
  "socket2",
  "tokio",
  "tokio-util 0.7.3",

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -49,8 +49,3 @@ version = "1.2"
 [dependencies.user-facing-errors]
 features = ["sql"]
 path = "../../../libs/user-facing-errors"
-
-[dev-dependencies]
-postgres = "0.19"
-tokio-postgres = "0.7"
-mysql_async = { git="https://github.com/prisma/mysql_async", branch="vendored-openssl" }

--- a/query-engine/connectors/sql-query-connector/examples/mysql_async.rs
+++ b/query-engine/connectors/sql-query-connector/examples/mysql_async.rs
@@ -1,4 +1,4 @@
-use mysql_async::prelude::*;
+use quaint::connector::mysql_async::{self, prelude::*};
 use std::time::Instant;
 
 #[tokio::main]

--- a/query-engine/connectors/sql-query-connector/examples/quaint_query.rs
+++ b/query-engine/connectors/sql-query-connector/examples/quaint_query.rs
@@ -1,6 +1,5 @@
-use std::time::Instant;
-
 use quaint::{pooled::Quaint, prelude::Queryable};
+use std::time::Instant;
 
 #[tokio::main]
 async fn main() -> () {

--- a/query-engine/connectors/sql-query-connector/examples/tokio_pg.rs
+++ b/query-engine/connectors/sql-query-connector/examples/tokio_pg.rs
@@ -1,3 +1,4 @@
+use quaint::connector::tokio_postgres;
 use std::time::Instant;
 
 #[tokio::main]
@@ -6,7 +7,7 @@ async fn main() -> () {
     let start = Instant::now();
 
     let now = Instant::now();
-    let (client, connection) = tokio_postgres::connect(&url, postgres::NoTls).await.unwrap();
+    let (client, connection) = tokio_postgres::connect(&url, tokio_postgres::NoTls).await.unwrap();
     println!("Connect: {:?}", now.elapsed());
 
     tokio::spawn(async move {


### PR DESCRIPTION
…async

- To compare with the same versions when using these examples.
- To reduce dependency tree size for the workspace.
- To unblock updates to prisma-engines in nixpkgs: https://github.com/NixOS/nixpkgs/pull/230907