### PR TITLE
feat(psl): add `@prisma/mysql` provider

### DIFF
--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -85,6 +85,10 @@ impl Connector for MySqlDatamodelConnector {
         "MySQL"
     }
 
+    fn is_provider(&self, name: &str) -> bool {
+        name == "mysql" || name == "@prisma/mysql"
+    }
+
     fn capabilities(&self) -> ConnectorCapabilities {
         CAPABILITIES
     }

--- a/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql.prisma
+++ b/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "@prisma/mysql"
+    url = "mysql://"
+    relationMode = "prisma"
+}

--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -70,6 +70,15 @@ async fn mysql(
     features: PreviewFeatures,
 ) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync>> {
     trace!("Loading MySQL query connector...");
+
+    if source.provider == "@prisma/mysql" {
+        // TODO: change this to a new PrismaMysql connector once
+        // https://github.com/prisma/client-planning/issues/326 is ready
+        let mysql = Mysql::from_source(source, url, features).await?;
+        trace!("Loaded @prisma/mysql query connector.");
+        return Ok(sql_executor(mysql, false));
+    }
+
     let mysql = Mysql::from_source(source, url, features).await?;
     trace!("Loaded MySQL query connector.");
     Ok(sql_executor(mysql, false))


### PR DESCRIPTION
Closes https://github.com/prisma/client-planning/issues/325.