### PR TITLE
ci(github): update send-tag-event.yml

### DIFF
--- a/.github/workflows/send-tag-event.yml
+++ b/.github/workflows/send-tag-event.yml
@@ -3,7 +3,7 @@ name: Send Tag Event
 on:
   push:
     tags:
-      - '!*-integration'
+      - '*'
 
 jobs:
   send-tag-event:


### PR DESCRIPTION
Remove negative glob as the action is not triggered currently with it. 

= back to original PR code in https://github.com/prisma/prisma-engines/pull/3955

[skip ci] 