### PR TITLE
psl: use a faster hash function in parser-database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2679,6 +2679,7 @@ dependencies = [
  "either",
  "enumflags2",
  "indexmap",
+ "rustc-hash",
  "schema-ast",
 ]
 

--- a/psl/parser-database/Cargo.toml
+++ b/psl/parser-database/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 diagnostics = { path = "../diagnostics" }
 schema-ast = { path = "../schema-ast" }
 
+either = "1.6.1"
 enumflags2 = "0.7"
 indexmap = "1.8.0"
-either = "1.6.1"
+rustc-hash = "1.1.0"

--- a/psl/parser-database/src/names.rs
+++ b/psl/parser-database/src/names.rs
@@ -8,7 +8,7 @@ use crate::{
     Context, DatamodelError, StringId,
 };
 use reserved_model_names::{validate_enum_name, validate_model_name};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
 /// Resolved names for use in the validation process.
 #[derive(Default)]
@@ -19,7 +19,7 @@ pub(super) struct Names {
     pub(super) generators: HashMap<StringId, TopId>,
     /// Datasources have their own namespace.
     pub(super) datasources: HashMap<StringId, TopId>,
-    pub(super) model_fields: BTreeMap<(ast::ModelId, StringId), ast::FieldId>,
+    pub(super) model_fields: HashMap<(ast::ModelId, StringId), ast::FieldId>,
     pub(super) composite_type_fields: HashMap<(ast::CompositeTypeId, StringId), ast::FieldId>,
 }
 
@@ -32,7 +32,7 @@ pub(super) struct Names {
 /// - Model fields for each model
 /// - Enum variants for each enum
 pub(super) fn resolve_names(ctx: &mut Context<'_>) {
-    let mut tmp_names: HashSet<&str> = HashSet::new(); // throwaway container for duplicate checking
+    let mut tmp_names: HashSet<&str> = HashSet::default(); // throwaway container for duplicate checking
     let mut names = Names::default();
 
     for (top_id, top) in ctx.ast.iter_tops() {

--- a/psl/parser-database/src/relations.rs
+++ b/psl/parser-database/src/relations.rs
@@ -6,10 +6,8 @@ use crate::{
     {context::Context, types::RelationField},
 };
 use enumflags2::bitflags;
-use std::{
-    collections::{BTreeSet, HashMap},
-    fmt,
-};
+use rustc_hash::FxHashMap as HashMap;
+use std::{collections::BTreeSet, fmt};
 
 /// Detect relation types and construct relation objects to the database.
 pub(super) fn infer_relations(ctx: &mut Context<'_>) {

--- a/psl/parser-database/src/types.rs
+++ b/psl/parser-database/src/types.rs
@@ -3,11 +3,9 @@ pub(crate) mod index_fields;
 use crate::{context::Context, interner::StringId, walkers::IndexFieldWalker, DatamodelError};
 use either::Either;
 use enumflags2::bitflags;
+use rustc_hash::FxHashMap as HashMap;
 use schema_ast::ast::{self, WithName};
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt,
-};
+use std::{collections::BTreeMap, fmt};
 
 pub(super) fn resolve_types(ctx: &mut Context<'_>) {
     for (top_id, top) in ctx.ast.iter_tops() {
@@ -51,7 +49,7 @@ impl Types {
     pub(super) fn range_model_scalar_fields(
         &self,
         model_id: ast::ModelId,
-    ) -> impl Iterator<Item = (ScalarFieldId, &ScalarField)> {
+    ) -> impl Iterator<Item = (ScalarFieldId, &ScalarField)> + Clone {
         let start = self.scalar_fields.partition_point(|sf| sf.model_id < model_id);
         self.scalar_fields[start..]
             .iter()

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -60,6 +60,15 @@ impl crate::ParserDatabase {
             .map(|enum_id| self.walk(enum_id))
     }
 
+    /// Find a model by name.
+    pub fn find_model<'db>(&'db self, name: &str) -> Option<ModelWalker<'db>> {
+        self.interner
+            .lookup(name)
+            .and_then(|name_id| self.names.tops.get(&name_id))
+            .and_then(|top_id| top_id.as_model_id())
+            .map(|model_id| self.walk(model_id))
+    }
+
     /// Traverse a schema element by id.
     pub fn walk<I>(&self, id: I) -> Walker<'_, I> {
         Walker { db: self, id }

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -109,7 +109,7 @@ impl<'db> ModelWalker<'db> {
     }
 
     /// Iterate all the scalar fields in a given model in the order they were defined.
-    pub fn scalar_fields(self) -> impl Iterator<Item = ScalarFieldWalker<'db>> {
+    pub fn scalar_fields(self) -> impl Iterator<Item = ScalarFieldWalker<'db>> + Clone {
         self.db
             .types
             .range_model_scalar_fields(self.id)


### PR DESCRIPTION
This fell out of the schema builder performance work going on in https://github.com/prisma/prisma-engines/pull/3977

We can merge this separately, it's a small win.