### PR TITLE
fix(fieldRef): generic args in ts client

### DIFF
--- a/query-engine/schema/src/build/input_types/objects/filter_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/filter_objects.rs
@@ -137,6 +137,7 @@ pub(crate) fn where_unique_object_type(ctx: &mut BuilderContext<'_>, model: &Mod
     };
 
     let mut input_object = init_input_object_type(ident.clone());
+    input_object.set_tag(ObjectTag::WhereInputType(ParentContainer::Model(model.clone())));
 
     if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
         input_object.require_at_least_one_field();


### PR DESCRIPTION
## Overview

- fixes https://github.com/prisma/prisma/issues/16997

It's hard to connect the changes to the actual fix. Setting the `WhereInputType` object tag to the `WhereUniqueInput` object types allows the DMMF renderer to add a `meta: { source: "<model_name>" }` property to the input object types, which the client eventually use to decide whether or not a generic is needed for the generated TypeScript types.

What happened is that we first implemented field refs, then we implemented the extendedWhereUnique feature, but forgot to add the required tag to `WhereUnique` input objects, which made both features incompatible.