### PR TITLE
ci: move "Release binary compilation test" to GH runners

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -17,10 +17,9 @@ jobs:
     name: "Compile top level crates on Linux"
     strategy:
       fail-fast: false
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
       - uses: dtolnay/rust-toolchain@stable
 
       - run: "cargo clean && cargo build --release -p schema-engine-cli"


### PR DESCRIPTION
On buildjet, runs take ~9 minutes. The runs on this branch take about
~26 minutes. We can make this change, for cost savings.