### PR TITLE
publish-prisma-fmt-wasm.yml: use cachix-action

### DIFF
--- a/.github/workflows/publish-prisma-fmt-wasm.yml
+++ b/.github/workflows/publish-prisma-fmt-wasm.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           ref: ${{ github.event.inputs.enginesHash }}
       - uses: cachix/install-nix-action@v21
+      # Use cachix cache to speed up building
+      - uses: cachix/cachix-action@v12
 
       #
       # Build


### PR DESCRIPTION
Use cachix cache to speed up building, see 
https://github.com/cachix/cachix-action