### PR TITLE
ci: make schema engine tests run on GH runners

### DIFF
--- a/.github/workflows/schema-engine.yml
+++ b/.github/workflows/schema-engine.yml
@@ -31,7 +31,7 @@ jobs:
             url: "mongodb://prisma:prisma@localhost:27017/?authSource=admin&retryWrites=true"
           - name: "mongodb5"
             url: "mongodb://prisma:prisma@localhost:27018/?authSource=admin&retryWrites=true"
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -101,7 +101,7 @@ jobs:
             is_vitess: true
             single_threaded: true
 
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Instead of buildjet. For cost savings. Looking at sample runs on main
vs. on this branch suggests that postgres runs go from ~3 minutes to ~15
minutes.