### PR TITLE
ci: make QE black box tests run on GH runners

### DIFF
--- a/.github/workflows/query-engine-black-box.yml
+++ b/.github/workflows/query-engine-black-box.yml
@@ -41,7 +41,7 @@ jobs:
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
 
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Instead of buildjet. For cost savings.