### PR TITLE
introspection: fix reintrospection of @default(uuid()) @db.Uuid

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
@@ -39,7 +39,7 @@ impl<'a> DefaultValuePair<'a> {
         let sql_kind = self.next.default().map(|d| d.kind());
         let family = self.next.column_type_family();
 
-        match (sql_kind, family) {
+        match dbg!((sql_kind, family)) {
             (Some(sql::DefaultKind::Sequence(name)), _) if self.context.is_cockroach() => {
                 let connector_data: &PostgresSchemaExt = self.context.sql_schema.downcast_connector_data();
 
@@ -122,7 +122,7 @@ impl<'a> DefaultValuePair<'a> {
                 _ => unreachable!(),
             },
 
-            (None, sql::ColumnTypeFamily::String) => match self.previous {
+            (None, sql::ColumnTypeFamily::String | sql::ColumnTypeFamily::Uuid) => match self.previous {
                 Some(previous) if previous.is_cuid() => Some(DefaultKind::Cuid),
                 Some(previous) if previous.is_uuid() => Some(DefaultKind::Uuid),
                 Some(previous) if previous.is_nanoid() => {

--- a/schema-engine/sql-introspection-tests/tests/re_introspection/postgresql.rs
+++ b/schema-engine/sql-introspection-tests/tests/re_introspection/postgresql.rs
@@ -256,3 +256,29 @@ async fn reserved_name_docs_are_only_added_once(api: &mut TestApi) -> TestResult
 
     Ok(())
 }
+
+#[test_connector(tags(Postgres))]
+async fn re_introspecting_uuid_default_on_uuid_typed_pk_field(api: &mut TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TABLE "mymodel" (
+            id UUID PRIMARY KEY
+        );
+    "#};
+
+    let prisma_schema = r#"
+        model mymodel {
+            id String @id @default(uuid()) @db.Uuid
+        }
+    "#;
+
+    api.raw_cmd(setup).await;
+
+    let expected = expect![[r#"
+        model mymodel {
+          id String @id @default(uuid()) @db.Uuid
+        }
+    "#]];
+
+    api.expect_re_introspected_datamodel(&prisma_schema, expected).await;
+    Ok(())
+}


### PR DESCRIPTION
In plain words: reintrospection of `@default(uuid())` defaults did not work on fields corresponding to columns of type `UUID` on postgres, because we assumed the sql-schema-describer column type family had to be `String`, but it is `Uuid`.

closes https://github.com/prisma/prisma/issues/18857