### PR TITLE
feat(psl): accept `@prisma/mysql` provider only when the `nodeDrivers` feature flag is enabled

### DIFF
--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -13,7 +13,7 @@ use psl_core::{
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{walkers, ReferentialAction, ScalarType},
-    PreviewFeature,
+    Datasource, PreviewFeature,
 };
 use MySqlType::*;
 
@@ -234,6 +234,20 @@ impl Connector for MySqlDatamodelConnector {
             for field in model.relation_fields() {
                 validations::uses_native_referential_action_set_default(self, field, errors);
             }
+        }
+    }
+
+    fn validate_datasource(
+        &self,
+        preview_features: BitFlags<PreviewFeature>,
+        ds: &Datasource,
+        errors: &mut Diagnostics,
+    ) {
+        if ds.provider == "@prisma/mysql" && !preview_features.contains(PreviewFeature::NodeDrivers) {
+            errors.push_error(DatamodelError::new_validation_error(
+                "The provider \"@prisma/mysql\" is currently in preview and must be explicitly enabled. Please add the preview feature flag \"nodeDrivers\" to the generator block in your schema.prisma file.",
+                Span::empty(),
+            ));
         }
     }
 

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -246,7 +246,7 @@ impl Connector for MySqlDatamodelConnector {
         if ds.provider == "@prisma/mysql" && !preview_features.contains(PreviewFeature::NodeDrivers) {
             errors.push_error(DatamodelError::new_validation_error(
                 "The provider \"@prisma/mysql\" is currently in preview and must be explicitly enabled. Please add the preview feature flag \"nodeDrivers\" to the generator block in your schema.prisma file.",
-                Span::empty(),
+                ds.provider_span,
             ));
         }
     }

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -10,6 +10,7 @@ pub struct Datasource {
     pub name: String,
     /// The provider string
     pub provider: String,
+    pub provider_span: Span,
     /// The provider that was selected as active from all specified providers
     pub active_provider: &'static str,
     pub url: StringFromEnvVar,

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -204,6 +204,7 @@ fn lift_datasource(
         schemas_span,
         name: source_name.to_owned(),
         provider: provider.to_owned(),
+        provider_span: provider_arg.span(),
         active_provider: active_connector.provider_name(),
         url,
         url_span,

--- a/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql.prisma
+++ b/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql.prisma
@@ -8,9 +8,8 @@ datasource db {
     relationMode = "prisma"
 }
 // [1;91merror[0m: [1mError validating: The provider "@prisma/mysql" is currently in preview and must be explicitly enabled. Please add the preview feature flag "nodeDrivers" to the generator block in your schema.prisma file.[0m
-//   [1;94m-->[0m  [4mschema.prisma:1[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m   | [0m
-// [1;94m 1 | [0m[1;91m[0mgenerator client {
-// [1;94m   | [0m[1;91m^ Unexpected token.[0m
+// [1;94m 5 | [0mdatasource db {
+// [1;94m 6 | [0m    provider = [1;91m"@prisma/mysql"[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql.prisma
+++ b/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql.prisma
@@ -7,3 +7,10 @@ datasource db {
     url = "mysql://"
     relationMode = "prisma"
 }
+// [1;91merror[0m: [1mError validating: The provider "@prisma/mysql" is currently in preview and must be explicitly enabled. Please add the preview feature flag "nodeDrivers" to the generator block in your schema.prisma file.[0m
+//   [1;94m-->[0m  [4mschema.prisma:1[0m
+// [1;94m   | [0m
+// [1;94m   | [0m
+// [1;94m 1 | [0m[1;91m[0mgenerator client {
+// [1;94m   | [0m[1;91m^ Unexpected token.[0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql_no_preview_error.prisma
+++ b/psl/psl/tests/validation/mysql/node_drivers/prisma_mysql_no_preview_error.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider = "prisma-client-js"
+    previewFeatures = ["nodeDrivers"]
+}
+
+datasource db {
+    provider = "@prisma/mysql"
+    url = "mysql://"
+    relationMode = "prisma"
+}


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/55