### PR TITLE
feat(query-engine): add Node.js playground in `nodejs-drivers/nodejs-examples`

### DIFF
--- a/query-engine/nodejs-drivers/nodejs-examples/.gitignore
+++ b/query-engine/nodejs-drivers/nodejs-examples/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/query-engine/nodejs-drivers/nodejs-examples/README.md
+++ b/query-engine/nodejs-drivers/nodejs-examples/README.md
@@ -1,0 +1,79 @@
+# @prisma/nodejs-playground
+
+This is a playground for testing the `libquery` client with the experimental Node.js drivers.
+It contains a subset of `@prisma/client`, plus a handy [`index.ts`](./src/index.ts) file with a `main` function.
+
+## How to use
+
+In the root directory:
+  - Run `cargo build -p query-engine-node-api` to compile the `libquery` Query Engine
+  - Spawn a MySQL8 database via `make dev-mysql8`
+  - Store the `export TEST_DATABASE_URL="mysql://root:prisma@localhost:3307/test"` env var in `.envrc.local` and expose it via `direnv allow .`
+
+In the current directory
+  - Copy the content of [`./src/index.sql`](./src/index.sql) into the MySQL8 database available at `mysql://root:prisma@localhost:3307/test`
+  - Run `pnpm i` to install dependencies
+  - Run `pnpm dev` to run the playground
+
+## How to test
+
+There is no automatic test. However, [./src/index.ts](./src/index.ts) includes a pipeline you can use to interactively experiment with the new Query Engine.
+
+In particular, the pipeline steps are currently the following:
+
+- Define `db`, a class instance wrapper around the `mysql2/promise` Node.js driver for MySQL
+- Define `nodejsFnCtx`, an object exposing (a)sync "Queryable" functions that can be safely passed to Rust, so that it can interact with `db`'s class methods
+- Load the *debug* version of `libquery`, i.e., the compilation artifact of the `query-engine-node-api` crate
+- Define `engine` via the `QueryEngine` constructor exposed by Rust
+- Initialize the connector via `engine.connect()`
+- Run a Prisma `findMany` query via the JSON protocol, according to the Prisma schema in [./prisma/schema.prisma](./prisma/schema.prisma), storing the result in `resultSet`
+- Release the connector via `engine.disconnect()`
+- Attempt a reconnection (useful to catch possible panics in the implementation)
+- Close the database connection via `nodejsFnCtx`
+
+Example test output:
+
+```
+❯ pnpm dev
+
+> @prisma/nodejs-playground@1.0.0 dev /Users/jkomyno/work/prisma/prisma-engines-2/query-engine/nodejs-drivers/nodejs-examples
+> ts-node ./src/index.ts
+
+[nodejs] initializing mock connection pool: mysql://root:prisma@localhost:3307/test
+[nodejs] initializing mysql connection pool: mysql://root:prisma@localhost:3307/test
+fn_ctx: true
+QueryEngine {}
+[nodejs] connecting...
+[nodejs] connected
+NodeJSQueryable::query()
+NodeJSQueryable::query_raw(SELECT `test`.`some_user`.`id`, `test`.`some_user`.`firstname`, `test`.`some_user`.`company_id` FROM `test`.`some_user` WHERE 1=1, [])
+[rs] calling query_raw: SELECT `test`.`some_user`.`id`, `test`.`some_user`.`firstname`, `test`.`some_user`.`company_id` FROM `test`.`some_user` WHERE 1=1
+[nodejs] calling queryRaw SELECT `test`.`some_user`.`id`, `test`.`some_user`.`firstname`, `test`.`some_user`.`company_id` FROM `test`.`some_user` WHERE 1=1
+[rs] awaiting promise
+[nodejs] after query
+[nodejs] resultSet {
+  columns: [ 'id', 'firstname', 'company_id' ],
+  rows: [ [ '1', 'Alberto', '1' ], [ '2', 'Tom', '1' ] ]
+}
+[rs] awaited: ResultSet { columns: ["id", "firstname", "company_id"], rows: [["1", "Alberto", "1"], ["2", "Tom", "1"]] }
+[nodejs] resultSet {"data":{"findManysome_user":[{"id":1,"firstname":"Alberto","company_id":1},{"id":2,"firstname":"Tom","company_id":1}]}}
+[nodejs] disconnecting...
+[nodejs] disconnected
+[nodejs] connecting...
+[nodejs] connecting
+[nodejs] disconnecting...
+[nodejs] disconnected
+[nodejs] closing database connection...
+[nodejs] calling close() on connection pool
+[nodejs] closed connection pool
+[nodejs] closed database connection
+```
+
+Note how the `[nodejs]` prefixes in the logs arise from using `console.log()` in Node.js, whereas the `[rs]` prefixes arise from using `println!()` in Rust.
+
+Feel free to experiment with different types of queries.
+
+## Main known limitations
+
+- Query parameters are not supported
+- Row values from e.g. `findMany` are always cast to string

--- a/query-engine/nodejs-drivers/nodejs-examples/package.json
+++ b/query-engine/nodejs-drivers/nodejs-examples/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@prisma/nodejs-playground",
+  "version": "1.0.0",
+  "description": "",
+  "type": "commonjs",
+  "main": "index.js",
+  "scripts": {
+    "dev": "ts-node ./src/index.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@napi-rs/cli": "^2.15.2",
+    "@types/node": "^20.1.2",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.0.4"
+  },
+  "dependencies": {
+    "mysql2": "^3.3.1"
+  }
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/pnpm-lock.yaml
+++ b/query-engine/nodejs-drivers/nodejs-examples/pnpm-lock.yaml
@@ -1,0 +1,212 @@
+lockfileVersion: 5.4
+
+specifiers:
+  '@napi-rs/cli': ^2.15.2
+  '@types/node': ^20.1.2
+  mysql2: ^3.3.1
+  ts-node: ^10.9.1
+  typescript: ^5.0.4
+
+dependencies:
+  mysql2: 3.3.1
+
+devDependencies:
+  '@napi-rs/cli': 2.15.2
+  '@types/node': 20.1.2
+  ts-node: 10.9.1_2iv32njo7zubg747f6idfhe53e
+  typescript: 5.0.4
+
+packages:
+
+  /@cspotcode/source-map-support/0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@jridgewell/resolve-uri/3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec/1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: true
+
+  /@jridgewell/trace-mapping/0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /@napi-rs/cli/2.15.2:
+    resolution: {integrity: sha512-80tBCtCnEhAmFtB9oPM0FL74uW7fAmtpeqjvERH7Q1z/aZzCAs/iNfE7U3ehpwg9Q07Ob2Eh/+1guyCdX/p24w==}
+    engines: {node: '>= 10'}
+    hasBin: true
+    dev: true
+
+  /@tsconfig/node10/1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12/1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14/1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16/1.0.3:
+    resolution: {integrity: sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==}
+    dev: true
+
+  /@types/node/20.1.2:
+    resolution: {integrity: sha512-CTO/wa8x+rZU626cL2BlbCDzydgnFNgc19h4YvizpTO88MFQxab8wqisxaofQJ/9bLGugRdWIuX/TbIs6VVF6g==}
+    dev: true
+
+  /acorn-walk/8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn/8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /arg/4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
+  /create-require/1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
+  /denque/2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
+
+  /diff/4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
+
+  /generate-function/2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+    dependencies:
+      is-property: 1.0.2
+    dev: false
+
+  /iconv-lite/0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      safer-buffer: 2.1.2
+    dev: false
+
+  /is-property/1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+    dev: false
+
+  /long/5.2.3:
+    resolution: {integrity: sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==}
+    dev: false
+
+  /lru-cache/7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /lru-cache/8.0.5:
+    resolution: {integrity: sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==}
+    engines: {node: '>=16.14'}
+    dev: false
+
+  /make-error/1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /mysql2/3.3.1:
+    resolution: {integrity: sha512-UD84/AvLwO5qmSABEsBTZ7y7JKv3sM8JzWGhuL4tDkJwVsClVVAcelNSR5Unyhxj6/KHBAkjS7qe5/c+gEmNvA==}
+    engines: {node: '>= 8.0'}
+    dependencies:
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.6.3
+      long: 5.2.3
+      lru-cache: 8.0.5
+      named-placeholders: 1.1.3
+      seq-queue: 0.0.5
+      sqlstring: 2.3.3
+    dev: false
+
+  /named-placeholders/1.1.3:
+    resolution: {integrity: sha512-eLoBxg6wE/rZkJPhU/xRX1WTpkFEwDJEN96oxFrTsqBdbT5ec295Q+CoHrL9IT0DipqKhmGcaZmwOt8OON5x1w==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      lru-cache: 7.18.3
+    dev: false
+
+  /safer-buffer/2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+    dev: false
+
+  /seq-queue/0.0.5:
+    resolution: {integrity: sha512-hr3Wtp/GZIc/6DAGPDcV4/9WoZhjrkXsi5B/07QgX8tsdc6ilr7BFM6PM6rbdAX1kFSDYeZGLipIZZKyQP0O5Q==}
+    dev: false
+
+  /sqlstring/2.3.3:
+    resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /ts-node/10.9.1_2iv32njo7zubg747f6idfhe53e:
+    resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.3
+      '@types/node': 20.1.2
+      acorn: 8.8.2
+      acorn-walk: 8.2.0
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.0.4
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /typescript/5.0.4:
+    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
+    engines: {node: '>=12.20'}
+    hasBin: true
+    dev: true
+
+  /v8-compile-cache-lib/3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /yn/3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true

--- a/query-engine/nodejs-drivers/nodejs-examples/prisma/schema.prisma
+++ b/query-engine/nodejs-drivers/nodejs-examples/prisma/schema.prisma
@@ -1,0 +1,25 @@
+generator client {
+  provider = "prisma-client-js"
+  previewFeatures = ["nodeDrivers"]
+}
+
+datasource db {
+  provider = "@prisma/mysql"
+  url      = env("TEST_DATABASE_URL")
+}
+
+model company {
+  id        Int         @id
+  name      String      @db.VarChar(10)
+  some_user some_user[]
+}
+
+model some_user {
+  id         Int     @id
+  firstname  String  @db.VarChar(30)
+  lastname   String  @db.VarChar(30)
+  company_id Int
+  company    company @relation(fields: [company_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "some_user_ibfk_1")
+
+  @@index([company_id], map: "company_id")
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/JsonProtocol.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/JsonProtocol.ts
@@ -1,0 +1,78 @@
+import * as Transaction from './Transaction'
+
+export type JsonQuery = {
+  modelName?: string
+  action: JsonQueryAction
+  query: JsonFieldSelection
+}
+
+export type JsonBatchQuery = {
+  batch: JsonQuery[]
+  transaction?: { isolationLevel?: Transaction.IsolationLevel }
+}
+
+export type JsonQueryAction =
+  | 'findUnique'
+  | 'findUniqueOrThrow'
+  | 'findFirst'
+  | 'findFirstOrThrow'
+  | 'findMany'
+  | 'createOne'
+  | 'createMany'
+  | 'updateOne'
+  | 'updateMany'
+  | 'deleteOne'
+  | 'deleteMany'
+  | 'upsertOne'
+  | 'aggregate'
+  | 'groupBy'
+  | 'executeRaw'
+  | 'queryRaw'
+  | 'runCommandRaw'
+  | 'findRaw'
+  | 'aggregateRaw'
+
+export type JsonFieldSelection = {
+  arguments?: Record<string, JsonArgumentValue>
+  selection: JsonSelectionSet
+}
+
+export type JsonSelectionSet = {
+  $scalars?: boolean
+  $composites?: boolean
+} & {
+  [fieldName: string]: boolean | JsonFieldSelection
+}
+
+export type JsonArgumentValue =
+  | number
+  | string
+  | boolean
+  | null
+  | JsonTaggedValue
+  | JsonArgumentValue[]
+  | { [key: string]: JsonArgumentValue }
+
+export type DateTaggedValue = { $type: 'DateTime'; value: string }
+export type DecimalTaggedValue = { $type: 'Decimal'; value: string }
+export type BytesTaggedValue = { $type: 'Bytes'; value: string }
+export type BigIntTaggedValue = { $type: 'BigInt'; value: string }
+export type FieldRefTaggedValue = { $type: 'FieldRef'; value: { _ref: string } }
+export type EnumTaggedValue = { $type: 'Enum'; value: string }
+export type JsonTaggedValue = { $type: 'Json'; value: string }
+
+export type JsonInputTaggedValue =
+  | DateTaggedValue
+  | DecimalTaggedValue
+  | BytesTaggedValue
+  | BigIntTaggedValue
+  | FieldRefTaggedValue
+  | JsonTaggedValue
+  | EnumTaggedValue
+
+export type JsonOutputTaggedValue =
+  | DateTaggedValue
+  | DecimalTaggedValue
+  | BytesTaggedValue
+  | BigIntTaggedValue
+  | JsonTaggedValue

--- a/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/Library.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/Library.ts
@@ -1,0 +1,57 @@
+import type { QueryEngineConfig } from './QueryEngine'
+
+export type QueryEngineInstance = {
+  connect(headers: string): Promise<void>
+  disconnect(headers: string): Promise<void>
+  /**
+   * @param requestStr JSON.stringified `QueryEngineRequest | QueryEngineBatchRequest`
+   * @param headersStr JSON.stringified `QueryEngineRequestHeaders`
+   */
+  query(requestStr: string, headersStr: string, transactionId?: string): Promise<string>
+  sdlSchema(): Promise<string>
+  dmmf(traceparent: string): Promise<string>
+  startTransaction(options: string, traceHeaders: string): Promise<string>
+  commitTransaction(id: string, traceHeaders: string): Promise<string>
+  rollbackTransaction(id: string, traceHeaders: string): Promise<string>
+  metrics(options: string): Promise<string>
+}
+
+export type ResultSet = {
+  columns: string[]
+  rows: (string)[][] // Note: we're currently stringifying any result values
+}
+
+export type Queryable = {
+  queryRaw: (sql: string) => Promise<ResultSet>
+  executeRaw: (sql: string) => Promise<number>
+  version: () => string | undefined
+  isHealthy: () => boolean
+}
+
+export type Closeable = {
+  close: () => Promise<void>
+}
+
+export interface QueryEngineConstructor {
+  new (config: QueryEngineConfig, logger: (log: string) => void, nodejsFnCtx?: Queryable): QueryEngineInstance
+}
+
+export interface LibraryLoader {
+  loadLibrary(): Promise<Library>
+}
+
+// Main
+export type Library = {
+  QueryEngine: QueryEngineConstructor
+
+  version: () => {
+    // The commit hash of the engine
+    commit: string
+    // Currently 0.1.0 (Set in Cargo.toml)
+    version: string
+  }
+  /**
+   * This returns a string representation of `DMMF.Document`
+   */
+  dmmf: (datamodel: string) => Promise<string>
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/QueryEngine.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/QueryEngine.ts
@@ -1,0 +1,97 @@
+import { JsonBatchQuery, JsonQuery } from './JsonProtocol'
+import * as Transaction from './Transaction'
+
+// Events
+export type QueryEngineEvent = QueryEngineLogEvent | QueryEngineQueryEvent | QueryEnginePanicEvent
+
+export type QueryEngineLogEvent = {
+  level: string
+  module_path: string
+  message: string
+  span?: boolean
+}
+
+export type QueryEngineQueryEvent = {
+  level: 'info'
+  module_path: string
+  query: string
+  item_type: 'query'
+  params: string
+  duration_ms: string
+  result: string
+}
+
+export type QueryEnginePanicEvent = {
+  level: 'error'
+  module_path: string
+  message: 'PANIC'
+  reason: string
+  file: string
+  line: string
+  column: string
+}
+
+// Configuration
+export type QueryEngineLogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error' | 'off'
+
+export type QueryEngineTelemetry = {
+  enabled: Boolean
+  endpoint: string
+}
+
+export type GraphQLQuery = {
+  query: string
+  variables: object
+}
+
+export type EngineProtocol = 'graphql' | 'json'
+export type EngineQuery = GraphQLQuery | JsonQuery
+
+export type EngineBatchQueries = GraphQLQuery[] | JsonQuery[]
+
+export type QueryEngineConfig = {
+  // TODO rename datamodel here and other places
+  datamodel: string
+  configDir: string
+  logQueries: boolean
+  ignoreEnvVarErrors: boolean
+  datasourceOverrides?: Record<string, string>
+  env: Record<string, string | undefined>
+  logLevel: QueryEngineLogLevel
+  telemetry?: QueryEngineTelemetry
+  engineProtocol: EngineProtocol
+}
+
+// Errors
+export type SyncRustError = {
+  is_panic: boolean
+  message: string
+  meta: {
+    full_error: string
+  }
+  error_code: string
+}
+
+export type RustRequestError = {
+  is_panic: boolean
+  message: string
+  backtrace: string
+}
+
+export type QueryEngineResult<T> = {
+  data: T
+  elapsed: number
+}
+
+export type QueryEngineBatchRequest = QueryEngineBatchGraphQLRequest | JsonBatchQuery
+
+export type QueryEngineBatchGraphQLRequest = {
+  batch: QueryEngineRequest[]
+  transaction?: boolean
+  isolationLevel?: Transaction.IsolationLevel
+}
+
+export type QueryEngineRequest = {
+  query: string
+  variables: Object
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/Transaction.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/Transaction.ts
@@ -1,0 +1,35 @@
+export enum IsolationLevel {
+  ReadUncommitted = 'ReadUncommitted',
+  ReadCommitted = 'ReadCommitted',
+  RepeatableRead = 'RepeatableRead',
+  Snapshot = 'Snapshot',
+  Serializable = 'Serializable',
+}
+
+/**
+ * maxWait ?= 2000
+ * timeout ?= 5000
+ */
+export type Options = {
+  maxWait?: number
+  timeout?: number
+  isolationLevel?: IsolationLevel
+}
+
+export type InteractiveTransactionInfo<Payload = unknown> = {
+  /**
+   * Transaction ID returned by the query engine.
+   */
+  id: string
+
+  /**
+   * Arbitrary payload the meaning of which depends on the `Engine` implementation.
+   * For example, `DataProxyEngine` needs to associate different API endpoints with transactions.
+   * In `LibraryEngine` and `BinaryEngine` it is currently not used.
+   */
+  payload: Payload
+}
+
+export type TransactionHeaders = {
+  traceparent?: string
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/src/index.sql
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/index.sql
@@ -1,0 +1,25 @@
+-- Create a new database and insert some data
+
+CREATE DATABASE test;
+
+USE test;
+
+CREATE TABLE company (
+	id INT PRIMARY KEY,
+	name VARCHAR(10) NOT NULL
+);
+
+CREATE TABLE some_user (
+	id   INT PRIMARY KEY,
+	firstname VARCHAR(30) NOT NULL,
+	lastname VARCHAR(30) NOT NULL,
+	company_id INT NOT NULL,
+	FOREIGN KEY (company_id) REFERENCES company(id)
+);
+
+INSERT INTO company(id, name) VALUES
+	(1, 'Prisma');
+
+INSERT INTO some_user(id, firstname, lastname, company_id) VALUES
+	(1, 'Alberto', 'S', 1),
+	(2, 'Tom', 'H', 1);

--- a/query-engine/nodejs-drivers/nodejs-examples/src/index.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/index.ts
@@ -1,0 +1,107 @@
+import path from 'node:path'
+import os from 'node:os'
+import fs from 'node:fs'
+import { setImmediate, setTimeout } from 'node:timers/promises'
+
+import { Closeable, Library, Queryable } from './engines/types/Library'
+import { createMySQLQueryable } from './queryable/mysql'
+import { createMockQueryable } from './queryable/mock'
+
+// *.bind(db) is required to preserve the `this` context.
+// There are surely other ways than this to use class methods defined in JS within a
+// napi.rs context, but this is the most straightforward.
+const binder = (queryable: Queryable & Closeable): Queryable & Closeable => ({
+  queryRaw: queryable.queryRaw.bind(queryable),
+  executeRaw: queryable.executeRaw.bind(queryable),
+  version: queryable.version.bind(queryable),
+  isHealthy: queryable.isHealthy.bind(queryable),
+  close: queryable.close.bind(queryable),
+})
+
+async function main() {
+  const connectionString = `${process.env.TEST_DATABASE_URL as string}`
+
+  /* Use `mock` if you want to test local promises with no database */
+  const mock = createMockQueryable(connectionString)
+
+  /* Use `db` if you want to test the actual MySQL database */
+  const db = createMySQLQueryable(connectionString)
+
+  // `binder` is required to preserve the `this` context to the group of functions passed to libquery.
+  const nodejsFnCtx = binder(db)
+
+  // wait for the database pool to be initialized
+  await setImmediate(0)
+
+  // I assume nobody will run this on Windows ¯\_(ツ)_/¯
+  const libExt = os.platform() === 'darwin' ? 'dylib' : 'so'
+  const libQueryEnginePath = path.join(__dirname, `../../../../target/debug/libquery_engine.${libExt}`)
+  
+  const schemaPath = path.join(__dirname, `../prisma/schema.prisma`)
+
+  const libqueryEngine = { exports: {} as unknown as Library} 
+  // @ts-ignore
+  process.dlopen(libqueryEngine, libQueryEnginePath)
+
+  const QueryEngine = libqueryEngine.exports.QueryEngine
+
+  const queryEngineOptions = {
+    datamodel: fs.readFileSync(schemaPath, 'utf-8'),
+    configDir: '.',
+    engineProtocol: 'json' as const,
+    logLevel: 'info' as const,
+    logQueries: false,
+    env: process.env,
+    ignoreEnvVarErrors: false,
+  }
+
+  const logCallback = (...args) => console.log(args)
+  const engine = new QueryEngine(queryEngineOptions, logCallback, nodejsFnCtx)
+
+  console.log(engine)
+
+  console.log('[nodejs] connecting...')
+  await engine.connect('trace')
+  console.log('[nodejs] connected')
+
+  const resultSet = await engine.query(`{
+    "modelName": "some_user",
+    "action": "findMany",
+    "query": {
+        "selection": {
+          "id": true,
+          "firstname": true,
+          "company_id": true
+        }
+      } 
+    }`, 'trace', undefined)
+
+  console.log('[nodejs] resultSet', resultSet)
+
+  // Note: calling `engine.disconnect` won't actually close the database connection.
+  console.log('[nodejs] disconnecting...')
+  await engine.disconnect('trace')
+  console.log('[nodejs] disconnected')
+
+  console.log('[nodejs] connecting...')
+  await engine.connect('trace')
+  console.log('[nodejs] connecting')
+
+  await setTimeout(2000)
+
+  console.log('[nodejs] disconnecting...')
+  await engine.disconnect('trace')
+  console.log('[nodejs] disconnected')
+
+  // Close the database connection. This is required to prevent the process from hanging.
+  console.log('[nodejs] closing database connection...')
+  await nodejsFnCtx.close()
+  console.log('[nodejs] closed database connection')
+
+  process.exit(0)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mock.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mock.ts
@@ -1,0 +1,84 @@
+import { setTimeout } from 'node:timers/promises'
+
+import { Closeable, Queryable, ResultSet } from '../engines/types/Library'
+
+class MockSQL implements Queryable, Closeable {
+  private maybeVersion?: string
+  private isRunning: boolean = true
+
+  constructor(connectionString: string) {
+    console.log(`[nodejs] initializing mock connection pool: ${connectionString}`)
+
+    // lazily retrieve the version and store it into `maybeVersion`
+    setTimeout(50)
+      .then(() => {
+        this.maybeVersion = 'x.y.z'
+      })
+  }
+
+  async close(): Promise<void> {
+    console.log('[nodejs] calling close() on connection pool')
+    if (this.isRunning) {
+      this.isRunning = false
+      await setTimeout(150)
+      console.log('[nodejs] closed connection pool')
+    }
+  }
+
+  /**
+   * Returns false, if connection is considered to not be in a working state.
+   */
+  isHealthy(): boolean {
+    const result = this.maybeVersion !== undefined
+      && this.isRunning
+    console.log(`[nodejs] isHealthy: ${result}`)
+    return result
+  }
+
+  /**
+   * Execute a query given as SQL, interpolating the given parameters.
+   */
+  async queryRaw(query: string): Promise<ResultSet> {
+    console.log('[nodejs] calling queryRaw', query)
+    await setTimeout(100)
+    
+    const resultSet: ResultSet = {
+      columns: ['id', 'firstname', 'company_id'],
+      rows: [
+        ['1', 'Alberto', '1'],
+        ['2', 'Tom', '1'],
+      ],
+    }
+    console.log('[nodejs] resultSet', resultSet)
+    
+    return resultSet
+  }
+
+  /**
+   * Execute a query given as SQL, interpolating the given parameters and
+   * returning the number of affected rows.
+   * Note: Queryable expects a u64, but napi.rs only supports u32.
+   */
+  async executeRaw(query: string): Promise<number> {
+    console.log('[nodejs] calling executeRaw', query)
+    await setTimeout(100)
+
+    const affectedRows = 32
+    return affectedRows
+  }
+
+  /**
+   * Return the version of the underlying database, queried directly from the
+   * source. This corresponds to the `version()` function on PostgreSQL for
+   * example. The version string is returned directly without any form of
+   * parsing or normalization.
+   */
+  version(): string | undefined {
+    return this.maybeVersion
+  }
+}
+
+export const createMockQueryable = (connectionString: string): Queryable & Closeable => {
+  const db = new MockSQL(connectionString)
+  return db
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mysql.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mysql.ts
@@ -1,0 +1,101 @@
+import * as mysql from 'mysql2/promise'
+
+import { Closeable, Queryable, ResultSet } from '../engines/types/Library'
+
+class PrismaMySQL implements Queryable, Closeable {
+  private pool: mysql.Pool
+  private maybeVersion?: string
+  private isRunning: boolean = true
+
+  constructor(connectionString: string) {
+    console.log(`[nodejs] initializing mysql connection pool: ${connectionString}`)
+    this.pool = mysql.createPool(connectionString)
+
+    // lazily retrieve the version and store it into `maybeVersion`
+    this.pool.query<mysql.RowDataPacket[]>({
+      sql: 'SELECT @@version, @@GLOBAL.version',
+    }).then(([results, _]) => {
+      this.maybeVersion = results[0]['@@version']
+    })
+  }
+
+  async close(): Promise<void> {
+    console.log('[nodejs] calling close() on connection pool')
+    if (this.isRunning) {
+      this.isRunning = false
+      await this.pool.end()
+      console.log('[nodejs] closed connection pool')
+    }
+  }
+
+  /**
+   * Returns false, if connection is considered to not be in a working state.
+   */
+  isHealthy(): boolean {
+    const result = this.maybeVersion !== undefined
+      && this.isRunning
+    console.log(`[nodejs] isHealthy: ${result}`)
+    return result
+  }
+
+  /**
+   * Execute a query given as SQL, interpolating the given parameters.
+   */
+  async queryRaw(query: string): Promise<ResultSet> {
+    console.log('[nodejs] calling queryRaw', query)
+    const [results, fields] = await this.pool.query<mysql.RowDataPacket[]>({
+      sql: query,
+      rowsAsArray: false,
+    })
+    console.log('[nodejs] after query')
+
+    const columns = fields.map(field => field.name)
+    const resultSet: ResultSet = {
+      columns: columns,
+
+      // TODO: what if I remove the `toString()`?
+      // Currently, it would fail with something like:
+      // [Error: Failed to convert JavaScript value `Number 1 ` into rust type `String`],
+      // because the `id` column is a number, but the `ResultSet` expects a Vec<Vec<Str>>.
+      rows: results.map(result => columns.map(column => result[column].toString()))
+    };
+    console.log('[nodejs] resultSet', resultSet)
+
+    /*
+    resultSet {
+      columns: [ 'id', 'firstname', 'company_id' ],
+      rows: [ [ 1, 'Alberto', 1 ], [ 2, 'Tom', 1 ] ]
+    }
+    */
+
+    return resultSet
+  }
+
+  /**
+   * Execute a query given as SQL, interpolating the given parameters and
+   * returning the number of affected rows.
+   * Note: Queryable expects a u64, but napi.rs only supports u32.
+   */
+  async executeRaw(query: string): Promise<number> {
+    console.log('[nodejs] calling executeRaw', query)
+    const [{ affectedRows }, _] = await this.pool.execute<mysql.ResultSetHeader>({
+      sql: query,
+    })
+    return affectedRows
+  }
+
+  /**
+   * Return the version of the underlying database, queried directly from the
+   * source. This corresponds to the `version()` function on PostgreSQL for
+   * example. The version string is returned directly without any form of
+   * parsing or normalization.
+   */
+  version(): string | undefined {
+    return this.maybeVersion
+  }
+}
+
+export const createMySQLQueryable = (connectionString: string): Queryable & Closeable => {
+  const db = new PrismaMySQL(connectionString)
+  return db
+}

--- a/query-engine/nodejs-drivers/nodejs-examples/tsconfig.json
+++ b/query-engine/nodejs-drivers/nodejs-examples/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "ES2021.WeakRef"],
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "sourceMap": true,
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "noUncheckedIndexedAccess": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "useUnknownInCatchVariables": false,
+    "skipDefaultLibCheck": true,
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true,
+    "resolveJsonModule": true
+  },
+  "exclude": ["**/dist", "**/node_modules", "**/src/__tests__"]
+}


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/56.

The new playground is in `./query-engine/nodejs-drivers/nodejs-examples`. See its usage in https://github.com/prisma/prisma-engines/pull/3973.