### PR TITLE
fix(mongo): disallow filtered nested disconnect based on inlining

### DIFF
--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -55,7 +55,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     SupportsTxIsolationSerializable |
     NativeUpsert |
     MultiSchema |
-    FilteredInlineNestedToOneDisconnect
+    FilteredInlineChildNestedToOneDisconnect
 });
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -54,7 +54,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     OrderByNullsFirstLast |
     SupportsTxIsolationSerializable |
     NativeUpsert |
-    MultiSchema
+    MultiSchema |
+    FilteredInlineNestedToOneDisconnect
 });
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -47,6 +47,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     DecimalType |
     ClusteringSetting |
     OrderByNullsFirstLast |
+    FilteredInlineNestedToOneDisconnect |
     SupportsTxIsolationReadUncommitted |
     SupportsTxIsolationReadCommitted |
     SupportsTxIsolationRepeatableRead |

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -47,7 +47,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     DecimalType |
     ClusteringSetting |
     OrderByNullsFirstLast |
-    FilteredInlineNestedToOneDisconnect |
+    FilteredInlineChildNestedToOneDisconnect |
     SupportsTxIsolationReadUncommitted |
     SupportsTxIsolationReadCommitted |
     SupportsTxIsolationRepeatableRead |

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -54,6 +54,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     ImplicitManyToManyRelation |
     DecimalType |
     OrderByNullsFirstLast |
+    FilteredInlineNestedToOneDisconnect |
     SupportsTxIsolationReadUncommitted |
     SupportsTxIsolationReadCommitted |
     SupportsTxIsolationRepeatableRead |

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -54,7 +54,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     ImplicitManyToManyRelation |
     DecimalType |
     OrderByNullsFirstLast |
-    FilteredInlineNestedToOneDisconnect |
+    FilteredInlineChildNestedToOneDisconnect |
     SupportsTxIsolationReadUncommitted |
     SupportsTxIsolationReadCommitted |
     SupportsTxIsolationRepeatableRead |

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -57,7 +57,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     ImplicitManyToManyRelation |
     DecimalType |
     OrderByNullsFirstLast |
-    FilteredInlineNestedToOneDisconnect |
+    FilteredInlineChildNestedToOneDisconnect |
     SupportsTxIsolationReadUncommitted |
     SupportsTxIsolationReadCommitted |
     SupportsTxIsolationRepeatableRead |

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -57,6 +57,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     ImplicitManyToManyRelation |
     DecimalType |
     OrderByNullsFirstLast |
+    FilteredInlineNestedToOneDisconnect |
     SupportsTxIsolationReadUncommitted |
     SupportsTxIsolationReadCommitted |
     SupportsTxIsolationRepeatableRead |

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -24,7 +24,7 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     OrderByNullsFirstLast |
     SupportsTxIsolationSerializable |
     NativeUpsert |
-    FilteredInlineNestedToOneDisconnect
+    FilteredInlineChildNestedToOneDisconnect
 });
 
 pub struct SqliteDatamodelConnector;

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -23,7 +23,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     BackwardCompatibleQueryRaw |
     OrderByNullsFirstLast |
     SupportsTxIsolationSerializable |
-    NativeUpsert
+    NativeUpsert |
+    FilteredInlineNestedToOneDisconnect
 });
 
 pub struct SqliteDatamodelConnector;

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -93,6 +93,7 @@ capabilities!(
     DecimalType,                // Connector supports Prisma Decimal type.
     BackwardCompatibleQueryRaw, // Temporary SQLite specific capability. Should be removed once https://github.com/prisma/prisma/issues/12784 is fixed,
     OrderByNullsFirstLast,      // Connector supports ORDER BY NULLS LAST/FIRST
+    FilteredInlineNestedToOneDisconnect, // Connector supports a filtered nested disconnect on both sides of a to-one relation.
     // Block of isolation levels.
     SupportsTxIsolationReadUncommitted,
     SupportsTxIsolationReadCommitted,

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -93,7 +93,7 @@ capabilities!(
     DecimalType,                // Connector supports Prisma Decimal type.
     BackwardCompatibleQueryRaw, // Temporary SQLite specific capability. Should be removed once https://github.com/prisma/prisma/issues/12784 is fixed,
     OrderByNullsFirstLast,      // Connector supports ORDER BY NULLS LAST/FIRST
-    FilteredInlineNestedToOneDisconnect, // Connector supports a filtered nested disconnect on both sides of a to-one relation.
+    FilteredInlineChildNestedToOneDisconnect, // Connector supports a filtered nested disconnect on both sides of a to-one relation.
     // Block of isolation levels.
     SupportsTxIsolationReadUncommitted,
     SupportsTxIsolationReadCommitted,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
@@ -55,7 +55,7 @@ mod disconnect_inside_update {
     #[relation_link_test(
         on_parent = "ToOneOpt",
         on_child = "ToOneOpt",
-        capabilities(FilteredInlineNestedToOneDisconnect)
+        capabilities(FilteredInlineChildNestedToOneDisconnect)
     )]
     async fn p1_c1_by_filters_should_work(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
@@ -106,7 +106,7 @@ mod disconnect_inside_update {
     #[relation_link_test(
         on_parent = "ToOneOpt",
         on_child = "ToOneOpt",
-        capabilities(FilteredInlineNestedToOneDisconnect)
+        capabilities(FilteredInlineChildNestedToOneDisconnect)
     )]
     async fn p1_c1_by_fails_if_filters_no_match(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
@@ -52,7 +52,11 @@ mod disconnect_inside_update {
     }
 
     // "a P1 to C1 relation " should "be disconnectable through a nested mutation by id"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt")]
+    #[relation_link_test(
+        on_parent = "ToOneOpt",
+        on_child = "ToOneOpt",
+        capabilities(FilteredInlineNestedToOneDisconnect)
+    )]
     async fn p1_c1_by_filters_should_work(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
             run_query_json!(
@@ -99,8 +103,11 @@ mod disconnect_inside_update {
     }
 
     // "a P1 to C1 relation " should "be disconnectable through a nested mutation by id"
-    // TODO: MongoDB doesn't support joins on top-level updates. It should be un-excluded once we fix that.
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(MongoDb))]
+    #[relation_link_test(
+        on_parent = "ToOneOpt",
+        on_child = "ToOneOpt",
+        capabilities(FilteredInlineNestedToOneDisconnect)
+    )]
     async fn p1_c1_by_fails_if_filters_no_match(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
             run_query_json!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
@@ -61,7 +61,7 @@ mod disconnect_inside_upsert {
     #[relation_link_test(
         on_parent = "ToOneOpt",
         on_child = "ToOneOpt",
-        capabilities(FilteredInlineNestedToOneDisconnect)
+        capabilities(FilteredInlineChildNestedToOneDisconnect)
     )]
     async fn p1_c1_by_filters_should_work(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let res = run_query_json!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
@@ -58,7 +58,11 @@ mod disconnect_inside_upsert {
     }
 
     // "a P1 to C1 relation " should "be disconnectable through a nested mutation by id"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt")]
+    #[relation_link_test(
+        on_parent = "ToOneOpt",
+        on_child = "ToOneOpt",
+        capabilities(FilteredInlineNestedToOneDisconnect)
+    )]
     async fn p1_c1_by_filters_should_work(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let res = run_query_json!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
@@ -61,7 +61,7 @@ pub fn relation_link_test_impl(attr: TokenStream, input: TokenStream) -> TokenSt
                 #id_only,
                 &[#only],
                 &[#exclude],
-                enumflags2::make_bitflags!(ConnectorCapability::{#(#required_capabilities|)*}),
+                enumflags2::make_bitflags!(ConnectorCapability::{#(#required_capabilities)|*}),
                 (#suite_name, #test_name),
                 #runner_fn_ident
             )

--- a/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -38,8 +38,8 @@ pub fn nested_disconnect(
     } else {
         let filter: Filter = if relation.is_one_to_one() {
             // One-to-one relations can simply specify if they want to disconnect the child or not as a bool.
-            if let ParsedInputValue::Single(PrismaValue::Boolean(should_delete)) = value {
-                if !should_delete {
+            if let ParsedInputValue::Single(PrismaValue::Boolean(should_disconnect)) = value {
+                if !should_disconnect {
                     return Ok(());
                 }
 
@@ -171,7 +171,7 @@ fn handle_one_to_x(
             let parent_model = parent_relation_field.model();
             let extractor_model_id = parent_model.primary_identifier();
             let null_record_id = SelectionResult::from(&parent_relation_field.linking_fields());
-            // If the relation is inlined on the parent and a filter is applied on the child then it means the update will be done on the parent table.
+            // If the relation is inlined on the parent and a filter is applied on the child then update is done on the parent table.
             // Therefore, the filter applied on the child needs to be converted to a "relational" filter so that the connector renders the adequate SQL to join the Child table.
             let filter = if !filter.is_empty() {
                 parent_relation_field.to_one_related(filter)

--- a/query-engine/schema/src/build/input_types/fields/input_fields.rs
+++ b/query-engine/schema/src/build/input_types/fields/input_fields.rs
@@ -163,10 +163,15 @@ pub(crate) fn nested_disconnect_input_field<'a>(
             let mut types = vec![InputType::boolean()];
 
             if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
-                types.push(InputType::object(filter_objects::where_object_type(
-                    ctx,
-                    parent_field.related_model().into(),
-                )));
+                if ctx.has_capability(ConnectorCapability::FilteredInlineNestedToOneDisconnect)
+                    // If the disconnect happens on the inline side, then we can allow filters
+                    || parent_field.related_field().is_inlined_on_enclosing_model()
+                {
+                    types.push(InputType::object(filter_objects::where_object_type(
+                        ctx,
+                        parent_field.related_model().into(),
+                    )));
+                }
             }
 
             Some(input_field(operations::DISCONNECT, types, None).optional())

--- a/query-engine/schema/src/build/input_types/fields/input_fields.rs
+++ b/query-engine/schema/src/build/input_types/fields/input_fields.rs
@@ -162,16 +162,15 @@ pub(crate) fn nested_disconnect_input_field<'a>(
         (false, false) => {
             let mut types = vec![InputType::boolean()];
 
-            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
-                if ctx.has_capability(ConnectorCapability::FilteredInlineChildNestedToOneDisconnect)
+            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique)
+                && (ctx.has_capability(ConnectorCapability::FilteredInlineChildNestedToOneDisconnect)
                        // If the disconnect happens on the inline side, then we can allow filters
-                    || parent_field.related_field().is_inlined_on_enclosing_model()
-                {
-                    types.push(InputType::object(filter_objects::where_object_type(
-                        ctx,
-                        parent_field.related_model().into(),
-                    )));
-                }
+                    || parent_field.related_field().is_inlined_on_enclosing_model())
+            {
+                types.push(InputType::object(filter_objects::where_object_type(
+                    ctx,
+                    parent_field.related_model().into(),
+                )));
             }
 
             Some(input_field(operations::DISCONNECT, types, None).optional())

--- a/query-engine/schema/src/build/input_types/fields/input_fields.rs
+++ b/query-engine/schema/src/build/input_types/fields/input_fields.rs
@@ -163,8 +163,8 @@ pub(crate) fn nested_disconnect_input_field<'a>(
             let mut types = vec![InputType::boolean()];
 
             if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
-                if ctx.has_capability(ConnectorCapability::FilteredInlineNestedToOneDisconnect)
-                    // If the disconnect happens on the inline side, then we can allow filters
+                if ctx.has_capability(ConnectorCapability::FilteredInlineChildNestedToOneDisconnect)
+                       // If the disconnect happens on the inline side, then we can allow filters
                     || parent_field.related_field().is_inlined_on_enclosing_model()
                 {
                     types.push(InputType::object(filter_objects::where_object_type(


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/16869

Please read the issue above to understand the root problem.

Note: We could perform a separate read and then perform the update based on the found ids. Not sure it's worth adding complexity to the graph before we have demand.