### PR TITLE
qe: fix regression on CreateOne data argument nullability

### DIFF
--- a/query-engine/core-tests/tests/query_validation_tests/create/create_post_empty.query.json
+++ b/query-engine/core-tests/tests/query_validation_tests/create/create_post_empty.query.json
@@ -1,0 +1,5 @@
+{   
+    "action": "createOne",
+    "modelName": "Post",
+    "query": { "arguments": {}, "selection": { "$scalars": true } }
+}

--- a/query-engine/core-tests/tests/query_validation_tests/create/schema.prisma
+++ b/query-engine/core-tests/tests/query_validation_tests/create/schema.prisma
@@ -1,0 +1,36 @@
+datasource db {
+  provider = "postgres"
+  url      = env("SOME_DB")
+}
+
+// / User model comment
+model User {
+  id    String  @id @default(uuid())
+  email String  @unique
+  // / name comment
+  name  String?
+  posts Post[]
+  Like  Like[]
+}
+
+model Post {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  published Boolean
+  title     String
+  content   String?
+  authorId  String?
+  author    User?    @relation(fields: [authorId], references: [id])
+  Like      Like[]
+}
+
+model Like {
+  id     String @id @default(cuid())
+  userId String
+  user   User   @relation(fields: [userId], references: [id])
+  postId String
+  post   Post   @relation(fields: [postId], references: [id])
+
+  @@unique([userId, postId])
+}

--- a/query-engine/core-tests/tests/query_validation_tests/create_post_empty.expected.json
+++ b/query-engine/core-tests/tests/query_validation_tests/create_post_empty.expected.json
@@ -1,0 +1,143 @@
+{
+  "is_panic": false,
+  "message": "`data`: A value is required but not set",
+  "meta": {
+    "kind": "RequiredArgumentMissing",
+    "inputTypes": [
+      {
+        "kind": "object",
+        "name": "PostCreateInput",
+        "fields": [
+          {
+            "name": "id",
+            "typeNames": [
+              "String"
+            ],
+            "required": false
+          },
+          {
+            "name": "createdAt",
+            "typeNames": [
+              "DateTime"
+            ],
+            "required": false
+          },
+          {
+            "name": "updatedAt",
+            "typeNames": [
+              "DateTime"
+            ],
+            "required": false
+          },
+          {
+            "name": "published",
+            "typeNames": [
+              "Boolean"
+            ],
+            "required": true
+          },
+          {
+            "name": "title",
+            "typeNames": [
+              "String"
+            ],
+            "required": true
+          },
+          {
+            "name": "content",
+            "typeNames": [
+              "String",
+              "Null"
+            ],
+            "required": false
+          },
+          {
+            "name": "author",
+            "typeNames": [
+              "UserCreateNestedOneWithoutPostsInput"
+            ],
+            "required": false
+          },
+          {
+            "name": "Like",
+            "typeNames": [
+              "LikeCreateNestedManyWithoutPostInput"
+            ],
+            "required": false
+          }
+        ]
+      },
+      {
+        "kind": "object",
+        "name": "PostUncheckedCreateInput",
+        "fields": [
+          {
+            "name": "id",
+            "typeNames": [
+              "String"
+            ],
+            "required": false
+          },
+          {
+            "name": "createdAt",
+            "typeNames": [
+              "DateTime"
+            ],
+            "required": false
+          },
+          {
+            "name": "updatedAt",
+            "typeNames": [
+              "DateTime"
+            ],
+            "required": false
+          },
+          {
+            "name": "published",
+            "typeNames": [
+              "Boolean"
+            ],
+            "required": true
+          },
+          {
+            "name": "title",
+            "typeNames": [
+              "String"
+            ],
+            "required": true
+          },
+          {
+            "name": "content",
+            "typeNames": [
+              "String",
+              "Null"
+            ],
+            "required": false
+          },
+          {
+            "name": "authorId",
+            "typeNames": [
+              "String",
+              "Null"
+            ],
+            "required": false
+          },
+          {
+            "name": "Like",
+            "typeNames": [
+              "LikeUncheckedCreateNestedManyWithoutPostInput"
+            ],
+            "required": false
+          }
+        ]
+      }
+    ],
+    "argumentPath": [
+      "data"
+    ],
+    "selectionPath": [
+      "createOnePost"
+    ]
+  },
+  "error_code": "P2012"
+}


### PR DESCRIPTION
This is a regression introduced by
https://github.com/prisma/prisma-engines/pull/3977 — we failed to make the `data` argument required on CreateOne inputs if any field is required in the model.