### PR TITLE
qe: small performance improvements in query validation

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
@@ -40,16 +40,15 @@ impl JsonRequest {
 }
 
 fn graphql_selection_to_json_field_query(mut selection: Selection, schema_field: &OutputField<'_>) -> FieldQuery {
-    let args = schema_field.arguments().collect::<Vec<_>>();
     FieldQuery {
-        arguments: graphql_args_to_json_args(&mut selection, args.as_slice()),
+        arguments: graphql_args_to_json_args(&mut selection, schema_field.arguments()),
         selection: graphql_selection_to_json_selection(selection, schema_field),
     }
 }
 
 fn graphql_args_to_json_args(
     selection: &mut Selection,
-    args_fields: &[&InputField<'_>],
+    args_fields: &[InputField<'_>],
 ) -> Option<IndexMap<String, JsonValue>> {
     if selection.arguments().is_empty() {
         return None;
@@ -59,11 +58,8 @@ fn graphql_args_to_json_args(
 
     for (arg_name, arg_value) in selection.arguments().iter().cloned() {
         let arg_field = args_fields.iter().find(|arg_field| arg_field.name == arg_name);
-
-        let inferrer = FieldTypeInferrer::from_field(arg_field.copied()).infer(&arg_value);
-
+        let inferrer = FieldTypeInferrer::from_field(arg_field).infer(&arg_value);
         let json = arg_value_to_json(arg_value, inferrer);
-
         args.insert(arg_name, json);
     }
 

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
@@ -21,7 +21,11 @@ pub(super) fn render_input_field<'a>(input_field: &InputField<'a>, ctx: &mut Ren
 }
 
 pub(super) fn render_output_field<'a>(field: &OutputField<'a>, ctx: &mut RenderContext<'a>) -> DmmfOutputField {
-    let rendered_inputs = field.arguments().map(|arg| render_input_field(arg, ctx)).collect();
+    let rendered_inputs = field
+        .arguments()
+        .iter()
+        .map(|arg| render_input_field(arg, ctx))
+        .collect();
     let output_type = render_output_type(field.field_type(), ctx);
 
     let output_field = DmmfOutputField {

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
@@ -24,7 +24,7 @@ impl<'a> GqlFieldRenderer<'a> {
     }
 
     fn render_output_field(&self, field: &OutputField<'a>, ctx: &mut RenderContext) -> String {
-        let rendered_args = self.render_arguments(field.arguments(), ctx);
+        let rendered_args = self.render_arguments(field.arguments().iter(), ctx);
         let rendered_args = if rendered_args.is_empty() {
             "".into()
         } else if rendered_args.len() > 1 {

--- a/query-engine/schema/src/build/mutations/create_one.rs
+++ b/query-engine/schema/src/build/mutations/create_one.rs
@@ -8,7 +8,7 @@ use output_types::objects;
 use prisma_models::{Model, RelationFieldRef};
 
 /// Builds a create mutation field (e.g. createUser) for given model.
-pub(crate) fn create_one(ctx: &'_ QuerySchema, model: Model) -> OutputField<'_> {
+pub(crate) fn create_one(ctx: &QuerySchema, model: Model) -> OutputField<'_> {
     let field_name = format!("createOne{}", model.name());
     let cloned_model = model.clone();
     let model_id = model.id;
@@ -47,7 +47,7 @@ pub(crate) fn create_one_input_types(
 /// "Checked" input refers to disallowing writing relation scalars directly, as it can lead to unintended
 /// data integrity violations if used incorrectly.
 fn checked_create_input_type(
-    ctx: &'_ QuerySchema,
+    ctx: &QuerySchema,
     model: Model,
     parent_field: Option<RelationFieldRef>,
 ) -> InputObjectType<'_> {
@@ -73,7 +73,7 @@ fn checked_create_input_type(
 /// "Unchecked" input refers to allowing to write _all_ scalars on a model directly, which can
 /// lead to unintended data integrity violations if used incorrectly.
 fn unchecked_create_input_type(
-    ctx: &'_ QuerySchema,
+    ctx: &QuerySchema,
     model: Model,
     parent_field: Option<RelationFieldRef>,
 ) -> InputObjectType<'_> {

--- a/query-engine/schema/src/output_types.rs
+++ b/query-engine/schema/src/output_types.rs
@@ -198,8 +198,8 @@ impl<'a> OutputField<'a> {
         &self.name
     }
 
-    pub fn arguments(&self) -> impl Iterator<Item = &InputField<'a>> + '_ {
-        self.arguments.as_ref().into_iter().flat_map(|args| args.iter())
+    pub fn arguments(&self) -> &[InputField<'a>] {
+        self.arguments.as_ref().map(|f| (**f).as_slice()).unwrap_or(&[])
     }
 
     pub(crate) fn nullable(mut self) -> Self {


### PR DESCRIPTION
Continues the work in https://github.com/prisma/prisma-engines/pull/4009

We return a slice from arguments() so we can remove a bunch of to_owned() that clone the entire contents of the slice and allocate a Vec
    In [parser.rs](http://parser.rs/), the IndexMap with the arguments on every call to parse_arguments() is gone.