### PR TITLE
nix: concat sources overrides to the cargo config

### DIFF
--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -37,8 +37,8 @@ in
     ];
 
     configurePhase = ''
-      mkdir .cargo
-      ln -s ${deps}/config.toml .cargo/config.toml
+      echo -e "\n" >> .cargo/config.toml
+      cat ${deps}/config.toml >> .cargo/config.toml
     '';
 
     buildPhase = ''


### PR DESCRIPTION
Append the generated sources overrides from `$deps/config.toml`
(necessary for building in a sandbox without network access) to the now
existing `.cargo/config.toml` instead of creating it during the
configure phase.

This fixes building the Nix packages (including `.#prisma-fmt-wasm`) in
the node-drivers branch.
