### PR TITLE
fix: error on field ref used on different models

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/bigint_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/bigint_filter.rs
@@ -11,17 +11,17 @@ mod bigint_filter {
         setup::test_data_common_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { equals: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { equals: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { equals: { _ref: "bInt2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { equals: { _ref: "bInt2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { bInt: { not: { equals: { _ref: "bInt2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { bInt: { not: { equals: { _ref: "bInt2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -34,81 +34,81 @@ mod bigint_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { gt: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { gt: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { gt: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { gt: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gt: { _ref: "bInt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gt: { _ref: "bInt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gt: { _ref: "bInt2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gt: { _ref: "bInt2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { gte: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { gte: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { gte: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { gte: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gte: { _ref: "bInt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gte: { _ref: "bInt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gte: { _ref: "bInt2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { gte: { _ref: "bInt2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lt: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lt: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lt: { _ref: "bInt2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lt: { _ref: "bInt2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { lt: { _ref: "bInt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { lt: { _ref: "bInt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { not: { lt: { _ref: "bInt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { not: { lt: { _ref: "bInt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lte: { _ref: "bInt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lte: { _ref: "bInt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lte: { _ref: "bInt2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { lte: { _ref: "bInt2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { lte: { _ref: "bInt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { lte: { _ref: "bInt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { not: { lte: { _ref: "bInt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt2: { not: { lte: { _ref: "bInt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -120,17 +120,17 @@ mod bigint_filter {
         setup::test_data_common_mixed_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { in: { _ref: "bInt2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { in: { _ref: "bInt2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { notIn: { _ref: "bInt2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { notIn: { _ref: "bInt2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { in: { _ref: "bInt2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt: { not: { in: { _ref: "bInt2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -143,53 +143,53 @@ mod bigint_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { has: { _ref: "bInt" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { has: { _ref: "bInt", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { has: { _ref: "bInt" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { has: { _ref: "bInt", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasSome: { _ref: "bInt_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasSome: { _ref: "bInt_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasSome: { _ref: "bInt_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasSome: { _ref: "bInt_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasSome: { _ref: "bInt_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasSome: { _ref: "bInt_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasSome: { _ref: "bInt_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasSome: { _ref: "bInt_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasEvery: { _ref: "bInt_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasEvery: { _ref: "bInt_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasEvery: { _ref: "bInt_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bInt_list: { hasEvery: { _ref: "bInt_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasEvery: { _ref: "bInt_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasEvery: { _ref: "bInt_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasEvery: { _ref: "bInt_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bInt_list: { hasEvery: { _ref: "bInt_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/bytes_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/bytes_filter.rs
@@ -11,17 +11,17 @@ mod bytes_filter {
         setup::test_data_common_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { equals: { _ref: "bytes" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { equals: { _ref: "bytes", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { equals: { _ref: "bytes2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { equals: { _ref: "bytes2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { bytes: { not: { equals: { _ref: "bytes2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { bytes: { not: { equals: { _ref: "bytes2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -33,17 +33,17 @@ mod bytes_filter {
         setup::test_data_common_mixed_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { in: { _ref: "bytes2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { in: { _ref: "bytes2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { notIn: { _ref: "bytes2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { notIn: { _ref: "bytes2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { not: { in: { _ref: "bytes2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes: { not: { in: { _ref: "bytes2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -56,53 +56,53 @@ mod bytes_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { has: { _ref: "bytes" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { has: { _ref: "bytes", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { has: { _ref: "bytes" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { has: { _ref: "bytes", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasSome: { _ref: "bytes_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasSome: { _ref: "bytes_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasSome: { _ref: "bytes_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasSome: { _ref: "bytes_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasSome: { _ref: "bytes_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasSome: { _ref: "bytes_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasSome: { _ref: "bytes_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasSome: { _ref: "bytes_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasEvery: { _ref: "bytes_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasEvery: { _ref: "bytes_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasEvery: { _ref: "bytes_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { bytes_list: { hasEvery: { _ref: "bytes_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasEvery: { _ref: "bytes_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasEvery: { _ref: "bytes_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasEvery: { _ref: "bytes_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { bytes_list: { hasEvery: { _ref: "bytes_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/composite_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/composite_filter.rs
@@ -9,22 +9,22 @@ mod composite_filter {
         setup::test_data_mixed_composite(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp: { is: { string: { equals: { _ref: "string" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp: { is: { string: { equals: { _ref: "string", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp: { is: { string: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp: { is: { string: { equals: { _ref: "string2", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp: { isNot: { string: { equals: { _ref: "string" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp: { isNot: { string: { equals: { _ref: "string", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp: { isNot: { string: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp: { isNot: { string: { equals: { _ref: "string2", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -37,61 +37,61 @@ mod composite_filter {
 
         // some
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { some: { string: { equals: { _ref: "string" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { some: { string: { equals: { _ref: "string", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { some: { string: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { some: { string: { equals: { _ref: "string2", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not some
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { some: { string: { equals: { _ref: "string" } } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { some: { string: { equals: { _ref: "string", _container: "Composite" } } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { some: { string: { equals: { _ref: "string2" } } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { some: { string: { equals: { _ref: "string2", _container: "Composite" } } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // every
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { every: { string: { equals: { _ref: "string" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { every: { string: { equals: { _ref: "string", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { every: { string: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { every: { string: { equals: { _ref: "string2", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not every
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { every: { string: { equals: { _ref: "string" } } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { every: { string: { equals: { _ref: "string", _container: "Composite" } } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { every: { string: { equals: { _ref: "string2" } } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { every: { string: { equals: { _ref: "string2", _container: "Composite" } } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // none
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { none: { string: { equals: { _ref: "string" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { none: { string: { equals: { _ref: "string", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { none: { string: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { comp_list: { none: { string: { equals: { _ref: "string2", _container: "Composite" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // not none
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { none: { string: { equals: { _ref: "string" } } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { none: { string: { equals: { _ref: "string", _container: "Composite" } } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { none: { string: { equals: { _ref: "string2" } } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { NOT: { comp_list: { none: { string: { equals: { _ref: "string2", _container: "Composite" } } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/datetime_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/datetime_filter.rs
@@ -11,17 +11,17 @@ mod datetime_filter {
         setup::test_data_common_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { equals: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { equals: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { equals: { _ref: "dt2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { equals: { _ref: "dt2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { dt: { not: { equals: { _ref: "dt2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { dt: { not: { equals: { _ref: "dt2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -34,81 +34,81 @@ mod datetime_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { gt: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { gt: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { gt: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { gt: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gt: { _ref: "dt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gt: { _ref: "dt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gt: { _ref: "dt2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gt: { _ref: "dt2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { gte: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { gte: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { gte: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { gte: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gte: { _ref: "dt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gte: { _ref: "dt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gte: { _ref: "dt2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { gte: { _ref: "dt2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lt: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lt: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lt: { _ref: "dt2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lt: { _ref: "dt2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { lt: { _ref: "dt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { lt: { _ref: "dt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { not: { lt: { _ref: "dt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { not: { lt: { _ref: "dt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lte: { _ref: "dt" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lte: { _ref: "dt", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lte: { _ref: "dt2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { lte: { _ref: "dt2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { lte: { _ref: "dt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { lte: { _ref: "dt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { not: { lte: { _ref: "dt" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt2: { not: { lte: { _ref: "dt", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -120,17 +120,17 @@ mod datetime_filter {
         setup::test_data_common_mixed_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { in: { _ref: "dt2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { in: { _ref: "dt2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { notIn: { _ref: "dt2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { notIn: { _ref: "dt2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { in: { _ref: "dt2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt: { not: { in: { _ref: "dt2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -143,53 +143,53 @@ mod datetime_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { has: { _ref: "dt" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { has: { _ref: "dt", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { has: { _ref: "dt" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { has: { _ref: "dt", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasSome: { _ref: "dt_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasSome: { _ref: "dt_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasSome: { _ref: "dt_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasSome: { _ref: "dt_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasSome: { _ref: "dt_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasSome: { _ref: "dt_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasSome: { _ref: "dt_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasSome: { _ref: "dt_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasEvery: { _ref: "dt_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasEvery: { _ref: "dt_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasEvery: { _ref: "dt_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dt_list: { hasEvery: { _ref: "dt_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasEvery: { _ref: "dt_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasEvery: { _ref: "dt_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasEvery: { _ref: "dt_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dt_list: { hasEvery: { _ref: "dt_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/decimal_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/decimal_filter.rs
@@ -21,17 +21,17 @@ mod decimal_filter {
         test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { equals: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { equals: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { equals: { _ref: "dec2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { equals: { _ref: "dec2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { dec: { not: { equals: { _ref: "dec2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { dec: { not: { equals: { _ref: "dec2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -44,81 +44,81 @@ mod decimal_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { gt: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { gt: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { gt: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { gt: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gt: { _ref: "dec" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gt: { _ref: "dec", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gt: { _ref: "dec2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gt: { _ref: "dec2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { gte: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { gte: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { gte: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { gte: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gte: { _ref: "dec" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gte: { _ref: "dec", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gte: { _ref: "dec2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { gte: { _ref: "dec2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lt: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lt: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lt: { _ref: "dec2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lt: { _ref: "dec2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { lt: { _ref: "dec" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { lt: { _ref: "dec", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { not: { lt: { _ref: "dec" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { not: { lt: { _ref: "dec", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lte: { _ref: "dec" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lte: { _ref: "dec", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lte: { _ref: "dec2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { lte: { _ref: "dec2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { lte: { _ref: "dec" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { lte: { _ref: "dec", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { not: { lte: { _ref: "dec" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec2: { not: { lte: { _ref: "dec", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -143,17 +143,17 @@ mod decimal_filter {
         test_list_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { in: { _ref: "dec_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { in: { _ref: "dec_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { notIn: { _ref: "dec_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { notIn: { _ref: "dec_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { in: { _ref: "dec_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec: { not: { in: { _ref: "dec_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -166,53 +166,53 @@ mod decimal_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { has: { _ref: "dec" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { has: { _ref: "dec", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { has: { _ref: "dec" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { has: { _ref: "dec", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasSome: { _ref: "dec_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasSome: { _ref: "dec_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasSome: { _ref: "dec_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasSome: { _ref: "dec_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasSome: { _ref: "dec_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasSome: { _ref: "dec_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasSome: { _ref: "dec_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasSome: { _ref: "dec_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasEvery: { _ref: "dec_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasEvery: { _ref: "dec_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasEvery: { _ref: "dec_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { dec_list: { hasEvery: { _ref: "dec_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasEvery: { _ref: "dec_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasEvery: { _ref: "dec_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasEvery: { _ref: "dec_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { dec_list: { hasEvery: { _ref: "dec_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/failure.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/failure.rs
@@ -54,9 +54,33 @@ mod failure {
     async fn unknown_field_name_fails(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { id: { equals: { _ref: "unknown" } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { id: { equals: { _ref: "unknown", _container: "TestModel" } } }) { id } }"#,
             2019,
             "The referenced scalar field TestModel.unknown does not exist."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn fields_of_different_models_fails(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            r#"{ findManyTestModel(where: { id: { equals: { _ref: "testId", _container: "Child" } } }) { id } }"#,
+            2019,
+            "Expected a referenced scalar field of model TestModel, but found a field of model Child."
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(setup::mixed_composite_types), capabilities(CompositeTypes))]
+    async fn fields_of_different_container_fails(runner: Runner) -> TestResult<()> {
+        assert_error!(
+            runner,
+            r#"query { findManyTestModel(where: { id: { equals: { _ref: "string", _container: "Composite" } } }) { id }}"#,
+            2019,
+            "Expected a referenced scalar field of model TestModel, but found a field of composite type Composite."
         );
 
         Ok(())
@@ -66,7 +90,7 @@ mod failure {
     async fn relation_field_name_fails(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { id: { equals: { _ref: "children" } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { id: { equals: { _ref: "children", _container: "TestModel" } } }) { id } }"#,
             2019,
             "Expected a referenced scalar field TestModel.children but found a relation field."
         );
@@ -79,7 +103,7 @@ mod failure {
         // Simple scalar filter
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { id: { equals: { _ref: "str" } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { id: { equals: { _ref: "str", _container: "TestModel" } } }) { id } }"#,
             2019,
             "Expected a referenced scalar field of type Int but found TestModel.str of type String."
         );
@@ -87,7 +111,7 @@ mod failure {
         // Through a relation filter
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { children: { some: { id: { equals: { _ref: "str" } } } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { children: { some: { id: { equals: { _ref: "str", _container: "Child" } } } } }) { id } }"#,
             2019,
             "Expected a referenced scalar field of type Int but found Child.str of type String."
         );
@@ -100,7 +124,7 @@ mod failure {
         // Simple scalar filter
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { str: { equals: { _ref: "str_list" } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { str: { equals: { _ref: "str_list", _container: "TestModel" } } }) { id } }"#,
             2019,
             "Expected a referenced scalar field of type String but found TestModel.str_list of type String[]."
         );
@@ -108,7 +132,7 @@ mod failure {
         // Through a relation filter
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { children: { some: { str: { equals: { _ref: "str_list" } } } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { children: { some: { str: { equals: { _ref: "str_list", _container: "Child" } } } } }) { id } }"#,
             2019,
             "Expected a referenced scalar field of type String but found Child.str_list of type String[]."
         );
@@ -123,14 +147,14 @@ mod failure {
     async fn field_ref_inclusion_filter_fails(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { str: { in: { _ref: "smth" } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { str: { in: { _ref: "smth", _container: "TestModel" } } }) { id } }"#,
             2009,
             "Invalid argument type"
         );
 
         assert_error!(
             runner,
-            r#"{ findManyTestModel(where: { str: { notIn: { _ref: "smth" } } }) { id } }"#,
+            r#"{ findManyTestModel(where: { str: { notIn: { _ref: "smth", _container: "TestModel" } } }) { id } }"#,
             2009,
             "Invalid argument type"
         );
@@ -142,7 +166,7 @@ mod failure {
     async fn field_ref_in_having_must_be_selected(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"query { groupByTestModel(by: [int], having: { int: { _count: { equals: { _ref: "int_2" } } } }) { int }}"#,
+            r#"query { groupByTestModel(by: [int], having: { int: { _count: { equals: { _ref: "int_2", _container: "TestModel" } } } }) { int }}"#,
             2019,
             ""
         );
@@ -155,13 +179,13 @@ mod failure {
         // assert that referencing an Int field for the count of a string field works
         run_query!(
             &runner,
-            r#"query { groupByTestModel(by: [string, int], having: { string: { _count: { equals: { _ref: "int" } } } }) { string, int }}"#
+            r#"query { groupByTestModel(by: [string, int], having: { string: { _count: { equals: { _ref: "int", _container: "TestModel" } } } }) { string, int }}"#
         );
 
         // assert that the count of a String field expect the referenced field to be of type Int
         assert_error!(
             runner,
-            r#"query { groupByTestModel(by: [string, int], having: { string: { _count: { equals: { _ref: "string" } } } }) { id }}"#,
+            r#"query { groupByTestModel(by: [string, int], having: { string: { _count: { equals: { _ref: "string", _container: "TestModel" } } } }) { id }}"#,
             2019,
             "Expected a referenced scalar field of type Int but found TestModel.string of type String."
         );
@@ -173,39 +197,39 @@ mod failure {
     async fn json_string_expect_string_field_ref(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"query { findManyTestModel(where: { json: { string_contains: { _ref: "json" } } }) { id }}"#,
+            r#"query { findManyTestModel(where: { json: { string_contains: { _ref: "json", _container: "TestModel" } } }) { id }}"#,
             2019,
             "Expected a referenced scalar field of type String but found TestModel.json of type Json."
         );
         assert_error!(
             runner,
-            r#"query { findManyTestModel(where: { NOT: { json: { string_contains: { _ref: "json" } } } }) { id }}"#,
-            2019,
-            "Expected a referenced scalar field of type String but found TestModel.json of type Json."
-        );
-
-        assert_error!(
-            runner,
-            r#"query { findManyTestModel(where: { json: { string_ends_with: { _ref: "json" } } }) { id }}"#,
-            2019,
-            "Expected a referenced scalar field of type String but found TestModel.json of type Json."
-        );
-        assert_error!(
-            runner,
-            r#"query { findManyTestModel(where: { NOT: { json: { string_ends_with: { _ref: "json" } } } }) { id }}"#,
+            r#"query { findManyTestModel(where: { NOT: { json: { string_contains: { _ref: "json", _container: "TestModel" } } } }) { id }}"#,
             2019,
             "Expected a referenced scalar field of type String but found TestModel.json of type Json."
         );
 
         assert_error!(
             runner,
-            r#"query { findManyTestModel(where: { json: { string_starts_with: { _ref: "json" } } }) { id }}"#,
+            r#"query { findManyTestModel(where: { json: { string_ends_with: { _ref: "json", _container: "TestModel" } } }) { id }}"#,
             2019,
             "Expected a referenced scalar field of type String but found TestModel.json of type Json."
         );
         assert_error!(
             runner,
-            r#"query { findManyTestModel(where: { NOT: { json: { string_starts_with: { _ref: "json" } } } }) { id }}"#,
+            r#"query { findManyTestModel(where: { NOT: { json: { string_ends_with: { _ref: "json", _container: "TestModel" } } } }) { id }}"#,
+            2019,
+            "Expected a referenced scalar field of type String but found TestModel.json of type Json."
+        );
+
+        assert_error!(
+            runner,
+            r#"query { findManyTestModel(where: { json: { string_starts_with: { _ref: "json", _container: "TestModel" } } }) { id }}"#,
+            2019,
+            "Expected a referenced scalar field of type String but found TestModel.json of type Json."
+        );
+        assert_error!(
+            runner,
+            r#"query { findManyTestModel(where: { NOT: { json: { string_starts_with: { _ref: "json", _container: "TestModel" } } } }) { id }}"#,
             2019,
             "Expected a referenced scalar field of type String but found TestModel.json of type Json."
         );
@@ -217,7 +241,7 @@ mod failure {
     async fn referencing_composite_field_fails(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"query { findManyTestModel(where: { comp: { equals: { _ref: "comp" } } }) { id }}"#,
+            r#"query { findManyTestModel(where: { comp: { equals: { _ref: "comp", _container: "TestModel" } } }) { id }}"#,
             2009,
             "Unable to match input value to any allowed input type for the field"
         );
@@ -231,7 +255,7 @@ mod failure {
     async fn alphanumeric_json_filter_fails(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
-            r#"query { findManyTestModel(where: { json: { gt: { _ref: "json" } } }) { id }}"#,
+            r#"query { findManyTestModel(where: { json: { gt: { _ref: "json", _container: "TestModel" } } }) { id }}"#,
             2009,
             "Invalid argument type"
         );

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/float_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/float_filter.rs
@@ -11,17 +11,17 @@ mod float_filter {
         setup::test_data_common_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { equals: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { equals: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { equals: { _ref: "float2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { equals: { _ref: "float2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { float: { not: { equals: { _ref: "float2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { float: { not: { equals: { _ref: "float2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -34,81 +34,81 @@ mod float_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { gt: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { gt: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { gt: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { gt: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gt: { _ref: "float" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gt: { _ref: "float", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gt: { _ref: "float2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gt: { _ref: "float2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { gte: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { gte: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { gte: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { gte: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gte: { _ref: "float" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gte: { _ref: "float", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gte: { _ref: "float2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { gte: { _ref: "float2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lt: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lt: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lt: { _ref: "float2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lt: { _ref: "float2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { lt: { _ref: "float" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { lt: { _ref: "float", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { not: { lt: { _ref: "float" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { not: { lt: { _ref: "float", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lte: { _ref: "float" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lte: { _ref: "float", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lte: { _ref: "float2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { lte: { _ref: "float2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { lte: { _ref: "float" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { lte: { _ref: "float", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { not: { lte: { _ref: "float" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float2: { not: { lte: { _ref: "float", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -120,17 +120,17 @@ mod float_filter {
         setup::test_data_common_mixed_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { in: { _ref: "float2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { in: { _ref: "float2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { notIn: { _ref: "float2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { notIn: { _ref: "float2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { in: { _ref: "float2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float: { not: { in: { _ref: "float2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -143,53 +143,53 @@ mod float_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { has: { _ref: "float" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { has: { _ref: "float", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { has: { _ref: "float" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { has: { _ref: "float", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasSome: { _ref: "float_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasSome: { _ref: "float_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasSome: { _ref: "float_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasSome: { _ref: "float_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasSome: { _ref: "float_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasSome: { _ref: "float_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasSome: { _ref: "float_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasSome: { _ref: "float_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasEvery: { _ref: "float_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasEvery: { _ref: "float_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasEvery: { _ref: "float_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { float_list: { hasEvery: { _ref: "float_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasEvery: { _ref: "float_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasEvery: { _ref: "float_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasEvery: { _ref: "float_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { float_list: { hasEvery: { _ref: "float_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/having_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/having_filter.rs
@@ -33,7 +33,7 @@ mod having_filter {
         match_connector_result!(
           &runner,
           r#"query { groupByTestModel(by: [string, string2], having: {
-              string: { equals: { _ref: "string2" } }
+              string: { equals: { _ref: "string2", _container: "TestModel" } }
             }) {
               string
               string2
@@ -48,7 +48,7 @@ mod having_filter {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"query { groupByTestModel(by: [string, int], having: {
-              string: { _count: { equals: { _ref: "int" } } }
+              string: { _count: { equals: { _ref: "int", _container: "TestModel" } } }
             }) {
               string
               int
@@ -61,7 +61,7 @@ mod having_filter {
         match_connector_result!(
           &runner,
           r#"query { groupByTestModel(by: [string, int, int2], having: {
-              int: { _max: { equals: { _ref: "int2" } } }
+              int: { _max: { equals: { _ref: "int2", _container: "TestModel" } } }
             }) {
               string
               int2

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/int_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/int_filter.rs
@@ -11,17 +11,17 @@ mod int_filter {
         setup::test_data_common_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { equals: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { equals: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { equals: { _ref: "int2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { equals: { _ref: "int2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { int: { not: { equals: { _ref: "int2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { int: { not: { equals: { _ref: "int2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -34,81 +34,81 @@ mod int_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { gt: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { gt: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { gt: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { gt: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gt: { _ref: "int" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gt: { _ref: "int", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gt: { _ref: "int2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gt: { _ref: "int2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { gte: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { gte: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { gte: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { gte: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gte: { _ref: "int" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gte: { _ref: "int", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gte: { _ref: "int2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { gte: { _ref: "int2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lt: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lt: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lt: { _ref: "int2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lt: { _ref: "int2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { lt: { _ref: "int" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { lt: { _ref: "int", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { not: { lt: { _ref: "int" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { not: { lt: { _ref: "int", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lte: { _ref: "int" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lte: { _ref: "int", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lte: { _ref: "int2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { lte: { _ref: "int2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { lte: { _ref: "int" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { lte: { _ref: "int", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { not: { lte: { _ref: "int" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int2: { not: { lte: { _ref: "int", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -120,17 +120,17 @@ mod int_filter {
         setup::test_data_common_mixed_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { in: { _ref: "int2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { in: { _ref: "int2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { notIn: { _ref: "int2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { notIn: { _ref: "int2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { in: { _ref: "int2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int: { not: { in: { _ref: "int2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -143,53 +143,53 @@ mod int_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { has: { _ref: "int" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { has: { _ref: "int", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { has: { _ref: "int" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { has: { _ref: "int", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasSome: { _ref: "int_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasSome: { _ref: "int_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasSome: { _ref: "int_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasSome: { _ref: "int_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasSome: { _ref: "int_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasSome: { _ref: "int_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasSome: { _ref: "int_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasSome: { _ref: "int_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasEvery: { _ref: "int_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasEvery: { _ref: "int_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasEvery: { _ref: "int_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { int_list: { hasEvery: { _ref: "int_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasEvery: { _ref: "int_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasEvery: { _ref: "int_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasEvery: { _ref: "int_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { int_list: { hasEvery: { _ref: "int_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
@@ -22,17 +22,17 @@ mod json_filter {
         test_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json: { equals: { _ref: "json" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json: { equals: { _ref: "json", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json: { equals: { _ref: "json2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json: { equals: { _ref: "json2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json: { not: { _ref: "json2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json: { not: { _ref: "json2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
         );
 
@@ -45,81 +45,81 @@ mod json_filter {
 
         // gt
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gt: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gt: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gt: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gt: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         // not gt -> lte
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gt: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gt: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gt: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gt: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // gte
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gte: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gte: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gte: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, gte: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         // not gte -> lt
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gte: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gte: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gte: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, gte: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // lt
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lt: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lt: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lt: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lt: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // not lt -> gte
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lt: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lt: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lt: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lt: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         // lte
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lte: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lte: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lte: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, lte: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // not lte -> gt
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lte: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lte: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lte: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, lte: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
@@ -132,37 +132,37 @@ mod json_filter {
 
         // contains
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, string_contains: {{ _ref: "str" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, string_contains: {{ _ref: "str", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3},{"id":4}]}}"###
         );
 
         // not contains
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, string_contains: {{ _ref: "str" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, string_contains: {{ _ref: "str", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, string_starts_with: {{ _ref: "str" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, string_starts_with: {{ _ref: "str", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4}]}}"###
         );
 
         // not startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, string_starts_with: {{ _ref: "str" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, string_starts_with: {{ _ref: "str", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         // endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, string_ends_with: {{ _ref: "str" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, string_ends_with: {{ _ref: "str", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3},{"id":4}]}}"###
         );
 
         // not endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, string_ends_with: {{ _ref: "str" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, string_ends_with: {{ _ref: "str", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -175,61 +175,61 @@ mod json_filter {
 
         // contains
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_contains: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_contains: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_contains: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_contains: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not contains
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_contains: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_contains: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_contains: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_contains: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         // startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_starts_with: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_starts_with: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_starts_with: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_starts_with: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_starts_with: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_starts_with: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_starts_with: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_starts_with: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
         );
 
         // endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_ends_with: {{ _ref: "json" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_ends_with: {{ _ref: "json", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_ends_with: {{ _ref: "json2" }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"json: {{ {}, array_ends_with: {{ _ref: "json2", _container: "TestModel" }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // not endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_ends_with: {{ _ref: "json" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_ends_with: {{ _ref: "json", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_ends_with: {{ _ref: "json2" }} }} }}"#, json_path(&runner)))),
+          run_query!(&runner, jsonq(format!(r#"NOT: {{ json: {{ {}, array_ends_with: {{ _ref: "json2", _container: "TestModel" }} }} }}"#, json_path(&runner)))),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":3}]}}"###
         );
 
@@ -256,53 +256,53 @@ mod json_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { has: { _ref: "json" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { has: { _ref: "json", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { has: { _ref: "json" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { has: { _ref: "json", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasSome: { _ref: "json_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasSome: { _ref: "json_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasSome: { _ref: "json_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasSome: { _ref: "json_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasSome: { _ref: "json_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasSome: { _ref: "json_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasSome: { _ref: "json_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasSome: { _ref: "json_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasEvery: { _ref: "json_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasEvery: { _ref: "json_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasEvery: { _ref: "json_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { json_list: { hasEvery: { _ref: "json_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasEvery: { _ref: "json_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasEvery: { _ref: "json_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasEvery: { _ref: "json_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { json_list: { hasEvery: { _ref: "json_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/relation_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/relation_filter.rs
@@ -28,31 +28,31 @@ mod relation_filter {
         // The following assertions simply ensures that all those queries are running fine and thus that the referenced fields are properly aliased to the joins.
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { gt: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { gt: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { gte: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { gte: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { lt: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { lt: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { lte: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { lte: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { contains: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { contains: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { startsWith: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { startsWith: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { endsWith: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { endsWith: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
 
         Ok(())
@@ -83,19 +83,19 @@ mod relation_filter {
         // The following assertions simply ensures that all those queries are running fine and thus that the referenced fields are properly aliased to the joins.
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { in: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { in: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string1: { notIn: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string1: { notIn: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string2: { hasSome: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string2: { hasSome: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
         run_query!(
             runner,
-            r#"{ findManyTestModel(where: { child: { string2: { hasEvery: { _ref: "string2" } } } }) { id } }"#
+            r#"{ findManyTestModel(where: { child: { string2: { hasEvery: { _ref: "string2", _container: "Child" } } } }) { id } }"#
         );
 
         Ok(())
@@ -133,7 +133,7 @@ mod relation_filter {
         .await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { child: { string1: { equals: { _ref: "string2" } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { child: { string1: { equals: { _ref: "string2", _container: "Child" } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
@@ -164,17 +164,17 @@ mod relation_filter {
         create_to_many_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { children: { some: { string1: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { children: { some: { string1: { equals: { _ref: "string2", _container: "Child" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { children: { none: { string1: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { children: { none: { string1: { equals: { _ref: "string2", _container: "Child" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { children: { every: { string1: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { children: { every: { string1: { equals: { _ref: "string2", _container: "Child" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
@@ -204,17 +204,17 @@ mod relation_filter {
         create_to_many_data(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { children: { some: { string1: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { children: { some: { string1: { equals: { _ref: "string2", _container: "Child" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { children: { none: { string1: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { children: { none: { string1: { equals: { _ref: "string2", _container: "Child" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(runner, r#"{ findManyTestModel(where: { children: { every: { string1: { equals: { _ref: "string2" } } } } }) { id } }"#),
+          run_query!(runner, r#"{ findManyTestModel(where: { children: { every: { string1: { equals: { _ref: "string2", _container: "Child" } } } } }) { id } }"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
@@ -290,7 +290,7 @@ mod relation_filter {
             toMany: {
               some: {
                 toOne: {
-                  string1: { equals: { _ref: "string2" } }
+                  string1: { equals: { _ref: "string2", _container: "ToOne" } }
                 }
               }
             }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/string_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/string_filter.rs
@@ -11,17 +11,17 @@ mod string_filter {
         setup::test_data_common_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { equals: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { equals: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { equals: { _ref: "string2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { equals: { _ref: "string2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { string: { not: { equals: { _ref: "string2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { string: { not: { equals: { _ref: "string2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -33,17 +33,17 @@ mod string_filter {
         test_data_insensitive(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, equals: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, equals: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, equals: { _ref: "string2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, equals: { _ref: "string2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { string: { mode: insensitive, not: { equals: { _ref: "string2" } } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { AND: { string: { mode: insensitive, not: { equals: { _ref: "string2", _container: "TestModel" } } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -56,81 +56,81 @@ mod string_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { gt: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { gt: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { gt: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { gt: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gt: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gt: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gt: { _ref: "string2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gt: { _ref: "string2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { gte: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { gte: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { gte: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { gte: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gte: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gte: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gte: { _ref: "string2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { gte: { _ref: "string2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lt: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lt: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lt: { _ref: "string2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lt: { _ref: "string2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { lt: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { lt: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { not: { lt: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { not: { lt: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lte: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lte: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lte: { _ref: "string2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { lte: { _ref: "string2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { lte: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { lte: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { not: { lte: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { not: { lte: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -144,81 +144,81 @@ mod string_filter {
 
         // Gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, gt: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, gt: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, gt: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, gt: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not gt => lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gt: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gt: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gt: { _ref: "string2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gt: { _ref: "string2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, gte: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, gte: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, gte: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, gte: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not gte => lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gte: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gte: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gte: { _ref: "string2" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { gte: { _ref: "string2", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Lt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lt: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lt: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lt: { _ref: "string2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lt: { _ref: "string2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // Not lt => gte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { lt: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { lt: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, not: { lt: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, not: { lt: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Lte
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lte: { _ref: "string" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lte: { _ref: "string", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lte: { _ref: "string2" } }}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, lte: { _ref: "string2", _container: "TestModel" } }}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // Not lte => gt
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { lte: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { lte: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, not: { lte: { _ref: "string" } }}}) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string2: { mode: insensitive, not: { lte: { _ref: "string", _container: "TestModel" } }}}) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -247,61 +247,61 @@ mod string_filter {
 
         // contains
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { contains: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { contains: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { contains: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { contains: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5}]}}"###
         );
 
         // not contains
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { contains: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { contains: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { contains: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { contains: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { startsWith: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { startsWith: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { startsWith: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { startsWith: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4}]}}"###
         );
 
         // not startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { startsWith: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { startsWith: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { startsWith: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { startsWith: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2},{"id":5}]}}"###
         );
 
         // endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { endsWith: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { endsWith: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { endsWith: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { endsWith: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":5}]}}"###
         );
 
         // not endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { endsWith: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { endsWith: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { endsWith: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { endsWith: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4}]}}"###
         );
 
@@ -330,61 +330,61 @@ mod string_filter {
 
         // contains
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, contains: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, contains: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, contains: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, contains: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4},{"id":5}]}}"###
         );
 
         // not contains
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { contains: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { contains: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { contains: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { contains: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, startsWith: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, startsWith: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, startsWith: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, startsWith: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":4}]}}"###
         );
 
         // not startsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { startsWith: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { startsWith: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { startsWith: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { startsWith: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2},{"id":5}]}}"###
         );
 
         // endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, endsWith: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, endsWith: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":4},{"id":5}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, endsWith: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, endsWith: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":5}]}}"###
         );
 
         // not endsWith
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { endsWith: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { endsWith: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { endsWith: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { endsWith: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2},{"id":4}]}}"###
         );
 
@@ -396,17 +396,17 @@ mod string_filter {
         setup::test_data_common_mixed_types(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { in: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { in: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { notIn: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { notIn: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { in: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { not: { in: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -418,17 +418,17 @@ mod string_filter {
         test_data_mixed_types_insensitive(&runner).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, in: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, in: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, notIn: { _ref: "string2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, notIn: { _ref: "string2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { in: { _ref: "string2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string: { mode: insensitive, not: { in: { _ref: "string2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
@@ -441,53 +441,53 @@ mod string_filter {
 
         // has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { has: { _ref: "string" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { has: { _ref: "string", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not has
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { has: { _ref: "string" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { has: { _ref: "string", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 
         // hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasSome: { _ref: "string_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasSome: { _ref: "string_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasSome: { _ref: "string_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasSome: { _ref: "string_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
 
         // not hasSome
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasSome: { _ref: "string_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasSome: { _ref: "string_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasSome: { _ref: "string_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasSome: { _ref: "string_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
 
         // hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasEvery: { _ref: "string_list" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasEvery: { _ref: "string_list", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasEvery: { _ref: "string_list2" } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { string_list: { hasEvery: { _ref: "string_list2", _container: "TestModel" } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
         );
 
         // not hasEvery
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasEvery: { _ref: "string_list" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasEvery: { _ref: "string_list", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[]}}"###
         );
         insta::assert_snapshot!(
-          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasEvery: { _ref: "string_list2" } } } }) { id }}"#),
+          run_query!(&runner, r#"query { findManyTestModel(where: { NOT: { string_list: { hasEvery: { _ref: "string_list2", _container: "TestModel" } } } }) { id }}"#),
           @r###"{"data":{"findManyTestModel":[{"id":2}]}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -137,9 +137,9 @@ mod update {
         insta::assert_snapshot!(
           run_query!(&runner, r#"query {
             findManyTestModel(
-              where: { AND: [{updatedAt_w_default: { gt: { _ref: "createdAt" } }},
-                             {updatedAt_wo_default: { gt: { _ref: "createdAt" } }},
-                             {updatedAt_wo_default: { equals: { _ref: "updatedAt_w_default" } }}
+              where: { AND: [{updatedAt_w_default: { gt: { _ref: "createdAt", _container: "TestModel" } }},
+                             {updatedAt_wo_default: { gt: { _ref: "createdAt", _container: "TestModel" } }},
+                             {updatedAt_wo_default: { equals: { _ref: "updatedAt_w_default", _container: "TestModel" } }}
                      ]}
             ) {
               id

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
@@ -202,7 +202,7 @@ impl<'a, 'b> FieldTypeInferrer<'a, 'b> {
         match value {
             ArgumentValue::Object(obj) => {
                 let is_field_ref_obj = obj.contains_key(constants::filters::UNDERSCORE_REF)
-                    && obj.contains_key(constants::filters::UNDERSCORE_REF)
+                    && obj.contains_key(constants::filters::UNDERSCORE_CONTAINER)
                     && obj.len() == 2;
                 let schema_objects = self.get_object_types();
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
@@ -201,7 +201,9 @@ impl<'a, 'b> FieldTypeInferrer<'a, 'b> {
 
         match value {
             ArgumentValue::Object(obj) => {
-                let is_field_ref_obj = obj.contains_key(constants::filters::UNDERSCORE_REF) && obj.len() == 1;
+                let is_field_ref_obj = obj.contains_key(constants::filters::UNDERSCORE_REF)
+                    && obj.contains_key(constants::filters::UNDERSCORE_REF)
+                    && obj.len() == 2;
                 let schema_objects = self.get_object_types();
 
                 match schema_objects {

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -3,7 +3,7 @@ use connector::{
     ConditionListValue, ConditionValue, Filter, JsonCompare, JsonFilterPath, JsonTargetType, ScalarCompare,
     ScalarListCompare,
 };
-use prisma_models::{Field, PrismaValue, ScalarFieldRef, TypeIdentifier};
+use prisma_models::{prelude::ParentContainer, Field, PrismaValue, ScalarFieldRef, TypeIdentifier};
 use schema::constants::{aggregations, filters, json_null};
 use std::convert::TryInto;
 
@@ -430,6 +430,44 @@ impl<'a> ScalarFilterParser<'a> {
                 let field_ref_name = map.remove(filters::UNDERSCORE_REF).unwrap();
                 let field_ref_name = PrismaValue::try_from(field_ref_name)?.into_string().unwrap();
                 let field_ref = field.container().find_field(&field_ref_name);
+
+                let container_ref_name = map.remove(filters::UNDERSCORE_CONTAINER).unwrap();
+                let container_ref_name = PrismaValue::try_from(container_ref_name)?.into_string().unwrap();
+
+                if container_ref_name != field.container().name() {
+                    let expected_container_type = if field.container().is_model() {
+                        "model"
+                    } else {
+                        "composite type"
+                    };
+
+                    let container_ref = field
+                        .dm
+                        .models()
+                        .map(ParentContainer::from)
+                        .chain(field.dm.composite_types().map(ParentContainer::from))
+                        .find(|container| container.name() == container_ref_name)
+                        .ok_or_else(|| {
+                            QueryGraphBuilderError::InputError(format!(
+                                "Model or composite type {} used for field ref {} does not exist.",
+                                container_ref_name, field_ref_name
+                            ))
+                        })?;
+
+                    let found_container_type = if container_ref.is_model() {
+                        "model"
+                    } else {
+                        "composite type"
+                    };
+
+                    return Err(QueryGraphBuilderError::InputError(format!(
+                        "Expected a referenced scalar field of {} {}, but found a field of {} {}.",
+                        expected_container_type,
+                        field.container().name(),
+                        found_container_type,
+                        container_ref_name
+                    )));
+                }
 
                 match field_ref {
                     Some(Field::Scalar(field_ref))

--- a/query-engine/schema/src/build/input_types/fields/field_ref_type.rs
+++ b/query-engine/schema/src/build/input_types/fields/field_ref_type.rs
@@ -21,7 +21,12 @@ fn field_ref_input_object_type(allow_type: InputType<'_>) -> InputObjectType<'_>
     let ident = Identifier::new_prisma(field_ref_input_type_name(&allow_type));
     let mut object = init_input_object_type(ident);
     object.set_tag(ObjectTag::FieldRefType(Box::new(allow_type)));
-    object.set_fields(|| vec![input_field(filters::UNDERSCORE_REF, vec![InputType::string()], None)]);
+    object.set_fields(|| {
+        vec![
+            input_field(filters::UNDERSCORE_REF, vec![InputType::string()], None),
+            input_field(filters::UNDERSCORE_CONTAINER, vec![InputType::string()], None),
+        ]
+    });
     object
 }
 

--- a/query-engine/schema/src/constants.rs
+++ b/query-engine/schema/src/constants.rs
@@ -63,6 +63,7 @@ pub mod filters {
     pub const SEARCH: &str = "search";
     pub const IS_SET: &str = "isSet";
     pub const UNDERSCORE_REF: &str = "_ref";
+    pub const UNDERSCORE_CONTAINER: &str = "_container";
 
     // legacy filter
     pub const NOT_IN: &str = "notIn";


### PR DESCRIPTION
## Overview

- fixes https://github.com/prisma/team-orm/issues/154

Adds a `_container: String` field to the field ref object, which should contain the model of the field that's passed into the `_ref` field. This helps improve validation.