### PR TITLE
feat(node-drivers-poc): Implement a subset of a mysql driver that uses input and output types based on quaint::Value

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,6 +30,7 @@ jobs:
       - run: |
             cargo test --workspace \
                   --exclude=query-engine \
+                  --exclude=query-engine-node-api \
                   --exclude=black-box-tests \
                   --exclude=query-engine-tests \
                   --exclude=sql-migration-tests \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2376,6 +2376,7 @@ dependencies = [
  "once_cell",
  "quaint",
  "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/query-engine/nodejs-drivers/Cargo.toml
+++ b/query-engine/nodejs-drivers/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 async-trait = "0.1"
 once_cell = "1.15"
 serde.workspace = true
+serde_json.workspace = true
 quaint.workspace = true
 
 napi = { version = "2.12.4", default-features = false, features = ["napi8", "tokio_rt", "serde-json"] }

--- a/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/Library.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/engines/types/Library.ts
@@ -16,14 +16,39 @@ export type QueryEngineInstance = {
   metrics(options: string): Promise<string>
 }
 
-export type ResultSet = {
-  columns: string[]
-  rows: (string)[][] // Note: we're currently stringifying any result values
+export interface ResultSet {
+  columnTypes: Array<ColumnType>
+  columnNames: Array<string>
+  rows: Array<Array<any>>
+}
+
+export interface Query {
+  sql: string
+  args: Array<any>
+}
+
+// Same order as in rust js-drivers' `ColumnType`
+export const enum ColumnType {
+  Int32 = 0,
+  Int64 = 1,
+  Float = 2,
+  Double = 3,
+  Text = 4,
+  Enum = 5,
+  Bytes = 6,
+  Boolean = 7,
+  Char = 8,
+  Array = 9,
+  Numeric = 10,
+  Json = 11,
+  DateTime = 12,
+  Date = 13,
+  Time = 14
 }
 
 export type Queryable = {
-  queryRaw: (sql: string) => Promise<ResultSet>
-  executeRaw: (sql: string) => Promise<number>
+  queryRaw: (params: Query) => Promise<ResultSet>
+  executeRaw: (params: Query) => Promise<number>
   version: () => string | undefined
   isHealthy: () => boolean
 }
@@ -33,7 +58,7 @@ export type Closeable = {
 }
 
 export interface QueryEngineConstructor {
-  new (config: QueryEngineConfig, logger: (log: string) => void, nodejsFnCtx?: Queryable): QueryEngineInstance
+  new(config: QueryEngineConfig, logger: (log: string) => void, nodejsFnCtx?: Queryable): QueryEngineInstance
 }
 
 export interface LibraryLoader {

--- a/query-engine/nodejs-drivers/nodejs-examples/src/index.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/index.ts
@@ -36,10 +36,10 @@ async function main() {
   // I assume nobody will run this on Windows ¯\_(ツ)_/¯
   const libExt = os.platform() === 'darwin' ? 'dylib' : 'so'
   const libQueryEnginePath = path.join(__dirname, `../../../../target/debug/libquery_engine.${libExt}`)
-  
+
   const schemaPath = path.join(__dirname, `../prisma/schema.prisma`)
 
-  const libqueryEngine = { exports: {} as unknown as Library} 
+  const libqueryEngine = { exports: {} as unknown as Library }
   // @ts-ignore
   process.dlopen(libqueryEngine, libQueryEnginePath)
 
@@ -64,7 +64,7 @@ async function main() {
   await engine.connect('trace')
   console.log('[nodejs] connected')
 
-  const resultSet = await engine.query(`{
+  let resultSet = await engine.query(`{
     "modelName": "some_user",
     "action": "findMany",
     "query": {
@@ -76,7 +76,21 @@ async function main() {
       } 
     }`, 'trace', undefined)
 
-  console.log('[nodejs] resultSet', resultSet)
+  console.log('[nodejs] findMany resultSet', resultSet)
+
+  resultSet = await engine.query(`{
+    "modelName": "some_user",
+    "action": "findFirst",
+    "query": {
+        "selection": {
+          "id": true,
+          "firstname": true,
+          "company_id": true
+        }
+      } 
+    }`, 'trace', undefined)
+
+  console.log('[nodejs] findFirst resultSet', resultSet)
 
   // Note: calling `engine.disconnect` won't actually close the database connection.
   console.log('[nodejs] disconnecting...')

--- a/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mock.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mock.ts
@@ -1,6 +1,6 @@
 import { setTimeout } from 'node:timers/promises'
 
-import { Closeable, Queryable, ResultSet } from '../engines/types/Library'
+import { Closeable, ColumnType, Query, Queryable, ResultSet } from '../engines/types/Library'
 
 class MockSQL implements Queryable, Closeable {
   private maybeVersion?: string
@@ -38,19 +38,20 @@ class MockSQL implements Queryable, Closeable {
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: string): Promise<ResultSet> {
-    console.log('[nodejs] calling queryRaw', query)
+  async queryRaw(params: Query): Promise<ResultSet> {
+    console.log('[nodejs] calling queryRaw', params)
     await setTimeout(100)
-    
+
     const resultSet: ResultSet = {
-      columns: ['id', 'firstname', 'company_id'],
+      columnNames: ['id', 'firstname', 'company_id'],
+      columnTypes: [ColumnType.Int64, ColumnType.Text, ColumnType.Int64],
       rows: [
-        ['1', 'Alberto', '1'],
-        ['2', 'Tom', '1'],
+        [1, 'Alberto', 1],
+        [2, 'Tom', 1],
       ],
     }
     console.log('[nodejs] resultSet', resultSet)
-    
+
     return resultSet
   }
 
@@ -59,8 +60,8 @@ class MockSQL implements Queryable, Closeable {
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: string): Promise<number> {
-    console.log('[nodejs] calling executeRaw', query)
+  async executeRaw(params: Query): Promise<number> {
+    console.log('[nodejs] calling executeRaw', params)
     await setTimeout(100)
 
     const affectedRows = 32

--- a/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mysql.ts
+++ b/query-engine/nodejs-drivers/nodejs-examples/src/queryable/mysql.ts
@@ -1,6 +1,94 @@
 import * as mysql from 'mysql2/promise'
 
-import { Closeable, Queryable, ResultSet } from '../engines/types/Library'
+import { Closeable, Queryable, ResultSet, Query, ColumnType } from '../engines/types/Library'
+
+// See: https://github.com/mysql/mysql-server/blob/ea7087d885006918ad54458e7aad215b1650312c/include/field_types.h#L52-L87
+enum MySQLColumnType {
+  Decimal,
+  Tiny,
+  Short,
+  Long,
+  Float,
+  Double,
+  Null,
+  Timestamp,
+  LongLong,
+  Int24,
+  Date,
+  Time,
+  Datetime,
+  Year,
+  Newdate, /**< Internal to MySQL. Not used in protocol */
+  Varchar,
+  Bit,
+  Timestamp2,
+  Datetime2,   /**< Internal to MySQL. Not used in protocol */
+  Time2,       /**< Internal to MySQL. Not used in protocol */
+  TypedArray, /**< Used for replication only */
+  Invalid = 243,
+  Bool = 244, /**< Currently just a placeholder */
+  Json = 245,
+  Newdecimal = 246,
+  Enum = 247,
+  Set = 248,
+  TinyBlob = 249,
+  MediumBlob = 250,
+  LongBlob = 251,
+  Blob = 252,
+  VarString = 253,
+  String = 254,
+  Geometry = 255
+}
+
+/**
+ * This is a simplification of quaint's value inference logic. Take a look at quaint's conversion.rs
+ * module to see how other attributes of the field packet such as the field length are used to infer
+ * the correct quaint::Value variant.
+ */
+function fieldToColumnType(field: mysql.FieldPacket): ColumnType {
+  const columnTypeMapping: Readonly<Record<MySQLColumnType, ColumnType | undefined>> = {
+    [MySQLColumnType.Decimal]: undefined,
+    [MySQLColumnType.Tiny]: undefined,
+    [MySQLColumnType.Short]: undefined,
+    [MySQLColumnType.Long]: ColumnType.Int64,
+    [MySQLColumnType.Float]: undefined,
+    [MySQLColumnType.Double]: undefined,
+    [MySQLColumnType.Null]: undefined,
+    [MySQLColumnType.Timestamp]: undefined,
+    [MySQLColumnType.LongLong]: undefined,
+    [MySQLColumnType.Int24]: undefined,
+    [MySQLColumnType.Date]: undefined,
+    [MySQLColumnType.Time]: undefined,
+    [MySQLColumnType.Datetime]: undefined,
+    [MySQLColumnType.Year]: undefined,
+    [MySQLColumnType.Newdate]: undefined,
+    [MySQLColumnType.Varchar]: undefined,
+    [MySQLColumnType.Bit]: undefined,
+    [MySQLColumnType.Timestamp2]: undefined,
+    [MySQLColumnType.Datetime2]: undefined,
+    [MySQLColumnType.Time2]: undefined,
+    [MySQLColumnType.TypedArray]: undefined,
+    [MySQLColumnType.Invalid]: undefined,
+    [MySQLColumnType.Bool]: undefined,
+    [MySQLColumnType.Json]: undefined,
+    [MySQLColumnType.Newdecimal]: undefined,
+    [MySQLColumnType.Enum]: undefined,
+    [MySQLColumnType.Set]: undefined,
+    [MySQLColumnType.TinyBlob]: undefined,
+    [MySQLColumnType.MediumBlob]: undefined,
+    [MySQLColumnType.LongBlob]: undefined,
+    [MySQLColumnType.Blob]: undefined,
+    [MySQLColumnType.VarString]: ColumnType.Text,
+    [MySQLColumnType.String]: undefined,
+    [MySQLColumnType.Geometry]: undefined
+  };
+
+  let colType = columnTypeMapping[field.type]
+  if (colType === undefined) {
+    console.log(`Unsupported mysql type: ${field.type}`)
+  }
+  return colType
+}
 
 class PrismaMySQL implements Queryable, Closeable {
   private pool: mysql.Pool
@@ -41,32 +129,23 @@ class PrismaMySQL implements Queryable, Closeable {
   /**
    * Execute a query given as SQL, interpolating the given parameters.
    */
-  async queryRaw(query: string): Promise<ResultSet> {
-    console.log('[nodejs] calling queryRaw', query)
+  async queryRaw(params: Query): Promise<ResultSet> {
+    console.log('[nodejs] calling queryRaw', params)
     const [results, fields] = await this.pool.query<mysql.RowDataPacket[]>({
-      sql: query,
+      sql: params.sql,
+      values: params.args,
       rowsAsArray: false,
     })
     console.log('[nodejs] after query')
 
     const columns = fields.map(field => field.name)
     const resultSet: ResultSet = {
-      columns: columns,
-
-      // TODO: what if I remove the `toString()`?
-      // Currently, it would fail with something like:
-      // [Error: Failed to convert JavaScript value `Number 1 ` into rust type `String`],
-      // because the `id` column is a number, but the `ResultSet` expects a Vec<Vec<Str>>.
-      rows: results.map(result => columns.map(column => result[column].toString()))
+      columnNames: columns,
+      // TODO: cancel the promise and fail in case the column type is not supported by the driver
+      columnTypes: fields.map(field => fieldToColumnType(field)),
+      rows: results.map(result => columns.map(column => result[column]))
     };
     console.log('[nodejs] resultSet', resultSet)
-
-    /*
-    resultSet {
-      columns: [ 'id', 'firstname', 'company_id' ],
-      rows: [ [ 1, 'Alberto', 1 ], [ 2, 'Tom', 1 ] ]
-    }
-    */
 
     return resultSet
   }
@@ -76,10 +155,11 @@ class PrismaMySQL implements Queryable, Closeable {
    * returning the number of affected rows.
    * Note: Queryable expects a u64, but napi.rs only supports u32.
    */
-  async executeRaw(query: string): Promise<number> {
-    console.log('[nodejs] calling executeRaw', query)
+  async executeRaw(params: Query): Promise<number> {
+    console.log('[nodejs] calling executeRaw', params)
     const [{ affectedRows }, _] = await this.pool.execute<mysql.ResultSetHeader>({
-      sql: query,
+      sql: params.sql,
+      values: params.args,
     })
     return affectedRows
   }

--- a/query-engine/nodejs-drivers/src/driver.rs
+++ b/query-engine/nodejs-drivers/src/driver.rs
@@ -66,7 +66,7 @@ pub fn reify(js_driver: JsObject) -> napi::Result<Driver> {
 //
 #[napi(object)]
 #[derive(Debug)]
-pub struct ResultSet {
+pub struct JSResultSet {
     pub column_types: Vec<ColumnType>,
     pub column_names: Vec<String>,
     // Note this might be encoded differently for performance reasons
@@ -100,8 +100,8 @@ pub struct Query {
     pub args: Vec<serde_json::Value>,
 }
 
-impl From<ResultSet> for QuaintResultSet {
-    fn from(mut val: ResultSet) -> Self {
+impl From<JSResultSet> for QuaintResultSet {
+    fn from(mut val: JSResultSet) -> Self {
         // TODO: extract, todo: error rather than panic?
         let to_quaint_row = move |row: &mut Vec<serde_json::Value>| -> Vec<quaint::Value<'static>> {
             let mut res = Vec::with_capacity(row.len());
@@ -137,8 +137,8 @@ impl From<ResultSet> for QuaintResultSet {
 }
 
 impl Driver {
-    pub async fn query_raw(&self, params: Query) -> napi::Result<ResultSet> {
-        let promise = self.query_raw.call_async::<JsPromise<ResultSet>>(params).await?;
+    pub async fn query_raw(&self, params: Query) -> napi::Result<JSResultSet> {
+        let promise = self.query_raw.call_async::<JsPromise<JSResultSet>>(params).await?;
         let value = promise.await?;
         Ok(value)
     }

--- a/query-engine/nodejs-drivers/src/driver.rs
+++ b/query-engine/nodejs-drivers/src/driver.rs
@@ -1,8 +1,11 @@
-use napi::bindgen_prelude::Promise as JsPromise;
+use core::panic;
+
+use napi::bindgen_prelude::{FromNapiValue, Promise as JsPromise, ToNapiValue};
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
 use napi::JsObject;
 use napi_derive::napi;
-use serde::{Deserialize, Serialize};
+use quaint::connector::ResultSet as QuaintResultSet;
+use quaint::Value as QuaintValue;
 
 // Note: Every ThreadsafeFunction<T, ?> should have an explicit `ErrorStrategy::Fatal` set, as to avoid
 // "TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received null".
@@ -10,11 +13,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone)]
 pub struct Driver {
     /// Execute a query given as SQL, interpolating the given parameters.
-    query_raw: ThreadsafeFunction<String, ErrorStrategy::Fatal>,
+    query_raw: ThreadsafeFunction<Query, ErrorStrategy::Fatal>,
 
     /// Execute a query given as SQL, interpolating the given parameters and
     /// returning the number of affected rows.
-    execute_raw: ThreadsafeFunction<String, ErrorStrategy::Fatal>,
+    execute_raw: ThreadsafeFunction<Query, ErrorStrategy::Fatal>,
 
     /// Return the version of the underlying database, queried directly from the
     /// source.
@@ -47,20 +50,97 @@ pub fn reify(js_driver: JsObject) -> napi::Result<Driver> {
     Ok(driver)
 }
 
+// This result set is more convenient to be manipulated from both Rust and NodeJS.
+// Quaint's version of  ResultSet is:
+//
+// pub struct ResultSet {
+//     pub(crate) columns: Arc<Vec<String>>,
+//     pub(crate) rows: Vec<Vec<Value<'static>>>,
+//     pub(crate) last_insert_id: Option<u64>,
+// }
+//
+// If we used this ResultSet would we would have worse ergonomics as quaint::Value is a structured
+// enum and cannot be used directly with the #[napi(Object)] macro. Thus requiring us to implement
+// the FromNapiValue and ToNapiValue traits for quaint::Value, and use a different custom type
+// representing the Value in javascript.
+//
 #[napi(object)]
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug)]
 pub struct ResultSet {
-    pub columns: Vec<String>,
+    pub column_types: Vec<ColumnType>,
+    pub column_names: Vec<String>,
+    // Note this might be encoded differently for performance reasons
+    pub rows: Vec<Vec<serde_json::Value>>,
+}
 
-    // TODO: support any JS-serializable type, not just String.
-    pub rows: Vec<Vec<String>>,
+#[napi]
+#[derive(Debug)]
+pub enum ColumnType {
+    Int32,
+    Int64,
+    Float,
+    Double,
+    Text,
+    Enum,
+    Bytes,
+    Boolean,
+    Char,
+    Array,
+    Numeric,
+    Json,
+    DateTime,
+    Date,
+    Time,
+}
+
+#[napi(object)]
+#[derive(Debug)]
+pub struct Query {
+    pub sql: String,
+    pub args: Vec<serde_json::Value>,
+}
+
+impl From<ResultSet> for QuaintResultSet {
+    fn from(mut val: ResultSet) -> Self {
+        // TODO: extract, todo: error rather than panic?
+        let to_quaint_row = move |row: &mut Vec<serde_json::Value>| -> Vec<quaint::Value<'static>> {
+            let mut res = Vec::with_capacity(row.len());
+
+            for i in 0..row.len() {
+                match val.column_types[i] {
+                    ColumnType::Int64 => match row.remove(0) {
+                        serde_json::Value::Number(n) => {
+                            res.push(QuaintValue::int64(n.as_i64().expect("number must be an i64")))
+                        }
+                        serde_json::Value::Null => todo!(),
+                        mismatch => panic!("Expected a number, found {:?}", mismatch),
+                    },
+                    ColumnType::Text => match row.remove(0) {
+                        serde_json::Value::String(s) => res.push(QuaintValue::text(s)),
+                        serde_json::Value::Null => res.push(QuaintValue::Text(None)),
+                        mismatch => panic!("Expected a string, found {:?}", mismatch),
+                    },
+                    unimplemented => {
+                        todo!("support column type: Column: {:?}", unimplemented)
+                    }
+                }
+            }
+
+            res
+        };
+
+        let names = val.column_names;
+        let rows = val.rows.iter_mut().map(to_quaint_row).collect();
+
+        QuaintResultSet::new(names, rows)
+    }
 }
 
 impl Driver {
-    pub async fn query_raw(&self, sql: String) -> napi::Result<ResultSet> {
-        println!("[rs] calling query_raw: {}", &sql);
+    pub async fn query_raw(&self, params: Query) -> napi::Result<ResultSet> {
+        println!("[rs] calling query_raw: {:?}", &params);
 
-        let promise = self.query_raw.call_async::<JsPromise<ResultSet>>(sql).await?;
+        let promise = self.query_raw.call_async::<JsPromise<ResultSet>>(params).await?;
 
         println!("[rs] awaiting promise");
         let value = promise.await?;
@@ -69,9 +149,9 @@ impl Driver {
         Ok(value)
     }
 
-    pub async fn execute_raw(&self, sql: String) -> napi::Result<u32> {
-        println!("[rs] calling execute_raw: {}", &sql);
-        let promise = self.execute_raw.call_async::<JsPromise<u32>>(sql).await?;
+    pub async fn execute_raw(&self, params: Query) -> napi::Result<u32> {
+        println!("[rs] calling execute_raw: {:?}", &params);
+        let promise = self.execute_raw.call_async::<JsPromise<u32>>(params).await?;
 
         println!("[rs] awaiting promise");
         let value = promise.await?;

--- a/query-engine/nodejs-drivers/src/driver.rs
+++ b/query-engine/nodejs-drivers/src/driver.rs
@@ -138,44 +138,27 @@ impl From<ResultSet> for QuaintResultSet {
 
 impl Driver {
     pub async fn query_raw(&self, params: Query) -> napi::Result<ResultSet> {
-        println!("[rs] calling query_raw: {:?}", &params);
-
         let promise = self.query_raw.call_async::<JsPromise<ResultSet>>(params).await?;
-
-        println!("[rs] awaiting promise");
         let value = promise.await?;
-
-        println!("[rs] awaited: {:?}", &value);
         Ok(value)
     }
 
     pub async fn execute_raw(&self, params: Query) -> napi::Result<u32> {
-        println!("[rs] calling execute_raw: {:?}", &params);
         let promise = self.execute_raw.call_async::<JsPromise<u32>>(params).await?;
-
-        println!("[rs] awaiting promise");
         let value = promise.await?;
-        println!("[rs] got awaited value: {:?}", &value);
         Ok(value)
     }
 
     pub async fn version(&self) -> napi::Result<Option<String>> {
-        println!("[rs] calling version");
-
         let version = self.version.call_async::<Option<String>>(()).await?;
-        println!("[rs] version: {:?}", &version);
-
         Ok(version)
     }
 
     pub async fn close(&self) -> napi::Result<()> {
-        println!("[rs] calling close");
         self.close.call_async::<()>(()).await
     }
 
     pub fn is_healthy(&self) -> napi::Result<bool> {
-        println!("[rs] calling is_healthy");
-
         // TODO: call `is_healthy` in a blocking fashion, returning its result as a boolean.
         unimplemented!();
     }

--- a/query-engine/nodejs-drivers/src/queryable.rs
+++ b/query-engine/nodejs-drivers/src/queryable.rs
@@ -37,14 +37,11 @@ impl QuaintQueryable for Queryable {
     /// Execute the given query.
     async fn query(&self, q: QuaintQuery<'_>) -> quaint::Result<quaint::prelude::ResultSet> {
         let (sql, params) = visitor::Mysql::build(q)?;
-        println!("JSQueryable::query()");
         self.query_raw(&sql, &params).await
     }
 
     /// Execute a query given as SQL, interpolating the given parameters.
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<quaint::prelude::ResultSet> {
-        println!("JSQueryable::query_raw()");
-
         // Note: we ignore the parameters for now.
         // Todo: convert napi::Error to quaint::error::Error.
         let result_set = self.driver.query_raw((sql, params).into()).await.unwrap();
@@ -59,13 +56,11 @@ impl QuaintQueryable for Queryable {
     ///
     /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
     async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<quaint::prelude::ResultSet> {
-        println!("JSQueryable::query_raw()");
         self.query_raw(sql, params).await
     }
 
     /// Execute the given query, returning the number of affected rows.
     async fn execute(&self, q: QuaintQuery<'_>) -> quaint::Result<u64> {
-        println!("JSQueryable::execute()");
         let (sql, params) = visitor::Mysql::build(q)?;
         self.execute_raw(&sql, &params).await
     }
@@ -73,8 +68,6 @@ impl QuaintQueryable for Queryable {
     /// Execute a query given as SQL, interpolating the given parameters and
     /// returning the number of affected rows.
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        println!("JSQueryable::execute_raw()");
-
         // Note: we ignore the parameters for now.
         // Todo: convert napi::Error to quaint::error::Error.
         let affected_rows = self.driver.execute_raw((sql, params).into()).await.unwrap();
@@ -89,14 +82,12 @@ impl QuaintQueryable for Queryable {
     ///
     /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
     async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        println!("JSQueryable::execute_raw_typed()");
         self.execute_raw(sql, params).await
     }
 
     /// Run a command in the database, for queries that can't be run using
     /// prepared statements.
     async fn raw_cmd(&self, cmd: &str) -> quaint::Result<()> {
-        println!("JSQueryable::raw_cmdx({})", &cmd);
         self.execute_raw(cmd, &[]).await?;
 
         Ok(())
@@ -107,7 +98,6 @@ impl QuaintQueryable for Queryable {
     /// example. The version string is returned directly without any form of
     /// parsing or normalization.
     async fn version(&self) -> quaint::Result<Option<String>> {
-        println!("JSQueryable::version()");
         // Todo: convert napi::Error to quaint::error::Error.
         let version = self.driver.version().await.unwrap();
         Ok(version)

--- a/query-engine/nodejs-drivers/src/queryable.rs
+++ b/query-engine/nodejs-drivers/src/queryable.rs
@@ -43,7 +43,7 @@ impl QuaintQueryable for Queryable {
 
     /// Execute a query given as SQL, interpolating the given parameters.
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<quaint::prelude::ResultSet> {
-        println!("JSQueryable::query_raw({}, {:?})", &sql, params);
+        println!("JSQueryable::query_raw()");
 
         // Note: we ignore the parameters for now.
         // Todo: convert napi::Error to quaint::error::Error.
@@ -73,7 +73,7 @@ impl QuaintQueryable for Queryable {
     /// Execute a query given as SQL, interpolating the given parameters and
     /// returning the number of affected rows.
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        println!("JSQueryable::execute_raw({}, {:?})", &sql, &params);
+        println!("JSQueryable::execute_raw()");
 
         // Note: we ignore the parameters for now.
         // Todo: convert napi::Error to quaint::error::Error.
@@ -89,7 +89,7 @@ impl QuaintQueryable for Queryable {
     ///
     /// NOTE: This method will eventually be removed & merged into Queryable::query_raw().
     async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        println!("JSQueryable::execute_raw_typed({}, {:?})", &sql, &params);
+        println!("JSQueryable::execute_raw_typed()");
         self.execute_raw(sql, params).await
     }
 


### PR DESCRIPTION
Builds atop https://github.com/prisma/prisma-engines/pull/4042, review that one first.

Includes minimal functionality for coming up with measurements. It only supports `INT`, and `VARCHAR` MySQL schema types.

Closes https://github.com/prisma/team-orm/issues/57 
Closes https://github.com/prisma/team-orm/issues/58