### PR TITLE
fix: missing comments in enums

### DIFF
--- a/psl/schema-ast/src/parser/parse_enum.rs
+++ b/psl/schema-ast/src/parser/parse_enum.rs
@@ -24,8 +24,7 @@ pub fn parse_enum(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnostics: &m
                 let mut pending_value_comment = None;
                 inner_span = Some(current.as_span().into());
 
-                let mut items = current.into_inner();
-                while let Some(item) = items.next() {
+                for item in current.into_inner() {
                     match item.as_rule() {
                         Rule::block_attribute => attributes.push(parse_attribute(item, diagnostics)),
                         Rule::enum_value_declaration => {
@@ -34,11 +33,7 @@ pub fn parse_enum(pair: Pair<'_>, doc_comment: Option<Pair<'_>>, diagnostics: &m
                                 Err(err) => diagnostics.push_error(err),
                             }
                         }
-                        Rule::comment_block => {
-                            if let Some(Rule::enum_value_declaration) = items.peek().map(|t| t.as_rule()) {
-                                pending_value_comment = Some(item);
-                            }
-                        }
+                        Rule::comment_block => pending_value_comment = Some(item),
                         Rule::BLOCK_LEVEL_CATCH_ALL => diagnostics.push_error(DatamodelError::new_validation_error(
                             "This line is not an enum value definition.",
                             item.as_span().into(),

--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -54,6 +54,7 @@ fn enum_value_to_dmmf(en: walkers::EnumValueWalker<'_>) -> EnumValue {
     EnumValue {
         name: en.name().to_owned(),
         db_name: en.mapped_name().map(ToOwned::to_owned),
+        documentation: en.documentation().map(ToOwned::to_owned),
     }
 }
 

--- a/query-engine/dmmf/src/serialization_ast/datamodel_ast.rs
+++ b/query-engine/dmmf/src/serialization_ast/datamodel_ast.rs
@@ -104,4 +104,6 @@ pub struct Enum {
 pub struct EnumValue {
     pub name: String,
     pub db_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation: Option<String>,
 }

--- a/query-engine/dmmf/src/tests/test-schemas/postgres.prisma
+++ b/query-engine/dmmf/src/tests/test-schemas/postgres.prisma
@@ -1,0 +1,30 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../node_modules/.prisma/client"
+  previewFeatures = []
+}
+
+datasource db {
+  provider = "postgres"
+  url      = "file:dev.db"
+}
+
+/// User model comment
+model User {
+  id    String  @id @default(uuid())
+  email String  @unique
+  age   Int
+  /// name comment
+  name  String?
+  role Role
+}
+
+/// Role enum comment
+enum Role {
+  /// user comment
+  USER
+  READER
+  /// admin comment
+  ADMIN
+}
+


### PR DESCRIPTION
Similar Issue solution as https://github.com/prisma/prisma-engines/pull/4034
Fixes  https://github.com/prisma/prisma/issues/17828


Changes the way the test works a bit which could result in unexpected test failures in the future... apparently `let mut fields = it.fields.iter();` and `.any()` moves the cursor and fields are jumped over. This would cause issues if someone wants to check two field comments after another.

