### PR TITLE
ci: suppress stderr of `type` command

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -10,7 +10,7 @@ else
 fi
 
 # Check if the system has engineer installed, if not, use a local copy.
-if ! type "engineer" > /dev/null; then
+if ! type "engineer" &> /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
     set -e
     curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.56/latest/$OS/engineer.gz" --output engineer.gz


### PR DESCRIPTION
Redirect `stderr` to `/dev/null` too when checking if `engineer` exists
before downloading.

This fixes the following message being part of Buildkite logs:

```
[2023-06-14T14:27:51Z] ./.buildkite/engineer: line 13: type: engineer: not found
```

The `&> out` syntax is available in Bash 4 and higher, and is equivalent
to `> out 2>&1`.
