### PR TITLE
qe: Make jsonProtocol default and remove preview feature

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -91,7 +91,6 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
          | ExtendedWhereUnique
          | MultiSchema
          | Views
-         | JsonProtocol
     }),
     deprecated: enumflags2::make_bitflags!(PreviewFeature::{
         AtomicNumberOperations
@@ -122,6 +121,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | ClientExtensions
         | FilteredRelationCount
         | OrderByNulls
+        | JsonProtocol
     }),
     hidden: enumflags2::make_bitflags!(PreviewFeature::{
         NodeDrivers

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: fullTextSearch, fullTextIndex, tracing, metrics, multiSchema, fieldReference, postgresqlExtensions, deno, extendedWhereUnique, views, jsonProtocol[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: fullTextSearch, fullTextIndex, tracing, metrics, multiSchema, fieldReference, postgresqlExtensions, deno, extendedWhereUnique, views[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -192,13 +192,7 @@ impl QueryEngine {
 
         let enable_metrics = config.preview_features().contains(PreviewFeature::Metrics);
         let enable_tracing = config.preview_features().contains(PreviewFeature::Tracing);
-        let engine_protocol =
-            engine_protocol.unwrap_or_else(
-                || match config.preview_features().contains(PreviewFeature::JsonProtocol) {
-                    true => EngineProtocol::Json,
-                    false => EngineProtocol::Graphql,
-                },
-            );
+        let engine_protocol = engine_protocol.unwrap_or(EngineProtocol::Json);
 
         let builder = EngineBuilder {
             schema: Arc::new(schema),

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -57,13 +57,12 @@ impl CliCommand {
                 }))),
                 CliOpt::ExecuteRequest(input) => {
                     let schema = opts.schema(false)?;
-                    let features = schema.configuration.preview_features();
 
                     Ok(Some(CliCommand::ExecuteRequest(ExecuteRequest {
                         query: input.query.clone(),
                         enable_raw_queries: opts.enable_raw_queries,
                         schema,
-                        engine_protocol: opts.engine_protocol(features),
+                        engine_protocol: opts.engine_protocol(),
                     })))
                 }
                 CliOpt::DebugPanic(input) => Ok(Some(CliCommand::DebugPanic(DebugPanicRequest {

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -117,7 +117,7 @@ pub async fn setup(
 
     let datamodel = opts.schema(false)?;
     let config = &datamodel.configuration;
-    let protocol = opts.engine_protocol(config.preview_features());
+    let protocol = opts.engine_protocol();
     config.validate_that_one_datasource_is_provided()?;
 
     let span = tracing::info_span!("prisma:engine:connect");

--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -1,5 +1,4 @@
 use crate::{error::PrismaError, PrismaResult};
-use psl::{PreviewFeature, PreviewFeatures};
 use query_core::protocol::EngineProtocol;
 use serde::Deserialize;
 use std::{env, ffi::OsStr, fs::File, io::Read};
@@ -208,9 +207,8 @@ impl PrismaOpt {
         std::env::var("LOG_QUERIES").map(|_| true).unwrap_or(self.log_queries)
     }
 
-    /// The EngineProtocol to use for communication, it will be [EngineProtocol::Json] in case
-    /// the [PreviewFeature::JsonProtocol] flag is set to "json". Otherwise it will be
-    /// [EngineProtocol::Graphql]
+    /// The EngineProtocol to use for communication, it will be [EngineProtocol::Json] by
+    /// default
     ///
     /// This protocol will determine how the body of an HTTP request made by the client is processed.
     /// [request_handlers::JsonBody] and [request_handlers::GraphqlBody] are in charge
@@ -222,14 +220,11 @@ impl PrismaOpt {
     /// for submitting the query, this is due to the fact that DMMF is no longer used by the client
     /// to understand which types certain values are. See [query_core::QueryDocumentParser]
     ///
-    pub(crate) fn engine_protocol(&self, preview_features: PreviewFeatures) -> EngineProtocol {
+    pub(crate) fn engine_protocol(&self) -> EngineProtocol {
         self.engine_protocol
             .as_ref()
             .map(EngineProtocol::from)
-            .unwrap_or_else(|| match preview_features.contains(PreviewFeature::JsonProtocol) {
-                true => EngineProtocol::Json,
-                false => EngineProtocol::Graphql,
-            })
+            .unwrap_or(EngineProtocol::Json)
     }
 }
 


### PR DESCRIPTION
Default change is needed to make it work on DataProxy/mini-proxy for P5.

DO NOT MERGE BEFORE PRISMA 5