### PR TITLE
node-drivers-poc: rust instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1648,6 +1648,8 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -71,12 +71,12 @@ fmt-sql = ["sqlformat"]
 [dependencies]
 connection-string = "0.2"
 percent-encoding = "2"
+tracing = "0.1"
 tracing-core = "0.1"
 async-trait = "0.1"
 thiserror = "1.0"
 num_cpus = "1.12"
 metrics = "0.18"
-tracing = "0.1"
 futures = "0.3"
 url = "2.1"
 hex = "0.4"

--- a/query-engine/js-drivers/Cargo.toml
+++ b/query-engine/js-drivers/Cargo.toml
@@ -9,6 +9,8 @@ once_cell = "1.15"
 serde.workspace = true
 serde_json.workspace = true
 quaint.workspace = true
+tracing = "0.1"
+tracing-core = "0.1"
 
 napi.workspace = true
 napi-derive.workspace = true

--- a/query-engine/js-drivers/src/driver.rs
+++ b/query-engine/js-drivers/src/driver.rs
@@ -73,6 +73,12 @@ pub struct JSResultSet {
     pub rows: Vec<Vec<serde_json::Value>>,
 }
 
+impl JSResultSet {
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+}
+
 #[napi]
 #[derive(Debug)]
 pub enum ColumnType {

--- a/query-engine/js-drivers/src/lib.rs
+++ b/query-engine/js-drivers/src/lib.rs
@@ -5,4 +5,4 @@
 
 mod driver;
 mod queryable;
-pub use queryable::Queryable;
+pub use queryable::JsQueryable;

--- a/query-engine/js-drivers/src/queryable.rs
+++ b/query-engine/js-drivers/src/queryable.rs
@@ -10,30 +10,30 @@ use quaint::{
 use napi::JsObject;
 
 #[derive(Clone)]
-pub struct Queryable {
+pub struct JsQueryable {
     pub(crate) driver: Driver,
 }
 
-impl Queryable {
+impl JsQueryable {
     pub fn new(driver: Driver) -> Self {
         Self { driver }
     }
 }
 
-impl std::fmt::Display for Queryable {
+impl std::fmt::Display for JsQueryable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "JSQueryable(driver)")
     }
 }
 
-impl std::fmt::Debug for Queryable {
+impl std::fmt::Debug for JsQueryable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "JSQueryable(driver)")
     }
 }
 
 #[async_trait]
-impl QuaintQueryable for Queryable {
+impl QuaintQueryable for JsQueryable {
     /// Execute the given query.
     async fn query(&self, q: QuaintQuery<'_>) -> quaint::Result<ResultSet> {
         let (sql, params) = visitor::Mysql::build(q)?;
@@ -121,9 +121,9 @@ impl QuaintQueryable for Queryable {
     }
 }
 
-impl TransactionCapable for Queryable {}
+impl TransactionCapable for JsQueryable {}
 
-impl From<JsObject> for Queryable {
+impl From<JsObject> for JsQueryable {
     fn from(driver: JsObject) -> Self {
         let driver = driver::reify(driver).unwrap();
         Self { driver }

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -153,7 +153,7 @@ impl QueryEngine {
 
         #[cfg(feature = "js-drivers")]
         if let Some(driver) = maybe_driver {
-            let queryable = js_drivers::Queryable::from(driver);
+            let queryable = js_drivers::JsQueryable::from(driver);
             sql_connector::register_driver(Arc::new(queryable));
         }
 


### PR DESCRIPTION
Part of https://github.com/prisma/team-orm/issues/209

This PR adds tracing instrumentation to the `Runtime::JS` query execution, in particular it traces the following spans:

- `js:query` top level end-to-end span to measure the time it takes to convert arguments + query through the driver + convert the result set to a quaint format.
  - `js:query:args` sub-span to measure the time it takes to convert `quaint::Value` arguments into JS (FFI excluded)
  - `js:query:sql` sub span to measure the time it takes to execute the query through the node driver (FFI included)
  - `js:query:result` sub-span to measure the time it takes to deserialize a JSResultSet to a ResultSet