### PR TITLE
qe: Don't expose ignored views in DMMF

### DIFF
--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -23,7 +23,7 @@ pub(crate) fn schema_to_dmmf(schema: &psl::ValidatedSchema) -> Datamodel {
         .db
         .walk_models()
         .filter(|model| !model.is_ignored())
-        .chain(schema.db.walk_views())
+        .chain(schema.db.walk_views().filter(|view| !view.is_ignored()))
     {
         datamodel.models.push(model_to_dmmf(model));
     }

--- a/query-engine/dmmf/src/tests/test-schemas/views_ignore.prisma
+++ b/query-engine/dmmf/src/tests/test-schemas/views_ignore.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider        = "prisma-client-js"
+  output          = "../node_modules/.prisma/client"
+  previewFeatures = ["views"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:dev.db"
+}
+
+model User {
+  id    String  @id @default(uuid())
+}
+
+view IgnoredView {
+  id String @id
+
+  @@ignore
+}
+
+

--- a/query-engine/dmmf/src/tests/tests.rs
+++ b/query-engine/dmmf/src/tests/tests.rs
@@ -9,6 +9,15 @@ fn sqlite_ignore() {
     assert_eq!(dmmf.mappings.model_operations.len(), 1);
 }
 
+#[test]
+fn views_ignore() {
+    let dmmf = dmmf_from_schema(include_str!("./test-schemas/views_ignore.prisma"));
+
+    // The Ignored view is ignored.
+    assert_eq!(dmmf.data_model.models.len(), 1);
+    assert_eq!(dmmf.mappings.model_operations.len(), 1);
+}
+
 fn assert_comment(actual: Option<&String>, expected: &str) {
     assert!(actual.is_some_and(|c| c.as_str() == expected))
 }


### PR DESCRIPTION
Views with `@@ignore` annotations were still exposed to DMMF (unlike models), but had no available operations.
This broke some of the newly introduced types in TS client.

Fix prisma/prisma#19888