### PR TITLE
tech-debt: Context lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "context"
+version = "0.1.0"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/libs/context/Cargo.toml
+++ b/libs/context/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "context"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/libs/context/src/lib.rs
+++ b/libs/context/src/lib.rs
@@ -1,0 +1,87 @@
+use std::{
+    any::{Any, TypeId},
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Debug, Default)]
+pub struct Context {
+    store: HashMap<(String, TypeId), Box<dyn Any>>,
+}
+
+impl Context {
+    pub fn concurrent(self) -> Arc<Mutex<Context>> {
+        Arc::new(Mutex::new(self))
+    }
+
+    pub fn insert<T: Any>(&mut self, key: &str, value: T) {
+        self.store.insert((key.to_owned(), TypeId::of::<T>()), Box::new(value));
+    }
+
+    pub fn get<T: Any>(&self, key: &str) -> Option<&T> {
+        self.store
+            .get(&(key.to_owned(), TypeId::of::<T>()))
+            .map(|v| v.downcast_ref::<T>().unwrap())
+    }
+
+    pub fn get_mut<T: Any>(&mut self, key: &str) -> Option<&mut T> {
+        self.store
+            .get_mut(&(key.to_owned(), TypeId::of::<T>()))
+            .map(|v| v.downcast_mut::<T>().unwrap())
+    }
+
+    pub fn remove<T: Any>(&mut self, key: &str) -> Option<T> {
+        self.store
+            .remove(&(key.to_owned(), TypeId::of::<T>()))
+            .map(|v| *v.downcast::<T>().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Context;
+
+    #[test]
+    fn set_and_retrieve() {
+        let mut ctx: Context = Context::default();
+        ctx.insert("foo", 42 as u32);
+
+        let val: u32 = *ctx.get("foo").unwrap();
+        assert_eq!(val, 42 as u32)
+    }
+
+    #[test]
+    fn concurrent() {
+        let mut ctx: Context = Context::default();
+        ctx.insert("foo", 42 as u32);
+
+        assert_eq!(42 as u32, *ctx.get::<u32>("foo").unwrap());
+        assert_eq!(None, ctx.get::<u32>("bar"));
+
+        let safe_context = ctx.concurrent();
+        let mut ctx = safe_context.lock().unwrap();
+        ctx.insert("bar", 32 as u32);
+        assert_eq!(32 as u32, *ctx.get::<u32>("bar").unwrap());
+        assert_eq!(42 as u32, *ctx.get::<u32>("foo").unwrap());
+    }
+
+    #[test]
+    fn get_mut() {
+        let mut ctx: Context = Context::default();
+        ctx.insert("foo", 42 as u32);
+
+        let val: &mut u32 = ctx.get_mut("foo").unwrap();
+        *val = 32 as u32;
+        assert_eq!(32 as u32, *ctx.get::<u32>("foo").unwrap());
+    }
+
+    #[test]
+    fn remove() {
+        let mut ctx: Context = Context::default();
+        ctx.insert("foo", 42 as u32);
+
+        let val: u32 = ctx.remove("foo").unwrap();
+        assert_eq!(42 as u32, val);
+        assert_eq!(None, ctx.get::<u32>("foo"));
+    }
+}


### PR DESCRIPTION
# Problem

All the way down the stack, from the query engine entry point down to quiant, we pass a trace id for issuing telemetry traces. This is a very specific cross-cutting concern, the moment we need more things to be passed in, we will need more and more parameters to functions being called.

Because most of the behaviors down the stack are dynamic (i.e. a trait implementation with specific methods provides the behavior, rather than a struct holding the state) it’s each function in the trait that needs to be parameterized and changed in all the implementations. Consider this commit for instance (from a hackathon project), that passes down a prisma query, only for a subset of the read operations, it had to change more than 600 lines of code:

https://github.com/prisma/prisma-engines/pull/4059/commits/da24144cd8c994162e75c6b34f6c224aa05883e5

This lack of a mechanism to pass down a query context down the stack was also the reason why telemetry capturing was so complex. If it were in place it would have been much easier to implement that feature.

# Goals

- Define a struct for a generic Context object
- Apply the pattern gradually down the stack, gradually to prevent a very large PR.