### PR TITLE
feat: GA extendedWhereUnique

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -100,6 +100,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | DataProxy
         | Distinct
         | ExtendedIndexes
+        | ExtendedWhereUnique
         | FieldReference
         | FilteredRelationCount
         | FilterJson
@@ -121,7 +122,6 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | SelectRelationCount
         | TransactionApi
         | UncheckedScalarInputs
-        | ExtendedWhereUnique
     }),
     hidden: enumflags2::make_bitflags!(PreviewFeature::{
         NodeDrivers

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -82,7 +82,6 @@ features!(
 pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
         Deno
-         | ExtendedWhereUnique
          | FullTextIndex
          | FullTextSearch
          | Metrics
@@ -122,6 +121,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | SelectRelationCount
         | TransactionApi
         | UncheckedScalarInputs
+        | ExtendedWhereUnique
     }),
     hidden: enumflags2::make_bitflags!(PreviewFeature::{
         NodeDrivers

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, extendedWhereUnique, fullTextIndex, fullTextSearch, metrics, multiSchema, postgresqlExtensions, tracing, views[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, fullTextIndex, fullTextSearch, metrics, multiSchema, postgresqlExtensions, tracing, views[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/query-engine/schema/src/build.rs
+++ b/query-engine/schema/src/build.rs
@@ -16,7 +16,7 @@ pub(crate) use output_types::{mutation_type, query_type};
 use self::{enum_types::*, utils::*};
 use crate::*;
 use prisma_models::{ast, Field as ModelField, Model, RelationFieldRef, TypeIdentifier};
-use psl::{datamodel_connector::ConnectorCapability, PreviewFeature, PreviewFeatures};
+use psl::{datamodel_connector::ConnectorCapability, PreviewFeatures};
 
 pub fn build(schema: Arc<psl::ValidatedSchema>, enable_raw_queries: bool) -> QuerySchema {
     let preview_features = schema.configuration.preview_features();

--- a/query-engine/schema/src/build/input_types/fields/arguments.rs
+++ b/query-engine/schema/src/build/input_types/fields/arguments.rs
@@ -67,9 +67,7 @@ pub(crate) fn many_records_output_field_arguments(ctx: &QuerySchema, field: Mode
         ModelField::Relation(rf) if rf.is_list() => relation_to_many_selection_arguments(ctx, rf.related_model(), true),
 
         // To-one optional relation.
-        ModelField::Relation(rf) if !rf.is_required() && ctx.has_feature(PreviewFeature::ExtendedWhereUnique) => {
-            relation_to_one_selection_arguments(ctx, rf.related_model())
-        }
+        ModelField::Relation(rf) if !rf.is_required() => relation_to_one_selection_arguments(ctx, rf.related_model()),
 
         // To-one required relation.
         ModelField::Relation(_) => vec![],

--- a/query-engine/schema/src/build/input_types/fields/input_fields.rs
+++ b/query-engine/schema/src/build/input_types/fields/input_fields.rs
@@ -162,10 +162,9 @@ pub(crate) fn nested_disconnect_input_field<'a>(
         (false, false) => {
             let mut types = vec![InputType::boolean()];
 
-            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique)
-                && (ctx.has_capability(ConnectorCapability::FilteredInlineChildNestedToOneDisconnect)
+            if ctx.has_capability(ConnectorCapability::FilteredInlineChildNestedToOneDisconnect)
                        // If the disconnect happens on the inline side, then we can allow filters
-                    || parent_field.related_field().is_inlined_on_enclosing_model())
+                    || parent_field.related_field().is_inlined_on_enclosing_model()
             {
                 types.push(InputType::object(filter_objects::where_object_type(
                     ctx,
@@ -187,14 +186,13 @@ pub(crate) fn nested_delete_input_field<'a>(
     match (parent_field.is_list(), parent_field.is_required()) {
         (true, _) => Some(where_unique_input_field(ctx, operations::DELETE, parent_field)),
         (false, false) => {
-            let mut types = vec![InputType::boolean()];
-
-            if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
-                types.push(InputType::object(filter_objects::where_object_type(
+            let types = vec![
+                InputType::boolean(),
+                InputType::object(filter_objects::where_object_type(
                     ctx,
                     parent_field.related_model().into(),
-                )));
-            }
+                )),
+            ];
 
             Some(input_field(operations::DELETE, types, None).optional())
         }
@@ -216,7 +214,7 @@ pub(crate) fn nested_update_input_field(ctx: &'_ QuerySchema, parent_field: Rela
             update_one_objects::update_one_where_combination_object(ctx, update_shorthand_types.clone(), &parent_field);
 
         list_union_object_type(to_many_update_full_type, true)
-    } else if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
+    } else {
         let to_one_update_full_type = update_one_objects::update_to_one_rel_where_combination_object(
             ctx,
             update_shorthand_types.clone(),
@@ -227,8 +225,6 @@ pub(crate) fn nested_update_input_field(ctx: &'_ QuerySchema, parent_field: Rela
         to_one_types.append(&mut update_shorthand_types);
 
         to_one_types
-    } else {
-        update_shorthand_types
     };
 
     input_field(operations::UPDATE, update_types, None).optional()

--- a/query-engine/schema/src/build/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/upsert_objects.rs
@@ -52,14 +52,11 @@ fn nested_upsert_nonlist_input_object(
         let update_types =
             update_one_objects::update_one_input_types(ctx, related_model.clone(), Some(parent_field.clone()));
 
-        let mut fields = vec![
+        let fields = vec![
             input_field(args::UPDATE, update_types, None),
             input_field(args::CREATE, create_types.clone(), None),
+            where_argument(ctx, &related_model),
         ];
-
-        if ctx.has_feature(PreviewFeature::ExtendedWhereUnique) {
-            fields.push(where_argument(ctx, &related_model));
-        }
 
         fields
     }))


### PR DESCRIPTION
## Overview

Contributes to https://github.com/prisma/prisma/issues/19380

Deprecates the extendedWhereUnique preview feature flag to make it GA for Prisma 5