### PR TITLE
feat(schema-engine): add back `getDatabaseVersion` RPC support

### DIFF
--- a/schema-engine/cli/tests/cli_tests.rs
+++ b/schema-engine/cli/tests/cli_tests.rs
@@ -298,7 +298,7 @@ fn tls_errors_must_be_mapped_in_the_cli(api: TestApi) {
 }
 
 #[test_connector(tags(Postgres))]
-fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
+fn basic_jsonrpc_roundtrip_works_with_no_params(_api: TestApi) {
     let tmpdir = tempfile::tempdir().unwrap();
     let tmpfile = tmpdir.path().join("datamodel");
 
@@ -322,7 +322,7 @@ fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
         for _ in 0..2 {
             writeln!(
                 stdin,
-                r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {{ }}, "id": 1 }}"#,
+                r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "id": 1 }}"#,
             )
             .unwrap();
 
@@ -341,6 +341,43 @@ fn basic_jsonrpc_roundtrip_works_with_dynamic_url(_api: TestApi) {
 
     let params = format!(
         r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {{ "datasource": {{ "tag": "ConnectionString", "url": "{url}" }} }}, "id": 1 }}"#
+    );
+
+    with_child_process(command, |process| {
+        let stdin = process.stdin.as_mut().unwrap();
+        let mut stdout = BufReader::new(process.stdout.as_mut().unwrap());
+
+        for _ in 0..2 {
+            writeln!(stdin, "{}", &params).unwrap();
+
+            let mut response = String::new();
+            stdout.read_line(&mut response).unwrap();
+
+            assert!(response.contains("PostgreSQL") || response.contains("CockroachDB"));
+        }
+    });
+}
+
+#[test_connector(tags(Postgres))]
+fn basic_jsonrpc_roundtrip_works_with_dynamic_path(_api: TestApi) {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let tmpfile = tmpdir.path().join("datamodel");
+
+    let datamodel = r#"
+        datasource db {
+            provider = "postgres"
+            url = env("TEST_DATABASE_URL")
+        }
+    "#;
+
+    fs::create_dir_all(&tmpdir).unwrap();
+    fs::write(&tmpfile, datamodel).unwrap();
+
+    let command = Command::new(schema_engine_bin_path());
+
+    let path = tmpfile.to_str().unwrap();
+    let params = format!(
+        r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {{ "datasource": {{ "tag": "SchemaPath", "path": "{path}" }} }}, "id": 1 }}"#
     );
 
     with_child_process(command, |process| {

--- a/schema-engine/cli/tests/cli_tests.rs
+++ b/schema-engine/cli/tests/cli_tests.rs
@@ -352,14 +352,10 @@ fn basic_jsonrpc_roundtrip_works_with_params(_api: TestApi) {
     let command = Command::new(schema_engine_bin_path());
 
     let path = tmpfile.to_str().unwrap();
-    let schema_path_params = format!(
-        r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {{ "datasource": {{ "tag": "SchemaPath", "path": "{path}" }} }}, "id": 1 }}"#
-    );
+    let schema_path_params = format!(r#"{{ "datasource": {{ "tag": "SchemaPath", "path": "{path}" }} }}"#);
 
     let url = std::env::var("TEST_DATABASE_URL").unwrap();
-    let connection_string_params = format!(
-        r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {{ "datasource": {{ "tag": "ConnectionString", "url": "{url}" }} }}, "id": 1 }}"#
-    );
+    let connection_string_params = format!(r#"{{ "datasource": {{ "tag": "ConnectionString", "url": "{url}" }} }}"#);
 
     with_child_process(command, |process| {
         let stdin = process.stdin.as_mut().unwrap();
@@ -367,7 +363,10 @@ fn basic_jsonrpc_roundtrip_works_with_params(_api: TestApi) {
 
         for _ in 0..2 {
             for params in [&schema_path_params, &connection_string_params] {
-                writeln!(stdin, "{}", &params).unwrap();
+                let params_template =
+                    format!(r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {params}, "id": 1 }}"#);
+
+                writeln!(stdin, "{}", &params_template).unwrap();
 
                 let mut response = String::new();
                 stdout.read_line(&mut response).unwrap();

--- a/schema-engine/cli/tests/cli_tests.rs
+++ b/schema-engine/cli/tests/cli_tests.rs
@@ -334,6 +334,30 @@ fn basic_jsonrpc_roundtrip_works(_api: TestApi) {
     });
 }
 
+#[test_connector(tags(Postgres))]
+fn basic_jsonrpc_roundtrip_works_with_dynamic_url(_api: TestApi) {
+    let url = std::env::var("TEST_DATABASE_URL").unwrap();
+    let command = Command::new(schema_engine_bin_path());
+
+    let params = format!(
+        r#"{{ "jsonrpc": "2.0", "method": "getDatabaseVersion", "params": {{ "datasource": {{ "tag": "ConnectionString", "url": "{url}" }} }}, "id": 1 }}"#
+    );
+
+    with_child_process(command, |process| {
+        let stdin = process.stdin.as_mut().unwrap();
+        let mut stdout = BufReader::new(process.stdout.as_mut().unwrap());
+
+        for _ in 0..2 {
+            writeln!(stdin, "{}", &params).unwrap();
+
+            let mut response = String::new();
+            stdout.read_line(&mut response).unwrap();
+
+            assert!(response.contains("PostgreSQL") || response.contains("CockroachDB"));
+        }
+    });
+}
+
 #[test]
 fn introspect_sqlite_empty_database() {
     let tmpdir = tempfile::tempdir().unwrap();

--- a/schema-engine/core/src/api.rs
+++ b/schema-engine/core/src/api.rs
@@ -6,7 +6,7 @@ use crate::{commands, json_rpc::types::*, CoreResult};
 #[async_trait::async_trait]
 pub trait GenericApi: Send + Sync + 'static {
     /// Return the database version as a string.
-    async fn version(&self) -> CoreResult<String>;
+    async fn version(&self, params: GetDatabaseVersionInput) -> CoreResult<String>;
 
     /// Apply all the unapplied migrations from the migrations folder.
     async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput>;

--- a/schema-engine/core/src/api.rs
+++ b/schema-engine/core/src/api.rs
@@ -6,7 +6,7 @@ use crate::{commands, json_rpc::types::*, CoreResult};
 #[async_trait::async_trait]
 pub trait GenericApi: Send + Sync + 'static {
     /// Return the database version as a string.
-    async fn version(&self, params: GetDatabaseVersionInput) -> CoreResult<String>;
+    async fn version(&self, params: Option<GetDatabaseVersionInput>) -> CoreResult<String>;
 
     /// Apply all the unapplied migrations from the migrations folder.
     async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput>;

--- a/schema-engine/core/src/rpc.rs
+++ b/schema-engine/core/src/rpc.rs
@@ -35,7 +35,7 @@ async fn run_command(
         DIAGNOSE_MIGRATION_HISTORY => render(executor.diagnose_migration_history(params.parse()?).await),
         ENSURE_CONNECTION_VALIDITY => render(executor.ensure_connection_validity(params.parse()?).await),
         EVALUATE_DATA_LOSS => render(executor.evaluate_data_loss(params.parse()?).await),
-        GET_DATABASE_VERSION => render(executor.version().await),
+        GET_DATABASE_VERSION => render(executor.version(params.parse()?).await),
         INTROSPECT => render(executor.introspect(params.parse()?).await),
         LIST_MIGRATION_DIRECTORIES => render(executor.list_migration_directories(params.parse()?).await),
         MARK_MIGRATION_APPLIED => render(executor.mark_migration_applied(params.parse()?).await),

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -183,8 +183,8 @@ impl EngineState {
 
 #[async_trait::async_trait]
 impl GenericApi for EngineState {
-    async fn version(&self) -> CoreResult<String> {
-        self.with_default_connector(Box::new(|connector| connector.version()))
+    async fn version(&self, params: GetDatabaseVersionInput) -> CoreResult<String> {
+        self.with_connector_from_datasource_param(&params.datasource, Box::new(|connector| connector.version()))
             .await
     }
 

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -183,9 +183,13 @@ impl EngineState {
 
 #[async_trait::async_trait]
 impl GenericApi for EngineState {
-    async fn version(&self, params: GetDatabaseVersionInput) -> CoreResult<String> {
-        self.with_connector_from_datasource_param(&params.datasource, Box::new(|connector| connector.version()))
-            .await
+    async fn version(&self, params: Option<GetDatabaseVersionInput>) -> CoreResult<String> {
+        let f: ConnectorRequest<String> = Box::new(|connector| connector.version());
+
+        match params {
+            Some(params) => self.with_connector_from_datasource_param(&params.datasource, f).await,
+            None => self.with_default_connector(f).await,
+        }
     }
 
     async fn apply_migrations(&self, input: ApplyMigrationsInput) -> CoreResult<ApplyMigrationsOutput> {

--- a/schema-engine/json-rpc-api-build/methods/getDatabaseVersion.toml
+++ b/schema-engine/json-rpc-api-build/methods/getDatabaseVersion.toml
@@ -4,6 +4,7 @@ requestShape = "getDatabaseVersionInput"
 responseShape = "getDatabaseVersionOutput"
 
 [recordShapes.getDatabaseVersionInput]
+fields.datasource.shape = "DatasourceParam"
 
 [recordShapes.getDatabaseVersionOutput.fields.version]
 shape = "string"


### PR DESCRIPTION
This PR contributes to https://github.com/prisma/prisma-private/issues/203.
Related TypeScript PR: https://github.com/prisma/prisma-engines/pull/4071.

Note: this PR can be merged right away, as it doesn't influence `prisma/prisma` in any way until https://github.com/prisma/prisma-engines/pull/4071 is merged.