### PR TITLE
qe: Fix batch results processing for enums

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
@@ -317,7 +317,7 @@ mod singular_batch {
             }
 
             model TestModel {
-                id IdEnum @id
+                #id(id, IdEnum, @id)
             }
             "#
         };

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batch/select_one_singular.rs
@@ -308,6 +308,46 @@ mod singular_batch {
         Ok(())
     }
 
+    fn enum_id() -> String {
+        let schema = indoc! {
+            r#"
+            enum IdEnum {
+                A
+                B
+            }
+
+            model TestModel {
+                id IdEnum @id
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(enum_id), capabilities(Enums))]
+    async fn batch_enum(runner: Runner) -> TestResult<()> {
+        run_query!(&runner, r#"mutation { createOneTestModel(data: { id: "A" }) { id } }"#);
+        run_query!(&runner, r#"mutation { createOneTestModel(data: { id: "B" }) { id } }"#);
+
+        let (res, compact_doc) = compact_batch(
+            &runner,
+            vec![
+                r#"{ findUniqueTestModel(where: { id: "A" }) { id } }"#.to_string(),
+                r#"{ findUniqueTestModel(where: { id: "B" }) { id } }"#.to_string(),
+            ],
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          res.to_string(),
+          @r###"{"batchResult":[{"data":{"findUniqueTestModel":{"id":"A"}}},{"data":{"findUniqueTestModel":{"id":"B"}}}]}"###
+        );
+        assert!(compact_doc.is_compact());
+
+        Ok(())
+    }
+
     // Regression test for https://github.com/prisma/prisma/issues/16548
     #[connector_test(schema(schemas::generic))]
     async fn repro_16548(runner: Runner) -> TestResult<()> {

--- a/query-engine/request-handlers/src/handler.rs
+++ b/query-engine/request-handlers/src/handler.rs
@@ -236,6 +236,7 @@ impl<'a> RequestHandler<'a> {
     /// - DateTime/String: User-input: DateTime / Response: String
     /// - Int/BigInt: User-input: Int / Response: BigInt
     /// - (JSON protocol only) Custom types (eg: { "$type": "BigInt", value: "1" }): User-input: Scalar / Response: Object
+    /// - (JSON protocol only) String/Enum: User-input: String / Response: Enum
     /// This should likely _not_ be used outside of this specific context.
     fn compare_values(left: &ArgumentValue, right: &ArgumentValue) -> bool {
         match (left, right) {
@@ -248,6 +249,10 @@ impl<'a> RequestHandler<'a> {
             (ArgumentValue::Scalar(PrismaValue::Int(i1)), ArgumentValue::Scalar(PrismaValue::BigInt(i2)))
             | (ArgumentValue::Scalar(PrismaValue::BigInt(i2)), ArgumentValue::Scalar(PrismaValue::Int(i1))) => {
                 *i1 == *i2
+            }
+            (ArgumentValue::Scalar(PrismaValue::Enum(s1)), ArgumentValue::Scalar(PrismaValue::String(s2)))
+            | (ArgumentValue::Scalar(PrismaValue::String(s1)), ArgumentValue::Scalar(PrismaValue::Enum(s2))) => {
+                *s1 == *s2
             }
             (ArgumentValue::Object(t1), t2) | (t2, ArgumentValue::Object(t1)) => match Self::unwrap_value(t1) {
                 Some(t1) => Self::compare_values(t1, t2),


### PR DESCRIPTION
When JSON protocol is used and batching is happening, if the unique
value is enum, we incorrectly compared the results with the inputs:
inputs are PrismaValue::String, while outputs are PrismaValue::Enum.

Fix prisma/prisma#20227
