### PR TITLE
Add integration test for connecting to SQL DBs with IPv6 address in URL

### DIFF
--- a/schema-engine/sql-migration-tests/tests/initialization/mod.rs
+++ b/schema-engine/sql-migration-tests/tests/initialization/mod.rs
@@ -84,3 +84,28 @@ fn connecting_to_a_postgres_database_with_missing_schema_creates_it(api: TestApi
         assert!(schema_exists)
     }
 }
+
+#[test_connector(exclude(Sqlite))]
+fn ipv6_addresses_are_supported_in_connection_strings(api: TestApi) {
+    let url = api.connection_string().replace("localhost", "[::1]");
+    assert!(url.contains("[::1]"));
+
+    let provider = api.provider();
+
+    let schema = format!(
+        r#"
+        datasource db {{
+            provider = "{provider}"
+            url = "{url}"
+        }}
+        "#
+    );
+
+    let engine = schema_api(Some(schema.clone()), None).unwrap();
+    tok(
+        engine.ensure_connection_validity(schema_core::json_rpc::types::EnsureConnectionValidityParams {
+            datasource: schema_core::json_rpc::types::DatasourceParam::SchemaString(SchemaContainer { schema }),
+        }),
+    )
+    .unwrap();
+}


### PR DESCRIPTION
This PR ~~includes the commit from https://github.com/prisma/prisma-engines/pull/4051 (to run the full CI including Buildkite)~~ (UPD: original PR merged) and the integration test for IPv6 URLs for the schema engine.

Adding a similar integration test in the query engine seems to be a little more involved given how its test setup works (with connection strings being built dynamically, and using domain names from docker network rather than `localhost` or `127.0.0.1` on CI). It's certainly possible but I'm not sure is worth the effort given that the change was purely in quaint, and affects both engines in the same way.

A test for MongoDB wasn't added as it is currently blocked by https://github.com/mongodb/mongo-rust-driver/issues/916, it needs to be implemented upstream first.