### PR TITLE
perf: avoid read after updates when possible

### DIFF
--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -56,7 +56,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     NativeUpsert |
     MultiSchema |
     FilteredInlineChildNestedToOneDisconnect |
-    InsertReturning
+    InsertReturning |
+    UpdateReturning
 });
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -63,7 +63,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     SupportsTxIsolationRepeatableRead |
     SupportsTxIsolationSerializable |
     NativeUpsert |
-    InsertReturning
+    InsertReturning |
+    UpdateReturning
 });
 
 pub struct PostgresDatamodelConnector;

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -101,7 +101,8 @@ capabilities!(
     SupportsTxIsolationSerializable,
     SupportsTxIsolationSnapshot,
     NativeUpsert,
-    InsertReturning
+    InsertReturning,
+    UpdateReturning,
 );
 
 /// Contains all capabilities that the connector is able to serve.

--- a/quaint/src/ast/update.rs
+++ b/quaint/src/ast/update.rs
@@ -9,6 +9,7 @@ pub struct Update<'a> {
     pub(crate) values: Vec<Expression<'a>>,
     pub(crate) conditions: Option<ConditionTree<'a>>,
     pub(crate) comment: Option<Cow<'a, str>>,
+    pub(crate) returning: Option<Vec<Column<'a>>>,
 }
 
 impl<'a> From<Update<'a>> for Query<'a> {
@@ -29,6 +30,7 @@ impl<'a> Update<'a> {
             values: Vec::new(),
             conditions: None,
             comment: None,
+            returning: None,
         }
     }
 
@@ -131,6 +133,33 @@ impl<'a> Update<'a> {
         T: Into<ConditionTree<'a>>,
     {
         self.conditions = Some(conditions.into());
+        self
+    }
+
+    /// Sets the returned columns.
+    ///
+    /// ```rust
+    /// # use quaint::{ast::*, visitor::{Visitor, Postgres}};
+    /// # fn main() -> Result<(), quaint::error::Error> {
+    /// let update = Update::table("users").set("foo", 10);
+    /// let update = update.returning(vec!["id"]);
+    /// let (sql, _) = Postgres::build(update)?;
+    ///
+    /// assert_eq!("UPDATE \"users\" SET \"foo\" = $1 RETURNING \"id\"", sql);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(any(feature = "postgresql", feature = "sqlite"))]
+    #[cfg_attr(
+        feature = "docs",
+        doc(cfg(any(feature = "postgresql", feature = "sqlite")))
+    )]
+    pub fn returning<K, I>(mut self, columns: I) -> Self
+    where
+        K: Into<Column<'a>>,
+        I: IntoIterator<Item = K>,
+    {
+        self.returning = Some(columns.into_iter().map(|k| k.into()).collect());
         self
     }
 }

--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -334,6 +334,14 @@ pub trait Visitor<'a> {
             self.visit_conditions(conditions)?;
         }
 
+        if let Some(returning) = update.returning {
+            if !returning.is_empty() {
+                let values = returning.into_iter().map(|r| r.into()).collect();
+                self.write(" RETURNING ")?;
+                self.visit_columns(values)?;
+            }
+        }
+
         if let Some(comment) = update.comment {
             self.write(" ")?;
             self.visit_comment(comment)?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -33,7 +33,7 @@ mod metrics {
             CockroachDb => (), // not deterministic
             MySql(_) => assert_eq!(total_queries, 12),
             Vitess(_) => assert_eq!(total_queries, 11),
-            Postgres(_) => assert_eq!(total_queries, 11),
+            Postgres(_) => assert_eq!(total_queries, 7),
         }
 
         assert_eq!(total_operations, 2);

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -398,11 +398,6 @@ mod one2many_opt {
             @r###"{"data":{"updateOneParent":{"uniq":"1u"}}}"###
         );
 
-        // insta::assert_snapshot!(
-        //     run_query!(&runner, "query { findManyParent { uniq children { parent_uniq } }}"),
-        //     @r###"{"data":{"findManyParent":[{"uniq":"1u","children":[{"parent_uniq":"1u"}]}]}}"###
-        // );
-
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -398,10 +398,10 @@ mod one2many_opt {
             @r###"{"data":{"updateOneParent":{"uniq":"1u"}}}"###
         );
 
-        insta::assert_snapshot!(
-            run_query!(&runner, "query { findManyParent { uniq children { parent_uniq } }}"),
-            @r###"{"data":{"findManyParent":[{"uniq":"1u","children":[{"parent_uniq":"1u"}]}]}}"###
-        );
+        // insta::assert_snapshot!(
+        //     run_query!(&runner, "query { findManyParent { uniq children { parent_uniq } }}"),
+        //     @r###"{"data":{"findManyParent":[{"uniq":"1u","children":[{"parent_uniq":"1u"}]}]}}"###
+        // );
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -398,6 +398,11 @@ mod one2many_opt {
             @r###"{"data":{"updateOneParent":{"uniq":"1u"}}}"###
         );
 
+        insta::assert_snapshot!(
+            run_query!(&runner, "query { findManyParent { uniq children { parent_uniq } }}"),
+            @r###"{"data":{"findManyParent":[{"uniq":"1u","children":[{"parent_uniq":"1u"}]}]}}"###
+        );
+
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -186,6 +186,30 @@ mod update {
         Ok(())
     }
 
+    #[connector_test(schema(schema_1))]
+    async fn update_noop(runner: Runner) -> TestResult<()> {
+        create_row(&runner, r#"{ id: 1, optString: "hello" }"#).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            updateOneTestModel(
+              where: { id: 1 }
+              data: {}
+            ) {
+              id
+              optString
+              optInt
+              optFloat
+              optBoolean
+              optDateTime
+            }
+          }"#),
+          @r###"{"data":{"updateOneTestModel":{"id":1,"optString":"hello","optInt":null,"optFloat":null,"optBoolean":null,"optDateTime":null}}}"###
+        );
+
+        Ok(())
+    }
+
     // "An updateOne mutation" should "update an item with shorthand notation"
     #[connector_test(schema(schema_1))]
     async fn update_with_shorthand_notation(runner: Runner) -> TestResult<()> {

--- a/query-engine/connector-test-kit-rs/test-configs/mysql57
+++ b/query-engine/connector-test-kit-rs/test-configs/mysql57
@@ -1,3 +1,4 @@
 {
-    "connector": "mysql",
-    "version": "5.7"}
+  "connector": "mysql",
+  "version": "5.7"
+}

--- a/query-engine/connector-test-kit-rs/test-configs/postgres10
+++ b/query-engine/connector-test-kit-rs/test-configs/postgres10
@@ -1,3 +1,4 @@
 {
-    "connector": "postgres",
-    "version": "10"}
+  "connector": "postgres",
+  "version": "10"
+}

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -316,8 +316,9 @@ pub trait WriteOperations {
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
+        selected_fields: Option<FieldSelection>,
         trace_id: Option<String>,
-    ) -> crate::Result<Option<SelectionResult>>;
+    ) -> crate::Result<Option<SingleRecord>>;
 
     /// Native upsert
     /// Use the connectors native upsert to upsert the `Model`

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -470,9 +470,8 @@ pub fn merge_write_args(loaded_ids: Vec<SelectionResult>, incoming_args: WriteAr
         .into_iter()
         .map(|mut id| {
             for (position, write_op) in positions.iter() {
-                let current_val = id.pairs[position.to_owned()].1.clone();
-                id.pairs[position.to_owned()].1 =
-                    apply_expression(current_val, (*write_op.as_scalar().unwrap()).clone());
+                let current_val = id.pairs[*position].1.clone();
+                id.pairs[*position].1 = apply_expression(current_val, (*write_op.as_scalar().unwrap()).clone());
             }
 
             id

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -216,12 +216,13 @@ where
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
+        selected_fields: Option<FieldSelection>,
         trace_id: Option<String>,
-    ) -> connector::Result<Option<SelectionResult>> {
+    ) -> connector::Result<Option<SingleRecord>> {
         catch(self.connection_info.clone(), async move {
             let ctx = Context::new(&self.connection_info, trace_id.as_deref());
-            let mut res = write::update_record(&self.inner, model, record_filter, args, &ctx).await?;
-            Ok(res.pop())
+
+            write::update_record(&self.inner, model, record_filter, args, selected_fields, &ctx).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/mod.rs
@@ -1,3 +1,4 @@
 pub mod read;
+pub(crate) mod update;
 pub mod upsert;
 pub mod write;

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -166,7 +166,7 @@ pub(crate) async fn get_related_m2m_record_ids(
 
     // [DTODO] To verify: We might need chunked fetch here (too many parameters in the query).
     let select = Select::from_table(table)
-        .so_that(query_builder::conditions(&from_columns, from_record_ids))
+        .so_that(query_builder::in_conditions(&from_columns, from_record_ids))
         .columns(from_columns.into_iter().chain(to_columns.into_iter()));
 
     let parent_model_id = from_field.model().primary_identifier();

--- a/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
@@ -1,0 +1,179 @@
+use super::read::get_single_record;
+
+use crate::column_metadata::{self, ColumnMetadata};
+use crate::filter_conversion::AliasedCondition;
+use crate::model_extensions::AsColumns;
+use crate::query_builder::in_conditions;
+use crate::query_builder::write::{build_update_and_set_query, chunk_update_with_ids};
+use crate::row::ToSqlRow;
+use crate::{Context, QueryExt, Queryable};
+
+use connector_interface::*;
+use itertools::Itertools;
+use prisma_models::*;
+use quaint::prelude::ConditionTree;
+use std::usize;
+
+/// Performs an update with an explicit selection set.
+/// This function is called for connectors that supports the `UpdateReturning` capability.
+pub(crate) async fn update_one_with_selection(
+    conn: &dyn Queryable,
+    model: &Model,
+    record_filter: RecordFilter,
+    args: WriteArgs,
+    selected_fields: FieldSelection,
+    ctx: &Context<'_>,
+) -> crate::Result<Option<SingleRecord>> {
+    let selected_fields = ModelProjection::from(selected_fields);
+
+    // If there's nothing to update, just read the record.
+    // TODO(perf): Technically, if the selectors are fulfilling the field selection, there's no need to perform an additional read.
+    if args.args.is_empty() {
+        return get_single_record(conn, model, &record_filter.filter, &selected_fields, &[], ctx).await;
+    }
+
+    let update = build_update_and_set_query(model, args, Some(&selected_fields), ctx)
+        .so_that(build_update_one_filter(record_filter, ctx));
+
+    let field_names: Vec<_> = selected_fields.db_names().collect();
+    let idents = selected_fields.type_identifiers_with_arities();
+    let meta = column_metadata::create(&field_names, &idents);
+
+    let result_row = conn.query(update.into()).await?.into_iter().next();
+    let record = result_row
+        .map(|row| process_result_row(row, &meta, &selected_fields))
+        .transpose()?
+        .map(|selection| SingleRecord {
+            record: Record::from(selection),
+            field_names: selected_fields.db_names().collect(),
+        });
+
+    Ok(record)
+}
+
+/// Performs an update without an explicit selection set.
+/// This function is called for connectors lacking the `UpdateReturning` capability.
+/// As we don't have a selection set to work with, this function always returns a record with the primary identifier of the model (provided that a record was found).
+/// However, since we can't get the updated values back from the update operation, we need to read the primary identifier _before_ the update and then update the ids in-memory if they were updated.
+pub(crate) async fn update_one_without_selection(
+    conn: &dyn Queryable,
+    model: &Model,
+    record_filter: RecordFilter,
+    args: WriteArgs,
+    ctx: &Context<'_>,
+) -> crate::Result<Option<SingleRecord>> {
+    // If there's nothing to update, just return the ids.
+    // If the parent operation did not pass any ids, then perform a read so that the following operations can be resolved.
+    if args.args.is_empty() {
+        let ids: Vec<SelectionResult> = conn.filter_selectors(model, record_filter.clone(), ctx).await?;
+
+        let record = ids.into_iter().next().map(|id| SingleRecord {
+            record: Record::from(id),
+            field_names: model.primary_identifier().db_names().collect_vec(),
+        });
+
+        return Ok(record);
+    }
+
+    // Pick the primary identifiers args from the WriteArgs if there are any.
+    let id_args = pick_args(&model.primary_identifier().into(), &args);
+    // Perform the update and return the ids on which we've applied the update.
+    // Note: We are _not_ getting back the ids from the update. Either we got some ids passed from the parent operation or we perform a read _before_ doing the update.
+    let (_, ids) = update_many_from_ids_and_filter(conn, model, record_filter, args, ctx).await?;
+    // Since we could not get the ids back from the update, we need to apply in-memory transformation to the ids in case they were part of the update.
+    // This is critical to ensure the following operations can operate on the updated ids.
+    let merged_ids = merge_write_args(ids, id_args);
+
+    let record = merged_ids.into_iter().next().map(|id| SingleRecord {
+        record: Record::from(id),
+        field_names: model.primary_identifier().db_names().collect(),
+    });
+
+    Ok(record)
+}
+
+// Generates a query like this:
+//  UPDATE "public"."User" SET "name" = $1 WHERE "public"."User"."age" > $1
+pub(crate) async fn update_many_from_filter(
+    conn: &dyn Queryable,
+    model: &Model,
+    record_filter: RecordFilter,
+    args: WriteArgs,
+    ctx: &Context<'_>,
+) -> crate::Result<usize> {
+    let update = build_update_and_set_query(model, args, None, ctx);
+    let filter_condition = record_filter.filter.aliased_condition_from(None, false, ctx);
+    let update = update.so_that(filter_condition);
+    let count = conn.execute(update.into()).await?;
+
+    Ok(count as usize)
+}
+
+// Generates a query like this:
+//  UPDATE "public"."User" SET "name" = $1 WHERE "public"."User"."id" IN ($2,$3,$4,$5,$6,$7,$8,$9,$10,$11) AND "public"."User"."age" > $1
+pub(crate) async fn update_many_from_ids_and_filter(
+    conn: &dyn Queryable,
+    model: &Model,
+    record_filter: RecordFilter,
+    args: WriteArgs,
+    ctx: &Context<'_>,
+) -> crate::Result<(usize, Vec<SelectionResult>)> {
+    let filter_condition = record_filter.filter.aliased_condition_from(None, false, ctx);
+    let ids: Vec<SelectionResult> = conn.filter_selectors(model, record_filter, ctx).await?;
+
+    if ids.is_empty() {
+        return Ok((0, Vec::new()));
+    }
+
+    let updates = {
+        let update = build_update_and_set_query(model, args, None, ctx);
+        let ids: Vec<&SelectionResult> = ids.iter().collect();
+
+        chunk_update_with_ids(update, model, &ids, filter_condition, ctx)?
+    };
+
+    let mut count = 0;
+
+    for update in updates {
+        let update_count = conn.execute(update).await?;
+
+        count += update_count;
+    }
+
+    Ok((count as usize, ids))
+}
+
+fn process_result_row(
+    row: quaint::prelude::ResultRow,
+    meta: &[ColumnMetadata<'_>],
+    selected_fields: &ModelProjection,
+) -> crate::Result<SelectionResult> {
+    let sql_row = row.to_sql_row(meta)?;
+    let prisma_row = selected_fields.scalar_fields().zip(sql_row.values).collect_vec();
+
+    Ok(SelectionResult::new(prisma_row))
+}
+
+/// Given a record filter, builds a ConditionTree composed of:
+/// 1. The `RecordFilter.filter`
+/// 2. The `RecordFilter.selectors`, if any are present, transformed to an `In()` filter
+///
+/// Both filters are 'AND'ed.
+///
+/// Note: This function should only be called for update_one filters. It is not chunking the filters into multiple queries.
+/// Note: Using this function to render an update_many filter could exceed the maximum query parameters available for a connector.
+fn build_update_one_filter(record_filter: RecordFilter, ctx: &Context<'_>) -> ConditionTree<'static> {
+    let filter_condition = record_filter.filter.aliased_condition_from(None, false, ctx);
+
+    if let Some(selectors) = record_filter.selectors {
+        let columns = selectors
+            .iter()
+            .filter_map(|selection| selection.as_scalar_fields())
+            .flat_map(|f| f.as_columns(ctx))
+            .collect_vec();
+
+        filter_condition.and(in_conditions(&columns, selectors.iter()))
+    } else {
+        filter_condition
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/upsert.rs
@@ -22,7 +22,8 @@ pub(crate) async fn native_upsert(
     let meta = column_metadata::create(&field_names, &idents);
 
     let where_condition = upsert.filter().aliased_condition_from(None, false, ctx);
-    let update = build_update_and_set_query(upsert.model(), upsert.update().clone(), ctx).so_that(where_condition);
+    let update =
+        build_update_and_set_query(upsert.model(), upsert.update().clone(), None, ctx).so_that(where_condition);
 
     let insert = create_record(upsert.model(), upsert.create().clone(), &selected_fields, ctx);
 

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -196,12 +196,13 @@ impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
+        selected_fields: Option<FieldSelection>,
         trace_id: Option<String>,
-    ) -> connector::Result<Option<SelectionResult>> {
+    ) -> connector::Result<Option<SingleRecord>> {
         catch(self.connection_info.clone(), async move {
             let ctx = Context::new(&self.connection_info, trace_id.as_deref());
-            let mut res = write::update_record(&self.inner, model, record_filter, args, &ctx).await?;
-            Ok(res.pop())
+
+            write::update_record(&self.inner, model, record_filter, args, selected_fields, &ctx).await
         })
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/selection_result.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/selection_result.rs
@@ -1,13 +1,10 @@
-use crate::context::Context;
-
-use super::{AsColumn, ScalarFieldExt};
+use super::ScalarFieldExt;
 use prisma_models::{PrismaValue, SelectedField, SelectionResult};
-use quaint::{prelude::Column, Value};
+use quaint::Value;
 
 pub(crate) trait SelectionResultExt {
     fn misses_autogen_value(&self) -> bool;
     fn db_values<'a>(&self) -> Vec<Value<'a>>;
-    fn columns<'a>(&self, ctx: &Context<'_>) -> Vec<Column<'a>>;
 
     fn add_autogen_value<V>(&mut self, value: V) -> bool
     where
@@ -39,16 +36,6 @@ impl SelectionResultExt for SelectionResult {
             .map(|(selection, v)| match selection {
                 SelectedField::Scalar(sf) => sf.value(v.clone()),
                 SelectedField::Composite(_cf) => todo!(), // [Composites] todo
-            })
-            .collect()
-    }
-
-    fn columns<'a>(&self, ctx: &Context<'_>) -> Vec<Column<'a>> {
-        self.pairs
-            .iter()
-            .map(|(field, _)| match field {
-                SelectedField::Scalar(sf) => sf.as_column(ctx),
-                SelectedField::Composite(_) => todo!(), // [Composites] todo,
             })
             .collect()
     }

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/selection_result.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/selection_result.rs
@@ -1,10 +1,13 @@
-use super::ScalarFieldExt;
-use prisma_models::{PrismaValue, SelectedField, SelectionResult};
-use quaint::Value;
+use crate::context::Context;
 
-pub trait SelectionResultExt {
+use super::{AsColumn, ScalarFieldExt};
+use prisma_models::{PrismaValue, SelectedField, SelectionResult};
+use quaint::{prelude::Column, Value};
+
+pub(crate) trait SelectionResultExt {
     fn misses_autogen_value(&self) -> bool;
     fn db_values<'a>(&self) -> Vec<Value<'a>>;
+    fn columns<'a>(&self, ctx: &Context<'_>) -> Vec<Column<'a>>;
 
     fn add_autogen_value<V>(&mut self, value: V) -> bool
     where
@@ -36,6 +39,16 @@ impl SelectionResultExt for SelectionResult {
             .map(|(selection, v)| match selection {
                 SelectedField::Scalar(sf) => sf.value(v.clone()),
                 SelectedField::Composite(_cf) => todo!(), // [Composites] todo
+            })
+            .collect()
+    }
+
+    fn columns<'a>(&self, ctx: &Context<'_>) -> Vec<Column<'a>> {
+        self.pairs
+            .iter()
+            .map(|(field, _)| match field {
+                SelectedField::Scalar(sf) => sf.as_column(ctx),
+                SelectedField::Composite(_) => todo!(), // [Composites] todo,
             })
             .collect()
     }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/mod.rs
@@ -19,13 +19,13 @@ where
     records
         .chunks(PARAMETER_LIMIT)
         .map(|chunk| {
-            let tree = conditions(columns, chunk.iter().copied());
+            let tree = in_conditions(columns, chunk.iter().copied());
             f(tree).into()
         })
         .collect()
 }
 
-pub(super) fn conditions<'a>(
+pub(super) fn in_conditions<'a>(
     columns: &'a [Column<'static>],
     results: impl IntoIterator<Item = &'a SelectionResult>,
 ) -> ConditionTree<'static> {

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -65,13 +65,14 @@ impl ExpressionResult {
                 },
 
                 // We always select IDs, the unwraps are safe.
-                QueryResult::RecordSelection(rs) => Some(
+                QueryResult::RecordSelection(Some(rs)) => Some(
                     rs.scalars
                         .extract_selection_results(field_selection)
                         .expect("Expected record selection to contain required model ID fields.")
                         .into_iter()
                         .collect(),
                 ),
+                QueryResult::RecordSelection(None) => Some(vec![]),
 
                 _ => None,
             },

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -64,14 +64,14 @@ fn read_one(
 
             None if query.options.contains(QueryOption::ThrowOnEmpty) => record_not_found(),
 
-            None => Ok(QueryResult::RecordSelection(Box::new(RecordSelection {
+            None => Ok(QueryResult::RecordSelection(Some(Box::new(RecordSelection {
                 name: query.name,
                 fields: query.selection_order,
                 scalars: ManyRecords::default(),
                 nested: vec![],
                 model,
                 aggregation_rows: None,
-            }))),
+            })))),
         }
     };
 

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -72,7 +72,7 @@ impl Display for ReadQuery {
             ),
             Self::RelatedRecordsQuery(q) => write!(
                 f,
-                "RelatedRecordsQuery(name: '{}', parent model: '{}', parent relation field: {}, selection: {})",
+                "RelatedRecordsQuery(name: '{}', parent model: '{}', parent relation field: '{}', selection: {})",
                 q.name,
                 q.parent_field.model().name(),
                 q.parent_field.name(),

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -24,9 +24,14 @@ impl WriteQuery {
     /// Takes a SelectionResult and writes its contents into the write arguments of the underlying query.
     pub fn inject_result_into_args(&mut self, result: SelectionResult) {
         let model = self.model();
+
         let args = match self {
             Self::CreateRecord(ref mut x) => &mut x.args,
-            Self::UpdateRecord(x) => &mut x.args,
+            Self::UpdateRecord(ref mut x) => match x {
+                UpdateRecord::WithExplicitSelection(u) => &mut u.args,
+                UpdateRecord::WithImplicitSelection(u) => &mut u.args,
+                UpdateRecord::WithoutSelection(u) => &mut u.args,
+            },
             Self::UpdateManyRecords(x) => &mut x.args,
             _ => return,
         };
@@ -75,7 +80,7 @@ impl WriteQuery {
         match self {
             Self::CreateRecord(q) => q.model.clone(),
             Self::CreateManyRecords(q) => q.model.clone(),
-            Self::UpdateRecord(q) => q.model.clone(),
+            Self::UpdateRecord(q) => q.model().clone(),
             Self::Upsert(q) => q.model().clone(),
             Self::DeleteRecord(q) => q.model.clone(),
             Self::UpdateManyRecords(q) => q.model.clone(),
@@ -136,10 +141,11 @@ impl std::fmt::Display for WriteQuery {
             Self::CreateManyRecords(q) => write!(f, "CreateManyRecord(model: {})", q.model.name()),
             Self::UpdateRecord(q) => write!(
                 f,
-                "UpdateRecord(model: {}, filter: {:?}, args: {:?})",
-                q.model.name(),
-                q.record_filter,
-                q.args,
+                "UpdateRecord(model: {}, filter: {:?}, args: {:?}, selected_fields: {:?})",
+                q.model().name(),
+                q.record_filter(),
+                q.args(),
+                q.selected_fields().map(|field| field.to_string()),
             ),
             Self::DeleteRecord(q) => write!(f, "DeleteRecord: {}, {:?}", q.model.name(), q.record_filter),
             Self::UpdateManyRecords(q) => write!(f, "UpdateManyRecords(model: {}, args: {:?})", q.model.name(), q.args),
@@ -165,7 +171,7 @@ impl ToGraphviz for WriteQuery {
         match self {
             Self::CreateRecord(q) => format!("CreateRecord(model: {}, args: {:?})", q.model.name(), q.args),
             Self::CreateManyRecords(q) => format!("CreateManyRecord(model: {})", q.model.name()),
-            Self::UpdateRecord(q) => format!("UpdateRecord(model: {})", q.model.name(),),
+            Self::UpdateRecord(q) => format!("UpdateRecord(model: {})", q.model().name(),),
             Self::DeleteRecord(q) => format!("DeleteRecord: {}, {:?}", q.model.name(), q.record_filter),
             Self::UpdateManyRecords(q) => format!("UpdateManyRecords(model: {}, args: {:?})", q.model.name(), q.args),
             Self::DeleteManyRecords(q) => format!("DeleteManyRecords: {}", q.model.name()),
@@ -208,7 +214,78 @@ impl CreateManyRecords {
 }
 
 #[derive(Debug, Clone)]
-pub struct UpdateRecord {
+#[allow(clippy::enum_variant_names)]
+pub enum UpdateRecord {
+    /// Update with explicitly selected fields that will eventually be serialized as results.
+    WithExplicitSelection(UpdateRecordWithSelection),
+    /// Update with implicit selection set (primary_identifier) that will only be used to fulfill other nodes requirements.
+    WithImplicitSelection(UpdateRecordWithoutSelection),
+    /// Update without any selection set. A subsequent read is required to fulfill other nodes requirements.
+    WithoutSelection(UpdateRecordWithoutSelection),
+}
+
+impl UpdateRecord {
+    pub(crate) fn args(&self) -> &WriteArgs {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => &u.args,
+            UpdateRecord::WithImplicitSelection(u) => &u.args,
+            UpdateRecord::WithoutSelection(u) => &u.args,
+        }
+    }
+
+    pub(crate) fn model(&self) -> &Model {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => &u.model,
+            UpdateRecord::WithImplicitSelection(u) => &u.model,
+            UpdateRecord::WithoutSelection(u) => &u.model,
+        }
+    }
+
+    pub(crate) fn record_filter(&self) -> &RecordFilter {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => &u.record_filter,
+            UpdateRecord::WithImplicitSelection(u) => &u.record_filter,
+            UpdateRecord::WithoutSelection(u) => &u.record_filter,
+        }
+    }
+
+    pub(crate) fn record_filter_mut(&mut self) -> &mut RecordFilter {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => &mut u.record_filter,
+            UpdateRecord::WithImplicitSelection(u) => &mut u.record_filter,
+            UpdateRecord::WithoutSelection(u) => &mut u.record_filter,
+        }
+    }
+
+    pub(crate) fn selected_fields(&self) -> Option<FieldSelection> {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => Some(u.selected_fields.clone()),
+            UpdateRecord::WithImplicitSelection(u) => Some(u.model.primary_identifier()),
+            UpdateRecord::WithoutSelection(_) => None,
+        }
+    }
+
+    pub(crate) fn set_record_filter(&mut self, record_filter: RecordFilter) {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => u.record_filter = record_filter,
+            UpdateRecord::WithImplicitSelection(u) => u.record_filter = record_filter,
+            UpdateRecord::WithoutSelection(u) => u.record_filter = record_filter,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateRecordWithSelection {
+    pub name: String,
+    pub model: Model,
+    pub record_filter: RecordFilter,
+    pub args: WriteArgs,
+    pub selected_fields: FieldSelection,
+    pub selection_order: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateRecordWithoutSelection {
     pub model: Model,
     pub record_filter: RecordFilter,
     pub args: WriteArgs,
@@ -259,11 +336,15 @@ pub struct RawQuery {
 
 impl FilteredQuery for UpdateRecord {
     fn get_filter(&mut self) -> Option<&mut Filter> {
-        Some(&mut self.record_filter.filter)
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => Some(&mut u.record_filter.filter),
+            UpdateRecord::WithImplicitSelection(u) => Some(&mut u.record_filter.filter),
+            UpdateRecord::WithoutSelection(u) => Some(&mut u.record_filter.filter),
+        }
     }
 
     fn set_filter(&mut self, filter: Filter) {
-        self.record_filter.filter = filter
+        self.record_filter_mut().filter = filter
     }
 }
 
@@ -302,7 +383,7 @@ impl FilteredQuery for DeleteRecord {
 
 impl FilteredNestedMutation for UpdateRecord {
     fn set_selectors(&mut self, selectors: Vec<SelectionResult>) {
-        self.record_filter.selectors = Some(selectors);
+        self.record_filter_mut().selectors = Some(selectors);
     }
 }
 

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -78,12 +78,17 @@ pub fn nested_update(
             }
         };
 
+        let data_map: ParsedInputMap<'_> = data.try_into()?;
+
+        // If there's nothing to update, skip the update entirely.
+        if data_map.is_empty() {
+            return Ok(());
+        }
+
         let find_child_records_node =
             utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter.clone())?;
 
-        let update_node =
-            update::update_record_node(graph, query_schema, filter, child_model.clone(), data.try_into()?)?;
-
+        let update_node = update::update_record_node(graph, query_schema, filter, child_model.clone(), data_map, None)?;
         let child_model_identifier = parent_relation_field.related_model().primary_identifier();
 
         let relation_name = parent_relation_field.relation().name().to_owned();

--- a/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -144,6 +144,7 @@ pub fn nested_upsert(
             filter.clone(),
             child_model.clone(),
             update_input.try_into()?,
+            None,
         )?;
 
         graph.create_edge(

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use connector::{Filter, IntoFilter};
 use prisma_models::Model;
+use psl::datamodel_connector::ConnectorCapability;
 use schema::{constants::args, QuerySchema};
 use std::convert::TryInto;
 
@@ -25,10 +26,16 @@ pub(crate) fn update_record(
     let data_argument = field.arguments.lookup(args::DATA).unwrap();
     let data_map: ParsedInputMap<'_> = data_argument.value.try_into()?;
 
-    let update_node = update_record_node(graph, query_schema, filter.clone(), model.clone(), data_map)?;
+    let can_use_atomic_update = can_use_atomic_update(query_schema, &field);
 
-    let read_query = read::find_unique(field, model.clone())?;
-    let read_node = graph.create_node(Query::Read(read_query));
+    let update_node = update_record_node(
+        graph,
+        query_schema,
+        filter.clone(),
+        model.clone(),
+        data_map,
+        Some(&field),
+    )?;
 
     if query_schema.relation_mode().is_prisma() {
         let read_parent_node = graph.create_node(utils::read_ids_infallible(
@@ -46,7 +53,7 @@ pub(crate) fn update_record(
                 model.primary_identifier(),
                 Box::new(move |mut update_node, parent_ids| {
                     if let Node::Query(Query::Write(WriteQuery::UpdateRecord(ref mut ur))) = update_node {
-                        ur.record_filter = parent_ids.into();
+                        ur.set_record_filter(parent_ids.into());
                     }
 
                     Ok(update_node)
@@ -55,28 +62,58 @@ pub(crate) fn update_record(
         )?;
     }
 
-    graph.add_result_node(&read_node);
-    graph.create_edge(
-        &update_node,
-        &read_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            model.primary_identifier(),
-            Box::new(move |mut read_node, mut parent_ids| {
-                let parent_id = match parent_ids.pop() {
-                    Some(pid) => Ok(pid),
-                    None => Err(QueryGraphBuilderError::RecordNotFound(
-                        "Record to update not found.".to_string(),
-                    )),
-                }?;
+    // If the update can be done in a single operation (which includes getting the result back),
+    // then make that node the result node.
+    if can_use_atomic_update {
+        graph.add_result_node(&update_node);
 
-                if let Node::Query(Query::Read(ReadQuery::RecordQuery(ref mut rq))) = read_node {
-                    rq.add_filter(parent_id.filter());
-                };
+        let check_node = graph.create_node(Node::Empty);
 
-                Ok(read_node)
-            }),
-        ),
-    )?;
+        graph.create_edge(
+            &update_node,
+            &check_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model.primary_identifier(),
+                Box::new(move |read_node, parent_ids| {
+                    if parent_ids.is_empty() {
+                        return Err(QueryGraphBuilderError::RecordNotFound(
+                            "Record to update not found.".to_string(),
+                        ));
+                    }
+
+                    Ok(read_node)
+                }),
+            ),
+        )?;
+    // Otherwise, perform the update, and then do an additional read.
+    } else {
+        let read_query = read::find_unique(field, model.clone())?;
+        let read_node = graph.create_node(Query::Read(read_query));
+
+        graph.add_result_node(&read_node);
+
+        graph.create_edge(
+            &update_node,
+            &read_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model.primary_identifier(),
+                Box::new(move |mut read_node, mut parent_ids| {
+                    let parent_id = match parent_ids.pop() {
+                        Some(pid) => Ok(pid),
+                        None => Err(QueryGraphBuilderError::RecordNotFound(
+                            "Record to update not found.".to_string(),
+                        )),
+                    }?;
+
+                    if let Node::Query(Query::Read(ReadQuery::RecordQuery(ref mut rq))) = read_node {
+                        rq.add_filter(parent_id.filter());
+                    };
+
+                    Ok(read_node)
+                }),
+            ),
+        )?;
+    }
 
     Ok(())
 }
@@ -131,30 +168,76 @@ pub fn update_many_records(
     Ok(())
 }
 
-/// Creates an update record query node and adds it to the query graph.
+/// Creates an update record write node and adds it to the query graph.
 pub fn update_record_node<T: Clone>(
     graph: &mut QueryGraph,
     query_schema: &QuerySchema,
     filter: T,
     model: Model,
     data_map: ParsedInputMap<'_>,
+    field: Option<&ParsedField<'_>>,
 ) -> QueryGraphBuilderResult<NodeRef>
 where
     T: Into<Filter>,
 {
-    graph.flag_transactional();
-
     let update_args = WriteArgsParser::from(&model, data_map)?;
     let mut args = update_args.args;
 
     args.update_datetimes(&model);
 
     let filter: Filter = filter.into();
-    let update_parent = Query::Write(WriteQuery::UpdateRecord(UpdateRecord {
-        model: model.clone(),
-        record_filter: filter.into(),
-        args,
-    }));
+
+    // If the connector can use `RETURNING`, always use it as it may:
+    // 1. Save a SELECT statement
+    // 2. Avoid from computing the ids in memory if they are updated. See `update_one_without_selection` function.
+    let update_parent = if query_schema.has_capability(ConnectorCapability::UpdateReturning) {
+        let has_nested_selection = field.map(|f| f.has_nested_selection()).unwrap_or(false);
+
+        // If there are nested operations or nested selections, then make the graph transactional.
+        // Otherwise, it means the operation can be done in a single, atomic update.
+        if !update_args.nested.is_empty() || has_nested_selection {
+            graph.flag_transactional();
+        }
+
+        // If there's a selected field, fulfill the scalar selection set.
+        if let Some(field) = field.cloned() {
+            let nested_fields = field.nested_fields.unwrap().fields;
+            let selection_order: Vec<String> = read::utils::collect_selection_order(&nested_fields);
+            let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
+
+            Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithExplicitSelection(
+                UpdateRecordWithSelection {
+                    name: field.name.to_owned(),
+                    model: model.clone(),
+                    record_filter: filter.into(),
+                    args,
+                    selected_fields,
+                    selection_order,
+                },
+            )))
+        // Otherwise, fallback to the primary identifier, that will be used to fulfill other nested operations requirements
+        } else {
+            Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithImplicitSelection(
+                UpdateRecordWithoutSelection {
+                    model: model.clone(),
+                    record_filter: filter.into(),
+                    args,
+                },
+            )))
+        }
+    } else {
+        // If the connector does not support returning the updated values, it's always transactional as we need another read after the update.
+        graph.flag_transactional();
+
+        Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithoutSelection(
+            UpdateRecordWithoutSelection {
+                model: model.clone(),
+                record_filter: filter.into(),
+                args,
+            },
+        )))
+    };
+
     let update_node = graph.create_node(update_parent);
 
     for (relation_field, data_map) in update_args.nested {
@@ -197,4 +280,24 @@ where
     }
 
     Ok(update_many_node)
+}
+
+/// An atomic update is an update performed in a single operation.
+/// It uses `UPDATE ... RETURNING` when the connector supports it.
+///
+/// We only perform such update when:
+/// 1. The connector supports returning updated values
+/// 2. The selection set contains no relation
+fn can_use_atomic_update(query_schema: &QuerySchema, field: &ParsedField<'_>) -> bool {
+    // If the connector does not support RETURNING at all
+    if !query_schema.has_capability(ConnectorCapability::UpdateReturning) {
+        return false;
+    }
+
+    // If the operation has nested selection sets
+    if field.has_nested_selection() {
+        return false;
+    }
+
+    true
 }

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -103,7 +103,14 @@ pub(crate) fn upsert_record(
 
     let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
 
-    let update_node = update::update_record_node(graph, query_schema, filter, model.clone(), update_argument)?;
+    let update_node = update::update_record_node(
+        graph,
+        query_schema,
+        filter,
+        model.clone(),
+        update_argument,
+        Some(&field),
+    )?;
 
     let read_node_create = graph.create_node(Query::Read(read_query.clone()));
     let read_node_update = graph.create_node(Query::Read(read_query));

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -1009,7 +1009,7 @@ pub fn insert_emulated_on_update(
 fn extract_update_args(parent_node: &Node) -> &WriteArgs {
     if let Node::Query(Query::Write(q)) = parent_node {
         match q {
-            WriteQuery::UpdateRecord(one) => &one.args,
+            WriteQuery::UpdateRecord(one) => one.args(),
             WriteQuery::UpdateManyRecords(many) => &many.args,
             _ => panic!("Parent operation for update emulation is not an update."),
         }

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -43,7 +43,7 @@ pub(crate) fn serialize_internal(
     query_schema: &QuerySchema,
 ) -> crate::Result<CheckedItemsWithParents> {
     match result {
-        QueryResult::RecordSelection(rs) => {
+        QueryResult::RecordSelection(Some(rs)) => {
             serialize_record_selection(*rs, field, field.field_type(), is_list, query_schema)
         }
         QueryResult::RecordAggregations(ras) => serialize_aggregations(field, ras),
@@ -58,7 +58,7 @@ pub(crate) fn serialize_internal(
             Ok(result)
         }
         QueryResult::Json(_) => unimplemented!(),
-        QueryResult::Id(_) => unimplemented!(),
+        QueryResult::Id(_) | QueryResult::RecordSelection(None) => unreachable!(),
         QueryResult::Unit => unimplemented!(),
     }
 }
@@ -433,7 +433,7 @@ fn process_nested_results(
     // Unwraps are safe due to query validation.
     for nested_result in nested {
         // todo Workaround, tb changed with flat reads.
-        if let QueryResult::RecordSelection(ref rs) = nested_result {
+        if let QueryResult::RecordSelection(Some(ref rs)) = nested_result {
             let name = rs.name.clone();
             let field = enclosing_type.find_field(&name).unwrap();
             let result = serialize_internal(nested_result, field, false, query_schema)?;

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -5,7 +5,7 @@ use prisma_models::{ManyRecords, Model, SelectionResult};
 pub(crate) enum QueryResult {
     Id(Option<SelectionResult>),
     Count(usize),
-    RecordSelection(Box<RecordSelection>),
+    RecordSelection(Option<Box<RecordSelection>>),
     Json(serde_json::Value),
     RecordAggregations(RecordAggregations),
     Unit,
@@ -36,7 +36,7 @@ pub struct RecordSelection {
 
 impl From<RecordSelection> for QueryResult {
     fn from(selection: RecordSelection) -> Self {
-        QueryResult::RecordSelection(Box::new(selection))
+        QueryResult::RecordSelection(Some(Box::new(selection)))
     }
 }
 


### PR DESCRIPTION
## Overview

closes https://github.com/prisma/prisma/issues/5043
closes https://github.com/prisma/prisma/issues/5919
closes https://github.com/prisma/prisma/issues/16864

For connectors that support it (PG & CRDB), we are now doing updates in a single operation when possible thanks to the use of `RETURNING`.

## Benchmark

(Scalar updates with scalar selection set)

Before
```
cpu: Apple M1 Max
runtime: node v18.12.1 (arm64-darwin)

benchmark               time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------------- -----------------------------
• prisma.movie.update(...)
---------------------------------------------------------- -----------------------------
PG (regular joins)    1.22 ms/iter  (732.79 µs … 19.75 ms)   1.07 ms   6.54 ms   18.9 ms
Prisma                5.08 ms/iter    (3.51 ms … 22.41 ms)   4.53 ms  22.09 ms  22.41 ms

summary for prisma.movie.update(...)
  PG (regular joins)
   4.18x faster than Prisma
```

After
```
cpu: Apple M1 Max
runtime: node v18.12.1 (arm64-darwin)

benchmark               time (avg)             (min … max)       p75       p99      p995
---------------------------------------------------------- -----------------------------
• prisma.movie.update(...)
---------------------------------------------------------- -----------------------------
PG (regular joins)    1.19 ms/iter  (743.96 µs … 19.12 ms)   1.08 ms   6.49 ms  18.05 ms
Prisma                1.87 ms/iter   (930.5 µs … 21.13 ms)   2.04 ms    8.4 ms  20.35 ms

summary for prisma.movie.update(...)
  PG (regular joins)
   1.57x faster than Prisma
```

## In-depth query differences

Below are a few different scenarios where fewer queries are issued:

```prisma
model User {
  id   Int     @id @default(autoincrement())
  name String

  posts Post[]
}

model Post {
  id    Int     @id @default(autoincrement())
  title String

  userId Int?
  user   User? @relation(fields: [userId], references: [id])
}
```

### Scenario 1: Scalar updates, scalar selection set

```graphql
{ updateOneUser(where: { id: 1 }, data: { name: "updated" }) { id name } }
```

**Before**
```sql
BEGIN
SELECT id FROM "User" WHERE "User".id = 1;
UPDATE FROM "User" WHERE "User".id = 1;
SELECT id, name FROM "User" WHERE "User".id = 1;
COMMIT
```

**After: -4 queries**
```sql
UPDATE FROM "User" WHERE "User".id = 1 RETURNING "User".id, "User".name;
```

### Scenario 2: Scalar updates, relational selection set

```graphql
{
  updateOneUser(
    where: { id: 1 },
    data: { name: "updated" }
  ) {
    id
    name
    posts { id title }
  }
}
```

**Before**

```sql
BEGIN
SELECT id FROM "User" WHERE "User".id = 1;
UPDATE "User" WHERE "User".id = 1;
SELECT id, name FROM "User" WHERE "User".id = 1;
SELECT id, title FROM "Post" WHERE "Post"."userId" = 1;
COMMIT
```

**After: -1 queries**

```sql
BEGIN
UPDATE "User" WHERE "User".id = 1;
SELECT id, name FROM "User" WHERE "User".id = 1;
SELECT id, title FROM "Post" WHERE "Post"."userId" = 1;
COMMIT
```

### Scenario 3: Empty update, scalar selection set

```graphql
{
  updateOneUser(
    where: { id: 1 },
    data: {}
  ) {
    id
    name
  }
}
```


**Before**

```sql
BEGIN
SELECT id, name FROM "User" WHERE "User".id = 1;
SELECT id, name FROM "User" WHERE "User".id = 1;
COMMIT
```

**After: -3 queries**

```sql
SELECT id, name FROM "User" WHERE "User".id = 1;
```

### Scenario 4: Scalar update + relational update, scalar selection set

```graphql
mutation {
  updateOneUser(where: { id: 1 }, data: {
    name: "updated",
    posts: {
      update: {
        where: { id: 1 },
        data: {
          title: "updated"
        }
      }
    }
  }) {
    id
    name
  }
}
```

**Before**
```sql
BEGIN
SELECT id, name FROM "User" WHERE "User".id = 1;
UPDATE "User" WHERE "User".id = 1;
SELECT "id", "postId" FROM "Post" WHERE "Post".id = 1;
UPDATE "Post" WHERE "Post"."userId" = 1 AND "Post".id = 1;
SELECT id, name FROM "User" WHERE "User".id = 1;
COMMIT
```

**After: -2 queries**

```sql
BEGIN
UPDATE "User" WHERE "User".id = 1;
SELECT "id", "postId" FROM "Post" WHERE "Post".id = 1;
UPDATE "Post" WHERE "Post"."userId" = 1 AND "Post".id = 1;
COMMIT
```