### PR TITLE
prisma-fmt: add a regression test for panic with multiSchema

### DIFF
--- a/prisma-fmt/tests/regressions/language_tools_1473.rs
+++ b/prisma-fmt/tests/regressions/language_tools_1473.rs
@@ -1,0 +1,34 @@
+#[test]
+fn code_actions_should_not_crash_on_validation_errors_with_multi_schema() {
+    let schema = r#"
+        generator client {
+          provider        = "prisma-client-js"
+          previewFeatures = ["multiSchema"]
+        }
+
+        datasource db {
+          provider = "postgresql"
+          url      = env("DATABASE_URL")
+          schemas  = ["auth", "public"]
+        }
+
+        model A {
+          id   Int @id
+          test
+        }
+    "#;
+
+    let params = lsp_types::CodeActionParams {
+        text_document: lsp_types::TextDocumentIdentifier {
+            uri: "file:/path/to/schema.prisma".parse().unwrap(),
+        },
+        range: lsp_types::Range::default(),
+        context: lsp_types::CodeActionContext::default(),
+        work_done_progress_params: lsp_types::WorkDoneProgressParams { work_done_token: None },
+        partial_result_params: lsp_types::PartialResultParams {
+            partial_result_token: None,
+        },
+    };
+
+    prisma_fmt::code_actions(schema.to_owned(), &serde_json::to_string_pretty(&params).unwrap());
+}

--- a/prisma-fmt/tests/regressions/mod.rs
+++ b/prisma-fmt/tests/regressions/mod.rs
@@ -1,1 +1,2 @@
 mod language_tools_1466;
+mod language_tools_1473;


### PR DESCRIPTION
https://github.com/prisma/language-tools/issues/1473 was also fixed by https://github.com/prisma/prisma-engines/pull/4087, this PR adds a regression test for that issue as well.

Closes: https://github.com/prisma/language-tools/issues/1473
