### PR TITLE
fix: noop update from selectors should work

### DIFF
--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -270,14 +270,6 @@ impl UpdateRecord {
             UpdateRecord::WithoutSelection(_) => None,
         }
     }
-
-    pub(crate) fn set_record_filter(&mut self, record_filter: RecordFilter) {
-        match self {
-            UpdateRecord::WithExplicitSelection(u) => u.record_filter = record_filter,
-            UpdateRecord::WithImplicitSelection(u) => u.record_filter = record_filter,
-            UpdateRecord::WithoutSelection(u) => u.record_filter = record_filter,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -270,6 +270,14 @@ impl UpdateRecord {
             UpdateRecord::WithoutSelection(_) => None,
         }
     }
+
+    pub(crate) fn set_record_filter(&mut self, record_filter: RecordFilter) {
+        match self {
+            UpdateRecord::WithExplicitSelection(u) => u.record_filter = record_filter,
+            UpdateRecord::WithImplicitSelection(u) => u.record_filter = record_filter,
+            UpdateRecord::WithoutSelection(u) => u.record_filter = record_filter,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -266,7 +266,7 @@ impl UpdateRecord {
     pub(crate) fn selected_fields(&self) -> Option<FieldSelection> {
         match self {
             UpdateRecord::WithExplicitSelection(u) => Some(u.selected_fields.clone()),
-            UpdateRecord::WithImplicitSelection(u) => Some(u.model.primary_identifier()),
+            UpdateRecord::WithImplicitSelection(u) => Some(u.selected_fields()),
             UpdateRecord::WithoutSelection(_) => None,
         }
     }

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -290,7 +290,7 @@ pub struct UpdateRecordWithoutSelection {
 }
 
 impl UpdateRecordWithoutSelection {
-    pub fn selected_fields(&self) -> FieldSelection {
+    pub(crate) fn selected_fields(&self) -> FieldSelection {
         self.model.primary_identifier()
     }
 }

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -64,7 +64,13 @@ impl WriteQuery {
         match self {
             Self::CreateRecord(_) => returns_id,
             Self::CreateManyRecords(_) => false,
-            Self::UpdateRecord(_) => returns_id,
+            Self::UpdateRecord(UpdateRecord::WithExplicitSelection(ur)) => {
+                ur.selected_fields.is_superset_of(field_selection)
+            }
+            Self::UpdateRecord(UpdateRecord::WithImplicitSelection(ur)) => {
+                ur.selected_fields().is_superset_of(field_selection)
+            }
+            Self::UpdateRecord(UpdateRecord::WithoutSelection(_)) => returns_id,
             Self::DeleteRecord(_) => returns_id,
             Self::UpdateManyRecords(_) => returns_id,
             Self::DeleteManyRecords(_) => false,
@@ -289,6 +295,12 @@ pub struct UpdateRecordWithoutSelection {
     pub model: Model,
     pub record_filter: RecordFilter,
     pub args: WriteArgs,
+}
+
+impl UpdateRecordWithoutSelection {
+    pub fn selected_fields(&self) -> FieldSelection {
+        self.model.primary_identifier()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -46,20 +46,7 @@ pub(crate) fn update_record(
 
         utils::insert_emulated_on_update(graph, query_schema, &model, &read_parent_node, &update_node)?;
 
-        graph.create_edge(
-            &read_parent_node,
-            &update_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                model.primary_identifier(),
-                Box::new(move |mut update_node, parent_ids| {
-                    if let Node::Query(Query::Write(WriteQuery::UpdateRecord(ref mut ur))) = update_node {
-                        ur.set_record_filter(parent_ids.into());
-                    }
-
-                    Ok(update_node)
-                }),
-            ),
-        )?;
+        graph.create_edge(&read_parent_node, &update_node, QueryGraphDependency::ExecutionOrder)?;
     }
 
     // If the update can be done in a single operation (which includes getting the result back),

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -46,7 +46,20 @@ pub(crate) fn update_record(
 
         utils::insert_emulated_on_update(graph, query_schema, &model, &read_parent_node, &update_node)?;
 
-        graph.create_edge(&read_parent_node, &update_node, QueryGraphDependency::ExecutionOrder)?;
+        graph.create_edge(
+            &read_parent_node,
+            &update_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model.primary_identifier(),
+                Box::new(move |mut update_node, parent_ids| {
+                    if let Node::Query(Query::Write(WriteQuery::UpdateRecord(ref mut ur))) = update_node {
+                        ur.set_record_filter(parent_ids.into());
+                    }
+
+                    Ok(update_node)
+                }),
+            ),
+        )?;
     }
 
     // If the update can be done in a single operation (which includes getting the result back),


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/prisma/prisma-engines/pull/4084. Fixes a regression for 1-1 update when relationMode=prisma.

The PR fixes two things:
1. Noop updates take selectors into account: In the case of an update with `relationMode=prisma`, we read the record to update _before_ doing the actual update to compute whether some referential actions will need to be added to the graph. When doing this additional read, we pass the read ids down to the update operation so that we save reading the ids again when the connector does not support `UpdateReturning`. These ids are passed as `RecordFilter.selectors`. However, the selectors were not considered when doing a simple read for a noop update. Therefore, the update node wasn't returning the correct ids, leading to failed operations later on.
2. `WriteArgs::returns` is now updated to take into account the fact that update nodes can now return more than just the primary identifier of a model. While we haven't noticed any bug, it could've resulted in missing reload nodes when the child of a node is requesting data dependencies that aren't fulfilled by the parent's selection set.

See https://prisma-company.slack.com/archives/C058VM009HT/p1690562457715389