### PR TITLE
add http mode for neon, fix parsing issues

### DIFF
--- a/query-engine/js-connectors/smoke-test-js/src/driver/neon.ts
+++ b/query-engine/js-connectors/smoke-test-js/src/driver/neon.ts
@@ -69,6 +69,7 @@ class PrismaNeon implements Connector, Closeable {
         throw Error('connectionString is required for http mode')
       }
       this.sql = neon(config.connectionString, { fullResults: true })
+      // lazily retrieve the version and store it into `maybeVersion`
       this.sql('SELECT VERSION()').then((results) => {
         this.maybeVersion = results.rows[0]['version']
       })

--- a/query-engine/js-connectors/smoke-test-js/src/neon.ts
+++ b/query-engine/js-connectors/smoke-test-js/src/neon.ts
@@ -11,6 +11,7 @@ async function main() {
   /* Use `db` if you want to test the actual Neon database */
   const db = createNeonConnector({
     connectionString,
+    httpMode: false,
   })
 
   // `binder` is required to preserve the `this` context to the group of functions passed to libquery.
@@ -45,7 +46,6 @@ async function main() {
         "text_column": true,
         "date_column": true,
         "time_column": true,
-        "datetime_column": true,
         "timestamp_column": true,
         "json_column": true,
         "enum_column": true


### PR DESCRIPTION
This PR adds HTTP single-flight support for Neon serverless driver, which reduces end-to-end latency for users using the driver. User can choose whether to opt-in by using the `httpMode` options. Also fixes several bugs related to parsing. Some Postgres data types (i.e., DATETIME) are not compatible with MySQL and we might need to write the Postgres parser along with `js_planetscale_value_to_quaint` at some time in the future, but for now I simply further removed some unsupported types from neon driver.

ref https://github.com/prisma/prisma-engines/pull/4086