### PR TITLE
Enable CreateMany features for sqlite connector

### DIFF
--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -24,7 +24,9 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     OrderByNullsFirstLast |
     SupportsTxIsolationSerializable |
     NativeUpsert |
-    FilteredInlineChildNestedToOneDisconnect
+    FilteredInlineChildNestedToOneDisconnect |
+    CreateMany |
+    CreateSkipDuplicates
     // InsertReturning - While SQLite does support RETURNING, it does not return column information on the way back from the database.
     // This column type information is necessary in order to preserve consistency for some data types such as int, where values could overflow.
     // Since we care to stay consistent with reads, it is not enabled.


### PR DESCRIPTION
We've had this enabled for a while in [Prisma Client Rust](https://prisma.brendonovich.dev/writing-data/create#create-many) and it's been working well, I figured I'll open a PR for it.
This probably needs a bunch of new tests and may possibly need `CreateManyWriteableAutoIncId`.

No worries if there's no interest in supporting this, it'd just make my life a bit easier as it's one less custom feature for me to support in PCR.