### PR TITLE
use cuid2 instead of cuid

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -744,14 +744,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "cuid"
-version = "1.2.0"
+name = "cuid-util"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2a2891c056384f8461606f2579208164d67475fb17a0f442ac8d5981d3c2807"
+checksum = "5ea2bfe0336ff1b7ca74819b2df8dfae9afea358aff6b1688baa5c181d8c3713"
+
+[[package]]
+name = "cuid2"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e460f3fc482e566e7197604dd96a39b5c4d4be72bd360aaab1beaa7166d866e"
 dependencies = [
- "hostname",
- "lazy_static",
+ "cuid-util",
+ "num",
  "rand 0.8.5",
+ "sha3",
 ]
 
 [[package]]
@@ -857,9 +864,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -1450,7 +1457,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1711,6 +1718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+dependencies = [
+ "cpufeatures",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +1956,7 @@ version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66b48670c893079d3c2ed79114e3644b7004df1c361a4e0ad52e2e6940d07c3d"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2168,7 +2184,7 @@ dependencies = [
  "bigdecimal",
  "bson",
  "chrono",
- "cuid",
+ "cuid2",
  "futures",
  "indexmap",
  "itertools",
@@ -2418,6 +2434,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2429,12 +2459,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2719,7 +2781,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271779f35b581956db91a3e55737327a03aa051e90b1c47aeb189508533adfd7"
 dependencies = [
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2993,7 +3055,7 @@ version = "0.0.0"
 dependencies = [
  "bigdecimal",
  "chrono",
- "cuid",
+ "cuid2",
  "itertools",
  "nanoid",
  "prisma-value",
@@ -3250,7 +3312,7 @@ dependencies = [
  "chrono",
  "connection-string",
  "crossbeam-channel",
- "cuid",
+ "cuid2",
  "enumflags2",
  "futures",
  "indexmap",
@@ -4116,7 +4178,7 @@ checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4127,7 +4189,7 @@ checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4151,7 +4213,17 @@ checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.3",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
+dependencies = [
+ "digest 0.10.7",
+ "keccak",
 ]
 
 [[package]]
@@ -4301,7 +4373,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
- "cuid",
+ "cuid2",
  "futures",
  "itertools",
  "once_cell",

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -46,8 +46,8 @@ workspace = true
 [dependencies.serde]
 workspace = true
 
-[dependencies.cuid]
-version = "1.2"
+[dependencies.cuid2]
+version = "0.1.1"
 
 [dependencies.user-facing-errors]
 features = ["sql"]

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -44,8 +44,8 @@ version = "0.4"
 features = ["derive"]
 version = "1.0"
 
-[dependencies.cuid]
-version = "1.2"
+[dependencies.cuid2]
+version = "0.1.1"
 
 [dependencies.user-facing-errors]
 features = ["sql"]

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.17.4"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "1"
-cuid = "1.2"
+cuid2 = "0.1.1"
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -44,7 +44,7 @@ const MINIMUM_TX_ID_LENGTH: usize = 24;
 
 impl Default for TxId {
     fn default() -> Self {
-        Self(cuid::cuid().unwrap())
+        Self(cuid2::cuid())
     }
 }
 

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -11,7 +11,7 @@ bigdecimal = "0.3"
 thiserror = "1.0"
 
 uuid = { workspace = true, optional = true }
-cuid = { version = "1.2", optional = true }
+cuid2 = { version = "0.1.1", optional = true }
 nanoid = { version = "0.4.0", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 
@@ -19,4 +19,4 @@ chrono = { version = "0.4.6", features = ["serde"] }
 # Support for generating default UUID, CUID, nanoid and datetime values. This
 # implies random number generation works, so it won't compile on targets like
 # wasm32.
-default_generators = ["uuid/v4", "cuid", "nanoid"]
+default_generators = ["uuid/v4", "cuid2", "nanoid"]

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -275,7 +275,7 @@ impl ValueGeneratorFn {
 
     #[cfg(feature = "default_generators")]
     fn generate_cuid() -> PrismaValue {
-        PrismaValue::String(cuid::cuid().unwrap())
+        PrismaValue::String(cuid2::cuid())
     }
 
     #[cfg(feature = "default_generators")]


### PR DESCRIPTION
The readme of [cuid](https://docs.rs/cuid/latest/cuid/) says:

> NOTE: The first version of the CUID specification is deprecated. Please use the cuid2() function from this crate instead, which is a re-export from the cuid2 crate. Please upgrade to that crate for more CUID construction options.

This is also a prerequisite for WASM compilation because cuid depends on hostname, which cannot be used in wasm, while cuid2 has fewer dependencies, and they can all compile in wasm32-unknown-unknown.

Might be a breaking change as it seems that cuid2 has one fewer characters than cuid.