### PR TITLE
feat(js-connectors): add transaction support for Neon

### DIFF
--- a/query-engine/js-connectors/js/neon-js-connector/src/neon.ts
+++ b/query-engine/js-connectors/js/neon-js-connector/src/neon.ts
@@ -119,10 +119,10 @@ class PrismaNeon implements Connector, Closeable {
   }
 
   /**
- * Run a query against the database, returning the result set.
- * Should the query fail due to a connection error, the connection is
- * marked as unhealthy.
- */
+   * Run a query against the database, returning the result set.
+   * Should the query fail due to a connection error, the connection is
+   * marked as unhealthy.
+   */
   private async performIO(query: Query) {
     const { sql, args: values } = query
 

--- a/query-engine/js-connectors/js/smoke-test-js/prisma/postgres-neon/schema.prisma
+++ b/query-engine/js-connectors/js/smoke-test-js/prisma/postgres-neon/schema.prisma
@@ -77,22 +77,3 @@ enum type_test_enum_column_null {
   value2
   value3
 }
-
-model Child {
-  c          String  @unique
-  c_1        String
-  c_2        String
-  parentId   String? @unique
-  non_unique String?
-  id         String  @id
-  @@unique([c_1, c_2])
-}
-
-model Parent {
-  p          String  @unique
-  p_1        String
-  p_2        String
-  non_unique String?
-  id         String  @id
-  @@unique([p_1, p_2])
-}

--- a/query-engine/js-connectors/js/smoke-test-js/src/test.ts
+++ b/query-engine/js-connectors/js/smoke-test-js/src/test.ts
@@ -124,7 +124,6 @@ class SmokeTest {
     return resultSet
   }
 
-  @withFlavor({ exclude: ['postgres'] })
   async testCreateAndDeleteChildParent() {
     /* Delete all child and parent records */
   


### PR DESCRIPTION
This PR:
- adds implicit transaction support for Neon
  - implicit transactions are e.g. the ones induced by `prisma['table_name'].deleteMany()`, which result in a bunch of queries  starting with `BEGIN` and ending with `COMMIT`
  - thanks to Neon's pooling APIs, the implementation is simpler than PlanetScale's
- relies on https://github.com/prisma/prisma-engines/pull/4104: please review and merge that PR first
- closes https://github.com/prisma/team-orm/issues/247