### PR TITLE
node-drivers: unwinding panics into napi errors, that can be convertible to quaint errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "expect-test",
+ "futures",
  "napi",
  "napi-derive",
  "num-bigint",

--- a/quaint/src/error.rs
+++ b/quaint/src/error.rs
@@ -133,6 +133,11 @@ impl Error {
     pub fn is_closed(&self) -> bool {
         matches!(self.kind, ErrorKind::ConnectionClosed)
     }
+
+    // Builds an error from a raw error coming from the connector
+    pub fn raw_connector_error(status: String, reason: String) -> Error {
+        Error::builder(ErrorKind::RawConnectorError { status, reason }).build()
+    }
 }
 
 impl fmt::Display for Error {
@@ -143,6 +148,9 @@ impl fmt::Display for Error {
 
 #[derive(Debug, Error)]
 pub enum ErrorKind {
+    #[error("Error in the underlying connector ({}): {}", status, reason)]
+    RawConnectorError { status: String, reason: String },
+
     #[error("Error querying the database: {}", _0)]
     QueryError(Box<dyn std::error::Error + Send + Sync + 'static>),
 

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -267,6 +267,10 @@ impl From<prisma_models::ConversionFailure> for SqlError {
 impl From<quaint::error::Error> for SqlError {
     fn from(e: quaint::error::Error) -> Self {
         match QuaintKind::from(e) {
+            QuaintKind::RawConnectorError { status, reason } => Self::RawError {
+                code: status,
+                message: reason,
+            },
             QuaintKind::QueryError(qe) => Self::QueryError(qe),
             QuaintKind::QueryInvalidInput(qe) => Self::QueryInvalidInput(qe),
             e @ QuaintKind::IoError(_) => Self::ConnectionError(e),

--- a/query-engine/js-connectors/Cargo.toml
+++ b/query-engine/js-connectors/Cargo.toml
@@ -18,6 +18,7 @@ tracing-core = "0.1"
 num-bigint = "0.4.3"
 bigdecimal = "0.3.0"
 chrono = "0.4.20"
+futures = "0.3"
 
 napi.workspace = true
 napi-derive.workspace = true

--- a/query-engine/js-connectors/smoke-test-js/prisma/mysql-planetscale/schema.prisma
+++ b/query-engine/js-connectors/smoke-test-js/prisma/mysql-planetscale/schema.prisma
@@ -80,6 +80,7 @@ model Child {
   parentId   String? @unique
   non_unique String?
   id         String  @id
+
   @@unique([c_1, c_2])
 }
 
@@ -89,5 +90,6 @@ model Parent {
   p_2        String
   non_unique String?
   id         String  @id
+
   @@unique([p_1, p_2])
 }

--- a/query-engine/js-connectors/src/error.rs
+++ b/query-engine/js-connectors/src/error.rs
@@ -18,10 +18,10 @@ pub(crate) async fn async_unwinding_panic<F, R>(fut: F) -> napi::Result<R>
 where
     F: Future<Output = napi::Result<R>>,
 {
-    match AssertUnwindSafe(fut).catch_unwind().await {
-        Ok(result) => result,
-        Err(panic_payload) => panic_to_napi_err(panic_payload),
-    }
+    AssertUnwindSafe(fut)
+        .catch_unwind()
+        .await
+        .unwrap_or_else(panic_to_napi_err)
 }
 
 /// catches a panic thrown during the execution of a closure and transforms it into a the Error

--- a/query-engine/js-connectors/src/error.rs
+++ b/query-engine/js-connectors/src/error.rs
@@ -1,0 +1,47 @@
+use futures::{Future, FutureExt};
+use napi::Error as NapiError;
+use quaint::error::Error as QuaintError;
+use std::{any::Any, panic::AssertUnwindSafe};
+
+/// transforms a napi error into a quaint error copying the status and reason
+/// properties over
+pub(crate) fn into_quaint_error(napi_err: NapiError) -> QuaintError {
+    let status = napi_err.status.as_ref().to_owned();
+    let reason = napi_err.reason.clone();
+
+    QuaintError::raw_connector_error(status, reason)
+}
+
+/// catches a panic thrown during the executuin of an asynchronous closure and transforms it into
+/// the Error variant of a napi::Result.
+pub(crate) async fn async_unwinding_panic<F, R>(fut: F) -> napi::Result<R>
+where
+    F: Future<Output = napi::Result<R>>,
+{
+    match AssertUnwindSafe(fut).catch_unwind().await {
+        Ok(result) => result,
+        Err(panic_payload) => panic_to_napi_err(panic_payload),
+    }
+}
+
+/// catches a panic thrown during the execution of a closure and transforms it into a the Error
+/// variant of a napi::Result.
+pub(crate) fn unwinding_panic<F, R>(f: F) -> napi::Result<R>
+where
+    F: Fn() -> napi::Result<R>,
+{
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(panic_payload) => panic_to_napi_err(panic_payload),
+    }
+}
+
+fn panic_to_napi_err<R>(panic_payload: Box<dyn Any + Send>) -> napi::Result<R> {
+    panic_payload
+        .downcast_ref::<&str>()
+        .map(|s| -> String { (*s).to_owned() })
+        .or_else(|| panic_payload.downcast_ref::<String>().map(|s| s.to_owned()))
+        .map(|message| Err(napi::Error::from_reason(format!("PANIC: {message}"))))
+        .ok_or(napi::Error::from_reason("PANIC: unknown panic".to_string()))
+        .unwrap()
+}

--- a/query-engine/js-connectors/src/lib.rs
+++ b/query-engine/js-connectors/src/lib.rs
@@ -7,6 +7,7 @@
 //! plus some transformation of types to adhere to what a quaint::Value expresses.
 //!
 
+mod error;
 mod proxy;
 mod queryable;
 pub use queryable::JsQueryable;


### PR DESCRIPTION
Contributes to https://github.com/prisma/team-orm/issues/260

This commit transforms panics into `napi::Error` values with the `GenericFailure` status.

It then transform any napi::Error into a `quaint::ErrorKind::RawConnectorError` kind of `quaint::Error`, copying over the `status` and `message` properties. 