### PR TITLE
perf: avoid reload nodes when possible

### DIFF
--- a/query-engine/core/src/query_ast/mod.rs
+++ b/query-engine/core/src/query_ast/mod.rs
@@ -16,10 +16,17 @@ pub(crate) enum Query {
 }
 
 impl Query {
-    pub(crate) fn returns(&self, fields: &FieldSelection) -> bool {
+    pub(crate) fn satisfies(&self, fields: &FieldSelection) -> bool {
         match self {
-            Self::Read(rq) => rq.returns(fields),
-            Self::Write(wq) => wq.returns(fields),
+            Self::Read(rq) => rq.satisfies(fields),
+            Self::Write(wq) => wq.satisfies(fields),
+        }
+    }
+
+    pub(crate) fn satisfy_dependency(&mut self, fields: FieldSelection) {
+        match self {
+            Self::Read(rq) => rq.satisfy_dependency(fields),
+            Self::Write(wq) => wq.satisfy_dependency(fields),
         }
     }
 
@@ -28,6 +35,18 @@ impl Query {
             Self::Read(rq) => rq.model(),
             Self::Write(wq) => wq.model(),
         }
+    }
+
+    pub(crate) fn is_update_one(&self) -> bool {
+        matches!(self, Query::Write(WriteQuery::UpdateRecord(_)))
+    }
+
+    pub(crate) fn is_create_one(&self) -> bool {
+        matches!(self, Query::Write(WriteQuery::CreateRecord(_)))
+    }
+
+    pub(crate) fn is_delete_one(&self) -> bool {
+        matches!(self, Query::Write(WriteQuery::CreateRecord(_)))
     }
 }
 

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -62,7 +62,7 @@ impl WriteQuery {
     }
 
     /// Returns the field selection of a write query.
-    /// 
+    ///
     /// Most write operations only return IDs at the moment, so anything different
     /// from the primary ID is automatically not returned.
     /// DeleteMany, Connect and Disconnect do not return anything.

--- a/query-engine/core/src/query_graph/guard.rs
+++ b/query-engine/core/src/query_graph/guard.rs
@@ -22,6 +22,10 @@ impl<T> Guard<T> {
         self.content.as_ref()
     }
 
+    pub fn borrow_mut(&mut self) -> Option<&mut T> {
+        self.content.as_mut()
+    }
+
     pub fn into_inner(self) -> Option<T> {
         self.content
     }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -18,7 +18,7 @@ use petgraph::{
     visit::{EdgeRef as PEdgeRef, NodeIndexable},
     *,
 };
-use prisma_models::{FieldSelection, Model, SelectionResult};
+use prisma_models::{FieldSelection, SelectionResult};
 use std::{collections::HashSet, fmt};
 
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
@@ -38,6 +38,24 @@ pub(crate) enum Node {
 
     /// Empty node.
     Empty,
+}
+
+impl Node {
+    pub(crate) fn as_query(&self) -> Option<&Query> {
+        if let Self::Query(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn as_query_mut(&mut self) -> Option<&mut Query> {
+        if let Self::Query(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<Query> for Node {
@@ -755,62 +773,35 @@ impl QueryGraph {
     /// The `Reload` node is always a "find many" query.
     /// Unwraps are safe because we're operating on the unprocessed state of the graph (`Expressionista` changes that).
     fn insert_reloads(&mut self) -> QueryGraphResult<()> {
-        let reloads: Vec<(NodeRef, Model, Vec<FieldSelection>)> = self
-            .graph
-            .node_indices()
-            .filter_map(|ix| {
-                let node = NodeRef { node_ix: ix };
+        let reloads = self.find_unsatisfied_dependencies();
 
-                if let Node::Query(q) = self.node_content(&node).unwrap() {
-                    let edges = self.outgoing_edges(&node);
+        for (node, identifiers) in reloads {
+            let query = self.node_content(&node).and_then(|node| node.as_query()).unwrap();
 
-                    let unsatisfied_dependencies: Vec<FieldSelection> = edges
-                        .into_iter()
-                        .filter_map(|edge| match self.edge_content(&edge).unwrap() {
-                            QueryGraphDependency::ProjectedDataDependency(ref requested_selection, _)
-                                if !q.satisfies(requested_selection) =>
-                            {
-                                trace!(
-                                    "Query {:?} does not return requested selection {:?} and will be reloaded.",
-                                    q,
-                                    requested_selection.prisma_names().collect::<Vec<_>>()
-                                );
-                                Some(requested_selection.clone())
-                            }
-                            _ => None,
-                        })
-                        .collect();
+            trace!(
+                "Query {:?} does not return requested selection {:?} and will be reloaded.",
+                query,
+                identifiers.prisma_names().collect::<Vec<_>>()
+            );
 
-                    if unsatisfied_dependencies.is_empty() {
-                        None
-                    } else {
-                        Some((node, q.model(), unsatisfied_dependencies))
-                    }
-                } else {
-                    None
-                }
-            })
-            .collect();
-
-        for (node, model, mut identifiers) in reloads {
             // Create reload node and connect it to the `node`.
+            let model = query.model();
             let primary_model_id = model.primary_identifier();
-            identifiers.push(primary_model_id.clone());
 
             let read_query = ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
                 name: "reload".into(),
                 alias: None,
                 model: model.clone(),
                 args: QueryArguments::new(model),
-                selected_fields: FieldSelection::union(identifiers),
+                selected_fields: identifiers.merge(primary_model_id.clone()),
                 nested: vec![],
                 selection_order: vec![],
                 aggregation_selections: vec![],
                 options: QueryOptions::none(),
             });
 
-            let query = Query::Read(read_query);
-            let reload_node = self.create_node(query);
+            let reload_query = Query::Read(read_query);
+            let reload_node = self.create_node(reload_query);
 
             self.create_edge(
                 &node,
@@ -878,43 +869,60 @@ impl QueryGraph {
     /// In the case of updates and inserts, for instance, only connectors supporting `InsertReturning` and `UpdateReturning` can do it,
     /// or else they're only able to return the primary identifier of the model inserted or updated.
     fn normalize_data_dependencies(&mut self, capabilities: ConnectorCapabilities) -> QueryGraphResult<()> {
-        let unsatisfied_deps: Vec<(NodeRef, Vec<FieldSelection>)> = self
-            .graph
+        let unsatisfied_deps = self.find_unsatisfied_dependencies();
+
+        for (node, identifiers) in unsatisfied_deps {
+            let query = self
+                .node_content_mut(&node)
+                .and_then(|node| node.as_query_mut())
+                .unwrap();
+
+            // If the connector does not support returning more than the primary identifier for an update,
+            // do not update the selection set.
+            if query.is_update_one() && !capabilities.contains(ConnectorCapability::UpdateReturning) {
+                continue;
+            }
+
+            // If the connector does not support returning more than the primary identifier for a create,
+            // do not update the selection set.
+            if query.is_create_one() && !capabilities.contains(ConnectorCapability::InsertReturning) {
+                continue;
+            }
+
+            // No connector supports returning more than the primary identifier for a delete just yet.
+            if query.is_delete_one() {
+                continue;
+            }
+
+            trace!(
+                "Query {:?} does not return requested selection {:?} and will be updated.",
+                query,
+                identifiers.prisma_names().collect::<Vec<_>>()
+            );
+
+            query.satisfy_dependency(identifiers);
+        }
+
+        Ok(())
+    }
+
+    /// Traverses the query graph and finds the query nodes that don't fulfill their children data dependencies.
+    /// We determine that based on incoming `ProjectedDataDependency` edge transformers, as those hold the `FieldSelection`s
+    /// that all records of the source result need to contain in order to satisfy dependencies.
+    fn find_unsatisfied_dependencies(&self) -> Vec<(NodeRef, FieldSelection)> {
+        self.graph
             .node_indices()
-            .filter_map(|ix| -> Option<(NodeRef, Vec<FieldSelection>)> {
+            .filter_map(|ix| {
                 let node = NodeRef { node_ix: ix };
 
                 if let Node::Query(q) = self.node_content(&node).unwrap() {
-                    // If the connector does not support returning more than the primary identifier for an update,
-                    // do not update the selection set.
-                    if q.is_update_one() && !capabilities.contains(ConnectorCapability::UpdateReturning) {
-                        return None;
-                    }
-
-                    // If the connector does not support returning more than the primary identifier for a create,
-                    // do not update the selection set.
-                    if q.is_create_one() && !capabilities.contains(ConnectorCapability::InsertReturning) {
-                        return None;
-                    }
-
-                    // No connector supports returning more than the primary identifier for a delete just yet.
-                    if q.is_delete_one() {
-                        return None;
-                    }
-
                     let edges = self.outgoing_edges(&node);
-
-                    let unsatisfied_dependencies: Vec<FieldSelection> = edges
+                    let unsatisfied_dependencies: Vec<_> = edges
                         .into_iter()
                         .filter_map(|edge| match self.edge_content(&edge).unwrap() {
                             QueryGraphDependency::ProjectedDataDependency(ref requested_selection, _)
                                 if !q.satisfies(requested_selection) =>
                             {
-                                trace!(
-                                    "Query {:?} does not return requested selection {:?} and will be updated.",
-                                    q,
-                                    requested_selection.prisma_names().collect::<Vec<_>>()
-                                );
                                 Some(requested_selection.clone())
                             }
                             _ => None,
@@ -922,23 +930,15 @@ impl QueryGraph {
                         .collect();
 
                     if unsatisfied_dependencies.is_empty() {
-                        return None;
+                        None
+                    } else {
+                        Some((node, FieldSelection::union(unsatisfied_dependencies)))
                     }
-
-                    Some((node, unsatisfied_dependencies))
                 } else {
                     None
                 }
             })
-            .collect();
-
-        for (node, identifiers) in unsatisfied_deps {
-            if let Node::Query(ref mut q) = self.node_content_mut(&node).unwrap() {
-                q.satisfy_dependency(FieldSelection::union(identifiers));
-            }
-        }
-
-        Ok(())
+            .collect()
     }
 }
 

--- a/query-engine/core/src/query_graph_builder/builder.rs
+++ b/query-engine/core/src/query_graph_builder/builder.rs
@@ -98,7 +98,7 @@ impl<'a> QueryGraphBuilder<'a> {
         }?;
 
         // Run final transformations.
-        graph.finalize()?;
+        graph.finalize(self.query_schema.capabilities())?;
         trace!("{}", graph);
 
         // Used to debug generated graph.

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -199,9 +199,9 @@ where
             let selection_order: Vec<String> = read::utils::collect_selection_order(&nested_fields);
             let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
 
-            Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithExplicitSelection(
+            Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithSelection(
                 UpdateRecordWithSelection {
-                    name: field.name.to_owned(),
+                    name: Some(field.name.to_owned()),
                     model: model.clone(),
                     record_filter: filter.into(),
                     args,
@@ -211,11 +211,17 @@ where
             )))
         // Otherwise, fallback to the primary identifier, that will be used to fulfill other nested operations requirements
         } else {
-            Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithImplicitSelection(
-                UpdateRecordWithoutSelection {
+            let selected_fields = model.primary_identifier();
+            let selection_order = selected_fields.db_names().collect();
+
+            Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithSelection(
+                UpdateRecordWithSelection {
+                    name: None,
                     model: model.clone(),
                     record_filter: filter.into(),
                     args,
+                    selected_fields,
+                    selection_order,
                 },
             )))
         }

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,7 +1,7 @@
 use crate::{IdentifierType, ObjectType, OutputField};
 use prisma_models::{ast, InternalDataModel};
 use psl::{
-    datamodel_connector::{Connector, ConnectorCapability, RelationMode},
+    datamodel_connector::{Connector, ConnectorCapabilities, ConnectorCapability, RelationMode},
     PreviewFeature, PreviewFeatures,
 };
 use std::{collections::HashMap, fmt};
@@ -102,6 +102,10 @@ impl QuerySchema {
 
     pub fn has_capability(&self, capability: ConnectorCapability) -> bool {
         self.connector.has_capability(capability)
+    }
+
+    pub fn capabilities(&self) -> ConnectorCapabilities {
+        self.connector.capabilities()
     }
 
     pub fn find_mutation_field(&self, name: &str) -> Option<OutputField<'_>> {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/20556

When a node does not select the fields to fulfill the data dependencies of its children, we used to always add some "reload node" (findMany queries) which goals are to re-read the data with a larger field selection so that it satisfies all the node's children.

This was always necessary before because all mutations couldn't return anything more than the primary identifier. With the addition of `InsertReturning` and `UpdateReturning` (and therefore, the ability for inserts and updates to return arbitrary field selections), we can now update a node's field selection in place so that it satisfies all of its children data dependencies.

Concretely, this avoids a roundtrip whenever a reload node was previously inserted.

```graphql
mutation {
  updateOnePost(
    where: { id: 1 }
    data: {
      user: {
        update: { data: { comment: { update: { data: { body: "updated" } } } } }
      }
    }
  ) {
    id
    title
  }
}
```

**Before**

```sql
SELECT "Post"."id", "Post"."title" FROM "Post" WHERE ("Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET $3
SELECT "Post"."id", "Post"."userId" FROM "Post" WHERE "Post"."id" = $1 OFFSET $2
SELECT "User"."id" FROM "User" WHERE (1=1 AND "User"."id" IN ($1)) OFFSET $2
SELECT "User"."id" FROM "User" WHERE ("User"."id" = $1 AND 1=1) LIMIT $2 OFFSET $3
SELECT "User"."id", "User"."commentId" FROM "User" WHERE "User"."id" = $1 OFFSET $2
SELECT "Comment"."id" FROM "Comment" WHERE (1=1 AND "Comment"."id" IN ($1)) OFFSET $2
UPDATE "Comment" SET "body" = $1 WHERE ("Comment"."id" = $2 AND 1=1) RETURNING "Comment"."id"
SELECT "Post"."id", "Post"."title" FROM "Post" WHERE "Post"."id" = $1 LIMIT $2 OFFSET $3
```

**After (-2 queries) (-1 query per relation hop)**

```sql
SELECT "Post"."id", "Post"."title", "Post"."userId" FROM "Post" WHERE ("Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET $3
SELECT "User"."id" FROM "User" WHERE (1=1 AND "User"."id" IN ($1)) OFFSET $2
SELECT "User"."id", "User"."commentId" FROM "User" WHERE ("User"."id" = $1 AND 1=1) LIMIT $2 OFFSET $3
SELECT "Comment"."id" FROM "Comment" WHERE (1=1 AND "Comment"."id" IN ($1)) OFFSET $2
UPDATE "Comment" SET "body" = $1 WHERE ("Comment"."id" = $2 AND 1=1) RETURNING "Comment"."id"
SELECT "Post"."id", "Post"."title" FROM "Post" WHERE "Post"."id" = $1 LIMIT $2 OFFSET $3
```