### PR TITLE
support http mode for neon driver

### DIFF
--- a/query-engine/js-connectors/js/smoke-test-js/src/neon.ts
+++ b/query-engine/js-connectors/js/smoke-test-js/src/neon.ts
@@ -6,6 +6,7 @@ async function neon() {
 
   const db = createNeonConnector({
     url: connectionString,
+    httpMode: false,
   })
 
   await smokeTest(db, '../prisma/postgres-neon/schema.prisma')


### PR DESCRIPTION
This PR enables the HTTP support for the driver. In HTTP mode, all queries are done in single-flight HTTP requests to the Neon server, which saves a lot of time in establishing the initial connection. Enabling it or not depends on the use case: if a user only have 1 SQL query per REST API call then it's likely they will benefit from HTTP mode, but if there are a lot, WebSocket would provide better performance, because after the initial connection is established, all subsequent queries will be fast.

https://neon.tech/blog/sub-10ms-postgres-queries-for-vercel-edge-functions

Interactive txn is not supported by HTTP endpoint yet. The current HTTP mode supports non-interactive batch transactions as proposed in this PR: https://github.com/neondatabase/serverless/pull/39

```
const sql = neon(...);
const results = await sql.transaction([
  sql`SELECT ${1}::int AS int`,
  sql`SELECT ${"hello"} AS str`
], /* options */);
```

However, it seems that Prisma engine will issue queries one by one even if the user issues a batch request on the ORM layer, and therefore we cannot adapt the batch txn API to the engine yet, and we have to reject transaction statements in http mode for now. We can do a fallback to WebSocket in future PRs.

https://github.com/prisma/prisma-engines/blob/4189690eafe0ceb8b47e5ec48c5dded56e043430/query-engine/core/src/executor/interpreting_executor.rs#L111 