### PR TITLE
feat(node-drivers): allow to push and pull the database with a JS connector

### DIFF
--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -7,7 +7,7 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
         NativeTypeInstance, RelationMode, StringFilter,
     },
     diagnostics::{DatamodelError, Diagnostics},
@@ -300,6 +300,10 @@ impl Connector for CockroachDatamodelConnector {
         if config.preview_features().contains(PreviewFeature::MultiSchema) && !ds.schemas_defined() {
             completions::schemas_completion(completion_list);
         }
+    }
+
+    fn flavour(&self) -> Flavour {
+        Flavour::Cockroach
     }
 }
 

--- a/psl/builtin-connectors/src/mongodb.rs
+++ b/psl/builtin-connectors/src/mongodb.rs
@@ -7,7 +7,7 @@ use enumflags2::BitFlags;
 use mongodb_types::*;
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
         NativeTypeInstance, RelationMode,
     },
     diagnostics::{Diagnostics, Span},
@@ -145,5 +145,9 @@ impl Connector for MongoDbDatamodelConnector {
     /// Avoid checking whether the fields appearing in a `@relation` attribute are included in an index.
     fn should_suggest_missing_referencing_fields_indexes(&self) -> bool {
         false
+    }
+
+    fn flavour(&self) -> Flavour {
+        Flavour::Mongo
     }
 }

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -8,7 +8,7 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
         NativeTypeInstance, RelationMode,
     },
     diagnostics::{Diagnostics, Span},
@@ -309,6 +309,10 @@ impl Connector for MsSqlDatamodelConnector {
         if config.preview_features().contains(PreviewFeature::MultiSchema) && !ds.schemas_defined() {
             completions::schemas_completion(completion_list);
         }
+    }
+
+    fn flavour(&self) -> Flavour {
+        Flavour::Sqlserver
     }
 }
 

--- a/psl/builtin-connectors/src/mysql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mysql_datamodel_connector.rs
@@ -8,7 +8,7 @@ use enumflags2::BitFlags;
 use lsp_types::CompletionList;
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
         NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
@@ -278,5 +278,9 @@ impl Connector for MySqlDatamodelConnector {
         if config.preview_features().contains(PreviewFeature::MultiSchema) && !ds.schemas_defined() {
             completions::schemas_completion(completion_list);
         }
+    }
+
+    fn flavour(&self) -> Flavour {
+        Flavour::Mysql
     }
 }

--- a/psl/builtin-connectors/src/neon.rs
+++ b/psl/builtin-connectors/src/neon.rs
@@ -1,11 +1,11 @@
 use crate::postgres_datamodel_connector;
 use psl_core::{
-    datamodel_connector::RelationMode,
-    js_connector::{Flavor, JsConnector},
+    datamodel_connector::{Flavour, RelationMode},
+    js_connector::JsConnector,
 };
 
 pub(crate) static NEON_SERVERLESS: JsConnector = JsConnector {
-    flavor: Flavor::Postgres,
+    flavour: Flavour::Postgres,
     canonical_connector: &postgres_datamodel_connector::PostgresDatamodelConnector,
 
     provider_name: "@prisma/neon",

--- a/psl/builtin-connectors/src/planetscale.rs
+++ b/psl/builtin-connectors/src/planetscale.rs
@@ -1,11 +1,11 @@
 use crate::mysql_datamodel_connector;
 use psl_core::{
-    datamodel_connector::RelationMode,
-    js_connector::{Flavor, JsConnector},
+    datamodel_connector::{Flavour, RelationMode},
+    js_connector::JsConnector,
 };
 
 pub(crate) static PLANETSCALE_SERVERLESS: JsConnector = JsConnector {
-    flavor: Flavor::MySQL,
+    flavour: Flavour::Mysql,
     canonical_connector: &mysql_datamodel_connector::MySqlDatamodelConnector,
 
     provider_name: "@prisma/planetscale",

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -8,7 +8,7 @@ use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat};
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
         NativeTypeInstance, RelationMode, StringFilter,
     },
     diagnostics::Diagnostics,
@@ -559,6 +559,10 @@ impl Connector for PostgresDatamodelConnector {
         let properties = PostgresDatasourceProperties { extensions };
 
         DatasourceConnectorData::new(Box::new(properties))
+    }
+
+    fn flavour(&self) -> Flavour {
+        Flavour::Postgres
     }
 }
 

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -1,7 +1,7 @@
 use enumflags2::BitFlags;
 use psl_core::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, NativeTypeConstructor,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
         NativeTypeInstance,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
@@ -127,5 +127,9 @@ impl Connector for SqliteDatamodelConnector {
         }
 
         Ok(())
+    }
+
+    fn flavour(&self) -> Flavour {
+        Flavour::Sqlite
     }
 }

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -1,4 +1,4 @@
-use crate::datamodel_connector::*;
+pub(crate) use crate::datamodel_connector::*;
 use diagnostics::{DatamodelError, Span};
 use enumflags2::BitFlags;
 
@@ -70,6 +70,10 @@ impl Connector for EmptyDatamodelConnector {
 
     fn validate_url(&self, _url: &str) -> Result<(), String> {
         Ok(())
+    }
+
+    fn flavour(&self) -> Flavour {
+        unreachable!()
     }
 }
 

--- a/psl/psl-core/src/js_connector.rs
+++ b/psl/psl-core/src/js_connector.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::datamodel_connector::*;
 use enumflags2::BitFlags;
 
@@ -9,14 +7,14 @@ use enumflags2::BitFlags;
 /// Rather than a unit struct per individual connector, like we have for the rest
 /// of the builtin connectors, we have a single struct which state represents the
 /// features that vary in this connector with respect to a cannonical connector
-/// for the flavor of SQL the particular JsConnector speaks.
+/// for the flavour of SQL the particular JsConnector speaks.
 ///
 /// For example, the _planetscale serverless_ connector is compatible with MySQL,
-/// so it reuses the builtin MySQL connector (the cannonical for the MySQL flavor)
+/// so it reuses the builtin MySQL connector (the cannonical for the MySQL flavour)
 /// for most of its features.
 #[derive(Copy, Clone)]
 pub struct JsConnector {
-    pub flavor: Flavor,
+    pub flavour: Flavour,
     pub canonical_connector: &'static dyn Connector,
 
     pub provider_name: &'static str,
@@ -31,23 +29,6 @@ impl JsConnector {
     /// then its a provider for a JS connector.
     pub fn is_provider(name: &str) -> bool {
         name.starts_with("@prisma/")
-    }
-}
-
-#[derive(Copy, Clone)]
-pub enum Flavor {
-    MySQL,
-    Postgres,
-}
-
-impl FromStr for Flavor {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().as_str() {
-            "mysql" => Ok(Self::MySQL),
-            "postgres" => Ok(Self::Postgres),
-            _ => Err(format!("Unknown flavor: {}", s)),
-        }
     }
 }
 
@@ -145,5 +126,9 @@ impl Connector for JsConnector {
         } else {
             self.canonical_connector.allowed_relation_mode_settings()
         }
+    }
+
+    fn flavour(&self) -> Flavour {
+        self.flavour
     }
 }

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -6,7 +6,6 @@ pub use psl_core::{
     datamodel_connector,
     diagnostics::{self, Diagnostics},
     is_reserved_type_name,
-    js_connector::Flavor as JsConnectorFlavor,
     mcf::config_to_mcf_json_value as get_config,
     mcf::{generators_to_json, render_sources_to_json}, // for tests
     parser_database::{self, SourceFile},

--- a/query-engine/js-connectors/js/js-connector-utils/src/binder.ts
+++ b/query-engine/js-connectors/js/js-connector-utils/src/binder.ts
@@ -9,7 +9,7 @@ export const binder = (queryable: Connector & Closeable): Connector & Closeable 
   version: queryable.version.bind(queryable),
   isHealthy: queryable.isHealthy.bind(queryable),
   close: queryable.close.bind(queryable),
-  flavor: queryable.flavor,
+  flavour: queryable.flavour,
 })
 
 export type ConnectorConfig

--- a/query-engine/js-connectors/js/js-connector-utils/src/types.ts
+++ b/query-engine/js-connectors/js/js-connector-utils/src/types.ts
@@ -14,7 +14,7 @@ export interface Query {
 }
 
 export type Connector = {
-  readonly flavor: 'mysql' | 'postgres',
+  readonly flavour: 'mysql' | 'postgres',
 
   queryRaw: (params: Query) => Promise<ResultSet>
   executeRaw: (params: Query) => Promise<number>

--- a/query-engine/js-connectors/js/neon-js-connector/src/neon.ts
+++ b/query-engine/js-connectors/js/neon-js-connector/src/neon.ts
@@ -16,7 +16,7 @@ const TRANSACTION_COMMIT = 'COMMIT'
 const TRANSACTION_ROLLBACK = 'ROLLBACK'
 
 class PrismaNeon implements Connector, Closeable {
-  readonly flavor = 'postgres'
+  readonly flavour = 'postgres'
 
   private client: Client
   private isRunning: boolean = true

--- a/query-engine/js-connectors/js/planetscale-js-connector/src/planetscale.ts
+++ b/query-engine/js-connectors/js/planetscale-js-connector/src/planetscale.ts
@@ -39,7 +39,7 @@ const TRANSACTION_COMMIT = 'COMMIT'
 const TRANSACTION_ROLLBACK = 'ROLLBACK'
 
 class PrismaPlanetScale implements Connector, Closeable {
-  readonly flavor = 'mysql'
+  readonly flavour = 'mysql'
   
   private driver: TransactionCapableDriver
   private isRunning: boolean = true

--- a/query-engine/js-connectors/js/smoke-test-js/README.md
+++ b/query-engine/js-connectors/js/smoke-test-js/README.md
@@ -24,10 +24,7 @@ This is very important to double-check if you have multiple versions installed, 
 - Create a new `shadow` database branch. Repeat the steps above (selecting the `shadow` branch instead of `main`), and paste the generated URL in the `JS_PLANETSCALE_SHADOW_DATABASE_URL` environment variable in `.envrc`.
 
 In the current directory:
-
-- Set the provider in [./prisma/mysql-planetscale/schema.prisma](./prisma/mysql-planetscale/schema.prisma) to `mysql`.
 - Run `pnpm prisma:planetscale` to push the Prisma schema and insert the test data.
-- Set the provider in [./prisma/mysql-planetscale/schema.prisma](./prisma/mysql-planetscale/schema.prisma) to `@prisma/planetscale`.
 - Run `pnpm planetscale` to run smoke tests against the PlanetScale database.
 
 Note: you used to be able to run these Prisma commands without changing the provider name, but [#4074](https://github.com/prisma/prisma-engines/pull/4074) changed that (see https://github.com/prisma/prisma-engines/pull/4074#issuecomment-1649942475).
@@ -38,8 +35,5 @@ Note: you used to be able to run these Prisma commands without changing the prov
 - Paste the connection string to `JS_NEON_DATABASE_URL`. Create a shadow branch and repeat the step above, paste the connection string to `JS_NEON_SHADOW_DATABASE_URL`.
 
 In the current directory:
-
-- Set the provider in [./prisma/postgres-neon/schema.prisma](./prisma/postgres-neon/schema.prisma) to `mysql`.
 - Run `pnpm prisma:neon` to push the Prisma schema and insert the test data.
-- Set the provider in [./prisma/postgres-neon/schema.prisma](./prisma/postgres-neon/schema.prisma) to `@prisma/neon`.
 - Run `pnpm neon` to run smoke tests against the Neon database.

--- a/query-engine/js-connectors/js/smoke-test-js/prisma/mysql-planetscale/schema.prisma
+++ b/query-engine/js-connectors/js/smoke-test-js/prisma/mysql-planetscale/schema.prisma
@@ -1,10 +1,9 @@
 generator client {
-  provider        = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-  provider          = "mysql"
-  // provider          = "@prisma/planetscale"
+  provider          = "@prisma/planetscale"
   url               = env("JS_PLANETSCALE_DATABASE_URL")
   shadowDatabaseUrl = env("JS_PLANETSCALE_SHADOW_DATABASE_URL")
 }

--- a/query-engine/js-connectors/js/smoke-test-js/prisma/postgres-neon/schema.prisma
+++ b/query-engine/js-connectors/js/smoke-test-js/prisma/postgres-neon/schema.prisma
@@ -1,10 +1,9 @@
 generator client {
-  provider        = "prisma-client-js"
+  provider = "prisma-client-js"
 }
 
 datasource db {
-  provider          = "postgres"
-  // provider          = "@prisma/neon"
+  provider          = "@prisma/neon"
   url               = env("JS_NEON_DATABASE_URL")
   shadowDatabaseUrl = env("JS_NEON_SHADOW_DATABASE_URL")
 }

--- a/query-engine/js-connectors/js/smoke-test-js/src/test.ts
+++ b/query-engine/js-connectors/js/smoke-test-js/src/test.ts
@@ -3,7 +3,7 @@ import type { Connector, Closeable } from '@jkomyno/prisma-js-connector-utils'
 import type { QueryEngineInstance } from './engines/types/Library'
 import { initQueryEngine } from './util'
 
-type Flavor = Connector['flavor']
+type Flavor = Connector['flavour']
 
 export async function smokeTest(db: Connector & Closeable, prismaSchemaRelativePath: string) {
   // wait for the database pool to be initialized
@@ -17,7 +17,7 @@ export async function smokeTest(db: Connector & Closeable, prismaSchemaRelativeP
 
   // console.log('[nodejs] isHealthy', await conn.isHealthy())
 
-  const test = new SmokeTest(engine, db.flavor)
+  const test = new SmokeTest(engine, db.flavour)
 
   await test.testFindManyTypeTest()
   await test.testCreateAndDeleteChildParent()
@@ -46,7 +46,7 @@ export async function smokeTest(db: Connector & Closeable, prismaSchemaRelativeP
 }
 
 class SmokeTest {
-  constructor(private readonly engine: QueryEngineInstance, readonly flavor: Connector['flavor']) {}
+  constructor(private readonly engine: QueryEngineInstance, readonly flavour: Connector['flavour']) {}
 
   async testFindManyTypeTest() {
     await this.testFindManyTypeTestMySQL()
@@ -243,13 +243,13 @@ type WithFlavorInput
 function withFlavor({ only, exclude }: WithFlavorInput) {
   return function decorator(originalMethod: () => any, _ctx: ClassMethodDecoratorContext<SmokeTest, () => unknown>) {
     return function replacement(this: SmokeTest) {
-      if ((exclude || []).includes(this.flavor)) {
-        console.log(`[nodejs::exclude] Skipping test "${originalMethod.name}" with flavor: ${this.flavor}`)
+      if ((exclude || []).includes(this.flavour)) {
+        console.log(`[nodejs::exclude] Skipping test "${originalMethod.name}" with flavour: ${this.flavour}`)
         return
       }
 
-      if ((only || []).length > 0 && !(only || []).includes(this.flavor)) {
-        console.log(`[nodejs::only] Skipping test "${originalMethod.name}" with flavor: ${this.flavor}`)
+      if ((only || []).length > 0 && !(only || []).includes(this.flavour)) {
+        console.log(`[nodejs::only] Skipping test "${originalMethod.name}" with flavour: ${this.flavour}`)
         return
       }
 

--- a/query-engine/js-connectors/src/proxy.rs
+++ b/query-engine/js-connectors/src/proxy.rs
@@ -2,13 +2,12 @@ use core::panic;
 use std::str::FromStr;
 use std::sync::{Arc, Condvar, Mutex};
 
+use crate::error::*;
 use napi::bindgen_prelude::{FromNapiValue, Promise as JsPromise, ToNapiValue};
 use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
 use napi::{JsObject, JsString};
 use napi_derive::napi;
-
-use crate::error::*;
-use psl::JsConnectorFlavor;
+use psl::datamodel_connector::Flavour;
 use quaint::connector::ResultSet as QuaintResultSet;
 use quaint::Value as QuaintValue;
 
@@ -44,9 +43,9 @@ pub struct Proxy {
     /// Moreover, `JsFunction` is not `Clone`.
     is_healthy: ThreadsafeFunction<(), ErrorStrategy::Fatal>,
 
-    /// Return the flavor for this driver.
+    /// Return the flavour for this driver.
     #[allow(dead_code)]
-    pub(crate) flavor: String,
+    pub(crate) flavour: String,
 }
 
 /// Reify creates a Rust proxy to access the JS driver passed in as a parameter.
@@ -56,7 +55,14 @@ pub fn reify(js_connector: JsObject) -> napi::Result<Proxy> {
     let version = js_connector.get_named_property("version")?;
     let close: ThreadsafeFunction<(), ErrorStrategy::Fatal> = js_connector.get_named_property("close")?;
     let is_healthy = js_connector.get_named_property("isHealthy")?;
-    let flavor: JsString = js_connector.get_named_property("flavor")?;
+
+    // TODO: we adjusted the property name from flavor to flavour to be consistent with schema
+    // introspection terms already existing in the codebase. Getting the value from `flavor`
+    // needs to be removed after we have adjusted terms in the drivers's code, which
+    // exists in a different repository.
+    let flavour: JsString = js_connector
+        .get_named_property("flavor")
+        .or(js_connector.get_named_property("flavour"))?;
 
     let driver = Proxy {
         query_raw,
@@ -64,7 +70,7 @@ pub fn reify(js_connector: JsObject) -> napi::Result<Proxy> {
         version,
         close,
         is_healthy,
-        flavor: flavor.into_utf8()?.as_str()?.to_owned(),
+        flavour: flavour.into_utf8()?.as_str()?.to_owned(),
     };
     Ok(driver)
 }
@@ -317,11 +323,12 @@ fn js_base_value_to_quaint(json_value: serde_json::Value, column_type: ColumnTyp
     }
 }
 
-pub struct FlavoredJSResultSet(pub (JsConnectorFlavor, JSResultSet));
+// TODO: this flavour-specific deserialization logic needs to be moved to the JS part of the connector
+pub struct FlavourSpecificResultSet(pub (Flavour, JSResultSet));
 
-impl From<FlavoredJSResultSet> for QuaintResultSet {
-    fn from(pair: FlavoredJSResultSet) -> Self {
-        let (flavor, mut js_result_set) = pair.0;
+impl From<FlavourSpecificResultSet> for QuaintResultSet {
+    fn from(pair: FlavourSpecificResultSet) -> Self {
+        let (flavour, mut js_result_set) = pair.0;
         // TODO: extract, todo: error rather than panic?
         let to_quaint_row = move |row: &mut Vec<serde_json::Value>| -> Vec<quaint::Value<'static>> {
             let mut res = Vec::with_capacity(row.len());
@@ -331,9 +338,13 @@ impl From<FlavoredJSResultSet> for QuaintResultSet {
                 let json_value = row.remove(0);
 
                 // Note: here, we could consider using conditional compile-time variables to avoid the match.
-                let quaint_value = match flavor {
-                    JsConnectorFlavor::MySQL => js_planetscale_value_to_quaint(json_value, column_type),
-                    JsConnectorFlavor::Postgres => js_neon_value_to_quaint(json_value, column_type),
+                let quaint_value = match flavour {
+                    Flavour::Mysql => js_planetscale_value_to_quaint(json_value, column_type),
+                    Flavour::Postgres => js_neon_value_to_quaint(json_value, column_type),
+                    _ => unreachable!(
+                        "Unsupported flavour {:?} in result set transformation from javascript",
+                        flavour
+                    ),
                 };
 
                 res.push(quaint_value);

--- a/query-engine/js-connectors/src/proxy.rs
+++ b/query-engine/js-connectors/src/proxy.rs
@@ -55,14 +55,7 @@ pub fn reify(js_connector: JsObject) -> napi::Result<Proxy> {
     let version = js_connector.get_named_property("version")?;
     let close: ThreadsafeFunction<(), ErrorStrategy::Fatal> = js_connector.get_named_property("close")?;
     let is_healthy = js_connector.get_named_property("isHealthy")?;
-
-    // TODO: we adjusted the property name from flavor to flavour to be consistent with schema
-    // introspection terms already existing in the codebase. Getting the value from `flavor`
-    // needs to be removed after we have adjusted terms in the drivers's code, which
-    // exists in a different repository.
-    let flavour: JsString = js_connector
-        .get_named_property("flavor")
-        .or(js_connector.get_named_property("flavour"))?;
+    let flavour: JsString = js_connector.get_named_property("flavour")?;
 
     let driver = Proxy {
         query_raw,

--- a/query-engine/js-connectors/src/queryable.rs
+++ b/query-engine/js-connectors/src/queryable.rs
@@ -1,10 +1,10 @@
 use crate::{
     error::into_quaint_error,
-    proxy::{self, FlavoredJSResultSet, JSResultSet, Proxy, Query},
+    proxy::{self, FlavourSpecificResultSet, JSResultSet, Proxy, Query},
 };
 use async_trait::async_trait;
 use napi::JsObject;
-use psl::JsConnectorFlavor;
+use psl::datamodel_connector::Flavour;
 use quaint::{
     connector::IsolationLevel,
     prelude::{Query as QuaintQuery, Queryable as QuaintQueryable, ResultSet, TransactionCapable},
@@ -18,7 +18,7 @@ use tracing::{info_span, Instrument};
 /// types to types that can be translated into javascript and viceversa. This is to let the rest of
 /// the query engine work as if it was using quaint itself. The aforementioned transformations are:
 ///
-/// Transforming a `quaint::ast::Query` into SQL by visiting it for the specific flavor of SQL
+/// Transforming a `quaint::ast::Query` into SQL by visiting it for the specific flavour of SQL
 /// expected by the client connector. (eg. using the mysql visitor for the Planetscale client
 /// connector)
 ///
@@ -29,12 +29,21 @@ use tracing::{info_span, Instrument};
 #[derive(Clone)]
 pub struct JsQueryable {
     pub(crate) proxy: Proxy,
-    pub(crate) flavor: JsConnectorFlavor,
+    pub(crate) flavour: Flavour,
 }
 
 impl JsQueryable {
-    pub fn new(proxy: Proxy, flavor: JsConnectorFlavor) -> Self {
-        Self { proxy, flavor }
+    pub fn new(proxy: Proxy, flavour: Flavour) -> Self {
+        Self { proxy, flavour }
+    }
+
+    /// visit a query according to the flavour of the JS connector
+    pub fn visit_query<'a>(&self, q: QuaintQuery<'a>) -> quaint::Result<(String, Vec<Value<'a>>)> {
+        match self.flavour {
+            Flavour::Mysql => visitor::Mysql::build(q),
+            Flavour::Postgres => visitor::Postgres::build(q),
+            _ => unimplemented!("Unsupported flavour for JS connector {:?}", self.flavour),
+        }
     }
 }
 
@@ -54,10 +63,7 @@ impl std::fmt::Debug for JsQueryable {
 impl QuaintQueryable for JsQueryable {
     /// Execute the given query.
     async fn query(&self, q: QuaintQuery<'_>) -> quaint::Result<ResultSet> {
-        let (sql, params) = match self.flavor {
-            JsConnectorFlavor::MySQL => visitor::Mysql::build(q)?,
-            JsConnectorFlavor::Postgres => visitor::Postgres::build(q)?,
-        };
+        let (sql, params) = self.visit_query(q)?;
         self.query_raw(&sql, &params).await
     }
 
@@ -79,10 +85,7 @@ impl QuaintQueryable for JsQueryable {
 
     /// Execute the given query, returning the number of affected rows.
     async fn execute(&self, q: QuaintQuery<'_>) -> quaint::Result<u64> {
-        let (sql, params) = match self.flavor {
-            JsConnectorFlavor::MySQL => visitor::Mysql::build(q)?,
-            JsConnectorFlavor::Postgres => visitor::Postgres::build(q)?,
-        };
+        let (sql, params) = self.visit_query(q)?;
         self.execute_raw(&sql, &params).await
     }
 
@@ -108,7 +111,6 @@ impl QuaintQueryable for JsQueryable {
     /// prepared statements.
     async fn raw_cmd(&self, cmd: &str) -> quaint::Result<()> {
         self.execute_raw(cmd, &[]).await?;
-
         Ok(())
     }
 
@@ -146,9 +148,9 @@ impl JsQueryable {
         Query { sql, args }
     }
 
-    async fn transform_result_set(flavor: JsConnectorFlavor, result_set: JSResultSet) -> quaint::Result<ResultSet> {
-        let flavored_js_result_set = FlavoredJSResultSet((flavor, result_set));
-        Ok(ResultSet::from(flavored_js_result_set))
+    async fn transform_result_set(flavour: Flavour, result_set: JSResultSet) -> quaint::Result<ResultSet> {
+        let flavoured_js_result_set = FlavourSpecificResultSet((flavour, result_set));
+        Ok(ResultSet::from(flavoured_js_result_set))
     }
 
     async fn do_query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
@@ -166,7 +168,7 @@ impl JsQueryable {
 
         let len = result_set.len();
         let deserialization_span = info_span!("js:query:result", user_facing = true, "length" = %len);
-        Self::transform_result_set(self.flavor, result_set)
+        Self::transform_result_set(self.flavour, result_set)
             .instrument(deserialization_span)
             .await
     }
@@ -190,7 +192,7 @@ impl From<JsObject> for JsQueryable {
     fn from(driver: JsObject) -> Self {
         let driver = proxy::reify(driver).unwrap();
         Self {
-            flavor: driver.flavor.parse().unwrap(),
+            flavour: driver.flavour.parse().unwrap(),
             proxy: driver,
         }
     }

--- a/schema-engine/core/src/lib.rs
+++ b/schema-engine/core/src/lib.rs
@@ -155,6 +155,8 @@ fn connector_for_provider(provider: &str) -> CoreResult<Box<dyn schema_connector
             preview_features: Default::default(),
             shadow_database_connection_string: None,
         }))),
+        p if PLANETSCALE_SERVERLESS.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_mysql())),
+        p if NEON_SERVERLESS.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_postgres())),
         provider => Err(CoreError::from_msg(format!(
             "`{provider}` is not a supported connector."
         ))),

--- a/schema-engine/core/src/lib.rs
+++ b/schema-engine/core/src/lib.rs
@@ -21,7 +21,10 @@ pub use schema_connector;
 
 use enumflags2::BitFlags;
 use mongodb_schema_connector::MongoDbSchemaConnector;
-use psl::{builtin_connectors::*, parser_database::SourceFile, Datasource, PreviewFeature, ValidatedSchema};
+use psl::{
+    builtin_connectors::*, datamodel_connector::Flavour, parser_database::SourceFile, Datasource, PreviewFeature,
+    ValidatedSchema,
+};
 use schema_connector::ConnectorParams;
 use sql_schema_connector::SqlSchemaConnector;
 use std::{env, path::Path};
@@ -143,23 +146,23 @@ fn schema_to_connector(
 }
 
 fn connector_for_provider(provider: &str) -> CoreResult<Box<dyn schema_connector::SchemaConnector>> {
-    match provider {
-        p if POSTGRES.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_postgres())),
-        p if COCKROACH.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_cockroach())),
-        p if MYSQL.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_mysql())),
-        p if SQLITE.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_sqlite())),
-        p if MSSQL.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_mssql())),
-        // TODO: adopt a state machine pattern in the mongo connector too
-        p if MONGODB.is_provider(p) => Ok(Box::new(MongoDbSchemaConnector::new(ConnectorParams {
-            connection_string: String::new(),
-            preview_features: Default::default(),
-            shadow_database_connection_string: None,
-        }))),
-        p if PLANETSCALE_SERVERLESS.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_mysql())),
-        p if NEON_SERVERLESS.is_provider(p) => Ok(Box::new(SqlSchemaConnector::new_postgres())),
-        provider => Err(CoreError::from_msg(format!(
+    if let Some(connector) = BUILTIN_CONNECTORS.iter().find(|c| c.is_provider(provider)) {
+        match connector.flavour() {
+            Flavour::Cockroach => Ok(Box::new(SqlSchemaConnector::new_cockroach())),
+            Flavour::Mongo => Ok(Box::new(MongoDbSchemaConnector::new(ConnectorParams {
+                connection_string: String::new(),
+                preview_features: Default::default(),
+                shadow_database_connection_string: None,
+            }))),
+            Flavour::Sqlserver => Ok(Box::new(SqlSchemaConnector::new_mssql())),
+            Flavour::Mysql => Ok(Box::new(SqlSchemaConnector::new_mysql())),
+            Flavour::Postgres => Ok(Box::new(SqlSchemaConnector::new_postgres())),
+            Flavour::Sqlite => Ok(Box::new(SqlSchemaConnector::new_sqlite())),
+        }
+    } else {
+        Err(CoreError::from_msg(format!(
             "`{provider}` is not a supported connector."
-        ))),
+        )))
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/253

Before this PR, the schema engine didn´t recognize `@prisma/planetscale` and `@prisma/neon providers`

Now, it does, and is able to recognize any new builtin provider added to the registry in PSL without requiring further modifications. For that matter a `flavour(&self) -> Flavour` method was added to the psl `Connector` contract denoting the flavour of a particular database we are using. 

Two databases will have the same flavour if they are wire compatible and have close enough types and capabilities. As such, `@prisma/planetscale` denotes a connector that has the `Mysql` flavour, and `@prisma/neon` denotes a connector that has the `Postgres` flavour.

The code successfully running while pushing a schema  with the `@prisma/planetscale` provider.

<img width="673" alt="Screenshot 2023-08-07 at 16 48 35" src="https://github.com/prisma/prisma-engines/assets/210307/3e18c745-a248-4e84-af06-ff7e223d52e8">

