### PR TITLE
fix(js-connector): use newest dev version of Prisma

### DIFF
--- a/query-engine/js-connectors/js/smoke-test-js/package.json
+++ b/query-engine/js-connectors/js/smoke-test-js/package.json
@@ -21,10 +21,10 @@
     "@jkomyno/prisma-js-connector-utils": "workspace:*",
     "@jkomyno/prisma-neon-js-connector": "workspace:*",
     "@jkomyno/prisma-planetscale-js-connector": "workspace:*",
-    "@prisma/client": "5.1.0"
+    "@prisma/client": "5.2.0-dev.18"
   },
   "devDependencies": {
-    "prisma": "^5.1.0",
+    "prisma": "5.2.0-dev.18",
     "tsx": "^3.12.7"
   }
 }

--- a/query-engine/js-connectors/js/smoke-test-js/prisma/mysql-planetscale/schema.prisma
+++ b/query-engine/js-connectors/js/smoke-test-js/prisma/mysql-planetscale/schema.prisma
@@ -3,8 +3,8 @@ generator client {
 }
 
 datasource db {
-  provider          = "@prisma/planetscale"
-  url               = env("JS_PLANETSCALE_DATABASE_URL")
+  provider = "@prisma/planetscale"
+  url      = env("JS_PLANETSCALE_DATABASE_URL")
   shadowDatabaseUrl = env("JS_PLANETSCALE_SHADOW_DATABASE_URL")
 }
 


### PR DESCRIPTION
This fixes smoke tests by using a version of Prisma that includes https://github.com/prisma/prisma-engines/pull/4113.