### PR TITLE
feat(wasm): enable `wasm32-unknown-unknown` compilation of query connectors, query core, and request handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1021,6 +1021,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "dissimilar"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1837,6 +1843,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+ "js-sys",
+ "stdweb",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2529,7 +2539,7 @@ dependencies = [
  "saturating",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.5",
  "sha2 0.10.7",
  "smallvec",
  "subprocess",
@@ -3548,11 +3558,13 @@ dependencies = [
  "futures",
  "getrandom 0.2.10",
  "indexmap 1.9.3",
+ "instant",
  "itertools",
  "lru 0.7.8",
  "once_cell",
  "opentelemetry",
  "petgraph 0.4.13",
+ "pin-project",
  "prisma-models",
  "psl",
  "query-connector",
@@ -3568,6 +3580,7 @@ dependencies = [
  "tracing-subscriber",
  "user-facing-errors",
  "uuid",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -4498,6 +4511,15 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
@@ -4506,6 +4528,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -4807,6 +4835,57 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "serde",
+ "serde_json",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1 0.6.1",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "stringprep"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,12 +49,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "allocator-api2"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
-
-[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
-version = "0.6.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+checksum = "f0de5164e5edbf51c45fb8c2d9664ae1c095cce1b265ecf7569093c0d66ef690"
 dependencies = [
  "bytes",
  "futures-sink",
@@ -1406,21 +1400,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
  "ahash 0.8.3",
- "allocator-api2",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.8.3"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+checksum = "0761a1b9491c4f2e3d66aa0f62d0fba0af9a0e2852e4d48ea506632a4b56e6aa"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -3204,6 +3197,7 @@ dependencies = [
  "postgres-native-tls",
  "postgres-types",
  "rusqlite",
+ "serde",
  "serde_json",
  "sqlformat",
  "thiserror",
@@ -3241,6 +3235,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "getrandom 0.2.7",
  "indexmap",
  "itertools",
  "prisma-models",
@@ -3264,6 +3259,7 @@ dependencies = [
  "cuid",
  "enumflags2",
  "futures",
+ "getrandom 0.2.7",
  "indexmap",
  "itertools",
  "lru 0.7.8",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3197,7 +3197,6 @@ dependencies = [
  "postgres-native-tls",
  "postgres-types",
  "rusqlite",
- "serde",
  "serde_json",
  "sqlformat",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,20 +54,7 @@ napi-derive = "2.12.4"
 
 [workspace.dependencies.quaint]
 path = "quaint"
-features = [
-  "bigdecimal",
-  "chrono",
-  "expose-drivers",
-  "fmt-sql",
-  "json",
-  "mssql",
-  "mysql",
-  "pooled",
-  "postgresql",
-  "sqlite",
-  "uuid",
-  "connectors",
-]
+features = ["workspace-default"]
 
 [profile.dev.package.backtrace]
 opt-level = 3

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -11,7 +11,7 @@ backtrace = "0.3.40"
 tracing = "0.1"
 indoc.workspace = true
 itertools = "0.10"
-quaint = { workspace = true, optional = true }
+quaint = { path = "../../quaint", optional = true, features = ["slim"] }
 
 [features]
 default = []

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -31,6 +31,21 @@ expose-drivers = []
 
 all = ["slim", "connectors", "pooled"]
 
+workspace-default = [
+  "bigdecimal",
+  "chrono",
+  "expose-drivers",
+  "fmt-sql",
+  "json",
+  "mssql",
+  "mysql",
+  "postgresql",
+  "sqlite",
+  "uuid",
+  "serde-support",
+  "connectors"
+]
+
 connectors = [
   "postgresql-connector",
   "mysql-connector",
@@ -44,7 +59,6 @@ slim = [
   "mssql",
   "mysql",
   "postgresql",
-  "serde-support",
   "sqlite",
   "uuid",
   "bigdecimal",
@@ -123,7 +137,7 @@ serde = { version = "1.0", features = ["derive"] }
 test-macros = { path = "test-macros" }
 test-setup = { path = "test-setup" }
 uuid = { version = "1", features = ["v4"] }
-tokio = { version = "1.0", features = ["rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.25", features = ["macros", "time"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
 version = "0.2"

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -29,20 +29,12 @@ docs = []
 # way to access database-specific methods when you need extra control.
 expose-drivers = []
 
-all = ["slim", "connectors", "pooled"]
+all = ["slim", "connectors", "pooled", "serde-support"]
 
 workspace-default = [
-  "bigdecimal",
-  "chrono",
+  "slim",
   "expose-drivers",
   "fmt-sql",
-  "json",
-  "mssql",
-  "mysql",
-  "postgresql",
-  "sqlite",
-  "uuid",
-  "serde-support",
   "connectors"
 ]
 

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -16,7 +16,7 @@ rand = "0.7"
 regex = "1"
 serde_json = { version = "1.0", features = ["float_roundtrip"] }
 thiserror = "1.0"
-tokio.workspace = true
+tokio = { version = "1.25", features = ["macros", "sync", "io-util", "time"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 uuid.workspace = true

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -3,17 +3,24 @@ edition = "2021"
 name = "query-connector"
 version = "0.1.0"
 
+[features]
+default = ["native"]
+native = ["prisma-models/default_generators"]
+
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1.31"
 chrono = {version = "0.4", features = ["serde"]}
 futures = "0.3"
 itertools = "0.10"
-prisma-models = {path = "../../prisma-models"}
+prisma-models = {path = "../../prisma-models", features = ["wasm_generators"] }
 prisma-value = {path = "../../../libs/prisma-value"}
 serde.workspace = true
 serde_json.workspace = true
 thiserror = "1.0"
-user-facing-errors = {path = "../../../libs/user-facing-errors"}
+user-facing-errors = { path = "../../../libs/user-facing-errors", features = ["sql"] }
 uuid = "1"
 indexmap = "1.7"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -6,6 +6,8 @@ version = "0.1.0"
 [features]
 vendored-openssl = ["quaint/vendored-openssl"]
 js-connectors = []
+native-connectors = ["cuid", "connector-interface/native", "quaint/pooled", "quaint/connectors"]
+default = ["native-connectors"]
 
 [dependencies]
 psl.workspace = true
@@ -18,17 +20,18 @@ once_cell = "1.3"
 rand = "0.7"
 serde_json = {version = "1.0", features = ["float_roundtrip"]}
 thiserror = "1.0"
-tokio.workspace = true
+tokio = { version = "1.25", features = ["rt", "macros", "sync", "io-util", "time"] }
 tracing = "0.1"
 tracing-futures = "0.2"
 uuid.workspace = true
 opentelemetry = { version = "0.17", features = ["tokio"] }
 tracing-opentelemetry = "0.17.3"
-quaint.workspace = true
+quaint = { path = "../../../quaint", features = ["slim"] }
 
 [dependencies.connector-interface]
 package = "query-connector"
 path = "../query-connector"
+default-features = false
 
 [dependencies.prisma-models]
 path = "../../prisma-models"
@@ -46,6 +49,7 @@ version = "1.0"
 
 [dependencies.cuid]
 version = "1.2"
+optional = true
 
 [dependencies.user-facing-errors]
 features = ["sql"]

--- a/query-engine/connectors/sql-query-connector/src/database/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/mod.rs
@@ -1,9 +1,13 @@
 mod connection;
 #[cfg(feature = "js-connectors")]
 mod js;
+#[cfg(feature = "native-connectors")]
 mod mssql;
+#[cfg(feature = "native-connectors")]
 mod mysql;
+#[cfg(feature = "native-connectors")]
 mod postgresql;
+#[cfg(feature = "native-connectors")]
 mod sqlite;
 mod transaction;
 
@@ -14,9 +18,13 @@ use connector_interface::{error::ConnectorError, Connector};
 
 #[cfg(feature = "js-connectors")]
 pub use js::*;
+#[cfg(feature = "native-connectors")]
 pub use mssql::*;
+#[cfg(feature = "native-connectors")]
 pub use mysql::*;
+#[cfg(feature = "native-connectors")]
 pub use postgresql::*;
+#[cfg(feature = "native-connectors")]
 pub use sqlite::*;
 
 #[async_trait]

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -18,7 +18,7 @@ use std::{
     ops::Deref,
     usize,
 };
-use tracing::log::trace;
+use tracing::trace;
 use user_facing_errors::query_engine::DatabaseConstraint;
 
 async fn generate_id(

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -22,9 +22,11 @@ mod value_ext;
 use self::{column_metadata::*, context::Context, filter_conversion::*, query_ext::QueryExt, row::*};
 use quaint::prelude::Queryable;
 
+pub use database::FromSource;
 #[cfg(feature = "js-connectors")]
 pub use database::{register_js_connector, Js};
-pub use database::{FromSource, Mssql, Mysql, PostgreSql, Sqlite};
+#[cfg(feature = "native-connectors")]
+pub use database::{Mssql, Mysql, PostgreSql, Sqlite};
 pub use error::SqlError;
 
 type Result<T> = std::result::Result<T, error::SqlError>;

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -38,6 +38,9 @@ cuid = { version = "1.2", optional = true }
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"
+instant = { version = "0.1",  features = ["stdweb", "wasm-bindgen", "inaccurate"] } # Vercel Edge Function does not have performance API
+pin-project = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
+wasm-bindgen-futures = "0.4"

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -3,12 +3,17 @@ edition = "2021"
 name = "query-core"
 version = "0.1.0"
 
+[features]
+default = ["native"]
+native = ["metrics", "prisma-models/default_generators", "cuid", "connector/native"]
+metrics = ["query-engine-metrics"]
+
 [dependencies]
 async-trait = "0.1"
 bigdecimal = "0.3"
 chrono = "0.4"
 connection-string.workspace = true 
-connector = { path = "../connectors/query-connector", package = "query-connector" }
+connector = { path = "../connectors/query-connector", package = "query-connector", default-features = false }
 crossbeam-channel = "0.5.6"
 psl.workspace = true
 futures = "0.3"
@@ -16,21 +21,23 @@ indexmap = { version = "1.7", features = ["serde-1"] }
 itertools = "0.10"
 once_cell = "1"
 petgraph = "0.4"
-prisma-models = { path = "../prisma-models", features = ["default_generators"] }
+prisma-models = { path = "../prisma-models", features = ["wasm_generators"] }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
-query-engine-metrics = {path = "../metrics"}
+query-engine-metrics = { path = "../metrics", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror = "1.0"
-tokio.workspace = true
+tokio = { version = "1.25", features = ["macros", "sync", "io-util", "time"] }
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-futures = "0.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.17.4"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "1"
-cuid = "1.2"
+cuid = { version = "1.2", optional = true }
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }

--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -11,8 +11,9 @@ use query_engine_metrics::{
     histogram, increment_counter, metrics, PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, PRISMA_CLIENT_QUERIES_TOTAL,
 };
 
+use instant::Instant;
 use schema::{QuerySchema, QuerySchemaRef};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tracing::Instrument;
 use tracing_futures::WithSubscriber;
 
@@ -117,7 +118,7 @@ pub async fn execute_many_self_contained<C: Connector + Send + Sync>(
         );
         let conn = connector.get_connection().instrument(conn_span).await?;
 
-        futures.push(tokio::spawn(
+        futures.push(super::spawn(
             request_context::with_request_context(
                 engine_protocol,
                 execute_self_contained(

--- a/query-engine/core/src/interactive_transactions/actor_manager.rs
+++ b/query-engine/core/src/interactive_transactions/actor_manager.rs
@@ -1,3 +1,4 @@
+use crate::executor::JoinHandle;
 use crate::{protocol::EngineProtocol, ClosedTx, Operation, ResponseData};
 use connector::Connection;
 use lru::LruCache;
@@ -9,7 +10,6 @@ use tokio::{
         mpsc::{channel, Sender},
         RwLock,
     },
-    task::JoinHandle,
     time::Duration,
 };
 

--- a/query-engine/core/src/interactive_transactions/actors.rs
+++ b/query-engine/core/src/interactive_transactions/actors.rs
@@ -1,7 +1,7 @@
 use super::{CachedTx, TransactionError, TxOpRequest, TxOpRequestMsg, TxOpResponse};
 use crate::{
-    execute_many_operations, execute_single_operation, protocol::EngineProtocol,
-    telemetry::helpers::set_span_link_from_traceparent, ClosedTx, Operation, ResponseData, TxId,
+    execute_many_operations, execute_single_operation, protocol::EngineProtocol, ClosedTx, Operation, ResponseData,
+    TxId,
 };
 use connector::Connection;
 use schema::QuerySchemaRef;
@@ -17,6 +17,9 @@ use tokio::{
 use tracing::Span;
 use tracing_futures::Instrument;
 use tracing_futures::WithSubscriber;
+
+#[cfg(feature = "metrics")]
+use crate::telemetry::helpers::set_span_link_from_traceparent;
 
 #[derive(PartialEq)]
 enum RunState {
@@ -81,6 +84,8 @@ impl<'a> ITXServer<'a> {
         traceparent: Option<String>,
     ) -> crate::Result<ResponseData> {
         let span = info_span!("prisma:engine:itx_query_builder", user_facing = true);
+
+        #[cfg(feature = "metrics")]
         set_span_link_from_traceparent(&span, traceparent.clone());
 
         let conn = self.cached_tx.as_open()?;

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -42,9 +42,17 @@ pub struct TxId(String);
 
 const MINIMUM_TX_ID_LENGTH: usize = 24;
 
+#[cfg(feature = "native")]
 impl Default for TxId {
     fn default() -> Self {
-        Self(cuid::cuid().unwrap())
+        Self(cuid::cuid())
+    }
+}
+
+#[cfg(not(feature = "native"))]
+impl Default for TxId {
+    fn default() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
     }
 }
 

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -45,7 +45,7 @@ const MINIMUM_TX_ID_LENGTH: usize = 24;
 #[cfg(feature = "native")]
 impl Default for TxId {
     fn default() -> Self {
-        Self(cuid::cuid())
+        Self(cuid::cuid().unwrap())
     }
 }
 

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -9,6 +9,8 @@ pub mod protocol;
 pub mod query_document;
 pub mod query_graph_builder;
 pub mod response_ir;
+
+#[cfg(feature = "metrics")]
 pub mod telemetry;
 
 pub use self::{
@@ -16,8 +18,11 @@ pub use self::{
     executor::{QueryExecutor, TransactionOptions},
     interactive_transactions::{ExtendedTransactionUserFacingError, TransactionError, TxId},
     query_document::*,
-    telemetry::*,
 };
+
+#[cfg(feature = "metrics")]
+pub use self::telemetry::*;
+
 pub use connector::{error::ConnectorError, Connector};
 
 mod error;

--- a/query-engine/core/src/telemetry/capturing/mod.rs
+++ b/query-engine/core/src/telemetry/capturing/mod.rs
@@ -142,7 +142,10 @@ pub use tx_ext::TxTraceExt;
 use self::capturer::Processor;
 use once_cell::sync::Lazy;
 use opentelemetry::{global, sdk, trace};
+
+#[cfg(feature = "metrics")]
 use query_engine_metrics::MetricRegistry;
+
 use tracing::subscriber;
 use tracing_subscriber::{
     filter::filter_fn, layer::Layered, prelude::__tracing_subscriber_SubscriberExt, Layer, Registry,

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -19,4 +19,5 @@ chrono = { version = "0.4.6", features = ["serde"] }
 # Support for generating default UUID, CUID, nanoid and datetime values. This
 # implies random number generation works, so it won't compile on targets like
 # wasm32.
-default_generators = ["uuid/v4", "cuid", "nanoid"]
+default_generators = ["cuid", "wasm_generators"]
+wasm_generators = ["uuid/v4", "nanoid"]

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -66,7 +66,7 @@ impl DefaultKind {
 
     /// Returns either a copy of the contained single value or produces a new
     /// value as defined by the expression.
-    #[cfg(any(feature = "wasm_generators"))]
+    #[cfg(feature = "wasm_generators")]
     pub fn get(&self) -> Option<PrismaValue> {
         match self {
             DefaultKind::Single(ref v) => Some(v.clone()),
@@ -220,7 +220,7 @@ impl ValueGenerator {
         self.args.get(0).and_then(|v| v.1.as_string())
     }
 
-    #[cfg(any(feature = "wasm_generators"))]
+    #[cfg(feature = "wasm_generators")]
     pub fn generate(&self) -> Option<PrismaValue> {
         self.generator.invoke()
     }

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -66,7 +66,7 @@ impl DefaultKind {
 
     /// Returns either a copy of the contained single value or produces a new
     /// value as defined by the expression.
-    #[cfg(feature = "default_generators")]
+    #[cfg(any(feature = "wasm_generators"))]
     pub fn get(&self) -> Option<PrismaValue> {
         match self {
             DefaultKind::Single(ref v) => Some(v.clone()),
@@ -220,7 +220,7 @@ impl ValueGenerator {
         self.args.get(0).and_then(|v| v.1.as_string())
     }
 
-    #[cfg(feature = "default_generators")]
+    #[cfg(any(feature = "wasm_generators"))]
     pub fn generate(&self) -> Option<PrismaValue> {
         self.generator.invoke()
     }
@@ -260,11 +260,20 @@ impl ValueGeneratorFn {
         }
     }
 
-    #[cfg(feature = "default_generators")]
+    #[cfg(feature = "wasm_generators")]
     fn invoke(&self) -> Option<PrismaValue> {
         match self {
             Self::Uuid => Some(Self::generate_uuid()),
-            Self::Cuid => Some(Self::generate_cuid()),
+            Self::Cuid => {
+                #[cfg(feature = "default_generators")]
+                {
+                    Some(Self::generate_cuid())
+                }
+                #[cfg(not(feature = "default_generators"))]
+                {
+                    panic!("cuid not supported in wasm mode")
+                }
+            }
             Self::Nanoid(length) => Some(Self::generate_nanoid(length)),
             Self::Now => Some(Self::generate_now()),
             Self::Autoincrement => None,
@@ -278,12 +287,12 @@ impl ValueGeneratorFn {
         PrismaValue::String(cuid::cuid().unwrap())
     }
 
-    #[cfg(feature = "default_generators")]
+    #[cfg(feature = "wasm_generators")]
     fn generate_uuid() -> PrismaValue {
         PrismaValue::Uuid(uuid::Uuid::new_v4())
     }
 
-    #[cfg(feature = "default_generators")]
+    #[cfg(feature = "wasm_generators")]
     fn generate_nanoid(length: &Option<u8>) -> PrismaValue {
         if length.is_some() {
             let value: usize = usize::from(length.unwrap());
@@ -293,7 +302,7 @@ impl ValueGeneratorFn {
         }
     }
 
-    #[cfg(feature = "default_generators")]
+    #[cfg(feature = "wasm_generators")]
     fn generate_now() -> PrismaValue {
         PrismaValue::DateTime(chrono::Utc::now().into())
     }

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 prisma-models = { path = "../prisma-models" }
-query-core = { path = "../core" }
+query-core = { path = "../core", default-features = false }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 psl.workspace = true
 dmmf_crate = { path = "../dmmf", package = "dmmf" }
@@ -24,7 +24,7 @@ quaint.workspace = true
 once_cell = "1.15"
 
 mongodb-query-connector = { path = "../connectors/mongodb-query-connector", optional = true }
-sql-query-connector = { path = "../connectors/sql-query-connector", optional = true }
+sql-query-connector = { path = "../connectors/sql-query-connector", optional = true, default-features = false }
 
 [dev-dependencies]
 insta = "1.7.1"
@@ -32,10 +32,12 @@ schema = { path = "../schema" }
 codspeed-criterion-compat = "1.1.0"
 
 [features]
-default = ["mongodb", "sql"]
+default = ["mongodb", "sql", "metrics", "native-connectors"]
 mongodb = ["mongodb-query-connector"]
 sql = ["sql-query-connector"]
+native-connectors = ["sql-query-connector/native-connectors"]
 js-connectors = ["sql-query-connector"]
+metrics = ["query-core/metrics"]
 
 [[bench]]
 name = "query_planning_bench"

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -20,11 +20,11 @@ thiserror = "1"
 tracing = "0.1"
 url = "2"
 connection-string.workspace = true 
-quaint.workspace = true
+quaint = { path = "../../quaint", features = ["slim"] }
 once_cell = "1.15"
 
 mongodb-query-connector = { path = "../connectors/mongodb-query-connector", optional = true }
-sql-query-connector = { path = "../connectors/sql-query-connector", optional = true, default-features = false }
+sql-query-connector = { path = "../connectors/sql-query-connector", default-features = false }
 
 [dev-dependencies]
 insta = "1.7.1"
@@ -34,9 +34,9 @@ codspeed-criterion-compat = "1.1.0"
 [features]
 default = ["mongodb", "sql", "metrics", "native-connectors"]
 mongodb = ["mongodb-query-connector"]
-sql = ["sql-query-connector"]
+sql = []
 native-connectors = ["sql-query-connector/native-connectors"]
-js-connectors = ["sql-query-connector"]
+js-connectors = ["sql-query-connector/js-connectors"]
 metrics = ["query-core/metrics"]
 
 [[bench]]

--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -15,10 +15,15 @@ pub async fn load(
     url: &str,
 ) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync + 'static>> {
     match source.active_provider {
+        #[cfg(feature = "native-connectors")]
         p if SQLITE.is_provider(p) => sqlite(source, url, features).await,
+        #[cfg(feature = "native-connectors")]
         p if MYSQL.is_provider(p) => mysql(source, url, features).await,
+        #[cfg(feature = "native-connectors")]
         p if POSTGRES.is_provider(p) => postgres(source, url, features).await,
+        #[cfg(feature = "native-connectors")]
         p if MSSQL.is_provider(p) => mssql(source, url, features).await,
+        #[cfg(feature = "native-connectors")]
         p if COCKROACH.is_provider(p) => postgres(source, url, features).await,
 
         #[cfg(feature = "mongodb")]
@@ -33,6 +38,7 @@ pub async fn load(
     }
 }
 
+#[cfg(feature = "native-connectors")]
 async fn sqlite(
     source: &Datasource,
     url: &str,
@@ -44,6 +50,7 @@ async fn sqlite(
     Ok(executor_for(sqlite, false))
 }
 
+#[cfg(feature = "native-connectors")]
 async fn postgres(
     source: &Datasource,
     url: &str,
@@ -65,6 +72,7 @@ async fn postgres(
     Ok(executor_for(psql, force_transactions))
 }
 
+#[cfg(feature = "native-connectors")]
 async fn mysql(
     source: &Datasource,
     url: &str,
@@ -75,6 +83,7 @@ async fn mysql(
     Ok(executor_for(mysql, false))
 }
 
+#[cfg(feature = "native-connectors")]
 async fn mssql(
     source: &Datasource,
     url: &str,
@@ -93,6 +102,7 @@ where
     Box::new(InterpretingExecutor::new(connector, force_transactions))
 }
 
+#[cfg(feature = "native-connectors")]
 #[cfg(feature = "mongodb")]
 async fn mongodb(
     source: &Datasource,


### PR DESCRIPTION
Proceeding with the work started in https://github.com/prisma/prisma-engines/pull/4119, this PR enables compiling every local dependency up to `request-handlers` to WebAssembly (`wasm32-uknown-unknown`).

```
cd query-engine/request-handlers
cargo build --target wasm32-unknown-unknown --no-default-features
```

* In the `prisma-models` crate,  we removed `cuid` from the `wasm_generator` feature flag, so that it won't be compiled (as it depends on `hostname`, which is not available in WebAssembly).
* For crates that indirectly depends on `getrandom`, we added the `js` feature flag to make it Wasm-compatible.
* For query core, query connector, and request handler crates, we added the `native-connectors` feature flag for enabling native (e.g., `darwin-arm64`) compilation.
* To avoid runtime errors in Wasm with `std::time::Instant` (which is not supported in every Wasm interpreter, e.g., in browsers), we provide a shim (`instant`).

---

This PR closes https://github.com/prisma/team-orm/issues/280, https://github.com/prisma/team-orm/issues/281, https://github.com/prisma/team-orm/issues/282, https://github.com/prisma/team-orm/issues/283.

The original PR is at: https://github.com/prisma/prisma-engines/pull/4117.
