### PR TITLE
sql-schema-connector: remove BINARY from queries

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -104,16 +104,16 @@ impl SqlFlavour for MysqlFlavour {
     fn table_names(&mut self, _namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<Vec<String>>> {
         Box::pin(async move {
             let select = r#"
-                SELECT DISTINCT BINARY table_info.table_name AS table_name
+                SELECT DISTINCT table_info.table_name AS table_name
                 FROM information_schema.tables AS table_info
                 JOIN information_schema.columns AS column_info
-                    ON BINARY column_info.table_name = BINARY table_info.table_name
+                    ON column_info.table_name = table_info.table_name
                 WHERE
                     table_info.table_schema = ?
                     AND column_info.table_schema = ?
                     -- Exclude views.
                     AND table_info.table_type = 'BASE TABLE'
-                ORDER BY BINARY table_info.table_name
+                ORDER BY table_info.table_name
             "#;
 
             let database_name = self.database_name();

--- a/schema-engine/sql-schema-describer/src/mysql.rs
+++ b/schema-engine/sql-schema-describer/src/mysql.rs
@@ -288,18 +288,18 @@ impl<'a> SqlSchemaDescriber<'a> {
         // Only consider tables for which we can read at least one column.
         let sql = r#"
             SELECT DISTINCT
-              BINARY table_info.table_name AS table_name,
+              table_info.table_name AS table_name,
               table_info.create_options AS create_options,
               table_info.table_comment AS table_comment
             FROM information_schema.tables AS table_info
             JOIN information_schema.columns AS column_info
-                ON BINARY column_info.table_name = BINARY table_info.table_name
+                ON column_info.table_name = table_info.table_name
             WHERE
                 table_info.table_schema = ?
                 AND column_info.table_schema = ?
                 -- Exclude views.
                 AND table_info.table_type = 'BASE TABLE'
-            ORDER BY BINARY table_info.table_name"#;
+            ORDER BY table_info.table_name"#;
         let rows = self.conn.query_raw(sql, &[schema.into(), schema.into()]).await?;
         let names = rows.into_iter().map(|row| {
             (

--- a/schema-engine/sql-schema-describer/src/mysql/indexes_query.sql
+++ b/schema-engine/sql-schema-describer/src/mysql/indexes_query.sql
@@ -9,4 +9,4 @@ SELECT
     index_type AS index_type
 FROM information_schema.statistics
 WHERE table_schema = ?
-ORDER BY BINARY table_name, BINARY index_name, seq_in_index
+ORDER BY table_name, index_name, seq_in_index


### PR DESCRIPTION
From https://github.com/prisma/prisma-engines/pull/4130

[Internal Slack](https://prisma-company.slack.com/archives/C013Q9YP5HC/p1691742268144599)

Context: https://github.com/vitessio/vitess/issues/13764#issuecomment-1673895821

Docs: https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html
>The [BINARY](https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#operator_binary) operator converts the expression to a binary string (a string that has the binary character set and binary collation). A common use for [BINARY](https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#operator_binary) is to force a character string comparison to be done byte by byte using numeric byte values rather than character by character. The [BINARY](https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#operator_binary) operator also causes trailing spaces in comparisons to be significant.

Deprecation note: 
>The BINARY operator is deprecated as of MySQL 8.0.27, and you should expect its removal in a future version of MySQL. Use [CAST(... AS BINARY)](https://dev.mysql.com/doc/refman/8.0/en/cast-functions.html#function_cast) instead.

So one question to resolve before we can merge this is to know if the behavior mentioned in the docs is required here for us.
