### PR TITLE
introspection: use `obj_description` for view comments in postgres

### DIFF
--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -819,11 +819,10 @@ impl<'a> SqlSchemaDescriber<'a> {
                 views.viewname AS view_name,
                 views.definition AS view_sql,
                 views.schemaname AS namespace,
-                description.description AS description
+                obj_description(class.oid, 'pg_class') AS description
             FROM pg_catalog.pg_views views
             INNER JOIN pg_catalog.pg_namespace ns ON views.schemaname = ns.nspname
             INNER JOIN pg_catalog.pg_class class ON class.relnamespace = ns.oid AND class.relname = views.viewname
-            LEFT JOIN pg_catalog.pg_description description ON description.objoid = class.oid AND description.objsubid = 0
             WHERE schemaname = ANY ( $1 )
         "#};
 


### PR DESCRIPTION
Some additional conditions must have been missing in the `LEFT JOIN` in this query (probably something to check that the object belongs to `pg_class` catalog). In https://github.com/prisma/prisma-engines/pull/4132 this led to tests breaking because CockroachDB 23 added lots of descriptions for built-in functions, so this query started picking up descriptions of random functions with the same OID instead of the views.

This PR changes the query to use the built-in `obj_description` function instead of manually searching in `pg_catalog.pg_description` as suggested in https://github.com/prisma/prisma/issues/19935.