### PR TITLE
qe: fix dmmf generation for composite types with unsupported fields

### DIFF
--- a/query-engine/dmmf/src/tests/tests.rs
+++ b/query-engine/dmmf/src/tests/tests.rs
@@ -61,6 +61,32 @@ fn enum_docs() {
     }
 }
 
+// Regression test for https://github.com/prisma/prisma/issues/19694
+#[test]
+fn unsupported_in_composite_type() {
+    let schema = r#"
+        generator client {
+            provider = "prisma-client-js"
+        }
+
+        datasource db {
+            provider = "mongodb"
+            url      = env("DATABASE_URL")
+        }
+
+        type NestedType {
+            this_causes_error Unsupported("RegularExpression")
+        }
+
+        model sample_model {
+            id         String     @id @default(auto()) @map("_id") @db.ObjectId
+            some_field NestedType
+        }
+    "#;
+
+    dmmf_from_schema(schema);
+}
+
 const SNAPSHOTS_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/src",

--- a/query-engine/prisma-models/src/composite_type.rs
+++ b/query-engine/prisma-models/src/composite_type.rs
@@ -1,5 +1,4 @@
-use crate::Field;
-use psl::schema_ast::ast;
+use crate::{ast, Field};
 
 pub type CompositeType = crate::Zipper<ast::CompositeTypeId>;
 
@@ -9,7 +8,10 @@ impl CompositeType {
     }
 
     pub fn fields(&self) -> impl Iterator<Item = Field> + '_ {
-        self.walker().fields().map(|f| Field::from((self.dm.clone(), f)))
+        self.walker()
+            .fields()
+            .filter(|f| !matches!(f.ast_field().field_type, ast::FieldType::Unsupported(..)))
+            .map(|f| Field::from((self.dm.clone(), f)))
     }
 
     pub fn find_field(&self, prisma_name: &str) -> Option<Field> {


### PR DESCRIPTION
In query schema generation (not in PSL), fields of `Unsupported(...)`
types are always filtered out for models. The reason for that, and the
explanation from a user's perspective, is that these fields do not show
up in the Prisma Client API. In this commit, we fix the regression that
made the filtering not apply to fields of composite types.

closes https://github.com/prisma/prisma/issues/19694