### PR TITLE
se: test idempotence in `simple` harness, fix expression index commen…

### DIFF
--- a/schema-engine/datamodel-renderer/src/datamodel/field.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/field.rs
@@ -113,7 +113,7 @@ impl<'a> Field<'a> {
     /// ```
     pub fn documentation(&mut self, documentation: impl Into<Cow<'a, str>>) {
         match self.documentation.as_mut() {
-            Some(docs) => docs.push(documentation),
+            Some(docs) => docs.push(documentation.into()),
             None => self.documentation = Some(Documentation(documentation.into())),
         }
     }

--- a/schema-engine/datamodel-renderer/src/datamodel/model.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/model.rs
@@ -59,8 +59,9 @@ impl<'a> Model<'a> {
         }
     }
 
-    /// Documentation of the model. If called repeteadly,
-    /// adds the new docs to the end with a newline.
+    /// Documentation of the model. If called repeatedly, adds the new docs to the end with a
+    /// newline. This method is also responsible for avoiding to add the same comment twice (mainly
+    /// in reintrospection).
     ///
     /// ```ignore
     /// /// This is the documentation.
@@ -68,10 +69,21 @@ impl<'a> Model<'a> {
     ///   ....
     /// }
     /// ```
-    pub fn documentation(&mut self, documentation: impl Into<Cow<'a, str>>) {
+    pub fn documentation(&mut self, new_documentation: impl Into<Cow<'a, str>>) {
+        let new_documentation: Cow<'_, str> = new_documentation.into();
+
+        if self
+            .documentation
+            .as_ref()
+            .map(|d| d.0.contains(new_documentation.as_ref()))
+            .unwrap_or_default()
+        {
+            return;
+        }
+
         match self.documentation.as_mut() {
-            Some(docs) => docs.push(documentation),
-            None => self.documentation = Some(Documentation(documentation.into())),
+            Some(documentation) => documentation.push(new_documentation),
+            None => self.documentation = Some(Documentation(new_documentation)),
         }
     }
 

--- a/schema-engine/datamodel-renderer/src/datamodel/view.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/view.rs
@@ -42,8 +42,8 @@ impl<'a> View<'a> {
         }
     }
 
-    /// Documentation of the view. If called repeteadly,
-    /// adds the new docs to the end with a newline.
+    /// Documentation of the view. If called repeatedly, adds the new docs to the end with a
+    /// newline.
     ///
     /// ```ignore
     /// /// This is the documentation.
@@ -53,7 +53,7 @@ impl<'a> View<'a> {
     /// ```
     pub fn documentation(&mut self, documentation: impl Into<Cow<'a, str>>) {
         match self.documentation.as_mut() {
-            Some(docs) => docs.push(documentation),
+            Some(docs) => docs.push(documentation.into()),
             None => self.documentation = Some(Documentation(documentation.into())),
         }
     }

--- a/schema-engine/datamodel-renderer/src/value/documentation.rs
+++ b/schema-engine/datamodel-renderer/src/value/documentation.rs
@@ -5,8 +5,16 @@ use std::{borrow::Cow, fmt};
 pub struct Documentation<'a>(pub(crate) Cow<'a, str>);
 
 impl<'a> Documentation<'a> {
-    pub(crate) fn push(&mut self, docs: impl Into<Cow<'a, str>>) {
-        self.0 = Cow::Owned(format!("{}\n{}", self.0, docs.into()));
+    pub(crate) fn push(&mut self, docs: Cow<'a, str>) {
+        match &mut self.0 {
+            Cow::Owned(d) => {
+                d.push('\n');
+                d.push_str(docs.as_ref());
+            }
+            Cow::Borrowed(existing) => {
+                self.0 = Cow::Owned(format!("{existing}\n{}", docs));
+            }
+        }
     }
 }
 


### PR DESCRIPTION
…t duplication

This commit contains a test setup improvement and a bug fix, because they can't be easily separated (improving the test harness would make the test fail, and fixing the bug without the test harness improvement would be a fix without a test). The bug is
https://github.com/prisma/prisma/issues/20386.

In the declarative test harness for introspection (`simple`), we were not testing that reintrospecting with the introspected schema produces the same result, i.e. that introspection is idempotent. This commit introduces that check.

The solution implemented here to make adding the warning documentation idempotent is to check if the comment we are going to add is included in the existing ones, which isn't perfect but should be relatively robust.

There is also a small change in `Documentation::push()` to avoid unnecessary copies and allocations.

closes https://github.com/prisma/prisma/issues/20386