### PR TITLE
se: test reproduction for CREATE DEFAULT introspection on mssql

### DIFF
--- a/schema-engine/sql-introspection-tests/tests/simple/mssql/default_with_create_default.sql
+++ b/schema-engine/sql-introspection-tests/tests/simple/mssql/default_with_create_default.sql
@@ -1,0 +1,25 @@
+-- tags=mssql2017
+
+CREATE TABLE a (
+     id INT IDENTITY,
+     savings INT,
+     CONSTRAINT [A_pkey] PRIMARY KEY (id)
+);
+
+EXEC('CREATE DEFAULT NEARLY_NOTHING AS 0');
+EXEC('sp_bindefault ''NEARLY_NOTHING'', ''a.savings''');
+/*
+generator js {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlserver"
+  url      = env("DATABASE_URL")
+}
+
+model a {
+  id      Int  @id(map: "A_pkey") @default(autoincrement())
+  savings Int?
+}
+*/


### PR DESCRIPTION
We have multiple issues related to crashes with CREATE DEFAULT, but this one prompted this reproduction: https://github.com/prisma/prisma/issues/14208

We _cannot_ reproduce the crash, and the default is not introspected. So the bug is not confirmed.