### PR TITLE
fix(fmt): use camel case for new fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3405,6 +3405,7 @@ version = "0.1.0"
 dependencies = [
  "bigdecimal",
  "chrono",
+ "convert_case 0.6.0",
  "diagnostics",
  "enumflags2",
  "indoc",

--- a/psl/psl-core/Cargo.toml
+++ b/psl/psl-core/Cargo.toml
@@ -8,6 +8,7 @@ diagnostics = { path = "../diagnostics" }
 parser-database = { path = "../parser-database" }
 prisma-value = { path = "../../libs/prisma-value" }
 schema-ast = { path = "../schema-ast" }
+convert_case = "0.6.0"
 
 bigdecimal = "0.3"
 chrono = { version = "0.4.6", default_features = false }

--- a/psl/psl-core/src/reformat.rs
+++ b/psl/psl-core/src/reformat.rs
@@ -1,4 +1,5 @@
 use crate::ParserDatabase;
+use convert_case::{Case, Casing};
 use parser_database::{ast::WithSpan, walkers};
 use schema_ast::{ast, SourceFile};
 use std::{borrow::Cow, sync::Arc};
@@ -174,7 +175,7 @@ fn push_missing_relation_fields(inline: walkers::InlineRelationWalker<'_>, ctx: 
     }
 
     if inline.forward_relation_field().is_none() {
-        let field_name = inline.referenced_model().name();
+        let field_name = &inline.referenced_model().name().to_case(Case::Camel);
         let field_type = field_name;
         let arity = render_arity(forward_relation_field_arity(inline));
         let fields_arg = fields_argument(inline);
@@ -201,7 +202,7 @@ fn push_missing_scalar_fields(inline: walkers::InlineRelationWalker<'_>, ctx: &m
     });
 
     for field in missing_scalar_fields {
-        let field_name = &field.name;
+        let field_name = field.name.to_case(Case::Camel);
         let field_type = if let Some(ft) = field.tpe.as_builtin_scalar() {
             ft.as_str()
         } else {


### PR DESCRIPTION
Make the formatter add missing fields in camelCase instead of using the model's name.

Sorry for the poor pull request but I cannot build this nor run the tests. Hopefully it's as simple as this or someone better than me can take it over.

https://github.com/prisma/language-tools/issues/793
https://github.com/prisma/language-tools/issues/713