### PR TITLE
reproduce prisma/prisma/20557

### DIFF
--- a/.test_database_urls/cockroachdb_23_1
+++ b/.test_database_urls/cockroachdb_23_1
@@ -1,0 +1,2 @@
+export TEST_DATABASE_URL="postgresql://prisma@localhost:26260"
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
 version: "3"
 services:
+  cockroach_23_1:
+    image: prismagraphql/cockroachdb-custom:23.1
+    command: |
+      start-single-node --insecure
+    ports:
+      - "26260:26257"
+    networks:
+      - databases
+
   cockroach_22_2:
     image: prismagraphql/cockroachdb-custom:22.2
     restart: always

--- a/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
@@ -1233,6 +1233,49 @@ fn bigint_defaults_work(api: TestApi) {
     api.schema_push(schema).send().assert_green().assert_no_steps();
 }
 
+// regression test for https://github.com/prisma/prisma/issues/20557
+#[test_connector(tags(CockroachDb))]
+fn alter_type_works(api: TestApi) {
+    let schema = r#"
+        datasource db {
+            provider = "cockroachdb"
+            url = env("TEST_DATABASE_URL")
+        }
+
+        model test {
+            id Int @id
+            one BigInt
+            two BigInt
+        }
+
+    "#;
+    api.schema_push(schema).send().assert_green();
+    api.schema_push(schema).send().assert_green().assert_no_steps();
+
+    let to_schema = r#"
+        datasource db {
+            provider = "cockroachdb"
+            url = env("TEST_DATABASE_URL")
+        }
+
+        model test {
+            id Int @id
+            one Int
+            two Int
+        }
+
+    "#;
+
+    let migration = api.connector_diff(
+        DiffTarget::Datamodel(schema.into()),
+        DiffTarget::Datamodel(to_schema.into()),
+        None,
+    );
+
+    // panic!("{migration}");
+    api.raw_cmd(&migration);
+}
+
 #[test_connector(tags(CockroachDb))]
 fn schema_from_introspection_docs_works(api: TestApi) {
     let sql = r#"


### PR DESCRIPTION
The issue shows up (the test fails) on cockroachdb 23.1 but not 22.2.

Also sets up cockroachdb 23.1 but does not add it to CI (that will be done in https://github.com/prisma/prisma-engines/pull/4132).

see https://github.com/prisma/prisma/issues/20557