### PR TITLE
fix(js-connectors): remove ssl config in `pg`

### DIFF
--- a/query-engine/js-connectors/js/pg-js-connector/src/pg.ts
+++ b/query-engine/js-connectors/js/pg-js-connector/src/pg.ts
@@ -93,12 +93,11 @@ class PgTransaction extends PgQueryable<TransactionClient>
 class PrismaPg extends PgQueryable<StdClient> implements Connector {
   constructor(config: PrismaPgConfig) {
     const { url: connectionString } = config
+    
     const client = new pg.Pool({
       connectionString,
-      ssl: {
-        rejectUnauthorized: false,
-      },
     })
+
     super(client)
   }
 

--- a/query-engine/js-connectors/js/smoke-test-js/.envrc.example
+++ b/query-engine/js-connectors/js/smoke-test-js/.envrc.example
@@ -1,3 +1,5 @@
 export JS_PLANETSCALE_DATABASE_URL="mysql://USER:PASSWORD@aws.connect.psdb.cloud/DATABASE?sslaccept=strict"
 export JS_NEON_DATABASE_URL="postgres://USER:PASSWORD@DATABASE-pooler.eu-central-1.aws.neon.tech/neondb?pgbouncer=true&connect_timeout=10"
+
+# Note: if you use hosted Postgres instances (e.g., from PDP provision), you need `?sslmode=disable`
 export JS_PG_DATABASE_URL="postgres://postgres:prisma@localhost:5438"


### PR DESCRIPTION
This PR contributes to https://github.com/prisma/team-orm/issues/314.

Consider the following config parameter for `pg`, which was removed in this PR:
```typescript
ssl: {
  rejectUnauthorized: false,
},
```

This allowed using publicly available Postgres URLs (e.g., `postgres://***:***@***.us-east-1.rds.amazonaws.com:5432/db`) out of the box. However, it also made it awkward to run local database instances (e.g., `"postgres://prisma:prisma@localhost:5432/db"`), as any connection attempt would fail unless the `?sslmode=disable` parameter is added to the connection string.

Since most of our tests are using local Postgres instances, this PR reverses the logic above: now you only need to add `?sslmode=disable` to publicly available Postgres URLs.

Note: we don't plan on achieving feature parity with `tokio_postgres` (nor getting the same URL parsing semantics), as confirmed on [Slack](https://prisma-company.slack.com/archives/C04TW4A2H8C/p1692703575438169?thread_ts=1692608168.979919&cid=C04TW4A2H8C).