### PR TITLE
feat: add debug statements to `performIO` in case of errors

### DIFF
--- a/query-engine/js-connectors/js/neon-js-connector/src/neon.ts
+++ b/query-engine/js-connectors/js/neon-js-connector/src/neon.ts
@@ -57,9 +57,16 @@ class NeonWsQueryable<ClientT extends Pool|PoolClient> extends NeonQueryable {
     super()
   }
 
-  override performIO(query: Query): Promise<PerformIOResult> {
+  override async performIO(query: Query): Promise<PerformIOResult> {
     const { sql, args: values } = query
-    return this.client.query(sql, values)
+
+    try {
+      return await this.client.query(sql, values)
+    } catch (e) {
+      const error = e as Error
+      debug('Error in performIO: %O', error)
+      throw error
+    }
   }
 }
 

--- a/query-engine/js-connectors/js/pg-js-connector/src/pg.ts
+++ b/query-engine/js-connectors/js/pg-js-connector/src/pg.ts
@@ -57,7 +57,14 @@ class PgQueryable<ClientT extends StdClient | TransactionClient>
   private async performIO(query: Query) {
     const { sql, args: values } = query
 
-    return await this.client.query(sql, values)
+    try {
+      const result = await this.client.query(sql, values)
+      return result
+    } catch (e) {
+      const error = e as Error
+      debug('Error in performIO: %O', error)
+      throw error
+    }
   }
 }
 

--- a/query-engine/js-connectors/js/planetscale-js-connector/src/planetscale.ts
+++ b/query-engine/js-connectors/js/planetscale-js-connector/src/planetscale.ts
@@ -67,7 +67,14 @@ class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.
   private async performIO(query: Query) {
     const { sql, args: values } = query
 
-    return await this.client.execute(sql, values)
+    try {
+      const result = await this.client.execute(sql, values)
+      return result
+    } catch (e) {
+      const error = e as Error
+      debug('Error in performIO: %O', error)
+      throw error
+    }
   }
 }
 

--- a/query-engine/js-connectors/js/pnpm-lock.yaml
+++ b/query-engine/js-connectors/js/pnpm-lock.yaml
@@ -77,12 +77,12 @@ importers:
         specifier: workspace:*
         version: link:../planetscale-js-connector
       '@prisma/client':
-        specifier: 5.2.0-dev.30
-        version: 5.2.0-dev.30(prisma@5.2.0-dev.30)
+        specifier: 5.2.0
+        version: 5.2.0(prisma@5.2.0)
     devDependencies:
       prisma:
-        specifier: 5.2.0-dev.30
-        version: 5.2.0-dev.30
+        specifier: 5.2.0
+        version: 5.2.0
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -568,8 +568,8 @@ packages:
     engines: {node: '>=16'}
     dev: false
 
-  /@prisma/client@5.2.0-dev.30(prisma@5.2.0-dev.30):
-    resolution: {integrity: sha512-tkeZIzm6JwjO7DYbCB4MuCVqud69DoT8Wr1GZM3Mvzla7zuBVGVKthO86c8O/yTmnRSyWK0/ImTr5Cjzl2wIqg==}
+  /@prisma/client@5.2.0(prisma@5.2.0):
+    resolution: {integrity: sha512-AiTjJwR4J5Rh6Z/9ZKrBBLel3/5DzUNntMohOy7yObVnVoTNVFi2kvpLZlFuKO50d7yDspOtW6XBpiAd0BVXbQ==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -578,16 +578,16 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.2.0-9.72e483371c97d235868eb0cffe89118c47c96bb4
-      prisma: 5.2.0-dev.30
+      '@prisma/engines-version': 5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f
+      prisma: 5.2.0
     dev: false
 
-  /@prisma/engines-version@5.2.0-9.72e483371c97d235868eb0cffe89118c47c96bb4:
-    resolution: {integrity: sha512-DC6tJkSCMV1XxaRaJJEZVKZf3SxB4kzmtjTeeVlx1+XoSVkNR9sBWZ0YtesmSGE+He/Fh82SKo6cUsZaZ8KJ5g==}
+  /@prisma/engines-version@5.2.0-25.2804dc98259d2ea960602aca6b8e7fdc03c1758f:
+    resolution: {integrity: sha512-jsnKT5JIDIE01lAeCj2ghY9IwxkedhKNvxQeoyLs6dr4ZXynetD0vTy7u6wMJt8vVPv8I5DPy/I4CFaoXAgbtg==}
     dev: false
 
-  /@prisma/engines@5.2.0-dev.30:
-    resolution: {integrity: sha512-tOTF4oELwgywI+mUK1VvoiVC9gu8sg/TvcjjR7PyP94mgXG+Va+/rV5lTjHwmI0ZN2jTSFbgM/2VZC+SsmUoAQ==}
+  /@prisma/engines@5.2.0:
+    resolution: {integrity: sha512-dT7FOLUCdZmq+AunLqB1Iz+ZH/IIS1Fz2THmKZQ6aFONrQD/BQ5ecJ7g2wGS2OgyUFf4OaLam6/bxmgdOBDqig==}
     requiresBuild: true
 
   /@types/debug@4.1.8:
@@ -1209,13 +1209,13 @@ packages:
     resolution: {integrity: sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==}
     dev: true
 
-  /prisma@5.2.0-dev.30:
-    resolution: {integrity: sha512-waGqIxagLaOuOdQEKjnWtIUJVgWoc7Fz9rxEPmDt9DLxX8gZXR2/F+JRwyrfysxtggajGxHMEq4yqVsn/Z2Gug==}
+  /prisma@5.2.0:
+    resolution: {integrity: sha512-FfFlpjVCkZwrqxDnP4smlNYSH1so+CbfjgdpioFzGGqlQAEm6VHAYSzV7jJgC3ebtY9dNOhDMS2+4/1DDSM7bQ==}
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.2.0-dev.30
+      '@prisma/engines': 5.2.0
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}

--- a/query-engine/js-connectors/js/smoke-test-js/package.json
+++ b/query-engine/js-connectors/js/smoke-test-js/package.json
@@ -26,10 +26,10 @@
     "@jkomyno/prisma-pg-js-connector": "workspace:*",
     "@jkomyno/prisma-neon-js-connector": "workspace:*",
     "@jkomyno/prisma-planetscale-js-connector": "workspace:*",
-    "@prisma/client": "5.2.0-dev.30"
+    "@prisma/client": "5.2.0"
   },
   "devDependencies": {
-    "prisma": "5.2.0-dev.30",
+    "prisma": "5.2.0",
     "tsx": "^3.12.7"
   }
 }


### PR DESCRIPTION
When running JS connectors with `DEBUG="prisma:js-connector:*"`, we can now see what kind of errors happened in `performIO`.

This helps out with local development/testing due to https://github.com/prisma/team-orm/issues/260 still being open.