### PR TITLE
chore: make debug impl of zippers more helpful

### DIFF
--- a/query-engine/prisma-models/src/composite_type.rs
+++ b/query-engine/prisma-models/src/composite_type.rs
@@ -22,3 +22,9 @@ impl CompositeType {
         self.fields().find(|f| f.db_name() == db_name)
     }
 }
+
+impl std::fmt::Debug for CompositeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("CompositeType").field(&self.name().to_string()).finish()
+    }
+}

--- a/query-engine/prisma-models/src/composite_type.rs
+++ b/query-engine/prisma-models/src/composite_type.rs
@@ -25,6 +25,6 @@ impl CompositeType {
 
 impl std::fmt::Debug for CompositeType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("CompositeType").field(&self.name().to_string()).finish()
+        f.debug_tuple("CompositeType").field(&self.name()).finish()
     }
 }

--- a/query-engine/prisma-models/src/field/composite.rs
+++ b/query-engine/prisma-models/src/field/composite.rs
@@ -79,3 +79,11 @@ impl Display for CompositeField {
         write!(f, "{}.{}", self.container().name(), self.name())
     }
 }
+
+impl std::fmt::Debug for CompositeField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("CompositeField")
+            .field(&format!("{}.{}", self.container().name(), self.name()))
+            .finish()
+    }
+}

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -8,14 +8,6 @@ use std::fmt::Display;
 pub type RelationField = crate::Zipper<RelationFieldId>;
 pub type RelationFieldRef = RelationField;
 
-impl std::fmt::Debug for RelationField {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("RelationField")
-            .field(&format!("{}.{}", self.model().name(), self.name(),))
-            .finish()
-    }
-}
-
 impl RelationField {
     pub fn borrowed_name<'a>(&self, schema: &'a psl::ValidatedSchema) -> &'a str {
         schema.db.walk(self.id).name()
@@ -156,5 +148,13 @@ impl Display for RelationField {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let walker = self.walker();
         write!(f, "{}.{}", walker.model().name(), walker.name())
+    }
+}
+
+impl std::fmt::Debug for RelationField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RelationField")
+            .field(&format!("{}.{}", self.model().name(), self.name(),))
+            .finish()
     }
 }

--- a/query-engine/prisma-models/src/field/relation.rs
+++ b/query-engine/prisma-models/src/field/relation.rs
@@ -8,6 +8,14 @@ use std::fmt::Display;
 pub type RelationField = crate::Zipper<RelationFieldId>;
 pub type RelationFieldRef = RelationField;
 
+impl std::fmt::Debug for RelationField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RelationField")
+            .field(&format!("{}.{}", self.model().name(), self.name(),))
+            .finish()
+    }
+}
+
 impl RelationField {
     pub fn borrowed_name<'a>(&self, schema: &'a psl::ValidatedSchema) -> &'a str {
         schema.db.walk(self.id).name()

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -260,3 +260,11 @@ pub fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<Sca
         other => unreachable!("{:?}", other),
     }
 }
+
+impl std::fmt::Debug for ScalarField {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("ScalarField")
+            .field(&format!("{}.{}", self.container().name(), self.name()))
+            .finish()
+    }
+}

--- a/query-engine/prisma-models/src/internal_enum.rs
+++ b/query-engine/prisma-models/src/internal_enum.rs
@@ -10,3 +10,11 @@ impl InternalEnum {
         self.dm.walk(self.id).name()
     }
 }
+
+impl std::fmt::Debug for InternalEnum {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("InternalEnum")
+            .field(&self.name())
+            .finish()
+    }
+}

--- a/query-engine/prisma-models/src/internal_enum.rs
+++ b/query-engine/prisma-models/src/internal_enum.rs
@@ -13,8 +13,6 @@ impl InternalEnum {
 
 impl std::fmt::Debug for InternalEnum {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("InternalEnum")
-            .field(&self.name())
-            .finish()
+        f.debug_tuple("InternalEnum").field(&self.name()).finish()
     }
 }

--- a/query-engine/prisma-models/src/model.rs
+++ b/query-engine/prisma-models/src/model.rs
@@ -59,3 +59,9 @@ impl Model {
             .filter(|index| !index.fields().any(|f| f.is_unsupported()))
     }
 }
+
+impl std::fmt::Debug for Model {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Model").field(&self.name().to_string()).finish()
+    }
+}

--- a/query-engine/prisma-models/src/model.rs
+++ b/query-engine/prisma-models/src/model.rs
@@ -62,6 +62,6 @@ impl Model {
 
 impl std::fmt::Debug for Model {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Model").field(&self.name().to_string()).finish()
+        f.debug_tuple("Model").field(&self.name()).finish()
     }
 }

--- a/query-engine/prisma-models/src/relation.rs
+++ b/query-engine/prisma-models/src/relation.rs
@@ -69,3 +69,9 @@ impl Relation {
             .unwrap_or(ReferentialAction::Cascade)
     }
 }
+
+impl std::fmt::Debug for Relation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("Relation").field(&self.name()).finish()
+    }
+}

--- a/query-engine/prisma-models/src/zipper.rs
+++ b/query-engine/prisma-models/src/zipper.rs
@@ -1,8 +1,5 @@
-use crate::{psl::parser_database::walkers::Walker, InternalDataModelRef};
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-};
+use crate::{psl::parser_database::walkers::Walker, InternalDataModelRef, TypeIdentifier};
+use std::hash::{Hash, Hasher};
 
 // Invariant: InternalDataModel must not contain any Zipper, this would be a reference counting
 // cycle (memory leak).
@@ -10,12 +7,6 @@ use std::{
 pub struct Zipper<I> {
     pub id: I,
     pub dm: InternalDataModelRef,
-}
-
-impl<I: fmt::Debug> fmt::Debug for Zipper<I> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.id.fmt(f)
-    }
 }
 
 impl<I: PartialEq> PartialEq for Zipper<I> {
@@ -35,5 +26,13 @@ impl<I: Copy> Zipper<I> {
 impl<I: Hash> Hash for Zipper<I> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id.hash(state)
+    }
+}
+
+impl std::fmt::Debug for Zipper<TypeIdentifier> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("TypeIdentifier")
+            .field(&format!("{:?}", self.id))
+            .finish()
     }
 }


### PR DESCRIPTION
## Overview

- Make debug implementations for zipper more helpful by displaying the name of the field instead of its id.