### PR TITLE
refactor: OrderBy::ScalarAggregation can't be relational

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -146,12 +146,7 @@ impl OrderByBuilder {
         for (i, hop) in rest_hops.iter().enumerate() {
             let previous_join = if i > 0 { joins.get(i - 1) } else { None };
 
-            let join = compute_one2m_join(
-                hop.into_relation_hop().unwrap(),
-                &self.join_prefix(),
-                previous_join,
-                ctx,
-            );
+            let join = compute_one2m_join(hop.as_relation_hop().unwrap(), &self.join_prefix(), previous_join, ctx);
 
             joins.push(join);
         }
@@ -163,7 +158,7 @@ impl OrderByBuilder {
 
         // We perform the aggregation on the last join
         let last_aggr_join = compute_aggr_join(
-            last_hop.into_relation_hop().unwrap(),
+            last_hop.as_relation_hop().unwrap(),
             aggregation_type,
             None,
             ORDER_AGGREGATOR_ALIAS,
@@ -190,12 +185,7 @@ impl OrderByBuilder {
 
         for (i, hop) in order_by.path.iter().enumerate() {
             let previous_join = if i > 0 { joins.get(i - 1) } else { None };
-            let join = compute_one2m_join(
-                hop.into_relation_hop().unwrap(),
-                &self.join_prefix(),
-                previous_join,
-                ctx,
-            );
+            let join = compute_one2m_join(hop.as_relation_hop().unwrap(), &self.join_prefix(), previous_join, ctx);
 
             joins.push(join);
         }

--- a/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -139,7 +139,7 @@ fn process_order_object(
 
                     if let Some(sort_aggr) = parent_sort_aggregation {
                         // If the parent is a sort aggregation then this scalar is part of that one.
-                        Ok(Some(OrderBy::scalar_aggregation(sf, vec![], sort_order, sort_aggr)))
+                        Ok(Some(OrderBy::scalar_aggregation(sf, sort_order, sort_aggr)))
                     } else {
                         Ok(Some(OrderBy::scalar(sf, path, sort_order, nulls_order)))
                     }

--- a/query-engine/prisma-models/src/order_by.rs
+++ b/query-engine/prisma-models/src/order_by.rs
@@ -165,12 +165,6 @@ pub struct OrderByScalar {
     pub nulls_order: Option<NullsOrder>,
 }
 
-impl OrderByScalar {
-    pub fn relation_hops(&self) -> Vec<&RelationFieldRef> {
-        self.path.iter().filter_map(|hop| hop.as_relation_hop()).collect()
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OrderByScalarAggregation {
     pub field: ScalarFieldRef,
@@ -183,12 +177,6 @@ pub struct OrderByToManyAggregation {
     pub path: Vec<OrderByHop>,
     pub sort_order: SortOrder,
     pub sort_aggregation: SortAggregation,
-}
-
-impl OrderByToManyAggregation {
-    pub fn relation_hops(&self) -> Vec<&RelationFieldRef> {
-        self.path.iter().filter_map(|hop| hop.as_relation_hop()).collect()
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]


### PR DESCRIPTION
## Overview

Small refactor which:

- removes the `path` property from `OrderBy::ScalarAggregation` as it is not used.
- renames `into_relation_hop` to `as_relation_hop`

