### PR TITLE
docs(smoke-tests-js): Add build step and remove misleading note

### DIFF
--- a/query-engine/js-connectors/js/smoke-test-js/README.md
+++ b/query-engine/js-connectors/js/smoke-test-js/README.md
@@ -10,12 +10,13 @@ It contains a subset of `@prisma/client`, plus some handy executable smoke tests
 We assume Node.js `v18.16.1`+ is installed. If not, run `nvm use` in the current directory.
 This is very important to double-check if you have multiple versions installed, as PlanetScale requires either Node.js `v18.16.1`+ or a custom `fetch` function.
 
-- Create a `.envrc` starting from `.envrc.example`, and fill in the missing values following the given template
+- Create a `.envrc` (in this folder) starting from `.envrc.example`, and fill in the missing values following the given template
 - Install Node.js dependencies via
   ```bash
   pnpm i
   ```
 - Run `cargo build -p query-engine-node-api` to compile the `libquery` Query Engine
+- Build the JS Connectors: `cd .. && pnpm run -r build`
 
 ### PlanetScale
 
@@ -25,8 +26,6 @@ This is very important to double-check if you have multiple versions installed, 
 In the current directory:
 - Run `pnpm prisma:planetscale` to push the Prisma schema and insert the test data.
 - Run `pnpm planetscale` to run smoke tests against the PlanetScale database.
-
-Note: you used to be able to run these Prisma commands without changing the provider name, but [#4074](https://github.com/prisma/prisma-engines/pull/4074) changed that (see https://github.com/prisma/prisma-engines/pull/4074#issuecomment-1649942475).
 
 ### Neon
 

--- a/query-engine/js-connectors/js/smoke-test-js/README.md
+++ b/query-engine/js-connectors/js/smoke-test-js/README.md
@@ -16,7 +16,7 @@ This is very important to double-check if you have multiple versions installed, 
   pnpm i
   ```
 - Run `cargo build -p query-engine-node-api` to compile the `libquery` Query Engine
-- Build the JS Connectors: `cd .. && pnpm run -r build`
+- Build the JS Connectors: `pnpm run -r build`
 
 ### PlanetScale
 


### PR DESCRIPTION
- Just following the instructions, you do not actually have built the JS Connectors so you will run into:
	```
	$ pnpm planetscale
	
	> @jkomyno/smoke-test-js@0.0.0 planetscale /workspace/prisma-engines/query-engine/js-connectors/js/smoke-test-js
	> tsx ./src/planetscale.ts
	
	node:internal/modules/cjs/loader:438
	      const err = new Error(
	                  ^
	
	Error: Cannot find module '/workspace/prisma-engines/query-engine/js-connectors/js/smoke-test-js/node_modules/@jkomyno/prisma-planetscale-js-connector/dist/index.js'. Please verify that the package.json has a valid "main" entry
	```
    Going one level up and running the build command fixes that.
- The note about the provider was misleading - everything is taken care of by the scripts as far as I can see. Nothing to do manually.