### PR TITLE
Revert "ci: remove the quaint clippy jobs"

### DIFF
--- a/.github/workflows/quaint.yml
+++ b/.github/workflows/quaint.yml
@@ -8,6 +8,22 @@ on:
       - 'quaint/**'
   
 jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install dependencies
+        run: sudo apt install -y openssl libkrb5-dev
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --features=all --manifest-path quaint/Cargo.toml
   tests:
     runs-on: ubuntu-latest
 
@@ -36,7 +52,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
 
       - uses: actions/cache@v3
         with:
@@ -56,4 +76,5 @@ jobs:
           time: 20s
 
       - name: Run tests
-        run: cargo test -p quaint ${{ matrix.features }}
+        run: cargo test ${{ matrix.features }}
+        working-directory: ./quaint


### PR DESCRIPTION
Reverts prisma/prisma-engines#4185 — that PR was not meant to be merged without manual testing.