### PR TITLE
ci: remove the quaint clippy jobs

### DIFF
--- a/.github/workflows/quaint.yml
+++ b/.github/workflows/quaint.yml
@@ -8,22 +8,6 @@ on:
       - 'quaint/**'
   
 jobs:
-  clippy:
-    runs-on: ubuntu-latest
-    env:
-      RUSTFLAGS: "-Dwarnings"
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Install dependencies
-        run: sudo apt install -y openssl libkrb5-dev
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --features=all --manifest-path quaint/Cargo.toml
   tests:
     runs-on: ubuntu-latest
 
@@ -52,11 +36,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
 
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/quaint.yml
+++ b/.github/workflows/quaint.yml
@@ -32,7 +32,6 @@ jobs:
       TEST_PSQL: "postgres://postgres:prisma@localhost:5432/postgres"
       TEST_MSSQL: "jdbc:sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true"
       TEST_CRDB: "postgresql://prisma@127.0.0.1:26259/postgres"
-      RUSTFLAGS: "-Dwarnings"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Re-work of https://github.com/prisma/prisma-engines/pull/4185 — see the discussion and revert PR for more details there.