### PR TITLE
fix(metrics): Clean up metrics descriptions + rename 1 const

### DIFF
--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -6,7 +6,7 @@ use crate::{
 use connector::{Connection, ConnectionLike, Connector};
 use futures::future;
 use query_engine_metrics::{
-    histogram, increment_counter, metrics, PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, PRISMA_CLIENT_QUERIES_TOTAL,
+    histogram, increment_counter, metrics, PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS, PRISMA_CLIENT_QUERIES_TOTAL,
 };
 use schema::{QuerySchema, QuerySchemaRef};
 use std::time::{Duration, Instant};
@@ -24,7 +24,7 @@ pub async fn execute_single_operation(
     let (graph, serializer) = build_graph(&query_schema, operation.clone())?;
     let result = execute_on(conn, graph, serializer, query_schema.as_ref(), trace_id).await;
 
-    histogram!(PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, operation_timer.elapsed());
+    histogram!(PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS, operation_timer.elapsed());
 
     result
 }
@@ -45,7 +45,7 @@ pub async fn execute_many_operations(
     for (i, (graph, serializer)) in queries.into_iter().enumerate() {
         let operation_timer = Instant::now();
         let result = execute_on(conn, graph, serializer, query_schema.as_ref(), trace_id.clone()).await;
-        histogram!(PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, operation_timer.elapsed());
+        histogram!(PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS, operation_timer.elapsed());
 
         match result {
             Ok(result) => results.push(Ok(result)),
@@ -158,7 +158,7 @@ async fn execute_self_contained(
         execute_self_contained_without_retry(conn, graph, serializer, force_transactions, &query_schema, trace_id).await
     };
 
-    histogram!(PRISMA_CLIENT_QUERIES_HISTOGRAM_MS, operation_timer.elapsed());
+    histogram!(PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS, operation_timer.elapsed());
 
     result
 }

--- a/query-engine/metrics/src/lib.rs
+++ b/query-engine/metrics/src/lib.rs
@@ -53,18 +53,21 @@ pub const MOBC_POOL_WAIT_COUNT: &str = "mobc_client_queries_wait";
 pub const MOBC_POOL_WAIT_DURATION: &str = "mobc_client_queries_wait_histogram_ms";
 
 // External metrics names that we expose.
+// counters
 pub const PRISMA_CLIENT_QUERIES_TOTAL: &str = "prisma_client_queries_total";
-pub const PRISMA_CLIENT_QUERIES_HISTOGRAM_MS: &str = "prisma_client_queries_duration_histogram_ms";
+pub const PRISMA_DATASOURCE_QUERIES_TOTAL: &str = "prisma_datasource_queries_total";
 pub const PRISMA_POOL_CONNECTIONS_OPENED_TOTAL: &str = "prisma_pool_connections_opened_total";
 pub const PRISMA_POOL_CONNECTIONS_CLOSED_TOTAL: &str = "prisma_pool_connections_closed_total";
+// gauges
 pub const PRISMA_POOL_CONNECTIONS_OPEN: &str = "prisma_pool_connections_open";
 pub const PRISMA_POOL_CONNECTIONS_BUSY: &str = "prisma_pool_connections_busy";
 pub const PRISMA_POOL_CONNECTIONS_IDLE: &str = "prisma_pool_connections_idle";
 pub const PRISMA_CLIENT_QUERIES_WAIT: &str = "prisma_client_queries_wait";
+pub const PRISMA_CLIENT_QUERIES_ACTIVE: &str = "prisma_client_queries_active";
+// histograms
+pub const PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS: &str = "prisma_client_queries_duration_histogram_ms";
 pub const PRISMA_CLIENT_QUERIES_WAIT_HISTOGRAM_MS: &str = "prisma_client_queries_wait_histogram_ms";
 pub const PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS: &str = "prisma_datasource_queries_duration_histogram_ms";
-pub const PRISMA_DATASOURCE_QUERIES_TOTAL: &str = "prisma_datasource_queries_total";
-pub const PRISMA_CLIENT_QUERIES_ACTIVE: &str = "prisma_client_queries_active";
 
 // We need a list of acceptable metrics, we don't want to accidentally process metrics emitted by a
 // third party library
@@ -76,7 +79,7 @@ const ACCEPT_LIST: &[&str] = &[
     MOBC_POOL_CONNECTIONS_IDLE,
     MOBC_POOL_WAIT_COUNT,
     MOBC_POOL_WAIT_DURATION,
-    PRISMA_CLIENT_QUERIES_HISTOGRAM_MS,
+    PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
     PRISMA_CLIENT_QUERIES_TOTAL,
     PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS,
     PRISMA_DATASOURCE_QUERIES_TOTAL,
@@ -118,6 +121,16 @@ pub fn setup() {
 // a new metric registry for a Query Instance the descriptions
 // will be in place
 pub fn describe_metrics() {
+
+    // counters
+    describe_counter!(
+        PRISMA_CLIENT_QUERIES_TOTAL,
+        "Total number of Prisma Client queries executed"
+    );
+    describe_counter!(
+        PRISMA_DATASOURCE_QUERIES_TOTAL,
+        "Total number of Datasource Queries executed"
+    );
     describe_counter!(
         PRISMA_POOL_CONNECTIONS_OPENED_TOTAL,
         "Total number of Pool Connections opened"
@@ -126,16 +139,25 @@ pub fn describe_metrics() {
         PRISMA_POOL_CONNECTIONS_CLOSED_TOTAL,
         "Total number of Pool Connections closed"
     );
+
+    absolute_counter!(PRISMA_CLIENT_QUERIES_TOTAL, 0);
+    absolute_counter!(PRISMA_DATASOURCE_QUERIES_TOTAL, 0);
+    absolute_counter!(PRISMA_POOL_CONNECTIONS_OPENED_TOTAL, 0);
+    absolute_counter!(PRISMA_POOL_CONNECTIONS_CLOSED_TOTAL, 0);
+
+    // gauges
+    describe_gauge!(
+        PRISMA_POOL_CONNECTIONS_OPEN,
+        "Number of currently open Pool Connections (able to execute a datasource query)"
+    );
     describe_gauge!(
         PRISMA_POOL_CONNECTIONS_BUSY,
         "Number of currently busy Pool Connections (executing a datasource query)"
     );
-
     describe_gauge!(
         PRISMA_POOL_CONNECTIONS_IDLE,
         "Number of currently unused Pool Connections (waiting for the next datasource query to run)"
     );
-
     describe_gauge!(
         PRISMA_CLIENT_QUERIES_WAIT,
         "Number of Prisma Client queries currently waiting for a connection"
@@ -145,31 +167,13 @@ pub fn describe_metrics() {
         "Number of currently active Prisma Client queries"
     );
 
+    gause!(PRISMA_POOL_CONNECTIONS_OPEN, 0.0);
     gauge!(PRISMA_POOL_CONNECTIONS_BUSY, 0.0);
     gauge!(PRISMA_POOL_CONNECTIONS_IDLE, 0.0);
     gauge!(PRISMA_CLIENT_QUERIES_WAIT, 0.0);
     gauge!(PRISMA_CLIENT_QUERIES_ACTIVE, 0.0);
 
-    describe_gauge!(
-        PRISMA_CLIENT_QUERIES_ACTIVE,
-        "Number of currently active Prisma Client queries"
-    );
-
-    describe_gauge!(
-        PRISMA_POOL_CONNECTIONS_BUSY,
-        "Number of currently busy Pool Connections (executing a datasource query)"
-    );
-
-    describe_gauge!(
-        PRISMA_POOL_CONNECTIONS_IDLE,
-        "Number of currently unused Pool Connections (waiting for the next datasource query to run)"
-    );
-
-    describe_gauge!(
-        PRISMA_CLIENT_QUERIES_WAIT,
-        "Number of Prisma Client queries currently waiting for a connection"
-    );
-
+    // histograms
     describe_histogram!(
         PRISMA_CLIENT_QUERIES_WAIT_HISTOGRAM_MS,
         "Histogram of the wait time of all Prisma Client Queries in ms"
@@ -178,24 +182,11 @@ pub fn describe_metrics() {
         PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS,
         "Histogram of the duration of all executed Datasource Queries in ms"
     );
-
     describe_histogram!(
-        PRISMA_CLIENT_QUERIES_HISTOGRAM_MS,
+        PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
         "Histogram of the duration of all executed Prisma Client queries in ms"
     );
 
-    describe_counter!(
-        PRISMA_DATASOURCE_QUERIES_TOTAL,
-        "Total number of Datasource Queries executed"
-    );
-
-    describe_counter!(
-        PRISMA_CLIENT_QUERIES_TOTAL,
-        "Total number of Prisma Client queries executed"
-    );
-
-    absolute_counter!(PRISMA_DATASOURCE_QUERIES_TOTAL, 0);
-    absolute_counter!(PRISMA_CLIENT_QUERIES_TOTAL, 0);
 }
 
 static METRIC_RECORDER: Once = Once::new();

--- a/query-engine/metrics/src/lib.rs
+++ b/query-engine/metrics/src/lib.rs
@@ -121,7 +121,6 @@ pub fn setup() {
 // a new metric registry for a Query Instance the descriptions
 // will be in place
 pub fn describe_metrics() {
-
     // counters
     describe_counter!(
         PRISMA_CLIENT_QUERIES_TOTAL,
@@ -186,7 +185,6 @@ pub fn describe_metrics() {
         PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
         "Histogram of the duration of all executed Prisma Client queries in ms"
     );
-
 }
 
 static METRIC_RECORDER: Once = Once::new();

--- a/query-engine/metrics/src/lib.rs
+++ b/query-engine/metrics/src/lib.rs
@@ -167,7 +167,7 @@ pub fn describe_metrics() {
         "Number of currently active Prisma Client queries"
     );
 
-    gause!(PRISMA_POOL_CONNECTIONS_OPEN, 0.0);
+    gauge!(PRISMA_POOL_CONNECTIONS_OPEN, 0.0);
     gauge!(PRISMA_POOL_CONNECTIONS_BUSY, 0.0);
     gauge!(PRISMA_POOL_CONNECTIONS_IDLE, 0.0);
     gauge!(PRISMA_CLIENT_QUERIES_WAIT, 0.0);


### PR DESCRIPTION
When searching for information re https://prisma-company.slack.com/archives/C016KUHB1R6/p1693500424189099 I stumbled about some weird stuff in the definition of metrics descriptions:

- Some were duplicated
- They were grouped super weird
- Some were missing the initialization
- One constant used did not match the metric name