### PR TITLE
qe: Fix JS errors propagation for raw queries

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -19,6 +19,9 @@ pub(crate) enum RawError {
     UnsupportedColumnType {
         column_type: String,
     },
+    External {
+        id: i32,
+    },
 }
 
 impl From<RawError> for SqlError {
@@ -39,6 +42,7 @@ impl From<RawError> for SqlError {
                 code: code.unwrap_or_else(|| String::from("N/A")),
                 message: message.unwrap_or_else(|| String::from("N/A")),
             },
+            RawError::External { id } => Self::ExternalError(id),
         }
     }
 }
@@ -57,6 +61,7 @@ impl From<quaint::error::Error> for RawError {
                 column_type: column_type.to_owned(),
             },
             quaint::error::ErrorKind::QueryInvalidInput(message) => Self::QueryInvalidInput(message.to_owned()),
+            quaint::error::ErrorKind::ExternalError(id) => Self::External { id: *id },
             _ => Self::Database {
                 code: e.original_code().map(ToString::to_string),
                 message: e.original_message().map(ToString::to_string),

--- a/query-engine/js-connectors/js/smoke-test-js/src/test.ts
+++ b/query-engine/js-connectors/js/smoke-test-js/src/test.ts
@@ -22,6 +22,7 @@ export async function smokeTest(db: ErrorCapturingConnector, prismaSchemaRelativ
   await test.createAutoIncrement()
   await test.testCreateAndDeleteChildParent()
   await test.testTransaction()
+  await test.testRawError()
 
   // Note: calling `engine.disconnect` won't actually close the database connection.
   console.log('[nodejs] disconnecting...')
@@ -418,6 +419,25 @@ class SmokeTest {
 
     const commitResponse = await this.engine.commitTransaction(tx_id, 'trace')
     console.log('[nodejs] commited', commitResponse)
+  }
+
+  async testRawError() {
+    try {
+      await this.doQuery({
+        action: 'queryRaw',
+        query: {
+          selection: { $scalars: true },
+          arguments: {
+            query: 'NOT A VALID SQL, THIS WILL FAIL',
+            parameters: '[]'
+          }
+        }
+      })
+      console.log(`[nodejs] expected exception, but query succeeded`)
+    } catch (error) {
+      console.log('[nodejs] caught expected error', error)
+    }
+
   }
 
   private async doQuery(query: JsonQuery, tx_id?: string) {


### PR DESCRIPTION
There is one more error type, specific to previous queries that previous
PR missed.
