### PR TITLE
feat(driver-adapters): rename preview feature `jsConnectors` -> `driverAdapters`

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -64,7 +64,7 @@ features!(
     NamedConstraints,
     NApi,
     NativeTypes,
-    JsConnectors,
+    DriverAdapters,
     OrderByAggregateGroup,
     OrderByNulls,
     OrderByRelation,
@@ -124,7 +124,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | UncheckedScalarInputs
     }),
     hidden: enumflags2::make_bitflags!(PreviewFeature::{
-        JsConnectors
+        DriverAdapters
     }),
 };
 

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/mysql/schema.prisma
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/mysql/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["jsConnectors"]
+  previewFeatures = ["driverAdapters"]
 }
 
 datasource db {

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/postgres/schema.prisma
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/postgres/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["jsConnectors"]
+  previewFeatures = ["driverAdapters"]
 }
 
 datasource db {

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -174,11 +174,10 @@ impl QueryEngine {
 
         let mut connector_mode = ConnectorMode::Rust;
 
-        // TODO: https://github.com/prisma/team-orm/issues/340
-        if !preview_features.contains(PreviewFeature::JsConnectors) {
+        if !preview_features.contains(PreviewFeature::DriverAdapters) {
             tracing::info!(
                 "Please enable the {} preview feature to use driver adapters.",
-                PreviewFeature::JsConnectors
+                PreviewFeature::DriverAdapters
             );
         } else {
             #[cfg(feature = "driver-adapters")]


### PR DESCRIPTION
This PR is based off https://github.com/prisma/prisma-engines/pull/4174.
It contributes to https://github.com/prisma/team-orm/issues/327.