### PR TITLE
feat(psl): first, minimal implementation of `cuid2` default generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,6 +3249,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "cuid",
+ "cuid2",
  "itertools",
  "nanoid",
  "prisma-value",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,8 +1504,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3250,6 +3252,7 @@ dependencies = [
  "chrono",
  "cuid",
  "cuid2",
+ "getrandom 0.2.10",
  "itertools",
  "nanoid",
  "prisma-value",
@@ -3529,7 +3532,7 @@ dependencies = [
  "chrono",
  "connection-string",
  "crossbeam-channel",
- "cuid",
+ "cuid2",
  "enumflags2",
  "futures",
  "indexmap 1.9.3",

--- a/psl/parser-database/src/attributes/default.rs
+++ b/psl/parser-database/src/attributes/default.rs
@@ -197,7 +197,7 @@ fn validate_model_builtin_scalar_type_default(
             validate_empty_function_args(funcname, &funcargs.arguments, accept, ctx)
         }
         (ScalarType::String, ast::Expression::Function(funcname, funcargs, _))
-            if funcname == FN_UUID || funcname == FN_CUID =>
+            if funcname == FN_UUID || funcname == FN_CUID || funcname == FN_CUID2 =>
         {
             validate_empty_function_args(funcname, &funcargs.arguments, accept, ctx)
         }
@@ -243,7 +243,7 @@ fn validate_composite_builtin_scalar_type_default(
     match (scalar_type, value) {
         // Functions
         (ScalarType::String, ast::Expression::Function(funcname, funcargs, _))
-            if funcname == FN_UUID || funcname == FN_CUID =>
+            if funcname == FN_UUID || funcname == FN_CUID || funcname == FN_CUID2 =>
         {
             validate_empty_function_args(funcname, &funcargs.arguments, accept, ctx)
         }
@@ -473,6 +473,7 @@ fn validate_builtin_scalar_list_default(
 
 const FN_AUTOINCREMENT: &str = "autoincrement";
 const FN_CUID: &str = "cuid";
+const FN_CUID2: &str = "cuid2";
 const FN_DBGENERATED: &str = "dbgenerated";
 const FN_NANOID: &str = "nanoid";
 const FN_NOW: &str = "now";
@@ -482,6 +483,7 @@ const FN_AUTO: &str = "auto";
 const KNOWN_FUNCTIONS: &[&str] = &[
     FN_AUTOINCREMENT,
     FN_CUID,
+    FN_CUID2,
     FN_DBGENERATED,
     FN_NANOID,
     FN_NOW,

--- a/psl/parser-database/src/walkers/scalar_field.rs
+++ b/psl/parser-database/src/walkers/scalar_field.rs
@@ -192,6 +192,11 @@ impl<'db> DefaultValueWalker<'db> {
         matches!(self.value(), ast::Expression::Function(name, _, _) if name == "cuid")
     }
 
+    /// Is this an `@default(cuid2())`?
+    pub fn is_cuid2(self) -> bool {
+        matches!(self.value(), ast::Expression::Function(name, _, _) if name == "cuid2")
+    }
+
     /// Is this an `@default(nanoid())`?
     pub fn is_nanoid(self) -> bool {
         matches!(self.value(), ast::Expression::Function(name, _, _) if name == "nanoid")

--- a/psl/psl/tests/attributes/id_positive.rs
+++ b/psl/psl/tests/attributes/id_positive.rs
@@ -51,6 +51,26 @@ fn should_allow_string_ids_with_cuid() {
 }
 
 #[test]
+fn should_allow_string_ids_with_cuid2() {
+    let dml = indoc! {r#"
+        model Model {
+          id String @id @default(cuid2())
+        }
+    "#};
+
+    let schema = psl::parse_schema(dml).unwrap();
+    let model = schema.assert_has_model("Model");
+
+    model
+        .assert_has_scalar_field("id")
+        .assert_scalar_type(ScalarType::String)
+        .assert_default_value()
+        .assert_cuid2();
+
+    model.assert_id_on_fields(&["id"]);
+}
+
+#[test]
 fn should_allow_string_ids_with_uuid() {
     let dml = indoc! {r#"
         model Model {

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -83,6 +83,7 @@ pub(crate) trait DefaultValueAssert {
     fn assert_bytes(&self, val: &[u8]) -> &Self;
     fn assert_now(&self) -> &Self;
     fn assert_cuid(&self) -> &Self;
+    fn assert_cuid2(&self) -> &Self;
     fn assert_uuid(&self) -> &Self;
     fn assert_dbgenerated(&self, val: &str) -> &Self;
     fn assert_mapped_name(&self, val: &str) -> &Self;
@@ -434,6 +435,12 @@ impl<'a> DefaultValueAssert for walkers::DefaultValueWalker<'a> {
     }
 
     #[track_caller]
+    fn assert_cuid2(&self) -> &Self {
+        self.value().assert_cuid2();
+        self
+    }
+
+    #[track_caller]
     fn assert_uuid(&self) -> &Self {
         self.value().assert_uuid();
         self
@@ -624,6 +631,15 @@ impl DefaultValueAssert for ast::Expression {
     fn assert_cuid(&self) -> &Self {
         assert!(
             matches!(self, ast::Expression::Function(name, args, _) if name == "cuid" && args.arguments.is_empty())
+        );
+
+        self
+    }
+
+    #[track_caller]
+    fn assert_cuid2(&self) -> &Self {
+        assert!(
+            matches!(self, ast::Expression::Function(name, args, _) if name == "cuid2" && args.arguments.is_empty())
         );
 
         self

--- a/psl/psl/tests/functions/server_side_functions.rs
+++ b/psl/psl/tests/functions/server_side_functions.rs
@@ -38,6 +38,24 @@ fn correctly_handle_server_side_cuid_function() {
 }
 
 #[test]
+fn correctly_handle_server_side_cuid2_function() {
+    let dml = indoc! {r#"
+        model User {
+          id Int @id
+          someId String @default(cuid2())
+        }
+    "#};
+
+    psl::parse_schema(dml)
+        .unwrap()
+        .assert_has_model("User")
+        .assert_has_scalar_field("someId")
+        .assert_scalar_type(ScalarType::String)
+        .assert_default_value()
+        .assert_cuid2();
+}
+
+#[test]
 fn correctly_handle_server_side_uuid_function() {
     let dml = indoc! {r#"
         model User {

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -29,7 +29,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.17.4"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "1"
-cuid = "1.2"
+cuid2 = "0.1.2"
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = { version = "1.7", features = ["serde-1"] }
 itertools = "0.10"
 once_cell = "1"
 petgraph = "0.4"
-prisma-models = { path = "../prisma-models", features = ["default_generators"] }
+prisma-models = { path = "../prisma-models" }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
 query-engine-metrics = {path = "../metrics"}
 serde.workspace = true
@@ -33,4 +33,3 @@ cuid2 = "0.1.2"
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"
-

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -40,12 +40,13 @@ pub(crate) use messages::*;
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct TxId(String);
 
-const MINIMUM_TX_ID_LENGTH: usize = 24;
+const MINIMUM_TX_ID_LENGTH: usize = 17;
+
+const CUID2_CONSTRUCTOR: cuid2::CuidConstructor = cuid2::CuidConstructor::new();
 
 impl Default for TxId {
     fn default() -> Self {
-        #[allow(deprecated)]
-        Self(cuid::cuid().unwrap())
+        Self(CUID2_CONSTRUCTOR.create_id())
     }
 }
 

--- a/query-engine/core/src/telemetry/capturing/tx_ext.rs
+++ b/query-engine/core/src/telemetry/capturing/tx_ext.rs
@@ -60,15 +60,9 @@ mod test {
     #[test]
     fn test_txid_into_traceid() {
         let fixture = vec![
-            ("clct0q6ma0000rb04768tiqbj", "71366d6130303030373638746971626a"),
-            // counter changed, trace id changed:
-            ("clct0q6ma0002rb04cpa6zkmx", "71366d6130303032637061367a6b6d78"),
-            // fingerprint changed, trace id did not change, as that chunk is ignored:
-            ("clct0q6ma00020000cpa6zkmx", "71366d6130303032637061367a6b6d78"),
-            // first 5 bytes changed, trace id did not change, as that chunk is ignored:
-            ("00000q6ma00020000cpa6zkmx", "71366d6130303032637061367a6b6d78"),
-            // 6 th byte changed, trace id changed, as that chunk is part of the lsb of the timestamp
-            ("0000006ma00020000cpa6zkmx", "30366d6130303032637061367a6b6d78"),
+            ("tz4a98xxat96iws9", "7a3461393878786174393669777339"),
+            ("pfh0haxfpzowht3o", "66683068617866707a6f776874336f"),
+            ("nc6bzmkmd014706r", "6336627a6d6b6d6430313437303672"),
         ];
 
         for (txid, expected_trace_id) in fixture {

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -10,7 +10,16 @@ serde.workspace = true
 serde_json.workspace = true
 schema = { path = "../schema" }
 indexmap = { version = "1.7", features = ["serde-1"] }
-prisma-models = { path = "../prisma-models" }
+
+[dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["wasm_generators"]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["all"]
 
 [dev-dependencies]
 expect-test = "1.2.2"

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -15,12 +15,17 @@ cuid = { version = "1.2", optional = true }
 cuid2 = { version = "0.1.2", optional = true } 
 nanoid = { version = "0.4.0", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
+getrandom = { version = "0.2" }
 
 [features]
-# Support for generating default UUID, CUID, nanoid and datetime values. This
-# implies random number generation works, so it won't compile on targets like
-# wasm32.
-# Note: this feature flag should be removed. It's fully possible to implement
-# some of these default generators in wasm32. We just need to conditionally
-# import the `getrandom` crate with the `js` feature when on `wasm32` arch.
-default_generators = ["uuid/v4", "cuid", "cuid2", "nanoid"]
+default = ["all"]
+all = ["wasm_generators", "sys_generators"]
+
+# Support for generating default UUID, CUID, nanoid and datetime values.
+sys_generators = ["cuid"]
+wasm_generators = ["uuid", "cuid2", "nanoid", "getrandom/js"]
+
+cuid = ["dep:cuid"]
+nanoid = ["dep:nanoid"]
+cuid2 = ["dep:cuid2"]
+uuid = ["uuid/v4"]

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1.0"
 
 uuid = { workspace = true, optional = true }
 cuid = { version = "1.2", optional = true }
+cuid2 = { version = "0.1.2", optional = true } 
 nanoid = { version = "0.4.0", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 
@@ -19,4 +20,7 @@ chrono = { version = "0.4.6", features = ["serde"] }
 # Support for generating default UUID, CUID, nanoid and datetime values. This
 # implies random number generation works, so it won't compile on targets like
 # wasm32.
-default_generators = ["uuid/v4", "cuid", "nanoid"]
+# Note: this feature flag should be removed. It's fully possible to implement
+# some of these default generators in wasm32. We just need to conditionally
+# import the `getrandom` crate with the `js` feature when on `wasm32` arch.
+default_generators = ["uuid/v4", "cuid", "cuid2", "nanoid"]

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -218,6 +218,9 @@ pub fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<Sca
         ast::Expression::Function(funcname, _args, _) if funcname == "cuid" => {
             DefaultKind::Expression(ValueGenerator::new_cuid())
         }
+        ast::Expression::Function(funcname, _args, _) if funcname == "cuid2" => {
+            DefaultKind::Expression(ValueGenerator::new_cuid2())
+        }
         ast::Expression::Function(funcname, args, _) if funcname == "nanoid" => {
             DefaultKind::Expression(ValueGenerator::new_nanoid(
                 args.arguments

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -202,6 +202,22 @@ fn cuid_fields_must_work() {
 }
 
 #[test]
+fn cuid2_fields_must_work() {
+    let datamodel = convert(
+        r#"
+            model Test {
+                id String @id @default(cuid2())
+            }
+        "#,
+    );
+
+    let model = datamodel.assert_model("Test");
+    model
+        .assert_scalar_field("id")
+        .assert_type_identifier(TypeIdentifier::String);
+}
+
+#[test]
 fn createdAt_works() {
     let datamodel = convert(
         r#"

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -4,10 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-prisma-models = { path = "../prisma-models" }
 psl.workspace = true
 rustc-hash = "1.1.0"
 once_cell = "1"
+
+[dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["wasm_generators"]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["all"]
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
@@ -16,6 +16,7 @@ pub(crate) enum DefaultKind<'a> {
     Autoincrement,
     Uuid,
     Cuid,
+    Cuid2,
     Nanoid(Option<u8>),
     Now,
     String(&'a str),
@@ -117,6 +118,7 @@ impl<'a> DefaultValuePair<'a> {
 
             (None, sql::ColumnTypeFamily::String | sql::ColumnTypeFamily::Uuid) => match self.previous {
                 Some(previous) if previous.is_cuid() => Some(DefaultKind::Cuid),
+                Some(previous) if previous.is_cuid2() => Some(DefaultKind::Cuid2),
                 Some(previous) if previous.is_uuid() => Some(DefaultKind::Uuid),
                 Some(previous) if previous.is_nanoid() => {
                     let length = previous.value().as_function().and_then(|(_, args, _)| {

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/defaults.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/defaults.rs
@@ -47,6 +47,7 @@ pub(crate) fn render(default: DefaultValuePair<'_>) -> Option<renderer::DefaultV
             DefaultKind::Autoincrement => Some(renderer::DefaultValue::function(Function::new("autoincrement"))),
             DefaultKind::Uuid => Some(renderer::DefaultValue::function(Function::new("uuid"))),
             DefaultKind::Cuid => Some(renderer::DefaultValue::function(Function::new("cuid"))),
+            DefaultKind::Cuid2 => Some(renderer::DefaultValue::function(Function::new("cuid2"))),
             DefaultKind::Nanoid(length) => {
                 let mut fun = Function::new("nanoid");
 

--- a/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
@@ -1004,6 +1004,11 @@ async fn virtual_cuid_default(api: &mut TestApi) {
         model User3 {
             id        String    @id @default(nanoid(7)) @db.VarChar(21)
         }
+
+        model User4 {
+            id        String    @id @default(cuid2()) @db.VarChar(25)
+            non_id    String    @default(cuid2()) @db.VarChar(25)
+        }
         "#;
 
     let final_dm = indoc! {r#"
@@ -1018,6 +1023,11 @@ async fn virtual_cuid_default(api: &mut TestApi) {
 
         model User3 {
             id        String    @id @default(nanoid(7)) @db.VarChar(21)
+        }
+
+        model User4 {
+            id        String    @id @default(cuid2()) @db.VarChar(25)
+            non_id    String    @default(cuid2()) @db.VarChar(25)
         }
 
         model Unrelated {

--- a/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
@@ -984,6 +984,10 @@ async fn virtual_cuid_default(api: &mut TestApi) {
                 t.add_column("id", types::varchar(21).primary(true));
             });
 
+            migration.create_table("User4", |t| {
+                t.add_column("id", types::varchar(25).primary(true));
+            });
+
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::primary());
             });


### PR DESCRIPTION
**DO NOT MERGE**

This PR now allows `cuid2` default generators, like so:

```prisma
model Model {
  id String @id @default(cuid2())
}
```

This is part of a series of experiments (see [Notion](https://www.notion.so/prismaio/Towards-a-WASM-compatible-CUID-82aaa6366a9c44109b73c4212988b57d)) to assess how we can replace the `cuid` crate (which isn't compatible with `wasm32-unknown-uknown` due to its `hostname` dependency) in `wasm32-unknown-unknown` targets. 