### PR TITLE
nix/shell: add NodeJS, TS language server, pnpm to packages

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -5,7 +5,14 @@ let
 in
 {
   devShells.default = pkgs.mkShell {
-    packages = [ devToolchain pkgs.llvmPackages_latest.bintools ];
+    packages = [
+      devToolchain
+      pkgs.llvmPackages_latest.bintools
+
+      pkgs.nodejs
+      pkgs.nodePackages.typescript-language-server
+      pkgs.nodePackages.pnpm
+    ];
     inputsFrom = [ self'.packages.prisma-engines ];
     shellHook = pkgs.lib.optionalString pkgs.stdenv.isLinux
       "export RUSTFLAGS='-C link-arg=-fuse-ld=lld'";


### PR DESCRIPTION
There will be more of that and less Rust in the future, so let's get these into the default devShell.


The regrettable part is that it will have to stay devShell only for now,
since there is no quality lockfile translator for the pnpm dependencies,
so we can't make a derivation out of these packages.