### PR TITLE
driver-adapters: Map neon errors to Prisma errors

### DIFF
--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -1,5 +1,5 @@
 mod conversion;
-mod error;
+pub mod error;
 
 use crate::{
     ast::{Query, Value},

--- a/quaint/src/connector/postgres/error.rs
+++ b/quaint/src/connector/postgres/error.rs
@@ -1,37 +1,64 @@
+use std::fmt::{Display, Formatter};
+
+use tokio_postgres::error::DbError;
+
 use crate::error::{DatabaseConstraint, Error, ErrorKind, Name};
 
-impl From<tokio_postgres::error::Error> for Error {
-    fn from(e: tokio_postgres::error::Error) -> Error {
-        use tokio_postgres::error::DbError;
+#[derive(Debug)]
+pub struct PostgresError {
+    pub code: String,
+    pub message: String,
+    pub severity: String,
+    pub detail: Option<String>,
+    pub column: Option<String>,
+    pub hint: Option<String>,
+}
 
-        if e.is_closed() {
-            return Error::builder(ErrorKind::ConnectionClosed).build();
+impl std::error::Error for PostgresError {}
+
+impl Display for PostgresError {
+    // copy of DbError::fmt
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(fmt, "{}: {}", self.severity, self.message)?;
+        if let Some(detail) = &self.detail {
+            write!(fmt, "\nDETAIL: {}", detail)?;
         }
+        if let Some(hint) = &self.hint {
+            write!(fmt, "\nHINT: {}", hint)?;
+        }
+        Ok(())
+    }
+}
 
-        match e.code().map(|c| c.code()) {
-            Some(code) if code == "22001" => {
-                let code = code.to_string();
+impl From<&DbError> for PostgresError {
+    fn from(value: &DbError) -> Self {
+        PostgresError {
+            code: value.code().code().to_string(),
+            severity: value.severity().to_string(),
+            message: value.message().to_string(),
+            detail: value.detail().map(ToString::to_string),
+            column: value.column().map(ToString::to_string),
+            hint: value.hint().map(ToString::to_string),
+        }
+    }
+}
 
+impl From<PostgresError> for Error {
+    fn from(value: PostgresError) -> Self {
+        match value.code.as_str() {
+            "22001" => {
                 let mut builder = Error::builder(ErrorKind::LengthMismatch {
                     column: Name::Unavailable,
                 });
 
-                builder.set_original_code(code);
-
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                if let Some(db_error) = db_error {
-                    builder.set_original_message(db_error.to_string());
-                }
+                builder.set_original_code(&value.code);
+                builder.set_original_message(value.to_string());
 
                 builder.build()
             }
-            Some(code) if code == "23505" => {
-                let code = code.to_string();
-
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let detail = db_error.as_ref().and_then(|e| e.detail()).map(ToString::to_string);
-
-                let constraint = detail
+            "23505" => {
+                let constraint = value
+                    .detail
                     .as_ref()
                     .and_then(|d| d.split(")=(").next())
                     .and_then(|d| d.split(" (").nth(1).map(|s| s.replace('\"', "")))
@@ -41,189 +68,138 @@ impl From<tokio_postgres::error::Error> for Error {
                 let kind = ErrorKind::UniqueConstraintViolation { constraint };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
+                builder.set_original_code(value.code);
 
-                if let Some(detail) = detail {
+                if let Some(detail) = value.detail {
                     builder.set_original_message(detail);
                 }
 
                 builder.build()
             }
+
             // Even lipstick will not save this...
-            Some(code) if code == "23502" => {
-                let code = code.to_string();
-
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let detail = db_error.as_ref().and_then(|e| e.detail()).map(ToString::to_string);
-
-                let constraint = db_error
-                    .as_ref()
-                    .map(|e| e.column())
-                    .map(DatabaseConstraint::fields)
-                    .unwrap_or(DatabaseConstraint::CannotParse);
+            "23502" => {
+                let constraint = DatabaseConstraint::fields(value.column);
 
                 let kind = ErrorKind::NullConstraintViolation { constraint };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
+                builder.set_original_code(value.code);
 
-                if let Some(detail) = detail {
+                if let Some(detail) = value.detail {
                     builder.set_original_message(detail);
                 }
 
                 builder.build()
             }
-            Some(code) if code == "23503" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
+            "23503" => match value.column {
+                Some(column) => {
+                    let mut builder = Error::builder(ErrorKind::ForeignKeyConstraintViolation {
+                        constraint: DatabaseConstraint::fields(Some(column)),
+                    });
 
-                match db_error.as_ref().and_then(|e| e.column()) {
-                    Some(column) => {
-                        let mut builder = Error::builder(ErrorKind::ForeignKeyConstraintViolation {
-                            constraint: DatabaseConstraint::fields(Some(column)),
-                        });
+                    builder.set_original_code(value.code);
+                    builder.set_original_message(value.message);
 
-                        builder.set_original_code(code);
-
-                        if let Some(message) = db_error.as_ref().map(|e| e.message()) {
-                            builder.set_original_message(message);
-                        }
-
-                        builder.build()
-                    }
-                    None => {
-                        let constraint = db_error
-                            .as_ref()
-                            .map(|e| e.message())
-                            .and_then(|e| e.split_whitespace().nth(10))
-                            .and_then(|s| s.split('"').nth(1))
-                            .map(ToString::to_string)
-                            .map(DatabaseConstraint::Index)
-                            .unwrap_or(DatabaseConstraint::CannotParse);
-
-                        let kind = ErrorKind::ForeignKeyConstraintViolation { constraint };
-                        let mut builder = Error::builder(kind);
-
-                        builder.set_original_code(code);
-
-                        if let Some(message) = db_error.as_ref().map(|e| e.message()) {
-                            builder.set_original_message(message);
-                        }
-
-                        builder.build()
-                    }
+                    builder.build()
                 }
-            }
-            Some(code) if code == "3D000" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
+                None => {
+                    let constraint = value
+                        .message
+                        .split_whitespace()
+                        .nth(10)
+                        .and_then(|s| s.split('"').nth(1))
+                        .map(ToString::to_string)
+                        .map(DatabaseConstraint::Index)
+                        .unwrap_or(DatabaseConstraint::CannotParse);
 
-                let db_name = message
-                    .as_ref()
-                    .and_then(|s| s.split_whitespace().nth(1))
+                    let kind = ErrorKind::ForeignKeyConstraintViolation { constraint };
+                    let mut builder = Error::builder(kind);
+
+                    builder.set_original_code(value.code);
+                    builder.set_original_message(value.message);
+
+                    builder.build()
+                }
+            },
+            "3D000" => {
+                let db_name = value
+                    .message
+                    .split_whitespace()
+                    .nth(1)
                     .and_then(|s| s.split('"').nth(1))
                     .into();
 
                 let kind = ErrorKind::DatabaseDoesNotExist { db_name };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
+                builder.set_original_code(value.code);
+                builder.set_original_message(value.message);
 
                 builder.build()
             }
-            Some(code) if code == "28000" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
-
-                let db_name = message
-                    .as_ref()
-                    .and_then(|m| m.split_whitespace().nth(5))
+            "28000" => {
+                let db_name = value
+                    .message
+                    .split_whitespace()
+                    .nth(5)
                     .and_then(|s| s.split('"').nth(1))
                     .into();
 
                 let kind = ErrorKind::DatabaseAccessDenied { db_name };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
+                builder.set_original_code(value.code);
+                builder.set_original_message(value.message);
 
                 builder.build()
             }
-            Some(code) if code == "28P01" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
+            "28P01" => {
+                let message = value.message;
 
                 let user = message
-                    .as_ref()
-                    .and_then(|m| m.split_whitespace().last())
+                    .split_whitespace()
+                    .last()
                     .and_then(|s| s.split('"').nth(1))
                     .into();
 
                 let kind = ErrorKind::AuthenticationFailed { user };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
+                builder.set_original_code(value.code);
+                builder.set_original_message(message);
 
                 builder.build()
             }
-            Some(code) if code == "40001" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
-                let mut builder = Error::builder(ErrorKind::TransactionWriteConflict);
+            "40001" => {
+                let mut builder: crate::error::ErrorBuilder = Error::builder(ErrorKind::TransactionWriteConflict);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
+                builder.set_original_code(value.code);
+                builder.set_original_message(value.message);
 
                 builder.build()
             }
-            Some(code) if code == "42P01" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
-
-                let table = message
-                    .as_ref()
-                    .and_then(|m| m.split_whitespace().nth(1))
+            "42P01" => {
+                let table = value
+                    .message
+                    .split_whitespace()
+                    .nth(1)
                     .and_then(|s| s.split('"').nth(1))
                     .into();
 
                 let kind = ErrorKind::TableDoesNotExist { table };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
+                builder.set_original_code(value.code);
+                builder.set_original_message(value.message);
 
                 builder.build()
             }
-            Some(code) if code == "42703" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
-
-                let column = message
-                    .as_ref()
-                    .and_then(|m| m.split_whitespace().nth(1))
+            "42703" => {
+                let column = value
+                    .message
+                    .split_whitespace()
+                    .nth(1)
                     .map(|s| s.split('\"'))
                     .and_then(|mut s| match (s.next(), s.next()) {
                         (Some(column), _) if !column.is_empty() => Some(column),
@@ -235,92 +211,102 @@ impl From<tokio_postgres::error::Error> for Error {
                 let kind = ErrorKind::ColumnNotFound { column };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
-
+                builder.set_original_code(value.code);
+                builder.set_original_message(value.message);
                 builder.build()
             }
 
-            Some(code) if code == "42P04" => {
-                let code = code.to_string();
-                let db_error = e.into_source().and_then(|e| e.downcast::<DbError>().ok());
-                let message = db_error.as_ref().map(|e| e.message());
-
-                let db_name = message
-                    .as_ref()
-                    .and_then(|m| m.split_whitespace().nth(1))
+            "42P04" => {
+                let db_name = value
+                    .message
+                    .split_whitespace()
+                    .nth(1)
                     .and_then(|s| s.split('"').nth(1))
                     .into();
 
                 let kind = ErrorKind::DatabaseAlreadyExists { db_name };
                 let mut builder = Error::builder(kind);
 
-                builder.set_original_code(code);
-
-                if let Some(message) = message {
-                    builder.set_original_message(message);
-                }
+                builder.set_original_code(value.code);
+                builder.set_original_message(value.message);
 
                 builder.build()
             }
-            code => {
-                // This is necessary, on top of the other conversions, for the cases where a
-                // native_tls error comes wrapped in a tokio_postgres error.
-                if let Some(tls_error) = try_extracting_tls_error(&e) {
-                    return tls_error;
-                }
 
-                // Same for IO errors.
-                if let Some(io_error) = try_extracting_io_error(&e) {
-                    return io_error;
-                }
+            _ => {
+                let code = value.code.to_owned();
+                let message = value.to_string();
+                let mut builder = Error::builder(ErrorKind::QueryError(value.into()));
 
-                #[cfg(feature = "uuid")]
-                if let Some(uuid_error) = try_extracting_uuid_error(&e) {
-                    return uuid_error;
-                }
+                builder.set_original_code(code);
+                builder.set_original_message(message);
+                builder.build()
+            }
+        }
+    }
+}
 
-                let reason = format!("{e}");
+impl From<tokio_postgres::error::Error> for Error {
+    fn from(e: tokio_postgres::error::Error) -> Error {
+        if e.is_closed() {
+            return Error::builder(ErrorKind::ConnectionClosed).build();
+        }
 
-                match reason.as_str() {
-                    "error connecting to server: timed out" => {
-                        let mut builder = Error::builder(ErrorKind::ConnectTimeout);
+        if let Some(db_error) = e.as_db_error() {
+            return PostgresError::from(db_error).into();
+        }
 
-                        if let Some(code) = code {
-                            builder.set_original_code(code);
-                        };
+        if let Some(tls_error) = try_extracting_tls_error(&e) {
+            return tls_error;
+        }
 
-                        builder.set_original_message(reason);
-                        builder.build()
-                    } // sigh...
-                    // https://github.com/sfackler/rust-postgres/blob/0c84ed9f8201f4e5b4803199a24afa2c9f3723b2/tokio-postgres/src/connect_tls.rs#L37
-                    "error performing TLS handshake: server does not support TLS" => {
-                        let mut builder = Error::builder(ErrorKind::TlsError {
-                            message: reason.clone(),
-                        });
+        // Same for IO errors.
+        if let Some(io_error) = try_extracting_io_error(&e) {
+            return io_error;
+        }
 
-                        if let Some(code) = code {
-                            builder.set_original_code(code);
-                        };
+        #[cfg(feature = "uuid")]
+        if let Some(uuid_error) = try_extracting_uuid_error(&e) {
+            return uuid_error;
+        }
 
-                        builder.set_original_message(reason);
-                        builder.build()
-                    } // double sigh
-                    _ => {
-                        let code = code.map(|c| c.to_string());
-                        let mut builder = Error::builder(ErrorKind::QueryError(e.into()));
+        let reason = format!("{e}");
+        let code = e.code().map(|c| c.code());
 
-                        if let Some(code) = code {
-                            builder.set_original_code(code);
-                        };
+        match reason.as_str() {
+            "error connecting to server: timed out" => {
+                let mut builder = Error::builder(ErrorKind::ConnectTimeout);
 
-                        builder.set_original_message(reason);
-                        builder.build()
-                    }
-                }
+                if let Some(code) = code {
+                    builder.set_original_code(code);
+                };
+
+                builder.set_original_message(reason);
+                return builder.build();
+            } // sigh...
+            // https://github.com/sfackler/rust-postgres/blob/0c84ed9f8201f4e5b4803199a24afa2c9f3723b2/tokio-postgres/src/connect_tls.rs#L37
+            "error performing TLS handshake: server does not support TLS" => {
+                let mut builder = Error::builder(ErrorKind::TlsError {
+                    message: reason.clone(),
+                });
+
+                if let Some(code) = code {
+                    builder.set_original_code(code);
+                };
+
+                builder.set_original_message(reason);
+                return builder.build();
+            } // double sigh
+            _ => {
+                let code = code.map(|c| c.to_string());
+                let mut builder = Error::builder(ErrorKind::QueryError(e.into()));
+
+                if let Some(code) = code {
+                    builder.set_original_code(code);
+                };
+
+                builder.set_original_message(reason);
+                return builder.build();
             }
         }
     }

--- a/quaint/src/error.rs
+++ b/quaint/src/error.rs
@@ -6,6 +6,8 @@ use thiserror::Error;
 #[cfg(feature = "pooled")]
 use std::time::Duration;
 
+pub use crate::connector::postgres::error::PostgresError;
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum DatabaseConstraint {
     Fields(Vec<String>),

--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -27,29 +27,25 @@ abstract class NeonQueryable implements Queryable {
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
-    const { fields, rows } = await this.performIO(query)
-
-    const columns = fields.map((field) => field.name)
-    const resultSet: ResultSet = {
-      columnNames: columns,
-      columnTypes: fields.map((field) => fieldToColumnType(field.dataTypeID)),
-      rows,
-    }
-
-    return ok(resultSet)
+    return (await this.performIO(query)).map(({ fields, rows }) => {
+      const columns = fields.map((field) => field.name)
+      return {
+        columnNames: columns,
+        columnTypes: fields.map((field) => fieldToColumnType(field.dataTypeID)),
+        rows,
+      }
+    })
   }
 
   async executeRaw(query: Query): Promise<Result<number>> {
     const tag = '[js::execute_raw]'
     debug(`${tag} %O`, query)
 
-    const { rowCount: rowsAffected } = await this.performIO(query)
-
     // Note: `rowsAffected` can sometimes be null (e.g., when executing `"BEGIN"`)
-    return ok(rowsAffected ?? 0)
+    return (await this.performIO(query)).map((r) => r.rowCount ?? 0)
   }
 
-  abstract performIO(query: Query): Promise<PerformIOResult>
+  abstract performIO(query: Query): Promise<Result<PerformIOResult>>
 }
 
 /**
@@ -60,15 +56,23 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
     super()
   }
 
-  override async performIO(query: Query): Promise<PerformIOResult> {
+  override async performIO(query: Query): Promise<Result<PerformIOResult>> {
     const { sql, args: values } = query
 
     try {
-      return await this.client.query({ text: sql, values, rowMode: 'array' })
+      return ok(await this.client.query({ text: sql, values, rowMode: 'array' }))
     } catch (e) {
-      const error = e as Error
-      debug('Error in performIO: %O', error)
-      throw error
+      debug('Error in performIO: %O', e)
+      if (e && e.code) {
+        return err({
+          kind: 'PostgresError',
+          code: e.code,
+          message: e.message,
+          detail: e.detail,
+          column: e.column,
+        })
+      }
+      throw e
     }
   }
 }
@@ -126,12 +130,14 @@ export class PrismaNeonHTTP extends NeonQueryable implements DriverAdapter {
     super()
   }
 
-  override async performIO(query: Query): Promise<PerformIOResult> {
+  override async performIO(query: Query): Promise<Result<PerformIOResult>> {
     const { sql, args: values } = query
-    return await this.client(sql, values, {
-      arrayMode: true,
-      fullResults: true,
-    })
+    return ok(
+      await this.client(sql, values, {
+        arrayMode: true,
+        fullResults: true,
+      }),
+    )
   }
 
   startTransaction(): Promise<Result<Transaction>> {

--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -67,9 +67,11 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
         return err({
           kind: 'PostgresError',
           code: e.code,
+          severity: e.severity,
           message: e.message,
           detail: e.detail,
           column: e.column,
+          hint: e.hint,
         })
       }
       throw e

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -39,9 +39,11 @@ export type Error = {
 } | {
   kind: 'PostgresError'
   code: string,
+  severity: string
   message: string
-  detail: string
-  column: string
+  detail: string | undefined
+  column: string | undefined
+  hint: string | undefined
 }
 
 export interface Queryable {

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -36,6 +36,12 @@ export type Query = {
 export type Error = {
   kind: 'GenericJsError'
   id: number
+} | {
+  kind: 'PostgresError'
+  code: string,
+  message: string
+  detail: string
+  column: string
 }
 
 export interface Queryable {

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/mysql/schema.prisma
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/mysql/schema.prisma
@@ -114,3 +114,7 @@ model Product {
   properties      Json
   properties_null Json?
 }
+
+model Unique {
+  email String @id
+}

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/postgres/schema.prisma
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/postgres/schema.prisma
@@ -103,3 +103,7 @@ model User {
   id    String @id @default(uuid())
   email String
 }
+
+model Unique {
+  email String @id
+}

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -21,21 +21,6 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
       await adapter.close()
     })
 
-    it('raw error', async () => {
-      await assert.rejects(async () => {
-        await doQuery({
-          action: 'queryRaw',
-          query: {
-            selection: { $scalars: true },
-            arguments: {
-              query: 'NOT A VALID SQL, THIS WILL FAIL',
-              parameters: '[]',
-            },
-          },
-        })
-      })
-    })
-
     it('create JSON values', async () => {
       const json = JSON.stringify({
         foo: 'bar',
@@ -292,6 +277,23 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
 
       const commitResponse = await engine.commitTransaction(tx_id, 'trace')
       console.log('[nodejs] commited', commitResponse)
+    })
+
+    it('expected error', async () => {
+      const result = await doQuery({
+        modelName: 'Unique',
+        action: 'createMany',
+        query: {
+          arguments: {
+            data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
+          },
+          selection: {
+            $scalars: true,
+          },
+        },
+      })
+
+      console.log('[nodejs] error result', JSON.stringify(result, null, 2))
     })
 
     describe('read scalar and non scalar types', () => {


### PR DESCRIPTION
Approach taken: instead of duplicating error handling logic in TS, we
extract all information we need from the error and forward it to engine.
Engine is than reuses error parsing code from native driver.

`PostgresError` is intermediate form for storing this information.
It can be created from eithe `tokio_postgres` error or from JS. It then
gets parsed and converted to a `quaint:Error`.

This allows to handle most of the DB level errors (read: everything that
actually reached running DB). It does not handle TLS and networking
errors since these look completely different in JS. We'll need to handle
them later.
