### PR TITLE
feat(core): add `cuid2` default generator 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3281,6 +3281,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "cuid 1.3.2 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
+ "cuid2 0.1.2 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
  "getrandom 0.2.10",
  "itertools",
  "nanoid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,12 +863,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51294db11d38eb763c92936c5c88425d0090e27dce21dd15748134af9e53e739"
 dependencies = [
  "base36",
- "cuid-util",
- "cuid2",
+ "cuid-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cuid2 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hostname",
  "num",
  "once_cell",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "cuid"
+version = "1.3.2"
+source = "git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32#4f9ce0f3c3991167c7fe7648bc1f2c220fe266b9"
+dependencies = [
+ "base36",
+ "cuid-util 0.1.0 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
+ "cuid2 0.1.2 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "sha3",
 ]
 
 [[package]]
@@ -878,12 +892,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ea2bfe0336ff1b7ca74819b2df8dfae9afea358aff6b1688baa5c181d8c3713"
 
 [[package]]
+name = "cuid-util"
+version = "0.1.0"
+source = "git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32#4f9ce0f3c3991167c7fe7648bc1f2c220fe266b9"
+
+[[package]]
 name = "cuid2"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47d99cacd52fd67db7490ad051c8c1973fb75520174d69aabbae08c534c9d0e8"
 dependencies = [
- "cuid-util",
+ "cuid-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num",
+ "rand 0.8.5",
+ "sha3",
+]
+
+[[package]]
+name = "cuid2"
+version = "0.1.2"
+source = "git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32#4f9ce0f3c3991167c7fe7648bc1f2c220fe266b9"
+dependencies = [
+ "cuid-util 0.1.0 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
  "num",
  "rand 0.8.5",
  "sha3",
@@ -1504,8 +1534,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2391,7 +2423,7 @@ dependencies = [
  "bigdecimal",
  "bson",
  "chrono",
- "cuid",
+ "cuid 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "indexmap 1.9.3",
  "itertools",
@@ -3248,7 +3280,8 @@ version = "0.0.0"
 dependencies = [
  "bigdecimal",
  "chrono",
- "cuid",
+ "cuid 1.3.2 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
+ "getrandom 0.2.10",
  "itertools",
  "nanoid",
  "prisma-value",
@@ -3528,7 +3561,7 @@ dependencies = [
  "chrono",
  "connection-string",
  "crossbeam-channel",
- "cuid",
+ "cuid 1.3.2 (git+https://github.com/jkomyno/cuid-rust?branch=jkomyno/wasm32)",
  "enumflags2",
  "futures",
  "indexmap 1.9.3",
@@ -4687,7 +4720,7 @@ dependencies = [
  "async-trait",
  "bigdecimal",
  "chrono",
- "cuid",
+ "cuid 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures",
  "itertools",
  "once_cell",

--- a/psl/parser-database/src/attributes/default.rs
+++ b/psl/parser-database/src/attributes/default.rs
@@ -197,7 +197,7 @@ fn validate_model_builtin_scalar_type_default(
             validate_empty_function_args(funcname, &funcargs.arguments, accept, ctx)
         }
         (ScalarType::String, ast::Expression::Function(funcname, funcargs, _))
-            if funcname == FN_UUID || funcname == FN_CUID =>
+            if funcname == FN_UUID || funcname == FN_CUID || funcname == FN_CUID2 =>
         {
             validate_empty_function_args(funcname, &funcargs.arguments, accept, ctx)
         }
@@ -243,7 +243,7 @@ fn validate_composite_builtin_scalar_type_default(
     match (scalar_type, value) {
         // Functions
         (ScalarType::String, ast::Expression::Function(funcname, funcargs, _))
-            if funcname == FN_UUID || funcname == FN_CUID =>
+            if funcname == FN_UUID || funcname == FN_CUID || funcname == FN_CUID =>
         {
             validate_empty_function_args(funcname, &funcargs.arguments, accept, ctx)
         }
@@ -473,6 +473,7 @@ fn validate_builtin_scalar_list_default(
 
 const FN_AUTOINCREMENT: &str = "autoincrement";
 const FN_CUID: &str = "cuid";
+const FN_CUID2: &str = "cuid2";
 const FN_DBGENERATED: &str = "dbgenerated";
 const FN_NANOID: &str = "nanoid";
 const FN_NOW: &str = "now";
@@ -482,6 +483,7 @@ const FN_AUTO: &str = "auto";
 const KNOWN_FUNCTIONS: &[&str] = &[
     FN_AUTOINCREMENT,
     FN_CUID,
+    FN_CUID2,
     FN_DBGENERATED,
     FN_NANOID,
     FN_NOW,

--- a/psl/parser-database/src/walkers/scalar_field.rs
+++ b/psl/parser-database/src/walkers/scalar_field.rs
@@ -192,6 +192,11 @@ impl<'db> DefaultValueWalker<'db> {
         matches!(self.value(), ast::Expression::Function(name, _, _) if name == "cuid")
     }
 
+    /// Is this an `@default(cuid2())`?
+    pub fn is_cuid2(self) -> bool {
+        matches!(self.value(), ast::Expression::Function(name, _, _) if name == "cuid2")
+    }
+
     /// Is this an `@default(nanoid())`?
     pub fn is_nanoid(self) -> bool {
         matches!(self.value(), ast::Expression::Function(name, _, _) if name == "nanoid")

--- a/psl/psl/tests/attributes/id_positive.rs
+++ b/psl/psl/tests/attributes/id_positive.rs
@@ -51,6 +51,26 @@ fn should_allow_string_ids_with_cuid() {
 }
 
 #[test]
+fn should_allow_string_ids_with_cuid2() {
+    let dml = indoc! {r#"
+        model Model {
+          id String @id @default(cuid2())
+        }
+    "#};
+
+    let schema = psl::parse_schema(dml).unwrap();
+    let model = schema.assert_has_model("Model");
+
+    model
+        .assert_has_scalar_field("id")
+        .assert_scalar_type(ScalarType::String)
+        .assert_default_value()
+        .assert_cuid2();
+
+    model.assert_id_on_fields(&["id"]);
+}
+
+#[test]
 fn should_allow_string_ids_with_uuid() {
     let dml = indoc! {r#"
         model Model {

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -83,6 +83,7 @@ pub(crate) trait DefaultValueAssert {
     fn assert_bytes(&self, val: &[u8]) -> &Self;
     fn assert_now(&self) -> &Self;
     fn assert_cuid(&self) -> &Self;
+    fn assert_cuid2(&self) -> &Self;
     fn assert_uuid(&self) -> &Self;
     fn assert_dbgenerated(&self, val: &str) -> &Self;
     fn assert_mapped_name(&self, val: &str) -> &Self;
@@ -434,6 +435,12 @@ impl<'a> DefaultValueAssert for walkers::DefaultValueWalker<'a> {
     }
 
     #[track_caller]
+    fn assert_cuid2(&self) -> &Self {
+        self.value().assert_cuid2();
+        self
+    }
+
+    #[track_caller]
     fn assert_uuid(&self) -> &Self {
         self.value().assert_uuid();
         self
@@ -624,6 +631,15 @@ impl DefaultValueAssert for ast::Expression {
     fn assert_cuid(&self) -> &Self {
         assert!(
             matches!(self, ast::Expression::Function(name, args, _) if name == "cuid" && args.arguments.is_empty())
+        );
+
+        self
+    }
+
+    #[track_caller]
+    fn assert_cuid2(&self) -> &Self {
+        assert!(
+            matches!(self, ast::Expression::Function(name, args, _) if name == "cuid2" && args.arguments.is_empty())
         );
 
         self

--- a/psl/psl/tests/functions/server_side_functions.rs
+++ b/psl/psl/tests/functions/server_side_functions.rs
@@ -38,6 +38,24 @@ fn correctly_handle_server_side_cuid_function() {
 }
 
 #[test]
+fn correctly_handle_server_side_cuid2_function() {
+    let dml = indoc! {r#"
+        model User {
+          id Int @id
+          someId String @default(cuid2())
+        }
+    "#};
+
+    psl::parse_schema(dml)
+        .unwrap()
+        .assert_has_model("User")
+        .assert_has_scalar_field("someId")
+        .assert_scalar_type(ScalarType::String)
+        .assert_default_value()
+        .assert_cuid2();
+}
+
+#[test]
 fn correctly_handle_server_side_uuid_function() {
     let dml = indoc! {r#"
         model User {

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = { version = "1.7", features = ["serde-1"] }
 itertools = "0.10"
 once_cell = "1"
 petgraph = "0.4"
-prisma-models = { path = "../prisma-models", features = ["default_generators"] }
+prisma-models = { path = "../prisma-models" }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
 query-engine-metrics = {path = "../metrics"}
 serde.workspace = true
@@ -29,7 +29,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-opentelemetry = "0.17.4"
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 uuid = "1"
-cuid = "1.2"
+cuid = { git = "https://github.com/jkomyno/cuid-rust", branch = "jkomyno/wasm32" }
+
 schema = { path = "../schema" }
 lru = "0.7.7"
 enumflags2 = "0.7"

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = { version = "1.7", features = ["serde-1"] }
 itertools = "0.10"
 once_cell = "1"
 petgraph = "0.4"
-prisma-models = { path = "../prisma-models" }
+prisma-models = { path = "../prisma-models", features = ["default_generators"] }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
 query-engine-metrics = {path = "../metrics"}
 serde.workspace = true

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -44,7 +44,6 @@ const MINIMUM_TX_ID_LENGTH: usize = 24;
 
 impl Default for TxId {
     fn default() -> Self {
-        #[allow(deprecated)]
         Self(cuid::cuid().unwrap())
     }
 }

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -10,7 +10,16 @@ serde.workspace = true
 serde_json.workspace = true
 schema = { path = "../schema" }
 indexmap = { version = "1.7", features = ["serde-1"] }
-prisma-models = { path = "../prisma-models" }
+
+[dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["wasm_generators"]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["all"]
 
 [dev-dependencies]
 expect-test = "1.2.2"

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -10,16 +10,7 @@ serde.workspace = true
 serde_json.workspace = true
 schema = { path = "../schema" }
 indexmap = { version = "1.7", features = ["serde-1"] }
-
-[dependencies.prisma-models]
-path = "../prisma-models"
-default-features = false
-features = ["wasm_generators"]
-
-[target.'cfg(not(target_family = "wasm"))'.dependencies.prisma-models]
-path = "../prisma-models"
-default-features = false
-features = ["all"]
+prisma-models = { path = "../prisma-models", features = ["default_generators"] }
 
 [dev-dependencies]
 expect-test = "1.2.2"

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -41,6 +41,9 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
         // Postgres Custom Types
         return ColumnTypeEnum.Enum
       }
+    case 1007:
+      return ColumnTypeEnum.Array
+    default:
       throw new Error(`Unsupported column type: ${fieldTypeId}`)
   }
 }

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -9,14 +9,20 @@ itertools = "0.10"
 prisma-value = { path = "../../libs/prisma-value" }
 bigdecimal = "0.3"
 thiserror = "1.0"
-
+getrandom = { version = "0.2" }
 uuid = { workspace = true, optional = true }
-cuid = { version = "1.2", optional = true }
+cuid = { git = "https://github.com/jkomyno/cuid-rust", branch = "jkomyno/wasm32", optional = true }
 nanoid = { version = "0.4.0", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 
 [features]
-# Support for generating default UUID, CUID, nanoid and datetime values. This
-# implies random number generation works, so it won't compile on targets like
-# wasm32.
-default_generators = ["uuid/v4", "cuid", "nanoid"]
+default = ["all"]
+all = ["wasm_generators", "sys_generators"]
+
+# Support for generating default UUID, CUID, nanoid and datetime values.
+sys_generators = []
+wasm_generators = ["cuid", "uuid", "nanoid", "getrandom/js"]
+
+cuid = ["dep:cuid"]
+nanoid = ["dep:nanoid"]
+uuid = ["uuid/v4"]

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -12,6 +12,7 @@ thiserror = "1.0"
 getrandom = { version = "0.2" }
 uuid = { workspace = true, optional = true }
 cuid = { git = "https://github.com/jkomyno/cuid-rust", branch = "jkomyno/wasm32", optional = true }
+cuid2 = { git = "https://github.com/jkomyno/cuid-rust", branch = "jkomyno/wasm32", optional = true }
 nanoid = { version = "0.4.0", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 
@@ -23,8 +24,9 @@ features = ["js"]
 default = []
 
 # Support for generating default UUID, CUID, nanoid and datetime values.
-default_generators = ["cuid", "uuid", "nanoid"]
+default_generators = ["cuid", "cuid2", "uuid", "nanoid"]
 
 cuid = ["dep:cuid"]
+cuid2 = ["dep:cuid2"]
 nanoid = ["dep:nanoid"]
 uuid = ["uuid/v4"]

--- a/query-engine/prisma-models/Cargo.toml
+++ b/query-engine/prisma-models/Cargo.toml
@@ -15,13 +15,15 @@ cuid = { git = "https://github.com/jkomyno/cuid-rust", branch = "jkomyno/wasm32"
 nanoid = { version = "0.4.0", optional = true }
 chrono = { version = "0.4.6", features = ["serde"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]
+
 [features]
-default = ["all"]
-all = ["wasm_generators", "sys_generators"]
+default = []
 
 # Support for generating default UUID, CUID, nanoid and datetime values.
-sys_generators = []
-wasm_generators = ["cuid", "uuid", "nanoid", "getrandom/js"]
+default_generators = ["cuid", "uuid", "nanoid"]
 
 cuid = ["dep:cuid"]
 nanoid = ["dep:nanoid"]

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -28,6 +28,11 @@ impl DefaultKind {
         matches!(self, DefaultKind::Expression(generator) if generator.name == "cuid")
     }
 
+    /// Does this match @default(cuid2(_))?
+    pub fn is_cuid2(&self) -> bool {
+        matches!(self, DefaultKind::Expression(generator) if generator.name == "cuid2")
+    }
+
     /// Does this match @default(dbgenerated(_))?
     pub fn is_dbgenerated(&self) -> bool {
         matches!(self, DefaultKind::Expression(generator) if generator.name == "dbgenerated")
@@ -98,6 +103,11 @@ impl DefaultValue {
     /// Does this match @default(cuid(_))?
     pub fn is_cuid(&self) -> bool {
         self.kind.is_cuid()
+    }
+
+    /// Does this match @default(cuid2(_))?
+    pub fn is_cuid2(&self) -> bool {
+        self.kind.is_cuid2()
     }
 
     /// Does this match @default(dbgenerated(_))?
@@ -184,6 +194,10 @@ impl ValueGenerator {
         ValueGenerator::new("cuid".to_owned(), vec![]).unwrap()
     }
 
+    pub fn new_cuid2() -> Self {
+        ValueGenerator::new("cuid2".to_owned(), vec![]).unwrap()
+    }
+
     pub fn new_uuid() -> Self {
         ValueGenerator::new("uuid".to_owned(), vec![]).unwrap()
     }
@@ -238,6 +252,7 @@ impl ValueGenerator {
 pub enum ValueGeneratorFn {
     Uuid,
     Cuid,
+    Cuid2,
     Nanoid(Option<u8>),
     Now,
     Autoincrement,
@@ -249,6 +264,7 @@ impl ValueGeneratorFn {
     fn new(name: &str) -> std::result::Result<Self, String> {
         match name {
             "cuid" => Ok(Self::Cuid),
+            "cuid2" => Ok(Self::Cuid2),
             "uuid" => Ok(Self::Uuid),
             "now" => Ok(Self::Now),
             "autoincrement" => Ok(Self::Autoincrement),
@@ -265,6 +281,7 @@ impl ValueGeneratorFn {
         match self {
             Self::Uuid => Some(Self::generate_uuid()),
             Self::Cuid => Some(Self::generate_cuid()),
+            Self::Cuid2 => Some(Self::generate_cuid2()),
             Self::Nanoid(length) => Some(Self::generate_nanoid(length)),
             Self::Now => Some(Self::generate_now()),
             Self::Autoincrement => None,
@@ -276,6 +293,11 @@ impl ValueGeneratorFn {
     #[cfg(feature = "default_generators")]
     fn generate_cuid() -> PrismaValue {
         PrismaValue::String(cuid::cuid().unwrap())
+    }
+
+    #[cfg(feature = "default_generators")]
+    fn generate_cuid2() -> PrismaValue {
+        PrismaValue::String(cuid2::cuid())
     }
 
     #[cfg(feature = "default_generators")]
@@ -347,6 +369,14 @@ mod tests {
 
         assert!(cuid_default.is_cuid());
         assert!(!cuid_default.is_now());
+    }
+
+    #[test]
+    fn default_value_is_cuid2() {
+        let cuid2_default = DefaultValue::new_expression(ValueGenerator::new_cuid2());
+
+        assert!(cuid2_default.is_cuid2());
+        assert!(!cuid2_default.is_now());
     }
 
     #[test]

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -275,7 +275,6 @@ impl ValueGeneratorFn {
 
     #[cfg(feature = "default_generators")]
     fn generate_cuid() -> PrismaValue {
-        #[allow(deprecated)]
         PrismaValue::String(cuid::cuid().unwrap())
     }
 

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -66,6 +66,7 @@ impl DefaultKind {
 
     /// Returns either a copy of the contained single value or produces a new
     /// value as defined by the expression.
+    #[cfg(feature = "default_generators")]
     pub fn get(&self) -> Option<PrismaValue> {
         match self {
             DefaultKind::Single(ref v) => Some(v.clone()),
@@ -219,6 +220,7 @@ impl ValueGenerator {
         self.args.get(0).and_then(|v| v.1.as_string())
     }
 
+    #[cfg(feature = "default_generators")]
     pub fn generate(&self) -> Option<PrismaValue> {
         self.generator.invoke()
     }
@@ -234,9 +236,8 @@ impl ValueGenerator {
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum ValueGeneratorFn {
-    #[cfg(feature = "cuid")]
-    Cuid,
     Uuid,
+    Cuid,
     Nanoid(Option<u8>),
     Now,
     Autoincrement,
@@ -247,7 +248,6 @@ pub enum ValueGeneratorFn {
 impl ValueGeneratorFn {
     fn new(name: &str) -> std::result::Result<Self, String> {
         match name {
-            #[cfg(feature = "cuid")]
             "cuid" => Ok(Self::Cuid),
             "uuid" => Ok(Self::Uuid),
             "now" => Ok(Self::Now),
@@ -260,11 +260,11 @@ impl ValueGeneratorFn {
         }
     }
 
+    #[cfg(feature = "default_generators")]
     fn invoke(&self) -> Option<PrismaValue> {
         match self {
-            #[cfg(feature = "cuid")]
-            Self::Cuid => Some(Self::generate_cuid()),
             Self::Uuid => Some(Self::generate_uuid()),
+            Self::Cuid => Some(Self::generate_cuid()),
             Self::Nanoid(length) => Some(Self::generate_nanoid(length)),
             Self::Now => Some(Self::generate_now()),
             Self::Autoincrement => None,
@@ -273,15 +273,18 @@ impl ValueGeneratorFn {
         }
     }
 
-    #[cfg(feature = "cuid")]
+    #[cfg(feature = "default_generators")]
     fn generate_cuid() -> PrismaValue {
+        #[allow(deprecated)]
         PrismaValue::String(cuid::cuid().unwrap())
     }
 
+    #[cfg(feature = "default_generators")]
     fn generate_uuid() -> PrismaValue {
         PrismaValue::Uuid(uuid::Uuid::new_v4())
     }
 
+    #[cfg(feature = "default_generators")]
     fn generate_nanoid(length: &Option<u8>) -> PrismaValue {
         if length.is_some() {
             let value: usize = usize::from(length.unwrap());
@@ -291,6 +294,7 @@ impl ValueGeneratorFn {
         }
     }
 
+    #[cfg(feature = "default_generators")]
     fn generate_now() -> PrismaValue {
         PrismaValue::DateTime(chrono::Utc::now().into())
     }

--- a/query-engine/prisma-models/src/default_value.rs
+++ b/query-engine/prisma-models/src/default_value.rs
@@ -66,7 +66,6 @@ impl DefaultKind {
 
     /// Returns either a copy of the contained single value or produces a new
     /// value as defined by the expression.
-    #[cfg(feature = "default_generators")]
     pub fn get(&self) -> Option<PrismaValue> {
         match self {
             DefaultKind::Single(ref v) => Some(v.clone()),
@@ -220,7 +219,6 @@ impl ValueGenerator {
         self.args.get(0).and_then(|v| v.1.as_string())
     }
 
-    #[cfg(feature = "default_generators")]
     pub fn generate(&self) -> Option<PrismaValue> {
         self.generator.invoke()
     }
@@ -236,8 +234,9 @@ impl ValueGenerator {
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum ValueGeneratorFn {
-    Uuid,
+    #[cfg(feature = "cuid")]
     Cuid,
+    Uuid,
     Nanoid(Option<u8>),
     Now,
     Autoincrement,
@@ -248,6 +247,7 @@ pub enum ValueGeneratorFn {
 impl ValueGeneratorFn {
     fn new(name: &str) -> std::result::Result<Self, String> {
         match name {
+            #[cfg(feature = "cuid")]
             "cuid" => Ok(Self::Cuid),
             "uuid" => Ok(Self::Uuid),
             "now" => Ok(Self::Now),
@@ -260,11 +260,11 @@ impl ValueGeneratorFn {
         }
     }
 
-    #[cfg(feature = "default_generators")]
     fn invoke(&self) -> Option<PrismaValue> {
         match self {
-            Self::Uuid => Some(Self::generate_uuid()),
+            #[cfg(feature = "cuid")]
             Self::Cuid => Some(Self::generate_cuid()),
+            Self::Uuid => Some(Self::generate_uuid()),
             Self::Nanoid(length) => Some(Self::generate_nanoid(length)),
             Self::Now => Some(Self::generate_now()),
             Self::Autoincrement => None,
@@ -273,18 +273,15 @@ impl ValueGeneratorFn {
         }
     }
 
-    #[cfg(feature = "default_generators")]
+    #[cfg(feature = "cuid")]
     fn generate_cuid() -> PrismaValue {
-        #[allow(deprecated)]
         PrismaValue::String(cuid::cuid().unwrap())
     }
 
-    #[cfg(feature = "default_generators")]
     fn generate_uuid() -> PrismaValue {
         PrismaValue::Uuid(uuid::Uuid::new_v4())
     }
 
-    #[cfg(feature = "default_generators")]
     fn generate_nanoid(length: &Option<u8>) -> PrismaValue {
         if length.is_some() {
             let value: usize = usize::from(length.unwrap());
@@ -294,7 +291,6 @@ impl ValueGeneratorFn {
         }
     }
 
-    #[cfg(feature = "default_generators")]
     fn generate_now() -> PrismaValue {
         PrismaValue::DateTime(chrono::Utc::now().into())
     }

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -218,6 +218,9 @@ pub fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<Sca
         ast::Expression::Function(funcname, _args, _) if funcname == "cuid" => {
             DefaultKind::Expression(ValueGenerator::new_cuid())
         }
+        ast::Expression::Function(funcname, _args, _) if funcname == "cuid2" => {
+            DefaultKind::Expression(ValueGenerator::new_cuid2())
+        }
         ast::Expression::Function(funcname, args, _) if funcname == "nanoid" => {
             DefaultKind::Expression(ValueGenerator::new_nanoid(
                 args.arguments

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -202,6 +202,22 @@ fn cuid_fields_must_work() {
 }
 
 #[test]
+fn cuid2_fields_must_work() {
+    let datamodel = convert(
+        r#"
+            model Test {
+                id String @id @default(cuid2())
+            }
+        "#,
+    );
+
+    let model = datamodel.assert_model("Test");
+    model
+        .assert_scalar_field("id")
+        .assert_type_identifier(TypeIdentifier::String);
+}
+
+#[test]
 fn createdAt_works() {
     let datamodel = convert(
         r#"

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -4,10 +4,19 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-prisma-models = { path = "../prisma-models" }
 psl.workspace = true
 rustc-hash = "1.1.0"
 once_cell = "1"
+
+[dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["wasm_generators"]
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies.prisma-models]
+path = "../prisma-models"
+default-features = false
+features = ["all"]
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/query-engine/schema/Cargo.toml
+++ b/query-engine/schema/Cargo.toml
@@ -7,16 +7,7 @@ edition = "2021"
 psl.workspace = true
 rustc-hash = "1.1.0"
 once_cell = "1"
-
-[dependencies.prisma-models]
-path = "../prisma-models"
-default-features = false
-features = ["wasm_generators"]
-
-[target.'cfg(not(target_family = "wasm"))'.dependencies.prisma-models]
-path = "../prisma-models"
-default-features = false
-features = ["all"]
+prisma-models = { path = "../prisma-models" }
 
 [dev-dependencies]
 codspeed-criterion-compat = "1.1.0"

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/default.rs
@@ -16,6 +16,7 @@ pub(crate) enum DefaultKind<'a> {
     Autoincrement,
     Uuid,
     Cuid,
+    Cuid2,
     Nanoid(Option<u8>),
     Now,
     String(&'a str),
@@ -117,6 +118,7 @@ impl<'a> DefaultValuePair<'a> {
 
             (None, sql::ColumnTypeFamily::String | sql::ColumnTypeFamily::Uuid) => match self.previous {
                 Some(previous) if previous.is_cuid() => Some(DefaultKind::Cuid),
+                Some(previous) if previous.is_cuid2() => Some(DefaultKind::Cuid2),
                 Some(previous) if previous.is_uuid() => Some(DefaultKind::Uuid),
                 Some(previous) if previous.is_nanoid() => {
                     let length = previous.value().as_function().and_then(|(_, args, _)| {

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/defaults.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/rendering/defaults.rs
@@ -47,6 +47,7 @@ pub(crate) fn render(default: DefaultValuePair<'_>) -> Option<renderer::DefaultV
             DefaultKind::Autoincrement => Some(renderer::DefaultValue::function(Function::new("autoincrement"))),
             DefaultKind::Uuid => Some(renderer::DefaultValue::function(Function::new("uuid"))),
             DefaultKind::Cuid => Some(renderer::DefaultValue::function(Function::new("cuid"))),
+            DefaultKind::Cuid2 => Some(renderer::DefaultValue::function(Function::new("cuid2"))),
             DefaultKind::Nanoid(length) => {
                 let mut fun = Function::new("nanoid");
 

--- a/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/re_introspection/mod.rs
@@ -984,6 +984,10 @@ async fn virtual_cuid_default(api: &mut TestApi) {
                 t.add_column("id", types::varchar(21).primary(true));
             });
 
+            migration.create_table("User4", |t| {
+                t.add_column("id", types::varchar(25).primary(true));
+            });
+
             migration.create_table("Unrelated", |t| {
                 t.add_column("id", types::primary());
             });
@@ -1004,6 +1008,11 @@ async fn virtual_cuid_default(api: &mut TestApi) {
         model User3 {
             id        String    @id @default(nanoid(7)) @db.VarChar(21)
         }
+
+        model User4 {
+            id        String    @id @default(cuid2()) @db.VarChar(25)
+            non_id    String    @default(cuid2()) @db.VarChar(25)
+        }
         "#;
 
     let final_dm = indoc! {r#"
@@ -1018,6 +1027,11 @@ async fn virtual_cuid_default(api: &mut TestApi) {
 
         model User3 {
             id        String    @id @default(nanoid(7)) @db.VarChar(21)
+        }
+
+        model User4 {
+            id        String    @id @default(cuid2()) @db.VarChar(25)
+            non_id    String    @default(cuid2()) @db.VarChar(25)
         }
 
         model Unrelated {


### PR DESCRIPTION
This PR is based on https://github.com/prisma/prisma-engines/pull/4217.

This PR adds support for the `cuid2` default generator to:
- `psl`
- `prisma-models`
- `sql-schema-connectors`

Tests include PSL validation, introspection, re-introspection.