### PR TITLE
qe: fix dmmf for compound unique and id with unsupported types

### DIFF
--- a/query-engine/dmmf/src/tests/tests.rs
+++ b/query-engine/dmmf/src/tests/tests.rs
@@ -87,6 +87,54 @@ fn unsupported_in_composite_type() {
     dmmf_from_schema(schema);
 }
 
+// Regression test for https://github.com/prisma/prisma/issues/20986
+#[test]
+fn unusupported_in_compound_unique_must_not_panic() {
+    let schema = r#"
+        datasource db {
+            provider = "postgresql"
+            url      = env("TEST_DATABASE_URL")
+        }
+
+        generator client {
+            provider = "postgresql"
+        }
+
+        model A {
+            id          Int                      @id
+            field       Int
+            unsupported Unsupported("tstzrange")
+
+            @@unique([field, unsupported])
+        }
+    "#;
+
+    dmmf_from_schema(schema);
+}
+
+#[test]
+fn unusupported_in_compound_id_must_not_panic() {
+    let schema = r#"
+        datasource db {
+            provider = "postgresql"
+            url      = env("TEST_DATABASE_URL")
+        }
+
+        generator client {
+            provider = "postgresql"
+        }
+
+        model A {
+            field       Int                      @unique
+            unsupported Unsupported("tstzrange")
+
+            @@id([field, unsupported])
+        }
+    "#;
+
+    dmmf_from_schema(schema);
+}
+
 const SNAPSHOTS_PATH: &str = concat!(
     env!("CARGO_MANIFEST_DIR"),
     "/src",

--- a/query-engine/schema/src/build/input_types/objects/filter_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/filter_objects.rs
@@ -113,6 +113,7 @@ pub(crate) fn where_unique_object_type(ctx: &'_ QuerySchema, model: Model) -> In
             .indexes()
             .filter(|idx| idx.is_unique())
             .filter(|index| index.fields().len() > 1)
+            .filter(|index| !index.fields().any(|f| f.is_unsupported()))
             .map(|index| {
                 let fields = index
                     .fields()
@@ -130,6 +131,7 @@ pub(crate) fn where_unique_object_type(ctx: &'_ QuerySchema, model: Model) -> In
             .walk(model.id)
             .primary_key()
             .filter(|pk| pk.fields().len() > 1)
+            .filter(|pk| !pk.fields().any(|f| f.is_unsupported()))
             .map(|pk| {
                 let name = compound_id_field_name(pk);
                 let fields = model.fields().id_fields().unwrap().collect();


### PR DESCRIPTION
Fix DMMF generation for schemas with compound `@@id` or `@@unique` that contain unsupported fields. Previously DMMF generation would panic with

```
unreachable code: No unsupported field should reach that path', query-engine/schema-builder/src/input_types/mod.rs:26:40
```

The issue with compound unique was re-introduced in Prisma 4.16 in https://github.com/prisma/prisma-engines/pull/3977 after being previously fixed in Prisma 4.14 in https://github.com/prisma/prisma-engines/pull/3960.

The issue with compound id is a new one, and is reproducible with Prisma 4.14 as well.

Fixes: https://github.com/prisma/prisma/issues/20986