### PR TITLE
fix(driver-adapters): stop caching the previous driver adapter

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/database/js.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/js.rs
@@ -32,7 +32,7 @@ fn registered_driver_adapter(provider: &str) -> connector::Result<DriverAdapter>
         .map(|conn_ref| conn_ref.to_owned())
 }
 
-pub fn register_driver_adapter(provider: &str, connector: Arc<dyn TransactionCapable>) -> () {
+pub fn register_driver_adapter(provider: &str, connector: Arc<dyn TransactionCapable>) {
     let mut lock = REGISTRY.lock().unwrap();
     let entry = lock.entry(provider.to_string());
 

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -185,13 +185,9 @@ impl QueryEngine {
                 let js_queryable = driver_adapters::from_napi(driver);
                 let provider_name = schema.connector.provider_name();
 
-                match sql_connector::register_driver_adapter(provider_name, Arc::new(js_queryable)) {
-                    Ok(_) => {
-                        connector_mode = ConnectorMode::Js;
-                        tracing::info!("Registered driver adapter for {provider_name}.")
-                    }
-                    Err(err) => tracing::error!("Failed to register driver adapter for {provider_name}. {err}"),
-                }
+                sql_connector::register_driver_adapter(provider_name, Arc::new(js_queryable));
+                connector_mode = ConnectorMode::Js;
+                tracing::info!("Registered driver adapter for {provider_name}.");
             }
         }
 


### PR DESCRIPTION
This PR prevents caching a previous adapter when the `libquery` is constructed for the `n`th time (`n` > 1) with a "provider"  that was already declared previously.

This fixes [this bug](https://prisma-company.slack.com/archives/C04TW4A2H8C/p1694427006442229) impacting the [`prisma/prisma` tests](https://github.com/prisma/prisma/pull/20991).

---

**Note**: currently we're using an `HashMap<String, DriverAdapter>` to register the driver adapters in `libquery`. I don't think there's any valid reason to do so. A simple `Option<DriverAdapter>` would do, and would have prevented this bug in the first place (which didn't arise when each driver adapter had its own 1:1 provider, and that we didn't notice in https://github.com/prisma/prisma-engines/pull/4141). This idea is implemented in https://github.com/prisma/prisma-engines/pull/4222.