### PR TITLE
impr(quaint/qe): `DISTINCT ON`

### DIFF
--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -64,7 +64,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     SupportsTxIsolationSerializable |
     NativeUpsert |
     InsertReturning |
-    UpdateReturning
+    UpdateReturning |
+    Distinct
 });
 
 pub struct PostgresDatamodelConnector;

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -103,6 +103,7 @@ capabilities!(
     NativeUpsert,
     InsertReturning,
     UpdateReturning,
+    Distinct // Connector supports DB-level distinct (e.g. postgres)
 );
 
 /// Contains all capabilities that the connector is able to serve.

--- a/quaint/src/ast.rs
+++ b/quaint/src/ast.rs
@@ -47,7 +47,7 @@ pub use ordering::{IntoOrderDefinition, Order, OrderDefinition, Orderable, Order
 pub use over::*;
 pub use query::{Query, SelectQuery};
 pub use row::Row;
-pub use select::Select;
+pub use select::{DistinctType, Select};
 pub use table::*;
 pub use union::Union;
 pub use update::*;

--- a/quaint/src/ast/select.rs
+++ b/quaint/src/ast/select.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 /// A builder for a `SELECT` statement.
 #[derive(Debug, PartialEq, Clone, Default)]
 pub struct Select<'a> {
-    pub(crate) distinct: bool,
+    pub(crate) distinct: Option<DistinctType<'a>>,
     pub(crate) tables: Vec<Table<'a>>,
     pub(crate) columns: Vec<Expression<'a>>,
     pub(crate) conditions: Option<ConditionTree<'a>>,
@@ -16,6 +16,12 @@ pub struct Select<'a> {
     pub(crate) joins: Vec<Join<'a>>,
     pub(crate) ctes: Vec<CommonTableExpression<'a>>,
     pub(crate) comment: Option<Cow<'a, str>>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum DistinctType<'a> {
+    Default,
+    OnClause(Vec<Expression<'a>>),
 }
 
 impl<'a> From<Select<'a>> for Expression<'a> {
@@ -236,7 +242,12 @@ impl<'a> Select<'a> {
     /// # }
     /// ```
     pub fn distinct(mut self) -> Self {
-        self.distinct = true;
+        self.distinct = Some(DistinctType::Default);
+        self
+    }
+
+    pub fn distinct_on(mut self, columns: Vec<Expression<'a>>) -> Self {
+        self.distinct = Some(DistinctType::OnClause(columns));
         self
     }
 

--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -206,9 +206,15 @@ pub trait Visitor<'a> {
 
         self.write("SELECT ")?;
 
-        if select.distinct {
-            self.write("DISTINCT ")?;
-        }
+        if let Some(distinct) = select.distinct {
+            match distinct {
+                DistinctType::Default => self.write("DISTINCT ")?,
+                DistinctType::OnClause(columns) => {
+                    self.write("DISTINCT ON ")?;
+                    self.surround_with("(", ") ", |ref mut s| s.visit_columns(columns))?;
+                }
+            }
+        };
 
         if !select.tables.is_empty() {
             if select.columns.is_empty() {

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -652,10 +652,11 @@ mod tests {
 
     #[test]
     fn test_distinct_on() {
-        let expected_sql = "SELECT DISTINCT ON (\"bar\") \"bar\" FROM \"test\"";
-        let query = Select::from_table("test")
-            .column(Column::new("bar"))
-            .distinct_on(vec![Expression::from(Column::from("bar"))]);
+        let expected_sql = "SELECT DISTINCT ON (\"bar\", \"foo\") \"bar\" FROM \"test\"";
+        let query = Select::from_table("test").column(Column::new("bar")).distinct_on(vec![
+            Expression::from(Column::from("bar")),
+            Expression::from(Column::from("foo")),
+        ]);
 
         let (sql, _) = Postgres::build(query).unwrap();
 

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -651,6 +651,18 @@ mod tests {
     }
 
     #[test]
+    fn test_distinct_on() {
+        let expected_sql = "SELECT DISTINCT ON (\"bar\") \"bar\" FROM \"test\"";
+        let query = Select::from_table("test")
+            .column(Column::new("bar"))
+            .distinct_on(vec![Expression::from(Column::from("bar"))]);
+
+        let (sql, _) = Postgres::build(query).unwrap();
+
+        assert_eq!(expected_sql, sql);
+    }
+
+    #[test]
     fn test_distinct_with_subquery() {
         let expected_sql = "SELECT DISTINCT (SELECT $1 FROM \"test2\"), \"bar\" FROM \"test\"";
         let query = Select::from_table("test")

--- a/query-engine/connectors/query-connector/src/query_arguments.rs
+++ b/query-engine/connectors/query-connector/src/query_arguments.rs
@@ -1,5 +1,5 @@
 use crate::filter::Filter;
-use prisma_models::*;
+use prisma_models::{psl::datamodel_connector::ConnectorCapability, *};
 
 /// `QueryArguments` define various constraints queried data should fulfill:
 /// - `cursor`, `take`, `skip` page through the data.
@@ -71,7 +71,15 @@ impl QueryArguments {
     /// retrieved by the connector or if it requires the query engine to fetch a raw set
     /// of records and perform certain operations itself, in-memory.
     pub fn requires_inmemory_processing(&self) -> bool {
-        self.distinct.is_some() || self.contains_unstable_cursor() || self.contains_null_cursor()
+        let has_distinct = self.distinct.is_some()
+            && !self
+                .model()
+                .dm
+                .schema
+                .connector
+                .has_capability(ConnectorCapability::Distinct);
+
+        has_distinct || self.contains_unstable_cursor() || self.contains_null_cursor()
     }
 
     /// An unstable cursor is a cursor that is used in conjunction with an unstable (non-unique) combination of orderBys.


### PR DESCRIPTION
- Added quaint support for `DISTINCT ON`
- TODO: QE

closes https://github.com/prisma/prisma/issues/14765