### PR TITLE
driver-adapters: add example of loading the parent .envrc

### DIFF
--- a/query-engine/driver-adapters/js/smoke-test-js/.envrc.example
+++ b/query-engine/driver-adapters/js/smoke-test-js/.envrc.example
@@ -1,3 +1,5 @@
+source_up
+
 export JS_PLANETSCALE_DATABASE_URL="mysql://USER:PASSWORD@aws.connect.psdb.cloud/DATABASE?sslaccept=strict"
 export JS_NEON_DATABASE_URL="postgres://USER:PASSWORD@DATABASE-pooler.eu-central-1.aws.neon.tech/neondb?pgbouncer=true&connect_timeout=10"
 

--- a/query-engine/driver-adapters/js/smoke-test-js/.envrc.example
+++ b/query-engine/driver-adapters/js/smoke-test-js/.envrc.example
@@ -1,5 +1,8 @@
-# This will load the .envrc at the root of the `prisma-engines` repository before loading this one
-source_up
+# Uncomment "source_up" if you need to load the .envrc at the root of the
+# `prisma-engines` repository before loading this one (for example, if you
+# are using Nix).
+#
+# source_up
 
 export JS_PLANETSCALE_DATABASE_URL="mysql://USER:PASSWORD@aws.connect.psdb.cloud/DATABASE?sslaccept=strict"
 export JS_NEON_DATABASE_URL="postgres://USER:PASSWORD@DATABASE-pooler.eu-central-1.aws.neon.tech/neondb?pgbouncer=true&connect_timeout=10"

--- a/query-engine/driver-adapters/js/smoke-test-js/.envrc.example
+++ b/query-engine/driver-adapters/js/smoke-test-js/.envrc.example
@@ -1,3 +1,4 @@
+# This will load the .envrc at the root of the `prisma-engines` repository before loading this one
 source_up
 
 export JS_PLANETSCALE_DATABASE_URL="mysql://USER:PASSWORD@aws.connect.psdb.cloud/DATABASE?sslaccept=strict"


### PR DESCRIPTION
The example `.envrc` file was missing the `source_up` call to make it
inherit the parent `.envrc` from the root of the repo. This caused
everything from the root `.envrc` to be unloaded and unset.
