### PR TITLE
psl: simplify attribute list validation

### DIFF
--- a/psl/parser-database/src/context/attributes.rs
+++ b/psl/parser-database/src/context/attributes.rs
@@ -4,7 +4,7 @@ use crate::interner::StringId;
 #[derive(Default, Debug)]
 pub(super) struct AttributesValidationState {
     /// The attributes list being validated.
-    pub(super) attributes: Vec<ast::AttributeContainer>,
+    pub(super) attributes: Option<ast::AttributeContainer>,
     pub(super) unused_attributes: HashSet<ast::AttributeId>, // the _remaining_ attributes
 
     /// The attribute being validated.
@@ -13,10 +13,11 @@ pub(super) struct AttributesValidationState {
 }
 
 impl AttributesValidationState {
-    pub(super) fn extend_attributes(&mut self, attributes: ast::AttributeContainer, ast: &ast::SchemaAst) {
+    pub(super) fn set_attributes(&mut self, attributes: ast::AttributeContainer, ast: &ast::SchemaAst) {
         let attribute_ids = (0..ast[attributes].len()).map(|idx| ast::AttributeId::new_in_container(attributes, idx));
+        self.unused_attributes.clear();
         self.unused_attributes.extend(attribute_ids);
 
-        self.attributes.push(attributes);
+        self.attributes = Some(attributes);
     }
 }


### PR DESCRIPTION
Since type aliases are not a thing anymore,
`AttributesValidationState.attributes` does not need to be a Vec anymore (we were accumulating attributes defined on the model and on aliases), it can be an Option. This is simpler to reason about.