### PR TITLE
fix(qe): Prevent descriptions from mobc leaking into the presentation of metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,6 +323,7 @@ dependencies = [
  "enumflags2",
  "indoc",
  "insta",
+ "query-engine-metrics",
  "query-engine-tests",
  "query-tests-setup",
  "reqwest",

--- a/query-engine/black-box-tests/Cargo.toml
+++ b/query-engine/black-box-tests/Cargo.toml
@@ -14,3 +14,4 @@ tokio.workspace = true
 user-facing-errors.workspace = true
 insta = "1.7.1"
 enumflags2 = "0.7"
+query-engine-metrics = {path = "../metrics"}

--- a/query-engine/black-box-tests/tests/black_box_tests.rs
+++ b/query-engine/black-box-tests/tests/black_box_tests.rs
@@ -4,3 +4,5 @@ mod helpers;
 
 mod metrics;
 mod protocols;
+
+use query_engine_metrics;

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -59,6 +59,7 @@ mod smoke_tests {
             // I would have loved to use insta in here and check the snapshot but the order of the metrics is not guaranteed
             // And I opted for the manual checking of invariant data that provided enough confidence instead
 
+            // counters
             assert_eq!(metrics.matches("# HELP prisma_client_queries_total The total number of Prisma Client queries executed").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_total counter").count(), 1);
 
@@ -71,6 +72,7 @@ mod smoke_tests {
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_opened_total The total number of pool connections opened").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_opened_total counter").count(), 1);
 
+            // gauges
             assert_eq!(metrics.matches("# HELP prisma_client_queries_active The number of currently active Prisma Client queries").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_active gauge").count(), 1);
 
@@ -86,6 +88,7 @@ mod smoke_tests {
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_open The number of pool connections currently open").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_open gauge").count(), 1);
 
+            // histograms
             assert_eq!(metrics.matches("# HELP prisma_client_queries_duration_histogram_ms The distribution of the time Prisma Client queries took to run end to end").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_duration_histogram_ms histogram").count(), 1);
 

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -55,8 +55,9 @@ mod smoke_tests {
                 .text()
                 .await
                 .unwrap();
-
-            println!("{}", &metrics);
+            
+            // I would have loved to use insta in here and check the snapshot but the order of the metrics is not guaranteed
+            // And I opted for the manual checking of invariant data that provided enough confidence instead
 
             assert_eq!(metrics.matches("# HELP prisma_client_queries_total The total number of Prisma Client queries executed").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_total counter").count(), 1);

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -61,88 +61,40 @@ mod smoke_tests {
 
             assert_eq!(metrics.matches("# HELP prisma_client_queries_total The total number of Prisma Client queries executed").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_total 1").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_datasource_queries_total The total number of datasource queries executed").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_datasource_queries_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_total 1").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_closed_total The total number of pool connections closed").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_closed_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_closed_total 0").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_opened_total The total number of pool connections opened").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_opened_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_opened_total 1").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_client_queries_active The number of currently active Prisma Client queries").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_active gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_active 0").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_client_queries_wait The number of datasource queries currently waiting for an free connection").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_wait gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait 0").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_busy The number of pool connections currently executing datasource queries").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_busy gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_busy 0").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_idle The number of pool connections that are not busy running a query").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_idle gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_idle").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_open The number of pool connections currently open").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_open gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_open 1").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_client_queries_duration_histogram_ms The distribution of the time Prisma Client queries took to run end to end").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_duration_histogram_ms histogram").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"0\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"1\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"5\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"10\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"50\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"100\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"500\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"1000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"5000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"50000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_sum").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_count 1").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_client_queries_wait_histogram_ms The distribution of the time all datasource queries spent waiting for a free connection").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_client_queries_wait_histogram_ms histogram").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"0\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"1\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"5\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"10\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"50\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"100\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"500\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"1000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"5000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"50000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_sum").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_count").count(), 1);
-
+            
             assert_eq!(metrics.matches("# HELP prisma_datasource_queries_duration_histogram_ms The distribution of the time datasource queries took to run").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_datasource_queries_duration_histogram_ms histogram").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"0\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"1\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"5\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"10\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"50\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"100\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"500\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"1000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"5000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"50000\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_sum").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_count").count(), 1);
-
+            
             // Check that exist as many metrics as being accepted
             let accepted_metric_count = query_engine_metrics::ACCEPT_LIST.len();
             let displayed_metric_count = metrics.matches("# TYPE").count();

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -56,21 +56,91 @@ mod smoke_tests {
                 .await
                 .unwrap();
 
-            // counters
-            assert_eq!(metrics.matches("prisma_client_queries_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_opened_total counter").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_closed_total counter").count(), 1);
-            // gauges
-            assert_eq!(metrics.matches("prisma_pool_connections_open gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_busy gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_idle gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_active gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait gauge").count(), 1);
-            // histograms
-            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms histogram").count(), 1);
-            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms histogram").count(), 1);
-            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms histogram").count(), 1)
+            println!("{}", &metrics);
+
+            assert_eq!(metrics.matches("# HELP prisma_client_queries_total The total number of Prisma Client queries executed").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_client_queries_total counter").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_total 1").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_datasource_queries_total The total number of datasource queries executed").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_datasource_queries_total counter").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_total 1").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_pool_connections_closed_total The total number of pool connections closed").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_pool_connections_closed_total counter").count(), 1);
+            assert_eq!(metrics.matches("prisma_pool_connections_closed_total 0").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_pool_connections_opened_total The total number of pool connections opened").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_pool_connections_opened_total counter").count(), 1);
+            assert_eq!(metrics.matches("prisma_pool_connections_opened_total 1").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_client_queries_active The number of currently active Prisma Client queries").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_client_queries_active gauge").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_active 0").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_client_queries_wait The number of datasource queries currently waiting for an free connection").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_client_queries_wait gauge").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait 0").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_pool_connections_busy The number of pool connections currently executing datasource queries").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_pool_connections_busy gauge").count(), 1);
+            assert_eq!(metrics.matches("prisma_pool_connections_busy 0").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_pool_connections_idle The number of pool connections that are not busy running a query").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_pool_connections_idle gauge").count(), 1);
+            assert_eq!(metrics.matches("prisma_pool_connections_idle 21").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_pool_connections_open The number of pool connections currently open").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_pool_connections_open gauge").count(), 1);
+            assert_eq!(metrics.matches("prisma_pool_connections_open 1").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_client_queries_duration_histogram_ms The distribution of the time Prisma Client queries took to run end to end").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_client_queries_duration_histogram_ms histogram").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"0\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"1\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"5\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"10\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"50\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"100\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"500\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"1000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"5000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"50000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_sum").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_duration_histogram_ms_count 1").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_client_queries_wait_histogram_ms The distribution of the time all datasource queries spent waiting for a free connection").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_client_queries_wait_histogram_ms histogram").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"0\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"1\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"5\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"10\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"50\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"100\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"500\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"1000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"5000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"50000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_sum").count(), 1);
+            assert_eq!(metrics.matches("prisma_client_queries_wait_histogram_ms_count").count(), 1);
+
+            assert_eq!(metrics.matches("# HELP prisma_datasource_queries_duration_histogram_ms The distribution of the time datasource queries took to run").count(), 1);
+            assert_eq!(metrics.matches("# TYPE prisma_datasource_queries_duration_histogram_ms histogram").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"0\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"1\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"5\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"10\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"50\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"100\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"500\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"1000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"5000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"50000\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_sum").count(), 1);
+            assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_count").count(), 1);
         }).await
     }
 }

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -141,6 +141,9 @@ mod smoke_tests {
             assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_bucket{le=\"+Inf\"}").count(), 1);
             assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_sum").count(), 1);
             assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_count").count(), 1);
+
+            assert_eq!(metrics.matches("# TYPE").count(), query_engine_metrics::ACCEPT_LIST.len());
+            
         }).await
     }
 }

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -88,7 +88,7 @@ mod smoke_tests {
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_idle The number of pool connections that are not busy running a query").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_idle gauge").count(), 1);
-            assert_eq!(metrics.matches("prisma_pool_connections_idle 21").count(), 1);
+            assert_eq!(metrics.matches("prisma_pool_connections_idle").count(), 1);
 
             assert_eq!(metrics.matches("# HELP prisma_pool_connections_open The number of pool connections currently open").count(), 1);
             assert_eq!(metrics.matches("# TYPE prisma_pool_connections_open gauge").count(), 1);

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -142,7 +142,13 @@ mod smoke_tests {
             assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_sum").count(), 1);
             assert_eq!(metrics.matches("prisma_datasource_queries_duration_histogram_ms_count").count(), 1);
 
-            assert_eq!(metrics.matches("# TYPE").count(), query_engine_metrics::ACCEPT_LIST.len());
+            // Check that exist as many metrics as being accepted
+            let accepted_metric_count = query_engine_metrics::ACCEPT_LIST.len();
+            let displayed_metric_count = metrics.matches("# TYPE").count();
+            let non_prisma_metric_count = displayed_metric_count - metrics.matches("# TYPE prisma").count();
+            
+            assert_eq!(displayed_metric_count, accepted_metric_count);
+            assert_eq!(non_prisma_metric_count, 0);
             
         }).await
     }

--- a/query-engine/metrics/src/common.rs
+++ b/query-engine/metrics/src/common.rs
@@ -52,7 +52,30 @@ pub(crate) struct Metric {
 }
 
 impl Metric {
-    pub fn new(key: Key, description: String, value: MetricValue, global_labels: HashMap<String, String>) -> Self {
+    pub(crate) fn renamed(
+        key: Key,
+        descriptions: &HashMap<String, String>,
+        value: MetricValue,
+        global_labels: &HashMap<String, String>,
+    ) -> Self {
+        match crate::METRIC_RENAMES.get(key.name()) {
+            Some((new_key, new_description)) => Self::new(
+                Key::from_parts(new_key.to_string(), key.labels()),
+                new_description.to_string(),
+                value,
+                global_labels.clone(),
+            ),
+            None => {
+                let description = descriptions
+                    .get(key.name())
+                    .map(|s| s.to_string())
+                    .unwrap_or(String::new());
+                Self::new(key, description, value, global_labels.clone())
+            }
+        }
+    }
+
+    fn new(key: Key, description: String, value: MetricValue, global_labels: HashMap<String, String>) -> Self {
         let (name, labels) = key.into_parts();
 
         let mut labels_map: HashMap<String, String> = labels
@@ -62,13 +85,8 @@ impl Metric {
 
         labels_map.extend(global_labels);
 
-        let mut key = name.as_str();
-        if let Some(rename) = crate::METRIC_RENAMES.get(key) {
-            key = rename;
-        }
-
         Self {
-            key: key.to_string(),
+            key: name.as_str().to_string(),
             value,
             description,
             labels: labels_map,

--- a/query-engine/metrics/src/lib.rs
+++ b/query-engine/metrics/src/lib.rs
@@ -34,7 +34,8 @@ use once_cell::sync::Lazy;
 use recorder::*;
 pub use registry::MetricRegistry;
 use serde::Deserialize;
-use std::{collections::HashMap, sync::Once};
+use std::collections::HashMap;
+use std::sync::Once;
 
 pub extern crate metrics;
 pub use metrics::{
@@ -42,36 +43,31 @@ pub use metrics::{
     increment_counter, increment_gauge,
 };
 
-// Dependency metrics names emitted by the connector pool implementation (mobc) that will be renamed
-// using the `METRIC_RENAMES` map.
-pub const MOBC_POOL_CONNECTIONS_OPENED_TOTAL: &str = "mobc_pool_connections_opened_total";
-pub const MOBC_POOL_CONNECTIONS_CLOSED_TOTAL: &str = "mobc_pool_connections_closed_total";
-pub const MOBC_POOL_CONNECTIONS_OPEN: &str = "mobc_pool_connections_open";
-pub const MOBC_POOL_CONNECTIONS_BUSY: &str = "mobc_pool_connections_busy";
-pub const MOBC_POOL_CONNECTIONS_IDLE: &str = "mobc_pool_connections_idle";
-pub const MOBC_POOL_WAIT_COUNT: &str = "mobc_client_queries_wait";
-pub const MOBC_POOL_WAIT_DURATION: &str = "mobc_client_queries_wait_histogram_ms";
+// Metrics that we emit from the engines, third party metrics emitted by libraries and that we rename are omitted.
+pub const PRISMA_CLIENT_QUERIES_TOTAL: &str = "prisma_client_queries_total"; // counter
+pub const PRISMA_DATASOURCE_QUERIES_TOTAL: &str = "prisma_datasource_queries_total"; // counter
+pub const PRISMA_CLIENT_QUERIES_ACTIVE: &str = "prisma_client_queries_active"; // gauge
+pub const PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS: &str = "prisma_client_queries_duration_histogram_ms"; // histogram
+pub const PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS: &str = "prisma_datasource_queries_duration_histogram_ms"; // histogram
 
-// External metrics names that we expose.
-// counters
-pub const PRISMA_CLIENT_QUERIES_TOTAL: &str = "prisma_client_queries_total";
-pub const PRISMA_DATASOURCE_QUERIES_TOTAL: &str = "prisma_datasource_queries_total";
-pub const PRISMA_POOL_CONNECTIONS_OPENED_TOTAL: &str = "prisma_pool_connections_opened_total";
-pub const PRISMA_POOL_CONNECTIONS_CLOSED_TOTAL: &str = "prisma_pool_connections_closed_total";
-// gauges
-pub const PRISMA_POOL_CONNECTIONS_OPEN: &str = "prisma_pool_connections_open";
-pub const PRISMA_POOL_CONNECTIONS_BUSY: &str = "prisma_pool_connections_busy";
-pub const PRISMA_POOL_CONNECTIONS_IDLE: &str = "prisma_pool_connections_idle";
-pub const PRISMA_CLIENT_QUERIES_WAIT: &str = "prisma_client_queries_wait";
-pub const PRISMA_CLIENT_QUERIES_ACTIVE: &str = "prisma_client_queries_active";
-// histograms
-pub const PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS: &str = "prisma_client_queries_duration_histogram_ms";
-pub const PRISMA_CLIENT_QUERIES_WAIT_HISTOGRAM_MS: &str = "prisma_client_queries_wait_histogram_ms";
-pub const PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS: &str = "prisma_datasource_queries_duration_histogram_ms";
+// metrics emitted by the connector pool implementation (mobc) that will be renamed using the `METRIC_RENAMES` map.
+const MOBC_POOL_CONNECTIONS_OPENED_TOTAL: &str = "mobc_pool_connections_opened_total"; // counter
+const MOBC_POOL_CONNECTIONS_CLOSED_TOTAL: &str = "mobc_pool_connections_closed_total"; // counter
+const MOBC_POOL_CONNECTIONS_OPEN: &str = "mobc_pool_connections_open"; // gauge
+const MOBC_POOL_CONNECTIONS_BUSY: &str = "mobc_pool_connections_busy"; // gauge
+const MOBC_POOL_CONNECTIONS_IDLE: &str = "mobc_pool_connections_idle"; // gauge
+const MOBC_POOL_WAIT_COUNT: &str = "mobc_client_queries_wait"; // gauge
+const MOBC_POOL_WAIT_DURATION: &str = "mobc_client_queries_wait_histogram_ms"; // histogram
 
-// We need a list of acceptable metrics, we don't want to accidentally process metrics emitted by a
-// third party library
+/// Accept list: both first-party (emitted by the query engine) and third-party (emitted) metrics
 const ACCEPT_LIST: &[&str] = &[
+    // first-party
+    PRISMA_CLIENT_QUERIES_TOTAL,
+    PRISMA_DATASOURCE_QUERIES_TOTAL,
+    PRISMA_CLIENT_QUERIES_ACTIVE,
+    PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
+    PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS,
+    // third-party, emitted by mobc
     MOBC_POOL_CONNECTIONS_OPENED_TOTAL,
     MOBC_POOL_CONNECTIONS_CLOSED_TOTAL,
     MOBC_POOL_CONNECTIONS_OPEN,
@@ -79,26 +75,79 @@ const ACCEPT_LIST: &[&str] = &[
     MOBC_POOL_CONNECTIONS_IDLE,
     MOBC_POOL_WAIT_COUNT,
     MOBC_POOL_WAIT_DURATION,
-    PRISMA_CLIENT_QUERIES_TOTAL,
-    PRISMA_DATASOURCE_QUERIES_TOTAL,
-    PRISMA_CLIENT_QUERIES_ACTIVE,
-    PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
-    PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS,
 ];
 
-// Some of the metrics we receive have their internal names, and we need to expose them under a different
-// name, this map translates from the internal names used by mobc to the external names we want to expose
-static METRIC_RENAMES: Lazy<HashMap<&str, &str>> = Lazy::new(|| {
+/// Map that for any given accepted metric that is emitted by a third-party, in this case only the
+/// connection pool library mobc, it points to an internal, accepted metrics name and its description
+/// as displayed to users. This is used to rebrand the third-party metrics to accepted, prisma-specific
+/// ones.
+#[rustfmt::skip]
+static METRIC_RENAMES: Lazy<HashMap<&'static str, (&'static str, &'static str)>> = Lazy::new(|| {
     HashMap::from([
-        (MOBC_POOL_CONNECTIONS_OPENED_TOTAL, PRISMA_POOL_CONNECTIONS_OPENED_TOTAL),
-        (MOBC_POOL_CONNECTIONS_CLOSED_TOTAL, PRISMA_POOL_CONNECTIONS_CLOSED_TOTAL),
-        (MOBC_POOL_CONNECTIONS_OPEN, PRISMA_POOL_CONNECTIONS_OPEN),
-        (MOBC_POOL_CONNECTIONS_BUSY, PRISMA_POOL_CONNECTIONS_BUSY),
-        (MOBC_POOL_CONNECTIONS_IDLE, PRISMA_POOL_CONNECTIONS_IDLE),
-        (MOBC_POOL_WAIT_COUNT, PRISMA_CLIENT_QUERIES_WAIT),
-        (MOBC_POOL_WAIT_DURATION, PRISMA_CLIENT_QUERIES_WAIT_HISTOGRAM_MS),
+        (MOBC_POOL_CONNECTIONS_OPENED_TOTAL, ("prisma_pool_connections_opened_total", "The total number of pool connections opened")),
+        (MOBC_POOL_CONNECTIONS_CLOSED_TOTAL, ("prisma_pool_connections_closed_total", "The total number of pool connections closed")),
+        (MOBC_POOL_CONNECTIONS_OPEN, ("prisma_pool_connections_open", "The number of pool connections currently open")),
+        (MOBC_POOL_CONNECTIONS_BUSY, ("prisma_pool_connections_busy", "The number of pool connections currently executing datasource queries")),
+        (MOBC_POOL_CONNECTIONS_IDLE, ("prisma_pool_connections_idle", "The number of pool connections that are not busy running a query")),
+        (MOBC_POOL_WAIT_COUNT, ("prisma_client_queries_wait", "The number of datasource queries currently waiting for an free connection")),
+        (MOBC_POOL_WAIT_DURATION, ("prisma_client_queries_wait_histogram_ms", "The distribution of the time all datasource queries spent waiting for a free connection")),
     ])
 });
+
+pub fn setup() {
+    set_recorder();
+    describe_first_party_metrics();
+    initialize_metrics();
+}
+
+static METRIC_RECORDER: Once = Once::new();
+
+fn set_recorder() {
+    METRIC_RECORDER.call_once(|| {
+        metrics::set_boxed_recorder(Box::new(MetricRecorder)).unwrap();
+    });
+}
+
+/// Describe all first-party metrics that we record in prisma-engines. Metrics recorded by third-parties
+/// --like mobc-- are described by such third parties, but ignored, and replaced by the descriptions in the
+/// METRICS_RENAMES map.
+pub fn describe_first_party_metrics() {
+    describe_counter!(
+        PRISMA_CLIENT_QUERIES_TOTAL,
+        "The total number of Prisma Client queries executed"
+    );
+    describe_counter!(
+        PRISMA_DATASOURCE_QUERIES_TOTAL,
+        "The total number of datasource queries executed"
+    );
+    describe_gauge!(
+        PRISMA_CLIENT_QUERIES_ACTIVE,
+        "The number of currently active Prisma Client queries"
+    );
+    describe_histogram!(
+        PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
+        "The distribution of the time Prisma Client queries took to run end to end"
+    );
+    describe_histogram!(
+        PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS,
+        "The distribution of the time datasource queries took to run"
+    );
+}
+
+/// Initialize all metrics that we record in prisma-engines.
+/// Histograms are excluded, as their initialization will alter the histogram values.
+/// (i.e. histograms don't have a neutral value, like counters or gauges)
+pub fn initialize_metrics() {
+    absolute_counter!(PRISMA_CLIENT_QUERIES_TOTAL, 0);
+    absolute_counter!(PRISMA_DATASOURCE_QUERIES_TOTAL, 0);
+    gauge!(PRISMA_CLIENT_QUERIES_ACTIVE, 0.0);
+    absolute_counter!(MOBC_POOL_CONNECTIONS_OPENED_TOTAL, 0);
+    absolute_counter!(MOBC_POOL_CONNECTIONS_CLOSED_TOTAL, 0);
+    gauge!(MOBC_POOL_CONNECTIONS_OPEN, 0.0);
+    gauge!(MOBC_POOL_CONNECTIONS_BUSY, 0.0);
+    gauge!(MOBC_POOL_CONNECTIONS_IDLE, 0.0);
+    gauge!(MOBC_POOL_WAIT_COUNT, 0.0);
+}
 
 // At the moment the histogram is only used for timings. So the bounds are hard coded here
 // The buckets are for ms
@@ -110,89 +159,6 @@ pub enum MetricFormat {
     Json,
     #[serde(alias = "prometheus")]
     Prometheus,
-}
-
-pub fn setup() {
-    set_recorder();
-    describe_metrics();
-}
-
-// Describe all metric here so that every time for create
-// a new metric registry for a Query Instance the descriptions
-// will be in place
-pub fn describe_metrics() {
-    // counters
-    describe_counter!(
-        PRISMA_CLIENT_QUERIES_TOTAL,
-        "Total number of Prisma Client queries executed"
-    );
-    describe_counter!(
-        PRISMA_DATASOURCE_QUERIES_TOTAL,
-        "Total number of Datasource Queries executed"
-    );
-    describe_counter!(
-        PRISMA_POOL_CONNECTIONS_OPENED_TOTAL,
-        "Total number of Pool Connections opened"
-    );
-    describe_counter!(
-        PRISMA_POOL_CONNECTIONS_CLOSED_TOTAL,
-        "Total number of Pool Connections closed"
-    );
-
-    absolute_counter!(PRISMA_CLIENT_QUERIES_TOTAL, 0);
-    absolute_counter!(PRISMA_DATASOURCE_QUERIES_TOTAL, 0);
-    absolute_counter!(MOBC_POOL_CONNECTIONS_OPENED_TOTAL, 0);
-    absolute_counter!(MOBC_POOL_CONNECTIONS_CLOSED_TOTAL, 0);
-
-    // gauges
-    describe_gauge!(
-        PRISMA_POOL_CONNECTIONS_OPEN,
-        "Number of currently open Pool Connections (able to execute a datasource query)"
-    );
-    describe_gauge!(
-        PRISMA_POOL_CONNECTIONS_BUSY,
-        "Number of currently busy Pool Connections (executing a datasource query)"
-    );
-    describe_gauge!(
-        PRISMA_POOL_CONNECTIONS_IDLE,
-        "Number of currently unused Pool Connections (waiting for the next datasource query to run)"
-    );
-    describe_gauge!(
-        PRISMA_CLIENT_QUERIES_WAIT,
-        "Number of Prisma Client queries currently waiting for a connection"
-    );
-    describe_gauge!(
-        PRISMA_CLIENT_QUERIES_ACTIVE,
-        "Number of currently active Prisma Client queries"
-    );
-
-    gauge!(MOBC_POOL_CONNECTIONS_OPEN, 0.0);
-    gauge!(MOBC_POOL_CONNECTIONS_BUSY, 0.0);
-    gauge!(MOBC_POOL_CONNECTIONS_IDLE, 0.0);
-    gauge!(PRISMA_CLIENT_QUERIES_WAIT, 0.0);
-    gauge!(PRISMA_CLIENT_QUERIES_ACTIVE, 0.0);
-
-    // histograms
-    describe_histogram!(
-        PRISMA_CLIENT_QUERIES_WAIT_HISTOGRAM_MS,
-        "Histogram of the wait time of all Prisma Client Queries in ms"
-    );
-    describe_histogram!(
-        PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS,
-        "Histogram of the duration of all executed Datasource Queries in ms"
-    );
-    describe_histogram!(
-        PRISMA_CLIENT_QUERIES_DURATION_HISTOGRAM_MS,
-        "Histogram of the duration of all executed Prisma Client queries in ms"
-    );
-}
-
-static METRIC_RECORDER: Once = Once::new();
-
-fn set_recorder() {
-    METRIC_RECORDER.call_once(|| {
-        metrics::set_boxed_recorder(Box::new(MetricRecorder)).unwrap();
-    });
 }
 
 #[cfg(test)]

--- a/query-engine/metrics/src/lib.rs
+++ b/query-engine/metrics/src/lib.rs
@@ -60,7 +60,7 @@ const MOBC_POOL_WAIT_COUNT: &str = "mobc_client_queries_wait"; // gauge
 const MOBC_POOL_WAIT_DURATION: &str = "mobc_client_queries_wait_histogram_ms"; // histogram
 
 /// Accept list: both first-party (emitted by the query engine) and third-party (emitted) metrics
-const ACCEPT_LIST: &[&str] = &[
+pub const ACCEPT_LIST: &[&str] = &[
     // first-party
     PRISMA_CLIENT_QUERIES_TOTAL,
     PRISMA_DATASOURCE_QUERIES_TOTAL,

--- a/query-engine/metrics/src/lib.rs
+++ b/query-engine/metrics/src/lib.rs
@@ -96,7 +96,6 @@ static METRIC_RENAMES: Lazy<HashMap<&'static str, (&'static str, &'static str)>>
 
 pub fn setup() {
     set_recorder();
-    describe_first_party_metrics();
     initialize_metrics();
 }
 
@@ -108,10 +107,16 @@ fn set_recorder() {
     });
 }
 
+/// Initialize metrics descriptions and values
+pub fn initialize_metrics() {
+    initialize_metrics_descriptions();
+    initialize_metrics_values();
+}
+
 /// Describe all first-party metrics that we record in prisma-engines. Metrics recorded by third-parties
 /// --like mobc-- are described by such third parties, but ignored, and replaced by the descriptions in the
 /// METRICS_RENAMES map.
-pub fn describe_first_party_metrics() {
+fn initialize_metrics_descriptions() {
     describe_counter!(
         PRISMA_CLIENT_QUERIES_TOTAL,
         "The total number of Prisma Client queries executed"
@@ -134,10 +139,12 @@ pub fn describe_first_party_metrics() {
     );
 }
 
-/// Initialize all metrics that we record in prisma-engines.
+/// Initialize all metrics values (first and third-party)
+///
+/// FIXME: https://github.com/prisma/prisma/issues/21070
 /// Histograms are excluded, as their initialization will alter the histogram values.
 /// (i.e. histograms don't have a neutral value, like counters or gauges)
-pub fn initialize_metrics() {
+fn initialize_metrics_values() {
     absolute_counter!(PRISMA_CLIENT_QUERIES_TOTAL, 0);
     absolute_counter!(PRISMA_DATASOURCE_QUERIES_TOTAL, 0);
     gauge!(PRISMA_CLIENT_QUERIES_ACTIVE, 0.0);

--- a/query-engine/metrics/src/registry.rs
+++ b/query-engine/metrics/src/registry.rs
@@ -160,20 +160,16 @@ impl MetricRegistry {
         let mut counters: Vec<Metric> = counter_handles
             .into_iter()
             .map(|(key, counter)| {
-                let key_name = key.name();
                 let value = counter.get_inner().load(Ordering::Acquire);
-                let description = descriptions.get(key_name).cloned().unwrap_or_default();
-                Metric::new(key, description, MetricValue::Counter(value), global_labels.clone())
+                Metric::renamed(key, &descriptions, MetricValue::Counter(value), &global_labels)
             })
             .collect();
 
         let mut gauges: Vec<Metric> = gauge_handles
             .into_iter()
             .map(|(key, gauge)| {
-                let key_name = key.name();
-                let description = descriptions.get(key_name).cloned().unwrap_or_default();
                 let value = f64::from_bits(gauge.get_inner().load(Ordering::Acquire));
-                Metric::new(key, description, MetricValue::Gauge(value), global_labels.clone())
+                Metric::renamed(key, &descriptions, MetricValue::Gauge(value), &global_labels)
             })
             .collect();
 
@@ -185,13 +181,11 @@ impl MetricRegistry {
                     histogram.record_many(s);
                 });
 
-                let key_name = key.name();
-                let description = descriptions.get(key_name).cloned().unwrap_or_default();
-                Metric::new(
+                Metric::renamed(
                     key,
-                    description,
+                    &descriptions,
                     MetricValue::Histogram(histogram.into()),
-                    global_labels.clone(),
+                    &global_labels,
                 )
             })
             .collect();

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -232,7 +232,7 @@ impl QueryEngine {
         if enable_metrics {
             napi_env.execute_tokio_future(
                 async {
-                    query_engine_metrics::describe_metrics();
+                    query_engine_metrics::initialize_metrics();
                     Ok(())
                 }
                 .with_subscriber(logger.dispatcher()),


### PR DESCRIPTION
This is the first of set of a series of patches to improve metrics correctness and tech-debt.

I recommend seeing the modified files entirely. The code has been clarified with comments.

In this patch, the fix is to rename the metrics descriptions properly instead of leaking the descriptions coming from mobc. 

I took the descriptions from the [docs](https://www.prisma.io/docs/concepts/components/prisma-client/metrics) and changed them for clarity. I'd love a review from @ruheni in here. You can find the descriptions of each metric in the updated smoke tests, and if you agree, maybe you can tweak the docs to reflect the new descriptions.

