### PR TITLE
fix(qe): correct /status route response body

### DIFF
--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -63,7 +63,7 @@ pub(crate) async fn routes(cx: Arc<PrismaContext>, req: Request<Body>) -> Result
     let mut res = match (req.method(), req.uri().path()) {
         (&Method::POST, "/") => request_handler(cx, req).await?,
         (&Method::GET, "/") if cx.enabled_features.contains(Feature::Playground) => playground_handler(),
-        (&Method::GET, "/status") => build_json_response(StatusCode::OK, r#"{"status":"ok"}"#),
+        (&Method::GET, "/status") => build_json_response(StatusCode::OK, &json!({"status": "ok"})),
 
         (&Method::GET, "/sdl") => {
             let schema = render_graphql_schema(cx.query_schema());


### PR DESCRIPTION
> Note: I haven't actually tested this, but it follows the same `json!()` structure used elsewhere in the file.

The changes in #4209 unintentionally breaks the Python client as the raw response body we receive is
```
"{\"status\":\"ok\"}"
```
When it should be:
```
{"status":"ok"}
```