### PR TITLE
perf: remove select before deleteMany

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -192,20 +192,14 @@ pub(crate) fn chunk_update_with_ids(
 
 pub(crate) fn delete_many(
     model: &Model,
-    ids: &[&SelectionResult],
     filter_condition: ConditionTree<'static>,
     ctx: &Context<'_>,
-) -> Vec<Query<'static>> {
-    let columns: Vec<_> = ModelProjection::from(model.primary_identifier())
-        .as_columns(ctx)
-        .collect();
-
-    super::chunked_conditions(&columns, ids, |conditions| {
-        Delete::from_table(model.as_table(ctx))
-            .so_that(conditions.and(filter_condition.clone()))
-            .append_trace(&Span::current())
-            .add_trace_id(ctx.trace_id)
-    })
+) -> Query<'static> {
+    Delete::from_table(model.as_table(ctx))
+        .so_that(filter_condition)
+        .append_trace(&Span::current())
+        .add_trace_id(ctx.trace_id)
+        .into()
 }
 
 pub(crate) fn create_relation_table_records(

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -52,6 +52,7 @@ pub(crate) fn delete_record(
     )?;
 
     graph.add_result_node(&read_node);
+
     Ok(())
 }
 
@@ -62,31 +63,36 @@ pub fn delete_many_records(
     model: Model,
     mut field: ParsedField<'_>,
 ) -> QueryGraphBuilderResult<()> {
-    graph.flag_transactional();
-
     let filter = match field.arguments.lookup(args::WHERE) {
         Some(where_arg) => extract_filter(where_arg.value.try_into()?, &model)?,
         None => Filter::empty(),
     };
 
     let model_id = model.primary_identifier();
-    let read_query = utils::read_ids_infallible(model.clone(), model_id, filter.clone());
-    let record_filter = filter.into();
+    let record_filter = filter.clone().into();
     let delete_many = WriteQuery::DeleteManyRecords(DeleteManyRecords {
         model: model.clone(),
         record_filter,
     });
 
-    let read_query_node = graph.create_node(read_query);
     let delete_many_node = graph.create_node(Query::Write(delete_many));
 
-    utils::insert_emulated_on_delete(graph, query_schema, &model, &read_query_node, &delete_many_node)?;
+    if query_schema.relation_mode().is_prisma() {
+        graph.flag_transactional();
 
-    graph.create_edge(
-        &read_query_node,
-        &delete_many_node,
-        QueryGraphDependency::ExecutionOrder,
-    )?;
+        let read_query = utils::read_ids_infallible(model.clone(), model_id, filter);
+        let read_query_node = graph.create_node(read_query);
+
+        utils::insert_emulated_on_delete(graph, query_schema, &model, &read_query_node, &delete_many_node)?;
+
+        graph.create_edge(
+            &read_query_node,
+            &delete_many_node,
+            QueryGraphDependency::ExecutionOrder,
+        )?;
+    }
+
+    graph.add_result_node(&delete_many_node);
 
     Ok(())
 }

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     query_ast::*,
-    query_graph::{QueryGraph, QueryGraphDependency},
+    query_graph::{Node, QueryGraph, QueryGraphDependency},
     ArgumentListLookup, FilteredQuery, ParsedField,
 };
 use connector::filter::Filter;
@@ -80,7 +80,7 @@ pub fn delete_many_records(
     if query_schema.relation_mode().is_prisma() {
         graph.flag_transactional();
 
-        let read_query = utils::read_ids_infallible(model.clone(), model_id, filter);
+        let read_query = utils::read_ids_infallible(model.clone(), model_id.clone(), filter);
         let read_query_node = graph.create_node(read_query);
 
         utils::insert_emulated_on_delete(graph, query_schema, &model, &read_query_node, &delete_many_node)?;
@@ -88,7 +88,16 @@ pub fn delete_many_records(
         graph.create_edge(
             &read_query_node,
             &delete_many_node,
-            QueryGraphDependency::ExecutionOrder,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id,
+                Box::new(|mut delete_many_node, ids| {
+                    if let Node::Query(Query::Write(WriteQuery::DeleteManyRecords(ref mut dmr))) = delete_many_node {
+                        dmr.record_filter = ids.into();
+                    }
+
+                    Ok(delete_many_node)
+                }),
+            ),
         )?;
     }
 


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/7232
fixes https://github.com/prisma/prisma/issues/8239
fixes https://github.com/prisma/prisma-private/issues/217
fixes https://github.com/prisma/prisma/issues/15085

### On SQL connectors

We used to perform two `SELECT`s to fetch the ids to delete before passing these ids to the actual delete statement. This was causing several issues:
1. The `SELECT`s were superfluous
2. A transaction was required
3. The delete operation could mess up index usage because it wouldn't only be using the filter but also an IN clause with all the ids fetched by the `SELECT`. (cf issue above)

This PR fixes the problem by removing the `SELECT` altogether (on a top-level deleteMany). This makes it possible to remove the transaction entirely.

### On MongoDB

We used to have duplicate selects before the delete. This is now fixed by passing the fetched ids down to the delete node in the graph. I'm unsure whether we can get rid of the select before the delete of Mongo because:
1. Joins aren't supported
2. More operators might not be supported and I need to verify. For now, we just solved the duplicate select issue.

## SQL Diff

```prisma
model Trade {
  id         Int
  marketId   Int      @db.SmallInt
  @@id([marketId, id])
}
```

```graphql
mutation {
  deleteManyTrade(where: { marketId: 1, id: { lte: 10 } }) { count }
}
```

```sql
-- before
BEGIN
SELECT id FROM "Trade" WHERE marketId = 1 AND id <= 10
SELECT id FROM "Trade" WHERE marketId = 1 AND id <= 10 AND id IN (<...select ids>)
DELETE FROM "Trade" WHERE id IN (<...select ids>) AND marketId = 1 AND id <= 10
COMMIT

-- after
DELETE FROM "Trade" WHERE marketId = 1 AND id <= 10;
```

## Benchmark

Datamodel:

```prisma
model User {
  id Int @id @default(autoincrement())
  name String
}
```

Dataset size: 200k users

Query:

```graphql
mutation {
  deleteManyUser(where: { id: {gt: 50000 }, name: { lt: { 'g' } } } { count }
}
```

Result:
```
Before: 387.930 ± 42.506ms
After: 62.992 ± 21.071ms
```