### PR TITLE
perf: optimize get_columns for CRDB

### DIFF
--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -886,6 +886,7 @@ impl<'a> SqlSchemaDescriber<'a> {
                  FROM pg_class
                  JOIN pg_namespace on pg_namespace.oid = pg_class.relnamespace
                  AND pg_namespace.nspname = ANY ( $1 )
+                 WHERE reltype > 0
                 ) as oid on oid.oid = att.attrelid 
                   AND relname = info.table_name
                   AND namespace = info.table_schema


### PR DESCRIPTION
Currently, get_columns on CockroachDB can end up using a parital index on pg_class, which can end up internally scanning the pg_class index multiple times.  Since get_columns only cares about tables, it can have an extra predicate to avoid unnecessary overhead.

Fixes: #4250