### PR TITLE
feat(driver-adapters): renamed npm scope to `@prisma/`

### DIFF
--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jkomyno/prisma-adapter-neon",
+  "name": "@prisma/adapter-neon",
   "version": "0.3.1",
   "description": "Prisma's driver adapter for \"@neondatabase/serverless\"",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@jkomyno/prisma-driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*"
   },
   "devDependencies": {
     "@neondatabase/serverless": "^0.6.0"

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ColumnTypeEnum, type ColumnType } from '@jkomyno/prisma-driver-adapter-utils'
+import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
 import { types } from '@neondatabase/serverless'
 
 const NeonColumnType = types.builtins

--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -1,6 +1,6 @@
 import type neon from '@neondatabase/serverless'
-import { Debug } from '@jkomyno/prisma-driver-adapter-utils'
-import type { DriverAdapter, ResultSet, Query, Queryable, Transaction, Result, TransactionOptions } from '@jkomyno/prisma-driver-adapter-utils'
+import { Debug } from '@prisma/driver-adapter-utils'
+import type { DriverAdapter, ResultSet, Query, Queryable, Transaction, Result, TransactionOptions } from '@prisma/driver-adapter-utils'
 import { fieldToColumnType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:neon')

--- a/query-engine/driver-adapters/js/adapter-pg/package.json
+++ b/query-engine/driver-adapters/js/adapter-pg/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jkomyno/prisma-adapter-pg",
+  "name": "@prisma/adapter-pg",
   "version": "0.3.1",
   "description": "Prisma's driver adapter for \"pg\"",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@jkomyno/prisma-driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*"
   },
   "devDependencies": {
     "pg": "^8.11.3",

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ColumnTypeEnum, type ColumnType } from '@jkomyno/prisma-driver-adapter-utils'
+import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
 import { types } from 'pg'
 
 const PgColumnType = types.builtins

--- a/query-engine/driver-adapters/js/adapter-pg/src/pg.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/pg.ts
@@ -1,6 +1,6 @@
 import type pg from 'pg'
-import { Debug } from '@jkomyno/prisma-driver-adapter-utils'
-import type { DriverAdapter, Query, Queryable, Result, ResultSet, Transaction, TransactionOptions } from '@jkomyno/prisma-driver-adapter-utils'
+import { Debug } from '@prisma/driver-adapter-utils'
+import type { DriverAdapter, Query, Queryable, Result, ResultSet, Transaction, TransactionOptions } from '@prisma/driver-adapter-utils'
 import { fieldToColumnType } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:pg')

--- a/query-engine/driver-adapters/js/adapter-planetscale/package.json
+++ b/query-engine/driver-adapters/js/adapter-planetscale/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jkomyno/prisma-adapter-planetscale",
+  "name": "@prisma/adapter-planetscale",
   "version": "0.3.1",
   "description": "Prisma's driver adapter for \"@planetscale/database\"",
   "main": "dist/index.js",
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@jkomyno/prisma-driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*"
   },
   "devDependencies": {
     "@planetscale/database": "^1.11.0"

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ColumnTypeEnum, type ColumnType } from '@jkomyno/prisma-driver-adapter-utils'
+import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
 
 // See: https://github.com/planetscale/vitess-types/blob/06235e372d2050b4c0fff49972df8111e696c564/src/vitess/query/v16/query.proto#L108-L218
 export type PlanetScaleColumnType

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
@@ -1,6 +1,6 @@
 import type planetScale from '@planetscale/database'
-import { Debug } from '@jkomyno/prisma-driver-adapter-utils'
-import type { DriverAdapter, ResultSet, Query, Queryable, Transaction, Result, TransactionOptions } from '@jkomyno/prisma-driver-adapter-utils'
+import { Debug } from '@prisma/driver-adapter-utils'
+import type { DriverAdapter, ResultSet, Query, Queryable, Transaction, Result, TransactionOptions } from '@prisma/driver-adapter-utils'
 import { type PlanetScaleColumnType, fieldToColumnType } from './conversion'
 import { createDeferred, Deferred } from './deferred'
 

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jkomyno/prisma-driver-adapter-utils",
+  "name": "@prisma/driver-adapter-utils",
   "version": "0.3.1",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -20,7 +20,7 @@ importers:
 
   adapter-neon:
     dependencies:
-      '@jkomyno/prisma-driver-adapter-utils':
+      '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
     devDependencies:
@@ -30,7 +30,7 @@ importers:
 
   adapter-pg:
     dependencies:
-      '@jkomyno/prisma-driver-adapter-utils':
+      '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
     devDependencies:
@@ -43,7 +43,7 @@ importers:
 
   adapter-planetscale:
     dependencies:
-      '@jkomyno/prisma-driver-adapter-utils':
+      '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
     devDependencies:
@@ -78,27 +78,27 @@ importers:
 
   smoke-test-js:
     dependencies:
-      '@jkomyno/prisma-adapter-neon':
-        specifier: workspace:*
-        version: link:../adapter-neon
-      '@jkomyno/prisma-adapter-pg':
-        specifier: workspace:*
-        version: link:../adapter-pg
-      '@jkomyno/prisma-adapter-planetscale':
-        specifier: workspace:*
-        version: link:../adapter-planetscale
-      '@jkomyno/prisma-driver-adapter-utils':
-        specifier: workspace:*
-        version: link:../driver-adapter-utils
       '@neondatabase/serverless':
         specifier: ^0.6.0
         version: 0.6.0
       '@planetscale/database':
         specifier: ^1.11.0
         version: 1.11.0
+      '@prisma/adapter-neon':
+        specifier: workspace:*
+        version: link:../adapter-neon
+      '@prisma/adapter-pg':
+        specifier: workspace:*
+        version: link:../adapter-pg
+      '@prisma/adapter-planetscale':
+        specifier: workspace:*
+        version: link:../adapter-planetscale
       '@prisma/client':
         specifier: 5.3.0-integration-feat-driver-adapters-in-client.3
         version: 5.3.0-integration-feat-driver-adapters-in-client.3(prisma@5.3.0-integration-feat-driver-adapters-in-client.3)
+      '@prisma/driver-adapter-utils':
+        specifier: workspace:*
+        version: link:../driver-adapter-utils
       pg:
         specifier: ^8.11.3
         version: 8.11.3

--- a/query-engine/driver-adapters/js/smoke-test-js/README.md
+++ b/query-engine/driver-adapters/js/smoke-test-js/README.md
@@ -1,4 +1,4 @@
-# @prisma/smoke-test-js
+# @prisma/driver-adapters-smoke-tests-js
 
 This is a playground for testing the `libquery` client with the experimental Node.js drivers.
 It contains a subset of `@prisma/client`, plus some handy executable smoke tests:

--- a/query-engine/driver-adapters/js/smoke-test-js/package.json
+++ b/query-engine/driver-adapters/js/smoke-test-js/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@jkomyno/smoke-test-js",
+  "name": "@prisma/driver-adapters-smoke-tests-js",
   "private": true,
   "type": "module",
   "version": "0.0.0",
@@ -35,10 +35,10 @@
   "license": "Apache-2.0",
   "sideEffects": true,
   "dependencies": {
-    "@jkomyno/prisma-adapter-neon": "workspace:*",
-    "@jkomyno/prisma-adapter-planetscale": "workspace:*",
-    "@jkomyno/prisma-adapter-pg": "workspace:*",
-    "@jkomyno/prisma-driver-adapter-utils": "workspace:*",
+    "@prisma/adapter-neon": "workspace:*",
+    "@prisma/adapter-planetscale": "workspace:*",
+    "@prisma/adapter-pg": "workspace:*",
+    "@prisma/driver-adapter-utils": "workspace:*",
     "@neondatabase/serverless": "^0.6.0",
     "@planetscale/database": "^1.11.0",
     "@prisma/client": "5.3.0-integration-feat-driver-adapters-in-client.3",

--- a/query-engine/driver-adapters/js/smoke-test-js/src/client/client.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/client/client.ts
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
 import { PrismaClient } from '@prisma/client'
-import type { DriverAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import type { DriverAdapter } from '@prisma/driver-adapter-utils'
 
 export async function smokeTestClient(driverAdapter: DriverAdapter) {
   const provider = driverAdapter.flavour

--- a/query-engine/driver-adapters/js/smoke-test-js/src/client/neon.http.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/client/neon.http.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'node:test'
 import { neon } from '@neondatabase/serverless'
-import { PrismaNeonHTTP } from '@jkomyno/prisma-adapter-neon'
+import { PrismaNeonHTTP } from '@prisma/adapter-neon'
 import { smokeTestClient } from './client'
 
 describe('neon with @prisma/client', async () => {

--- a/query-engine/driver-adapters/js/smoke-test-js/src/client/neon.ws.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/client/neon.ws.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'node:test'
 import { Pool, neonConfig } from '@neondatabase/serverless'
-import { PrismaNeon } from '@jkomyno/prisma-adapter-neon'
+import { PrismaNeon } from '@prisma/adapter-neon'
 import { WebSocket } from 'undici'
 import { smokeTestClient } from './client'
 

--- a/query-engine/driver-adapters/js/smoke-test-js/src/client/pg.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/client/pg.test.ts
@@ -1,6 +1,6 @@
 import { describe } from 'node:test'
 import pg from 'pg'
-import { PrismaPg } from '@jkomyno/prisma-adapter-pg'
+import { PrismaPg } from '@prisma/adapter-pg'
 import { smokeTestClient } from './client'
 
 describe('pg with @prisma/client', async () => {

--- a/query-engine/driver-adapters/js/smoke-test-js/src/client/planetscale.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/client/planetscale.test.ts
@@ -1,5 +1,5 @@
 import { connect } from '@planetscale/database'
-import { PrismaPlanetScale } from '@jkomyno/prisma-adapter-planetscale'
+import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 import { describe } from 'node:test'
 import { smokeTestClient } from './client'
 

--- a/query-engine/driver-adapters/js/smoke-test-js/src/engines/types/Library.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/engines/types/Library.ts
@@ -1,4 +1,4 @@
-import type { ErrorCapturingDriverAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import type { ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
 import type { QueryEngineConfig } from './QueryEngine'
 
 export type QueryEngineInstance = {

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -1,6 +1,6 @@
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert'
-import type { ErrorCapturingDriverAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import type { ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
 import type { QueryEngineInstance } from '../engines/types/Library'
 import { initQueryEngine } from './util'
 import { JsonQuery } from '../engines/types/JsonProtocol'

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.http.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.http.test.ts
@@ -1,5 +1,5 @@
-import { PrismaNeonHTTP } from '@jkomyno/prisma-adapter-neon'
-import { bindAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import { PrismaNeonHTTP } from '@prisma/adapter-neon'
+import { bindAdapter } from '@prisma/driver-adapter-utils'
 import { neon } from '@neondatabase/serverless'
 import { describe } from 'node:test'
 import { smokeTestLibquery } from './libquery'

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.ws.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.ws.test.ts
@@ -1,5 +1,5 @@
-import { PrismaNeon } from '@jkomyno/prisma-adapter-neon'
-import { bindAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import { PrismaNeon } from '@prisma/adapter-neon'
+import { bindAdapter } from '@prisma/driver-adapter-utils'
 import { WebSocket } from 'undici'
 import { Pool, neonConfig } from '@neondatabase/serverless'
 import { describe } from 'node:test'

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/pg.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/pg.test.ts
@@ -1,6 +1,6 @@
 import pg from 'pg'
-import { PrismaPg } from '@jkomyno/prisma-adapter-pg'
-import { bindAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { bindAdapter } from '@prisma/driver-adapter-utils'
 import { describe } from 'node:test'
 import { smokeTestLibquery } from './libquery'
 

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/planetscale.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/planetscale.test.ts
@@ -1,6 +1,6 @@
 import { connect } from '@planetscale/database'
-import { PrismaPlanetScale } from '@jkomyno/prisma-adapter-planetscale'
-import { bindAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
+import { bindAdapter } from '@prisma/driver-adapter-utils'
 import { describe } from 'node:test'
 import { smokeTestLibquery } from './libquery' 
 

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/util.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/util.ts
@@ -1,7 +1,7 @@
 import path from 'node:path'
 import os from 'node:os'
 import fs from 'node:fs'
-import type { ErrorCapturingDriverAdapter } from '@jkomyno/prisma-driver-adapter-utils'
+import type { ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
 import { Library, QueryEngineInstance } from '../engines/types/Library'
 
 export function initQueryEngine(driver: ErrorCapturingDriverAdapter, prismaSchemaRelativePath: string): QueryEngineInstance {


### PR DESCRIPTION
Contributes to https://github.com/prisma/team-orm/issues/261.

Note: a CI/CD step should be added ASAP to allow e.g. `@prisma/planetscale-adapter` to be published to npm, ideally with the same mechanism used by `@prisma/prisma-schema-wasm`: check out [Distribution](https://github.com/prisma/team-orm/issues/328).