### PR TITLE
driver-adapters: allow sqlite flavour

### DIFF
--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jkomyno/prisma-driver-adapter-utils",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -46,7 +46,7 @@ export type Result<T> = {
 }
 
 export interface Queryable  {
-  readonly flavour: 'mysql' | 'postgres'
+  readonly flavour: 'mysql' | 'postgres' | 'sqlite'
 
   /**
    * Execute a query given as SQL, interpolating the given parameters,

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -46,6 +46,7 @@ impl JsBaseQueryable {
         match self.flavour {
             Flavour::Mysql => visitor::Mysql::build(q),
             Flavour::Postgres => visitor::Postgres::build(q),
+            Flavour::Sqlite => visitor::Sqlite::build(q),
             _ => unimplemented!("Unsupported flavour for JS connector {:?}", self.flavour),
         }
     }


### PR DESCRIPTION
Extracted from https://github.com/prisma/prisma-engines/pull/4229 since the corresponding changes to `@jkomyno/prisma-driver-adapter-utils` were published to npm.