### PR TITLE
driver-adapters: fixup dependencies of connector-test-kit-executor

### DIFF
--- a/query-engine/driver-adapters/js/connector-test-kit-executor/package.json
+++ b/query-engine/driver-adapters/js/connector-test-kit-executor/package.json
@@ -13,8 +13,8 @@
   "sideEffects": false,
   "license": "Apache-2.0",
   "dependencies": {
-    "@jkomyno/prisma-adapter-pg": "workspace:*",
-    "@jkomyno/prisma-driver-adapter-utils": "workspace:*",
+    "@prisma/adapter-pg": "workspace:*",
+    "@prisma/driver-adapter-utils": "workspace:*",
     "pg": "^8.11.3",
     "@types/pg": "^8.10.2"
   }

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -53,10 +53,10 @@ importers:
 
   connector-test-kit-executor:
     dependencies:
-      '@jkomyno/prisma-adapter-pg':
+      '@prisma/adapter-pg':
         specifier: workspace:*
         version: link:../adapter-pg
-      '@jkomyno/prisma-driver-adapter-utils':
+      '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
       '@types/pg':


### PR DESCRIPTION
Update dependencies of `connector-test-kit-executor` after renaming the
packages in https://github.com/prisma/prisma-engines/pull/4252.
