### PR TITLE
qe: Fix undefined values in neon adapter

### DIFF
--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.http.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.http.test.ts
@@ -8,12 +8,12 @@ describe('neon (HTTP)', () => {
   const connectionString = `${process.env.JS_NEON_DATABASE_URL as string}`
 
   const neonConnection = neon(connectionString, {
-    arrayMode: false,
+    arrayMode: true,
     fullResults: true,
   })
 
   const adapter = new PrismaNeonHTTP(neonConnection)
   const driverAdapter = bindAdapter(adapter)
-  
+
   smokeTestLibquery(driverAdapter, '../../prisma/postgres/schema.prisma')
 })

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.ws.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.ws.test.ts
@@ -13,6 +13,6 @@ describe('neon (WebSocket)', () => {
   const pool = new Pool({ connectionString })
   const adapter = new PrismaNeon(pool)
   const driverAdapter = bindAdapter(adapter)
-  
+
   smokeTestLibquery(driverAdapter, '../../prisma/postgres/schema.prisma')
 })


### PR DESCRIPTION
When we switched to array mode, we adapted PG driver correctly, but
`neon` only partially. As a result, row values were returned as
`undefined` and deserialuzatuin failed on Rust side.
