### PR TITLE
js-connectors: Fixes for array mode in JS drivers

### DIFF
--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -14,7 +14,6 @@ import { fieldToColumnType } from './conversion'
 const debug = Debug('prisma:driver-adapter:neon')
 
 type ARRAY_MODE_ENABLED = true
-type FULL_RESULTS_ENABLED = true
 
 type PerformIOResult = neon.QueryResult<any> | neon.FullQueryResults<ARRAY_MODE_ENABLED>
 
@@ -123,13 +122,16 @@ export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdap
 }
 
 export class PrismaNeonHTTP extends NeonQueryable implements DriverAdapter {
-  constructor(private client: neon.NeonQueryFunction<ARRAY_MODE_ENABLED, FULL_RESULTS_ENABLED>) {
+  constructor(private client: neon.NeonQueryFunction<any, any>) {
     super()
   }
 
   override async performIO(query: Query): Promise<PerformIOResult> {
     const { sql, args: values } = query
-    return await this.client(sql, values)
+    return await this.client(sql, values, {
+      arrayMode: true,
+      fullResults: true,
+    })
   }
 
   startTransaction(): Promise<Result<Transaction>> {

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
@@ -1,6 +1,14 @@
 import type planetScale from '@planetscale/database'
 import { Debug } from '@prisma/driver-adapter-utils'
-import type { DriverAdapter, ResultSet, Query, Queryable, Transaction, Result, TransactionOptions } from '@prisma/driver-adapter-utils'
+import type {
+  DriverAdapter,
+  ResultSet,
+  Query,
+  Queryable,
+  Transaction,
+  Result,
+  TransactionOptions,
+} from '@prisma/driver-adapter-utils'
 import { type PlanetScaleColumnType, fieldToColumnType } from './conversion'
 import { createDeferred, Deferred } from './deferred'
 
@@ -17,11 +25,9 @@ class RollbackError extends Error {
   }
 }
 
-
 class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.Transaction> implements Queryable {
   readonly flavour = 'mysql'
-  constructor(protected client: ClientT) {
-  }
+  constructor(protected client: ClientT) {}
 
   /**
    * Execute a query given as SQL, interpolating the given parameters.
@@ -30,13 +36,13 @@ class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.
     const tag = '[js::query_raw]'
     debug(`${tag} %O`, query)
 
-    const { fields, insertId: lastInsertId, rows: results } = await this.performIO(query)
+    const { fields, insertId: lastInsertId, rows } = await this.performIO(query)
 
-    const columns = fields.map(field => field.name)
+    const columns = fields.map((field) => field.name)
     const resultSet: ResultSet = {
       columnNames: columns,
-      columnTypes: fields.map(field => fieldToColumnType(field.type as PlanetScaleColumnType)),
-      rows: results.map(result => columns.map(column => result[column])),
+      columnTypes: fields.map((field) => fieldToColumnType(field.type as PlanetScaleColumnType)),
+      rows: rows as ResultSet['rows'],
       lastInsertId,
     }
 
@@ -65,7 +71,9 @@ class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.
     const { sql, args: values } = query
 
     try {
-      const result = await this.client.execute(sql, values)
+      const result = await this.client.execute(sql, values, {
+        as: 'array',
+      })
       return result
     } catch (e) {
       const error = e as Error
@@ -98,7 +106,6 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
     this.txDeferred.reject(new RollbackError())
     return Promise.resolve({ ok: true, value: await this.txResultPromise })
   }
-
 }
 
 export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Connection> implements DriverAdapter {
@@ -115,21 +122,23 @@ export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Connecti
     debug(`${tag} options: %O`, options)
 
     return new Promise<Result<Transaction>>((resolve, reject) => {
-      const txResultPromise = this.client.transaction(async tx => {
-        const [txDeferred, deferredPromise] = createDeferred<void>()
-        const txWrapper = new PlanetScaleTransaction(tx, options, txDeferred, txResultPromise)
+      const txResultPromise = this.client
+        .transaction(async (tx) => {
+          const [txDeferred, deferredPromise] = createDeferred<void>()
+          const txWrapper = new PlanetScaleTransaction(tx, options, txDeferred, txResultPromise)
 
-        resolve({ ok: true, value: txWrapper })
-        return deferredPromise
-      }).catch(error => {
-        // Rollback error is ignored (so that tx.rollback() won't crash)
-        // any other error is legit and is re-thrown
-        if (!(error instanceof RollbackError)) {
-          return reject(error)
-        }
+          resolve({ ok: true, value: txWrapper })
+          return deferredPromise
+        })
+        .catch((error) => {
+          // Rollback error is ignored (so that tx.rollback() won't crash)
+          // any other error is legit and is re-thrown
+          if (!(error instanceof RollbackError)) {
+            return reject(error)
+          }
 
-        return undefined
-      })
+          return undefined
+        })
     })
   }
 

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.http.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/neon.http.test.ts
@@ -7,10 +7,7 @@ import { smokeTestLibquery } from './libquery'
 describe('neon (HTTP)', () => {
   const connectionString = `${process.env.JS_NEON_DATABASE_URL as string}`
 
-  const neonConnection = neon(connectionString, {
-    arrayMode: true,
-    fullResults: true,
-  })
+  const neonConnection = neon(connectionString)
 
   const adapter = new PrismaNeonHTTP(neonConnection)
   const driverAdapter = bindAdapter(adapter)


### PR DESCRIPTION
- Switch planetscale driver to array mode too
- For neon-http, pass `arrayMode` and `fullResult` options on all
  invocations, making us agnostic to the settings used in constructor.
