### PR TITLE
driver-adapters: Ensure error propogation works for `startTransaction`

### DIFF
--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
@@ -1,4 +1,11 @@
-import type { ErrorCapturingDriverAdapter, DriverAdapter, Transaction, ErrorRegistry, ErrorRecord, Result } from './types'
+import type {
+  ErrorCapturingDriverAdapter,
+  DriverAdapter,
+  Transaction,
+  ErrorRegistry,
+  ErrorRecord,
+  Result,
+} from './types'
 
 class ErrorRegistryInternal implements ErrorRegistry {
   private registeredErrors: ErrorRecord[] = []
@@ -22,36 +29,40 @@ class ErrorRegistryInternal implements ErrorRegistry {
 export const bindAdapter = (adapter: DriverAdapter): ErrorCapturingDriverAdapter => {
   const errorRegistry = new ErrorRegistryInternal()
 
+  const startTransaction = wrapAsync(errorRegistry, adapter.startTransaction.bind(adapter))
   return {
     errorRegistry,
     queryRaw: wrapAsync(errorRegistry, adapter.queryRaw.bind(adapter)),
     executeRaw: wrapAsync(errorRegistry, adapter.executeRaw.bind(adapter)),
     flavour: adapter.flavour,
     startTransaction: async (...args) => {
-      const result = await adapter.startTransaction(...args)
+      const result = await startTransaction(...args)
       if (result.ok) {
         return { ok: true, value: bindTransaction(errorRegistry, result.value) }
       }
       return result
     },
-    close: wrapAsync(errorRegistry, adapter.close.bind(adapter))
+    close: wrapAsync(errorRegistry, adapter.close.bind(adapter)),
   }
 }
 
 // *.bind(transaction) is required to preserve the `this` context of functions whose
 // execution is delegated to napi.rs.
 const bindTransaction = (errorRegistry: ErrorRegistryInternal, transaction: Transaction): Transaction => {
-  return ({
+  return {
     flavour: transaction.flavour,
     options: transaction.options,
     queryRaw: wrapAsync(errorRegistry, transaction.queryRaw.bind(transaction)),
     executeRaw: wrapAsync(errorRegistry, transaction.executeRaw.bind(transaction)),
     commit: wrapAsync(errorRegistry, transaction.commit.bind(transaction)),
     rollback: wrapAsync(errorRegistry, transaction.rollback.bind(transaction)),
-  });
+  }
 }
 
-function wrapAsync<A extends unknown[], R>(registry: ErrorRegistryInternal, fn: (...args: A) => Promise<Result<R>>): (...args: A) => Promise<Result<R>> {
+function wrapAsync<A extends unknown[], R>(
+  registry: ErrorRegistryInternal,
+  fn: (...args: A) => Promise<Result<R>>,
+): (...args: A) => Promise<Result<R>> {
   return async (...args) => {
     try {
       return await fn(...args)

--- a/query-engine/driver-adapters/js/smoke-test-js/package.json
+++ b/query-engine/driver-adapters/js/smoke-test-js/package.json
@@ -24,6 +24,7 @@
     "pg:libquery": "cross-env-shell DATABASE_URL=\"${JS_PG_DATABASE_URL}\" node --test --loader=tsx ./src/libquery/pg.test.ts",
     "pg:client": "DATABASE_URL=\"${JS_PG_DATABASE_URL}\" node --test --loader=tsx ./src/client/pg.test.ts",
     "pg": "pnpm pg:libquery && pnpm pg:client",
+    "errors": "DATABASE_URL=\"${JS_PG_DATABASE_URL}\" node --test --loader=tsx ./src/libquery/errors.test.ts",
     "prisma:planetscale": "cross-env-shell DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" \"pnpm prisma:db:push:mysql && pnpm prisma:db:execute:mysql\"",
     "studio:planetscale": "cross-env-shell DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" \"pnpm prisma:studio:mysql\"",
     "planetscale:libquery": "DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" node --test --loader=tsx ./src/libquery/planetscale.test.ts",

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/postgres/schema.prisma
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/postgres/schema.prisma
@@ -98,3 +98,8 @@ model Product {
   properties      Json
   properties_null Json?
 }
+
+model User {
+  id    String @id @default(uuid())
+  email String
+}

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/errors.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/errors.test.ts
@@ -14,7 +14,7 @@ const fakeAdapter = bindAdapter({
   },
 
   executeRaw() {
-    throw new Error('Error in queryRaw')
+    throw new Error('Error in executeRaw')
   },
   close() {
     return Promise.resolve({ ok: true, value: undefined })
@@ -53,6 +53,24 @@ describe('errors propagation', () => {
         },
       }),
       /Error in queryRaw/,
+    )
+  })
+
+  test('works for executeRaw', async () => {
+    await assert.rejects(
+      doQuery({
+        action: 'executeRaw',
+        query: {
+          arguments: {
+            query: 'SELECT 1',
+            parameters: '[]',
+          },
+          selection: {
+            $scalars: true,
+          },
+        },
+      }),
+      /Error in executeRaw/,
     )
   })
 

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/errors.test.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/errors.test.ts
@@ -1,0 +1,78 @@
+import { bindAdapter } from '@prisma/driver-adapter-utils'
+import test, { after, before, describe } from 'node:test'
+import { createQueryFn, initQueryEngine, throwAdapterError } from './util'
+import assert from 'node:assert'
+
+const fakeAdapter = bindAdapter({
+  flavour: 'postgres',
+  startTransaction() {
+    throw new Error('Error in startTransaction')
+  },
+
+  queryRaw() {
+    throw new Error('Error in queryRaw')
+  },
+
+  executeRaw() {
+    throw new Error('Error in queryRaw')
+  },
+  close() {
+    return Promise.resolve({ ok: true, value: undefined })
+  },
+})
+
+const engine = initQueryEngine(fakeAdapter, '../../prisma/postgres/schema.prisma')
+const doQuery = createQueryFn(engine, fakeAdapter)
+
+const startTransaction = async () => {
+  const args = { isolation_level: 'Serializable', max_wait: 5000, timeout: 15000 }
+  const res = JSON.parse(await engine.startTransaction(JSON.stringify(args), '{}'))
+  if (res['error_code']) {
+    throwAdapterError(res, fakeAdapter)
+  }
+}
+
+describe('errors propagation', () => {
+  before(async () => {
+    await engine.connect('{}')
+  })
+  after(async () => {
+    await engine.disconnect('{}')
+  })
+
+  test('works for queries', async () => {
+    await assert.rejects(
+      doQuery({
+        modelName: 'Product',
+        action: 'findMany',
+        query: {
+          arguments: {},
+          selection: {
+            $scalars: true,
+          },
+        },
+      }),
+      /Error in queryRaw/,
+    )
+  })
+
+  test('works with implicit transaction', async () => {
+    await assert.rejects(
+      doQuery({
+        modelName: 'Product',
+        action: 'deleteMany',
+        query: {
+          arguments: {},
+          selection: {
+            $scalars: true,
+          },
+        },
+      }),
+      /Error in startTransaction/,
+    )
+  })
+
+  test('works with explicit transaction', async () => {
+    await assert.rejects(startTransaction(), /Error in startTransaction/)
+  })
+})

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -2,28 +2,14 @@ import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert'
 import type { ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
 import type { QueryEngineInstance } from '../engines/types/Library'
-import { initQueryEngine } from './util'
+import { createQueryFn, initQueryEngine } from './util'
 import { JsonQuery } from '../engines/types/JsonProtocol'
 
 export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSchemaRelativePath: string) {
   const engine = initQueryEngine(adapter, prismaSchemaRelativePath)
   const flavour = adapter.flavour
 
-  const doQuery = async (query: JsonQuery, tx_id?: string) => {
-    const result = await engine.query(JSON.stringify(query), 'trace', tx_id)
-    const parsedResult = JSON.parse(result)
-    if (parsedResult.errors) {
-      const error = parsedResult.errors[0]?.user_facing_error
-      if (error.error_code === 'P2036') {
-        const jsError = adapter.errorRegistry.consumeError(error.meta.id)
-        if (!jsError) {
-          throw new Error(`Something went wrong. Engine reported external error with id ${error.meta.id}, but it was not registered.`)
-        }
-        throw jsError.error
-      }
-    }
-    return parsedResult
-  }
+  const doQuery = createQueryFn(engine, adapter)
 
   describe('using libquery with Driver Adapters', () => {
     before(async () => {
@@ -43,9 +29,9 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
             selection: { $scalars: true },
             arguments: {
               query: 'NOT A VALID SQL, THIS WILL FAIL',
-              parameters: '[]'
-            }
-          }
+              parameters: '[]',
+            },
+          },
         })
       })
     })
@@ -56,149 +42,134 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
         baz: 1,
       })
 
-      const created = await doQuery(
-        {
-          "action": "createOne",
-          "modelName": "Product",
-          "query": {
-            "arguments": {
-              "data": {
-                "properties": json,
-                "properties_null": null
-              }
+      const created = await doQuery({
+        action: 'createOne',
+        modelName: 'Product',
+        query: {
+          arguments: {
+            data: {
+              properties: json,
+              properties_null: null,
             },
-            "selection": {
-              "properties": true
-            }
-          }
-        })
+          },
+          selection: {
+            properties: true,
+          },
+        },
+      })
 
       assert.strictEqual(created.data.createOneProduct.properties.$type, 'Json')
       console.log('[nodejs] created', JSON.stringify(created, null, 2))
 
-      const resultSet = await doQuery(
-        {
-          "action": "findMany",
-          "modelName": "Product",
-          "query": {
-            "selection": {
-              "id": true,
-              "properties": true,
-              "properties_null": true
-            }
-          }
-        }
-      )
+      const resultSet = await doQuery({
+        action: 'findMany',
+        modelName: 'Product',
+        query: {
+          selection: {
+            id: true,
+            properties: true,
+            properties_null: true,
+          },
+        },
+      })
       console.log('[nodejs] resultSet', JSON.stringify(resultSet, null, 2))
 
-      await doQuery(
-        {
-          "action": "deleteMany",
-          "modelName": "Product",
-          "query": {
-            "arguments": {
-              "where": {}
-            },
-            "selection": {
-              "count": true
-            }
-          }
-        }
-      )
+      await doQuery({
+        action: 'deleteMany',
+        modelName: 'Product',
+        query: {
+          arguments: {
+            where: {},
+          },
+          selection: {
+            count: true,
+          },
+        },
+      })
     })
 
     it('create with autoincrement', async () => {
-      await doQuery(
-        {
-          "modelName": "Author",
-          "action": "deleteMany",
-          "query": {
-            "arguments": {
-              "where": {}
-            },
-            "selection": {
-              "count": true
-            }
-          }
-        }
-      )
+      await doQuery({
+        modelName: 'Author',
+        action: 'deleteMany',
+        query: {
+          arguments: {
+            where: {},
+          },
+          selection: {
+            count: true,
+          },
+        },
+      })
 
-      const author = await doQuery(
-        {
-          "modelName": "Author",
-          "action": "createOne",
-          "query": {
-            "arguments": {
-              "data": {
-                "firstName": "Firstname from autoincrement",
-                "lastName": "Lastname from autoincrement",
-                "age": 99
-              }
+      const author = await doQuery({
+        modelName: 'Author',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              firstName: 'Firstname from autoincrement',
+              lastName: 'Lastname from autoincrement',
+              age: 99,
             },
-            "selection": {
-              "id": true,
-              "firstName": true,
-              "lastName": true
-            }
-          }
-        }
-      )
+          },
+          selection: {
+            id: true,
+            firstName: true,
+            lastName: true,
+          },
+        },
+      })
       console.log('[nodejs] author', JSON.stringify(author, null, 2))
     })
 
     it('create non scalar types', async () => {
-      const create = await doQuery(
-        {
-          "action": "createOne",
-          "modelName": "type_test_2",
-          "query": {
-            "arguments": {
-              "data": {}
-            },
-            "selection": {
-              "id": true,
-              "datetime_column": true,
-              "datetime_column_null": true
-            }
-          }
-        }
-      )
+      const create = await doQuery({
+        action: 'createOne',
+        modelName: 'type_test_2',
+        query: {
+          arguments: {
+            data: {},
+          },
+          selection: {
+            id: true,
+            datetime_column: true,
+            datetime_column_null: true,
+          },
+        },
+      })
 
       console.log('[nodejs] create', JSON.stringify(create, null, 2))
 
-      const resultSet = await doQuery(
-        {
-          "action": "findMany",
-          "modelName": "type_test_2",
-          "query": {
-            "selection": {
-              "id": true,
-              "datetime_column": true,
-              "datetime_column_null": true
-            },
-            "arguments": {
-              "where": {}
-            }
-          }
-        }
-      )
+      const resultSet = await doQuery({
+        action: 'findMany',
+        modelName: 'type_test_2',
+        query: {
+          selection: {
+            id: true,
+            datetime_column: true,
+            datetime_column_null: true,
+          },
+          arguments: {
+            where: {},
+          },
+        },
+      })
 
       console.log('[nodejs] resultSet', JSON.stringify(resultSet, null, 2))
 
-      await doQuery(
-        {
-          "action": "deleteMany",
-          "modelName": "type_test_2",
-          "query": {
-            "arguments": {
-              "where": {}
-            },
-            "selection": {
-              "count": true
-            }
-          }
-        }
-      )
+      await doQuery({
+        action: 'deleteMany',
+        modelName: 'type_test_2',
+        query: {
+          arguments: {
+            where: {},
+          },
+          selection: {
+            count: true,
+          },
+        },
+      })
     })
 
     it('create/delete parent and child', async () => {
@@ -209,40 +180,36 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
       //   'SELECT `cf-users`.`Child`.`id` FROM `cf-users`.`Child` WHERE 1=1',
       //   'DELETE FROM `cf-users`.`Child` WHERE (`cf-users`.`Child`.`id` IN (?) AND 1=1)'
       // ]
-      await doQuery(
-        {
-          "modelName": "Child",
-          "action": "deleteMany",
-          "query": {
-            "arguments": {
-              "where": {}
-            },
-            "selection": {
-              "count": true
-            }
-          }
-        }
-      )
+      await doQuery({
+        modelName: 'Child',
+        action: 'deleteMany',
+        query: {
+          arguments: {
+            where: {},
+          },
+          selection: {
+            count: true,
+          },
+        },
+      })
 
       // Queries: [
       //   'SELECT `cf-users`.`Parent`.`id` FROM `cf-users`.`Parent` WHERE 1=1',
       //   'SELECT `cf-users`.`Parent`.`id` FROM `cf-users`.`Parent` WHERE 1=1',
       //   'DELETE FROM `cf-users`.`Parent` WHERE (`cf-users`.`Parent`.`id` IN (?) AND 1=1)'
       // ]
-      await doQuery(
-        {
-          "modelName": "Parent",
-          "action": "deleteMany",
-          "query": {
-            "arguments": {
-              "where": {}
-            },
-            "selection": {
-              "count": true
-            }
-          }
-        }
-      )
+      await doQuery({
+        modelName: 'Parent',
+        action: 'deleteMany',
+        query: {
+          arguments: {
+            where: {},
+          },
+          selection: {
+            count: true,
+          },
+        },
+      })
 
       /* Create a parent with some new children, within a transaction */
 
@@ -252,36 +219,34 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
       //   'SELECT `cf-users`.`Parent`.`id`, `cf-users`.`Parent`.`p` FROM `cf-users`.`Parent` WHERE `cf-users`.`Parent`.`id` = ? LIMIT ? OFFSET ?',
       //   'SELECT `cf-users`.`Child`.`id`, `cf-users`.`Child`.`c`, `cf-users`.`Child`.`parentId` FROM `cf-users`.`Child` WHERE `cf-users`.`Child`.`parentId` IN (?)'
       // ]
-      await doQuery(
-        {
-          "modelName": "Parent",
-          "action": "createOne",
-          "query": {
-            "arguments": {
-              "data": {
-                "p": "p1",
-                "p_1": "1",
-                "p_2": "2",
-                "childOpt": {
-                  "create": {
-                    "c": "c1",
-                    "c_1": "foo",
-                    "c_2": "bar"
-                  }
-                }
-              }
+      await doQuery({
+        modelName: 'Parent',
+        action: 'createOne',
+        query: {
+          arguments: {
+            data: {
+              p: 'p1',
+              p_1: '1',
+              p_2: '2',
+              childOpt: {
+                create: {
+                  c: 'c1',
+                  c_1: 'foo',
+                  c_2: 'bar',
+                },
+              },
             },
-            "selection": {
-              "p": true,
-              "childOpt": {
-                "selection": {
-                  "c": true
-                }
-              }
-            }
-          }
-        }
-      )
+          },
+          selection: {
+            p: true,
+            childOpt: {
+              selection: {
+                c: true,
+              },
+            },
+          },
+        },
+      })
 
       /* Delete the parent */
 
@@ -292,41 +257,39 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
       //   'SELECT `cf-users`.`Parent`.`id` FROM `cf-users`.`Parent` WHERE `cf-users`.`Parent`.`p` = ?',
       //   'DELETE FROM `cf-users`.`Parent` WHERE (`cf-users`.`Parent`.`id` IN (?) AND `cf-users`.`Parent`.`p` = ?)'
       // ]
-      await doQuery(
-        {
-          "modelName": "Parent",
-          "action": "deleteMany",
-          "query": {
-            "arguments": {
-              "where": {
-                "p": "p1"
-              }
+      await doQuery({
+        modelName: 'Parent',
+        action: 'deleteMany',
+        query: {
+          arguments: {
+            where: {
+              p: 'p1',
             },
-            "selection": {
-              "count": true
-            }
-          }
-        }
-      )
+          },
+          selection: {
+            count: true,
+          },
+        },
+      })
     })
 
     it('create explicit transaction', async () => {
       const args = { isolation_level: 'Serializable', max_wait: 5000, timeout: 15000 }
       const startResponse = await engine.startTransaction(JSON.stringify(args), 'trace')
       const tx_id = JSON.parse(startResponse).id
-  
+
       console.log('[nodejs] transaction id', tx_id)
       await doQuery(
         {
-          "action": "findMany",
-          "modelName": "Author",
-          "query": {
-            "selection": { "$scalars": true }
-          }
+          action: 'findMany',
+          modelName: 'Author',
+          query: {
+            selection: { $scalars: true },
+          },
         },
-        tx_id
+        tx_id,
       )
-  
+
       const commitResponse = await engine.commitTransaction(tx_id, 'trace')
       console.log('[nodejs] commited', commitResponse)
     })
@@ -334,68 +297,65 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
     describe('read scalar and non scalar types', () => {
       if (['mysql'].includes(flavour)) {
         it('mysql', async () => {
-          const resultSet = await doQuery(
-            {
-              "action": "findMany",
-              "modelName": "type_test",
-              "query": {
-                "selection": {
-                  "tinyint_column": true,
-                  "smallint_column": true,
-                  "mediumint_column": true,
-                  "int_column": true,
-                  "bigint_column": true,
-                  "float_column": true,
-                  "double_column": true,
-                  "decimal_column": true,
-                  "boolean_column": true,
-                  "char_column": true,
-                  "varchar_column": true,
-                  "text_column": true,
-                  "date_column": true,
-                  "time_column": true,
-                  "datetime_column": true,
-                  "timestamp_column": true,
-                  "json_column": true,
-                  "enum_column": true,
-                  "binary_column": true,
-                  "varbinary_column": true,
-                  "blob_column": true
-                }
-              }
-            })
-      
+          const resultSet = await doQuery({
+            action: 'findMany',
+            modelName: 'type_test',
+            query: {
+              selection: {
+                tinyint_column: true,
+                smallint_column: true,
+                mediumint_column: true,
+                int_column: true,
+                bigint_column: true,
+                float_column: true,
+                double_column: true,
+                decimal_column: true,
+                boolean_column: true,
+                char_column: true,
+                varchar_column: true,
+                text_column: true,
+                date_column: true,
+                time_column: true,
+                datetime_column: true,
+                timestamp_column: true,
+                json_column: true,
+                enum_column: true,
+                binary_column: true,
+                varbinary_column: true,
+                blob_column: true,
+              },
+            },
+          })
+
           console.log('[nodejs] findMany resultSet', JSON.stringify(resultSet, null, 2))
         })
       } else if (['postgres'].includes(flavour)) {
         it('postgres', async () => {
-          const resultSet = await doQuery(
-            {
-              "action": "findMany",
-              "modelName": "type_test",
-              "query": {
-                "selection": {
-                  "smallint_column": true,
-                  "int_column": true,
-                  "bigint_column": true,
-                  "float_column": true,
-                  "double_column": true,
-                  "decimal_column": true,
-                  "boolean_column": true,
-                  "char_column": true,
-                  "varchar_column": true,
-                  "text_column": true,
-                  "date_column": true,
-                  "time_column": true,
-                  "datetime_column": true,
-                  "timestamp_column": true,
-                  "json_column": true,
-                  "enum_column": true
-                }
-              }
-            }
-          )
-          console.log('[nodejs] findMany resultSet', JSON.stringify((resultSet), null, 2))
+          const resultSet = await doQuery({
+            action: 'findMany',
+            modelName: 'type_test',
+            query: {
+              selection: {
+                smallint_column: true,
+                int_column: true,
+                bigint_column: true,
+                float_column: true,
+                double_column: true,
+                decimal_column: true,
+                boolean_column: true,
+                char_column: true,
+                varchar_column: true,
+                text_column: true,
+                date_column: true,
+                time_column: true,
+                datetime_column: true,
+                timestamp_column: true,
+                json_column: true,
+                enum_column: true,
+              },
+            },
+          })
+          console.log('[nodejs] findMany resultSet', JSON.stringify(resultSet, null, 2))
         })
       } else {
         throw new Error(`Missing test for flavour ${flavour}`)
@@ -411,7 +371,6 @@ class SmokeTest {
     this.flavour = connector.flavour
   }
 
-
   async testFindManyTypeTest() {
     await this.testFindManyTypeTestMySQL()
     await this.testFindManyTypeTestPostgres()
@@ -422,36 +381,35 @@ class SmokeTest {
       return
     }
 
-    const resultSet = await this.doQuery(
-      {
-        "action": "findMany",
-        "modelName": "type_test",
-        "query": {
-          "selection": {
-            "tinyint_column": true,
-            "smallint_column": true,
-            "mediumint_column": true,
-            "int_column": true,
-            "bigint_column": true,
-            "float_column": true,
-            "double_column": true,
-            "decimal_column": true,
-            "boolean_column": true,
-            "char_column": true,
-            "varchar_column": true,
-            "text_column": true,
-            "date_column": true,
-            "time_column": true,
-            "datetime_column": true,
-            "timestamp_column": true,
-            "json_column": true,
-            "enum_column": true,
-            "binary_column": true,
-            "varbinary_column": true,
-            "blob_column": true
-          }
-        }
-      })
+    const resultSet = await this.doQuery({
+      action: 'findMany',
+      modelName: 'type_test',
+      query: {
+        selection: {
+          tinyint_column: true,
+          smallint_column: true,
+          mediumint_column: true,
+          int_column: true,
+          bigint_column: true,
+          float_column: true,
+          double_column: true,
+          decimal_column: true,
+          boolean_column: true,
+          char_column: true,
+          varchar_column: true,
+          text_column: true,
+          date_column: true,
+          time_column: true,
+          datetime_column: true,
+          timestamp_column: true,
+          json_column: true,
+          enum_column: true,
+          binary_column: true,
+          varbinary_column: true,
+          blob_column: true,
+        },
+      },
+    })
 
     console.log('[nodejs] findMany resultSet', JSON.stringify(resultSet, null, 2))
 
@@ -463,73 +421,67 @@ class SmokeTest {
       return
     }
 
-    const resultSet = await this.doQuery(
-      {
-        "action": "findMany",
-        "modelName": "type_test",
-        "query": {
-          "selection": {
-            "smallint_column": true,
-            "int_column": true,
-            "bigint_column": true,
-            "float_column": true,
-            "double_column": true,
-            "decimal_column": true,
-            "boolean_column": true,
-            "char_column": true,
-            "varchar_column": true,
-            "text_column": true,
-            "date_column": true,
-            "time_column": true,
-            "datetime_column": true,
-            "timestamp_column": true,
-            "json_column": true,
-            "enum_column": true
-          }
-        }
-      }
-    )
-    console.log('[nodejs] findMany resultSet', JSON.stringify((resultSet), null, 2))
+    const resultSet = await this.doQuery({
+      action: 'findMany',
+      modelName: 'type_test',
+      query: {
+        selection: {
+          smallint_column: true,
+          int_column: true,
+          bigint_column: true,
+          float_column: true,
+          double_column: true,
+          decimal_column: true,
+          boolean_column: true,
+          char_column: true,
+          varchar_column: true,
+          text_column: true,
+          date_column: true,
+          time_column: true,
+          datetime_column: true,
+          timestamp_column: true,
+          json_column: true,
+          enum_column: true,
+        },
+      },
+    })
+    console.log('[nodejs] findMany resultSet', JSON.stringify(resultSet, null, 2))
 
     return resultSet
   }
 
   async createAutoIncrement() {
-    await this.doQuery(
-      {
-        "modelName": "Author",
-        "action": "deleteMany",
-        "query": {
-          "arguments": {
-            "where": {}
-          },
-          "selection": {
-            "count": true
-          }
-        }
-      }
-    )
+    await this.doQuery({
+      modelName: 'Author',
+      action: 'deleteMany',
+      query: {
+        arguments: {
+          where: {},
+        },
+        selection: {
+          count: true,
+        },
+      },
+    })
 
-    const author = await this.doQuery(
-      {
-        "modelName": "Author",
-        "action": "createOne",
-        "query": {
-          "arguments": {
-            "data": {
-              "firstName": "Firstname from autoincrement",
-              "lastName": "Lastname from autoincrement",
-              "age": 99
-            }
+    const author = await this.doQuery({
+      modelName: 'Author',
+      action: 'createOne',
+      query: {
+        arguments: {
+          data: {
+            firstName: 'Firstname from autoincrement',
+            lastName: 'Lastname from autoincrement',
+            age: 99,
           },
-          "selection": {
-            "id": true,
-            "firstName": true,
-            "lastName": true
-          }
-        }
-      }
-    )
+        },
+        selection: {
+          id: true,
+          firstName: true,
+          lastName: true,
+        },
+      },
+    })
     console.log('[nodejs] author', JSON.stringify(author, null, 2))
   }
 
@@ -541,40 +493,36 @@ class SmokeTest {
     //   'SELECT `cf-users`.`Child`.`id` FROM `cf-users`.`Child` WHERE 1=1',
     //   'DELETE FROM `cf-users`.`Child` WHERE (`cf-users`.`Child`.`id` IN (?) AND 1=1)'
     // ]
-    await this.doQuery(
-      {
-        "modelName": "Child",
-        "action": "deleteMany",
-        "query": {
-          "arguments": {
-            "where": {}
-          },
-          "selection": {
-            "count": true
-          }
-        }
-      }
-    )
+    await this.doQuery({
+      modelName: 'Child',
+      action: 'deleteMany',
+      query: {
+        arguments: {
+          where: {},
+        },
+        selection: {
+          count: true,
+        },
+      },
+    })
 
     // Queries: [
     //   'SELECT `cf-users`.`Parent`.`id` FROM `cf-users`.`Parent` WHERE 1=1',
     //   'SELECT `cf-users`.`Parent`.`id` FROM `cf-users`.`Parent` WHERE 1=1',
     //   'DELETE FROM `cf-users`.`Parent` WHERE (`cf-users`.`Parent`.`id` IN (?) AND 1=1)'
     // ]
-    await this.doQuery(
-      {
-        "modelName": "Parent",
-        "action": "deleteMany",
-        "query": {
-          "arguments": {
-            "where": {}
-          },
-          "selection": {
-            "count": true
-          }
-        }
-      }
-    )
+    await this.doQuery({
+      modelName: 'Parent',
+      action: 'deleteMany',
+      query: {
+        arguments: {
+          where: {},
+        },
+        selection: {
+          count: true,
+        },
+      },
+    })
 
     /* Create a parent with some new children, within a transaction */
 
@@ -584,36 +532,34 @@ class SmokeTest {
     //   'SELECT `cf-users`.`Parent`.`id`, `cf-users`.`Parent`.`p` FROM `cf-users`.`Parent` WHERE `cf-users`.`Parent`.`id` = ? LIMIT ? OFFSET ?',
     //   'SELECT `cf-users`.`Child`.`id`, `cf-users`.`Child`.`c`, `cf-users`.`Child`.`parentId` FROM `cf-users`.`Child` WHERE `cf-users`.`Child`.`parentId` IN (?)'
     // ]
-    await this.doQuery(
-      {
-        "modelName": "Parent",
-        "action": "createOne",
-        "query": {
-          "arguments": {
-            "data": {
-              "p": "p1",
-              "p_1": "1",
-              "p_2": "2",
-              "childOpt": {
-                "create": {
-                  "c": "c1",
-                  "c_1": "foo",
-                  "c_2": "bar"
-                }
-              }
-            }
+    await this.doQuery({
+      modelName: 'Parent',
+      action: 'createOne',
+      query: {
+        arguments: {
+          data: {
+            p: 'p1',
+            p_1: '1',
+            p_2: '2',
+            childOpt: {
+              create: {
+                c: 'c1',
+                c_1: 'foo',
+                c_2: 'bar',
+              },
+            },
           },
-          "selection": {
-            "p": true,
-            "childOpt": {
-              "selection": {
-                "c": true
-              }
-            }
-          }
-        }
-      }
-    )
+        },
+        selection: {
+          p: true,
+          childOpt: {
+            selection: {
+              c: true,
+            },
+          },
+        },
+      },
+    })
 
     /* Delete the parent */
 
@@ -624,40 +570,41 @@ class SmokeTest {
     //   'SELECT `cf-users`.`Parent`.`id` FROM `cf-users`.`Parent` WHERE `cf-users`.`Parent`.`p` = ?',
     //   'DELETE FROM `cf-users`.`Parent` WHERE (`cf-users`.`Parent`.`id` IN (?) AND `cf-users`.`Parent`.`p` = ?)'
     // ]
-    const resultDeleteMany = await this.doQuery(
-      {
-        "modelName": "Parent",
-        "action": "deleteMany",
-        "query": {
-          "arguments": {
-            "where": {
-              "p": "p1"
-            }
+    const resultDeleteMany = await this.doQuery({
+      modelName: 'Parent',
+      action: 'deleteMany',
+      query: {
+        arguments: {
+          where: {
+            p: 'p1',
           },
-          "selection": {
-            "count": true
-          }
-        }
-      }
-    )
+        },
+        selection: {
+          count: true,
+        },
+      },
+    })
     console.log('[nodejs] resultDeleteMany', JSON.stringify(resultDeleteMany, null, 2))
   }
 
   async testTransaction() {
-    const startResponse = await this.engine.startTransaction(JSON.stringify({ isolation_level: 'Serializable', max_wait: 5000, timeout: 15000 }), 'trace')
+    const startResponse = await this.engine.startTransaction(
+      JSON.stringify({ isolation_level: 'Serializable', max_wait: 5000, timeout: 15000 }),
+      'trace',
+    )
 
     const tx_id = JSON.parse(startResponse).id
 
     console.log('[nodejs] transaction id', tx_id)
     await this.doQuery(
       {
-        "action": "findMany",
-        "modelName": "Author",
-        "query": {
-          "selection": { "$scalars": true }
-        }
+        action: 'findMany',
+        modelName: 'Author',
+        query: {
+          selection: { $scalars: true },
+        },
       },
-      tx_id
+      tx_id,
     )
 
     const commitResponse = await this.engine.commitTransaction(tx_id, 'trace')
@@ -672,7 +619,9 @@ class SmokeTest {
       if (error.error_code === 'P2036') {
         const jsError = this.connector.errorRegistry.consumeError(error.meta.id)
         if (!jsError) {
-          throw new Error(`Something went wrong. Engine reported external error with id ${error.meta.id}, but it was not registered.`)
+          throw new Error(
+            `Something went wrong. Engine reported external error with id ${error.meta.id}, but it was not registered.`,
+          )
         }
         throw jsError.error
       }


### PR DESCRIPTION
`startTransaction` was not correctly wrapped when converting `Adapter`
to `ErrorCapturingAdapter`. As a result, `GenericError` message was
returned in case of JS error. This PR fixes the problem.

Since it is hard to test those kinds of errors with real drivers, new
test suite for the error propogation is introduced. It uses fake
postgres adapter that throws on every call.
