### PR TITLE
test(qe) Improve DX for testing driver adapters locally in the query-engine and test prisma engines against postgres 13 using neon driver adapter

### DIFF
--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -27,6 +27,12 @@ jobs:
             connector: "postgres"
             version: "13"
             driver_adapter: "pg"
+          - name: "neon-postgres13"
+            connector: "postgres"
+            version: "13"
+            driver_adapter: "neon"
+            driver_adapter_config: |
+              { "proxyUrl": "127.0.0.1:5488/v1" }
         node_version: ["18"]
     env:
       LOG_LEVEL: "info"

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -27,10 +27,10 @@ jobs:
             connector: "postgres"
             version: "13"
             driver_adapter: "pg"
-          - name: "neon-postgres13"
+          - name: "neon-ws-postgres13"
             connector: "postgres"
             version: "13"
-            driver_adapter: "neon"
+            driver_adapter: "neon:ws"
             driver_adapter_config: |
               { "proxyUrl": "127.0.0.1:5488/v1" }
         node_version: ["18"]

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -17,22 +17,16 @@ concurrency:
 
 jobs:
   rust-query-engine-tests:
-    name: "Test `${{ matrix.database.driver_adapter }}` on node v${{ matrix.node_version }}"
+    name: "Test `${{ matrix.adapter.name }}` on node v${{ matrix.node_version }}"
 
     strategy:
       fail-fast: false
       matrix:
-        database:
-          - name: "pg-postgres13"
-            connector: "postgres"
-            version: "13"
-            driver_adapter: "pg"
-          - name: "neon-ws-postgres13"
-            connector: "postgres"
-            version: "13"
-            driver_adapter: "neon:ws"
-            driver_adapter_config: |
-              { "proxyUrl": "127.0.0.1:5488/v1" }
+        adapter:
+          - name: "pg"
+            setup_task: "dev-pg-postgres13"
+          - name: "neon:ws"
+            setup_task: "dev-neon-ws-postgres13"
         node_version: ["18"]
     env:
       LOG_LEVEL: "info" # Set to "debug" to trace the query engine and node process running the driver adapter
@@ -80,8 +74,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: "Start ${{ matrix.database.name }} and set .test_config"
-        run: make dev-${{ matrix.database.name }}
+      - run: make ${{ matrix.adapter.setup_task }}
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -35,7 +35,7 @@ jobs:
               { "proxyUrl": "127.0.0.1:5488/v1" }
         node_version: ["18"]
     env:
-      LOG_LEVEL: "info"
+      LOG_LEVEL: "info" # Set to "debug" to trace the query engine and node process running the driver adapter
       LOG_QUERIES: "y"
       RUST_LOG: "info"
       RUST_LOG_FORMAT: "devel"
@@ -93,6 +93,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - name: "Run tests"
-        run:  cargo test --package query-engine-tests writes::top_level_mutations::create_many::json_create_many::create_many_json_adv -- --test-threads=1
+        run:  cargo test --package query-engine-tests -- --test-threads=1
 
 

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          - name: "postgres13"
+          - name: "pg-postgres13"
             connector: "postgres"
             version: "13"
             driver_adapter: "pg"
@@ -45,7 +45,7 @@ jobs:
       # Driver adapter testing specific env vars
       EXTERNAL_TEST_EXECUTOR: "${{ github.workspace }}/query-engine/driver-adapters/js/connector-test-kit-executor/script/start_node.sh"
       DRIVER_ADAPTER: ${{ matrix.database.driver_adapter }}
-      DRIVER_ADAPTER_URL_OVERRIDE: ${{ matrix.database.driver_adapter_url }}
+      DRIVER_ADAPTER_CONFIG: ${{ matrix.database.driver_adapter_config }}
 
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
@@ -86,13 +86,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - name: "Build query-engine-node-api with driver support"
-        run: cargo build -p query-engine-node-api
-
-      - name: "Install and build driver adapter JS dependencies"
-        run: cd query-engine/driver-adapters/js && pnpm i && pnpm build
-
       - name: "Run tests"
-        run:  cargo test --package query-engine-tests -- --test-threads=1
+        run:  cargo test --package query-engine-tests writes::top_level_mutations::create_many::json_create_many::create_many_json_adv -- --test-threads=1
 
 

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -40,18 +40,11 @@ jobs:
       RUST_LOG: "info"
       RUST_LOG_FORMAT: "devel"
       RUST_BACKTRACE: "1"
-      PRISMA_DISABLE_QUAINT_EXECUTORS: "1"
       CLICOLOR_FORCE: "1"
       CLOSED_TX_CLEANUP: "2"
       SIMPLE_TEST_MODE: "1"
       QUERY_BATCH_SIZE: "10"
-      TEST_CONNECTOR: ${{ matrix.database.connector }}
-      TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
       WORKSPACE_ROOT: ${{ github.workspace }}
-      # Driver adapter testing specific env vars
-      EXTERNAL_TEST_EXECUTOR: "${{ github.workspace }}/query-engine/driver-adapters/js/connector-test-kit-executor/script/start_node.sh"
-      DRIVER_ADAPTER: ${{ matrix.database.driver_adapter }}
-      DRIVER_ADAPTER_CONFIG: ${{ matrix.database.driver_adapter_config }}
 
     runs-on: buildjet-16vcpu-ubuntu-2004
     steps:
@@ -87,8 +80,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: "Start ${{ matrix.database.name }}"
-        run: make start-${{ matrix.database.name }}
+      - name: "Start ${{ matrix.database.name }} and set .test_config"
+        run: make dev-${{ matrix.database.name }}
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,18 @@ start-postgres13:
 dev-postgres13: start-postgres13
 	cp $(CONFIG_PATH)/postgres13 $(CONFIG_FILE)
 
+.PHONY: start-pg-postgres13
+start-pg-postgres13: build-qe-napi build-connector-kit-js start-postgres13
+
+dev-pg-postgres13: start-pg-postgres13
+	cp $(CONFIG_PATH)/pg-postgres13 $(CONFIG_FILE)
+
+start-neon-postgres13: build-qe-napi build-connector-kit-js
+	docker compose -f docker-compose.yml up -d --remove-orphans neon-postgres13
+
+dev-neon-postgres13: start-neon-postgres13
+	cp $(CONFIG_PATH)/neon-postgres13 $(CONFIG_FILE)
+
 start-postgres14:
 	docker compose -f docker-compose.yml up -d --remove-orphans postgres14
 
@@ -238,6 +250,12 @@ dev-vitess_8_0: start-vitess_8_0
 ######################
 # Local dev commands #
 ######################
+
+build-qe-napi:
+	cargo build --package query-engine-node-api
+
+build-connector-kit-js:
+	cd query-engine/driver-adapters/js && pnpm i && pnpm build
 
 # Quick schema validation of whatever you have in the dev_datamodel.prisma file.
 validate:

--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,6 @@ dev-pg-postgres13: start-pg-postgres13
 start-neon-postgres13: build-qe-napi build-connector-kit-js
 	docker compose -f docker-compose.yml up -d --remove-orphans neon-postgres13
 
-# Alias for consistency with other connectors. It's used from query-engine-driver-adapters.yaml
-# when calling dynamically start-* tasks for particular driver adapter tests
-start-neon-ws-postgres13: start-neon-postgres13
-
 dev-neon-ws-postgres13: start-neon-ws-postgres13
 	cp $(CONFIG_PATH)/neon-ws-postgres13 $(CONFIG_FILE)
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ dev-pg-postgres13: start-pg-postgres13
 start-neon-postgres13: build-qe-napi build-connector-kit-js
 	docker compose -f docker-compose.yml up -d --remove-orphans neon-postgres13
 
-dev-neon-ws-postgres13: start-neon-ws-postgres13
+dev-neon-ws-postgres13: start-neon-postgres13
 	cp $(CONFIG_PATH)/neon-ws-postgres13 $(CONFIG_FILE)
 
 start-postgres14:

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,6 @@ start-postgres13:
 dev-postgres13: start-postgres13
 	cp $(CONFIG_PATH)/postgres13 $(CONFIG_FILE)
 
-.PHONY: start-pg-postgres13
 start-pg-postgres13: build-qe-napi build-connector-kit-js start-postgres13
 
 dev-pg-postgres13: start-pg-postgres13
@@ -116,7 +115,11 @@ dev-pg-postgres13: start-pg-postgres13
 start-neon-postgres13: build-qe-napi build-connector-kit-js
 	docker compose -f docker-compose.yml up -d --remove-orphans neon-postgres13
 
-dev-neon-ws-postgres13: start-neon-postgres13
+# Alias for consistency with other connectors. It's used from query-engine-driver-adapters.yaml
+# when calling dynamically start-* tasks for particular driver adapter tests
+start-neon-ws-postgres13: start-neon-postgres13
+
+dev-neon-ws-postgres13: start-neon-ws-postgres13
 	cp $(CONFIG_PATH)/neon-ws-postgres13 $(CONFIG_FILE)
 
 start-postgres14:

--- a/Makefile
+++ b/Makefile
@@ -116,8 +116,8 @@ dev-pg-postgres13: start-pg-postgres13
 start-neon-postgres13: build-qe-napi build-connector-kit-js
 	docker compose -f docker-compose.yml up -d --remove-orphans neon-postgres13
 
-dev-neon-postgres13: start-neon-postgres13
-	cp $(CONFIG_PATH)/neon-postgres13 $(CONFIG_FILE)
+dev-neon-ws-postgres13: start-neon-postgres13
+	cp $(CONFIG_PATH)/neon-ws-postgres13 $(CONFIG_FILE)
 
 start-postgres14:
 	docker compose -f docker-compose.yml up -d --remove-orphans postgres14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     image: ghcr.io/neondatabase/wsproxy:latest
     environment:
       # the port of the postgres13 within the databases network
-      APPEND_PORT: 'postgres:5432'
+      APPEND_PORT: 'postgres13:5432'
       ALLOW_ADDR_REGEX: '.*'
       LOG_TRAFFIC: 'true'
       LOG_CONN_INFO: 'true'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,21 @@ services:
     networks:
       - databases
 
+  neon-postgres13:
+    image: ghcr.io/neondatabase/wsproxy:latest
+    environment:
+      # the port of the postgres13 within the databases network
+      APPEND_PORT: 'postgres:5432'
+      ALLOW_ADDR_REGEX: '.*'
+      LOG_TRAFFIC: 'true'
+      LOG_CONN_INFO: 'true'
+    ports:
+      - '5488:80'
+    depends_on:
+      - postgres13
+    networks:
+      - databases
+
   postgres14:
     image: postgres:14
     restart: always

--- a/query-engine/connector-test-kit-rs/README.md
+++ b/query-engine/connector-test-kit-rs/README.md
@@ -71,18 +71,16 @@ This means that instead of drivers being implemented in Rust, it's a layer of ad
 
 To run tests through a driver adapters, you should also configure the following environment variables:
 
-* `EXTERNAL_TEST_EXECUTOR`: tells the query engine test kit to use an external process to run the queries, this is a node process running
-a program that will read the queries to run from STDIN, and return responses to STDOUT. The connector kit follows a protocol over JSON RPC for this communication. 
+* `EXTERNAL_TEST_EXECUTOR`: tells the query engine test kit to use an external process to run the queries, this is a node process running a program that will read the queries to run from STDIN, and return responses to STDOUT. The connector kit follows a protocol over JSON RPC for this communication. 
 * `DRIVER_ADAPTER`: tells the test executor to use a particular driver adapter. Set to `neon`, `planetscale` or any other supported adapter.
-* `DRIVER_ADAPTER_CONFIG`: a json string with the configuration for the driver adapter. This is adapter specific, but usually contains the connection string to the database.
- 
+* `DRIVER_ADAPTER_CONFIG`: a json string with the configuration for the driver adapter. This is adapter specific. See the [github workflow for driver adapter tests](.github/workflows/query-engine-driver-adapters.yml) for examples on how to configure the driver adapters.
 
 Example:
 
 ```shell
 export EXTERNAL_TEST_EXECUTOR="$WORKSPACE_ROOT/query-engine/driver-adapters/js/connector-test-kit-executor/script/start_node.sh"
 export DRIVER_ADAPTER=neon
-export DRIVER_ADAPTER_URL_OVERRIDE ="postgres://USER:PASSWORD@DATABASExxxx"
+export DRIVER_ADAPTER_CONFIG ='{ "proxyUrl": "127.0.0.1:5488/v1" }'
 ````
 
 ### Running

--- a/query-engine/connector-test-kit-rs/README.md
+++ b/query-engine/connector-test-kit-rs/README.md
@@ -74,7 +74,7 @@ To run tests through a driver adapters, you should also configure the following 
 * `EXTERNAL_TEST_EXECUTOR`: tells the query engine test kit to use an external process to run the queries, this is a node process running
 a program that will read the queries to run from STDIN, and return responses to STDOUT. The connector kit follows a protocol over JSON RPC for this communication. 
 * `DRIVER_ADAPTER`: tells the test executor to use a particular driver adapter. Set to `neon`, `planetscale` or any other supported adapter.
-* `DRIVER_ADAPTER_URL_OVERRIDE`: it overrides the schema URL for the database to use one understood by the driver adapter (ex. neon, planetscale)
+* `DRIVER_ADAPTER_CONFIG`: a json string with the configuration for the driver adapter. This is adapter specific, but usually contains the connection string to the database.
  
 
 Example:

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -146,7 +146,6 @@ impl TestConfig {
     }
 
     fn try_path(path: PathBuf) -> Option<Self> {
-        dbg!(&path);
         File::open(path).ok().and_then(|mut f| {
             let mut config = String::new();
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -94,9 +94,8 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
         .build()
         .unwrap()
         .block_on(async move {
-            eprintln!("Spawning test executor process at `{path}`");
             let process = match Command::new(path)
-                .envs(dbg!(CONFIG.for_external_executor()))
+                .envs(CONFIG.for_external_executor())
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -85,28 +85,25 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
     use std::process::Stdio;
     use tokio::process::Command;
 
-    let env_var = match crate::EXTERNAL_TEST_EXECUTOR.as_ref() {
-        Some(env_var) => env_var,
-        None => exit_with_message(
-            1,
-            "start_rpc_thread() error: EXTERNAL_TEST_EXECUTOR env var is not defined",
-        ),
-    };
+    let path = crate::CONFIG
+        .external_test_executor()
+        .unwrap_or_else(|| exit_with_message(1, "start_rpc_thread() error: external test executor is not set"));
 
     tokio::runtime::Builder::new_current_thread()
         .enable_io()
         .build()
         .unwrap()
         .block_on(async move {
-            eprintln!("Spawning test executor process at `{env_var}`");
-            let process = match Command::new(env_var)
+            eprintln!("Spawning test executor process at `{path}`");
+            let process = match Command::new(path)
+                .envs(dbg!(CONFIG.for_external_executor()))
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()
             {
                 Ok(process) => process,
-                Err(err) => exit_with_message(1, &format!("Failed to spawn the executor process: `{env_var}`. Details: {err}\n")),
+                Err(err) => exit_with_message(1, &format!("Failed to spawn the executor process: `{path}`. Details: {err}\n")),
             };
 
             let mut stdout = BufReader::new(process.stdout.unwrap()).lines();

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -18,7 +18,7 @@ pub(crate) use sql_server::*;
 pub(crate) use sqlite::*;
 pub(crate) use vitess::*;
 
-use crate::{datamodel_rendering::DatamodelRenderer, BoxFuture, TestError, CONFIG, EXTERNAL_TEST_EXECUTOR};
+use crate::{datamodel_rendering::DatamodelRenderer, BoxFuture, TestError, CONFIG};
 use psl::datamodel_connector::ConnectorCapabilities;
 use std::{convert::TryFrom, fmt};
 
@@ -302,7 +302,7 @@ pub(crate) fn should_run(
             .any(|only| ConnectorVersion::try_from(*only).unwrap().matches_pattern(&version));
     }
 
-    if EXTERNAL_TEST_EXECUTOR.is_some() && exclude.iter().any(|excl| excl.0.to_uppercase() == "JS") {
+    if CONFIG.external_test_executor().is_some() && exclude.iter().any(|excl| excl.0.to_uppercase() == "JS") {
         println!("Excluded test execution for JS driver adapters. Skipping test");
         return false;
     };

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -42,13 +42,11 @@ pub static ENV_LOG_LEVEL: Lazy<String> = Lazy::new(|| std::env::var("LOG_LEVEL")
 pub static ENGINE_PROTOCOL: Lazy<String> =
     Lazy::new(|| std::env::var("PRISMA_ENGINE_PROTOCOL").unwrap_or_else(|_| "graphql".to_owned()));
 
-static EXTERNAL_TEST_EXECUTOR: Lazy<Option<String>> = Lazy::new(|| std::env::var("EXTERNAL_TEST_EXECUTOR").ok());
-
 /// Teardown of a test setup.
 async fn teardown_project(datamodel: &str, db_schemas: &[&str], schema_id: Option<usize>) -> TestResult<()> {
     if let Some(schema_id) = schema_id {
         let params = serde_json::json!({ "schemaId": schema_id });
-        crate::executor_process_request::<serde_json::Value>("teardown", params).await?;
+        executor_process_request::<serde_json::Value>("teardown", params).await?;
     }
 
     Ok(qe_setup::teardown(datamodel, db_schemas).await?)

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -122,7 +122,7 @@ impl Runner {
         let data_source = schema.configuration.datasources.first().unwrap();
         let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
 
-        let executor = match crate::EXTERNAL_TEST_EXECUTOR.as_ref() {
+        let executor = match crate::CONFIG.external_test_executor() {
             Some(_) => RunnerExecutor::new_external(&url, &datamodel).await?,
             None => RunnerExecutor::Builtin(
                 request_handlers::load_executor(

--- a/query-engine/connector-test-kit-rs/test-configs/neon-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-postgres13
@@ -1,0 +1,7 @@
+{
+    "connector": "postgres",
+    "version": "13",
+    "driver_adapter": "neon",
+    "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
+    "external_test_executor": "default"
+}

--- a/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13
@@ -1,7 +1,7 @@
 {
     "connector": "postgres",
     "version": "13",
-    "driver_adapter": "neon",
+    "driver_adapter": "neon:ws",
     "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
     "external_test_executor": "default"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/pg-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/pg-postgres13
@@ -1,0 +1,6 @@
+{
+    "connector": "postgres",
+    "version": "13",
+    "driver_adapter": "pg",
+    "external_test_executor": "default"
+}

--- a/query-engine/connector-test-kit-rs/test-configs/postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/postgres13
@@ -1,3 +1,4 @@
 {
     "connector": "postgres",
-    "version": "13"}
+    "version": "13"
+}

--- a/query-engine/driver-adapters/js/connector-test-kit-executor/src/index.ts
+++ b/query-engine/driver-adapters/js/connector-test-kit-executor/src/index.ts
@@ -15,7 +15,7 @@ import * as prismaNeon from '@prisma/adapter-neon'
 import {bindAdapter, DriverAdapter, ErrorCapturingDriverAdapter} from "@prisma/driver-adapter-utils";
 
 const SUPPORTED_ADAPTERS: Record<string, (_ : string) => Promise<DriverAdapter>>
-    = {pg: pgAdapter, neon: neonAdapter};
+    = {"pg": pgAdapter, "neon:ws" : neonWsAdapter};
 
 async function main(): Promise<void> {
     const iface = readline.createInterface({
@@ -211,7 +211,7 @@ async function pgAdapter(url: string): Promise<DriverAdapter> {
     return new prismaPg.PrismaPg(pool)
 }
 
-async function neonAdapter(url: string): Promise<DriverAdapter> {
+async function neonWsAdapter(url: string): Promise<DriverAdapter> {
     const proxyURL = JSON.parse(process.env.DRIVER_ADAPTER_CONFIG || '{}').proxyUrl ?? ''
     if (proxyURL == '') {
         throw new Error("DRIVER_ADAPTER_URL_OVERRIDE is not defined or empty, but its required for neon adapter.");

--- a/query-engine/driver-adapters/js/connector-test-kit-executor/src/qe.ts
+++ b/query-engine/driver-adapters/js/connector-test-kit-executor/src/qe.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path'
 
 export type QueryLogCallback = (log: string) => void
 
-export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel: string, queryLogCallback: QueryLogCallback): lib.QueryEngineInstance {
+export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel: string, queryLogCallback: QueryLogCallback, debug: (...args: any[]) => void): lib.QueryEngineInstance {
     // I assume nobody will run this on Windows ¯\_(ツ)_/¯
     const libExt = os.platform() === 'darwin' ? 'dylib' : 'so'
     const dirname = path.dirname(new URL(import.meta.url).pathname)
@@ -22,7 +22,7 @@ export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel:
         datamodel,
         configDir: '.',
         engineProtocol: 'json' as const,
-        logLevel: process.env["RUST_LOG"] as any,
+        logLevel: process.env["RUST_LOG"] ?? 'info' as any,
         logQueries: true,
         env: process.env,
         ignoreEnvVarErrors: false,
@@ -34,11 +34,7 @@ export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel:
         if (parsed.is_query) {
             queryLogCallback(parsed.query)
         }
-
-        const level = process.env.LOG_LEVEL ?? ''
-        if (level.toLowerCase() == 'debug') {
-            console.error("[nodejs] ", parsed)
-        }
+        debug(parsed)
     }
 
     return new QueryEngine(queryEngineOptions, logCallback, adapter)

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -163,7 +163,17 @@ impl QueryEngine {
             config_dir,
             ignore_env_var_errors,
             engine_protocol,
-        } = napi_env.from_js_value(options)?;
+        } = napi_env.from_js_value(options).expect(
+            r###"
+            Failed to deserialize constructor options. 
+            
+            This usually happens when the javascript object passed to the constructor is missing 
+            properties for the ConstructorOptions fields that must have some value.
+            
+            If you set some of these in javascript trough environment variables, make sure there are
+            values for data_model, log_level, and any field that is not Option<T>
+            "###,
+        );
 
         let env = stringify_env_values(env)?; // we cannot trust anything JS sends us from process.env
         let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();


### PR DESCRIPTION
This PR allows to run tests with driver adapters as any other connector
test using some conventions:

`make dev-adapter-database`

and then

`cargo test -p query-engine-tests`

There are four new make tasks. Two for `pg-postgres13` and two for `neon-ws-postgres13`, testing the postgres13 connector suite, with the pg and neon driver adapters respectively:

```Makefile
.PHONY: start-pg-postgres13
start-pg-postgres13: build-qe-napi build-connector-kit-js start-postgres13

dev-pg-postgres13: start-pg-postgres13
	cp $(CONFIG_PATH)/pg-postgres13 $(CONFIG_FILE)
```

and

```Makefile
start-neon-postgres13: build-qe-napi build-connector-kit-js
	docker compose -f docker-compose.yml up -d --remove-orphans neon-ws-postgres13

dev-neon-ws-postgres13: start-neon-postgres13
	cp $(CONFIG_PATH)/neon-ws-postgres13 $(CONFIG_FILE)
```

The new .test_config file is copied from a template that has a few more keys:

```rust
/// The central test configuration.
#[derive(Debug, Default, Deserialize)]
pub struct TestConfig {
    /// The connector that tests should run for.
    /// Env key: `TEST_CONNECTOR`
    connector: String,

    /// The connector version tests should run for.
    /// If the test connector is versioned, this option is required.
    /// Env key: `TEST_CONNECTOR_VERSION`
    #[serde(rename = "version")]
    connector_version: Option<String>,

    /// An external process to execute the test queries and produced responses for assertion
    /// Used when testing driver adapters, this process is expected to be a javascript process
    /// loading the library engine (as a library, or WASM modules) and providing it with a
    /// driver adapter.
    /// Env key: `EXTERNAL_TEST_EXECUTOR`
    external_test_executor: Option<String>,

    /// The driver adapter to use when running tests, will be forwarded to the external test
    /// executor by setting the `DRIVER_ADAPTER` env var when spawning the executor process
    driver_adapter: Option<String>,

    /// The driver adapter configuration to forward as a stringified JSON object to the external
    /// test executor by setting the `DRIVER_ADAPTER_CONFIG` env var when spawning the executor
    driver_adapter_config: Option<serde_json::Value>,

    /// Indicates whether or not the tests are running in CI context.
    /// Env key: `BUILDKITE`
    #[serde(default)]
    is_ci: bool,
}
```

When the `default` key is provided in `EXTERNAL_TEST_EXECUTOR`, and `WORKSPACE_ROOT` is set,  the executor being used is that in `query-engine/driver-adapters/js/connector-test-kit-executor/script/start_node.sh`

Given all the above, a normal workflow to test driver adapters would be to either:

* `make dev-pg-postgres13`
* `make dev-neon-ws-postgres13`
* ...

and then run:

`cargo test -p query-engine-tests`

The PR also adds configuration run the `neon:ws` driver adapter against postgres 13 in CI