### PR TITLE
perf: remove enum variant query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#429e76047f28e64761ad63bc6cc9335c3d3337b5"
+source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#a1a2dc6d9584deaf70a14293c428e7b6ca614d98"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.4"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#429e76047f28e64761ad63bc6cc9335c3d3337b5"
+source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#a1a2dc6d9584deaf70a14293c428e7b6ca614d98"
 dependencies = [
  "base64 0.13.1",
  "byteorder",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.4"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#429e76047f28e64761ad63bc6cc9335c3d3337b5"
+source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#a1a2dc6d9584deaf70a14293c428e7b6ca614d98"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -5160,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.7"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#429e76047f28e64761ad63bc6cc9335c3d3337b5"
+source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#a1a2dc6d9584deaf70a14293c428e7b6ca614d98"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -5498,7 +5498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/quaint/src/connector/postgres/conversion.rs
+++ b/quaint/src/connector/postgres/conversion.rs
@@ -519,7 +519,7 @@ impl GetRow for PostgresRow {
                     None => Value::Array(None),
                 },
                 ref x => match x.kind() {
-                    Kind::Enum(_) => match row.try_get(i)? {
+                    Kind::Enum => match row.try_get(i)? {
                         Some(val) => {
                             let val: EnumString = val;
 
@@ -528,7 +528,7 @@ impl GetRow for PostgresRow {
                         None => Value::Enum(None),
                     },
                     Kind::Array(inner) => match inner.kind() {
-                        Kind::Enum(_) => match row.try_get(i)? {
+                        Kind::Enum => match row.try_get(i)? {
                             Some(val) => {
                                 let val: Vec<Option<EnumString>> = val;
                                 let variants = val.into_iter().map(|x| Value::Enum(x.map(|x| x.value.into())));


### PR DESCRIPTION
## Overview

Follow-up PR to https://github.com/prisma/rust-postgres/pull/3

Improves performance for:
- https://github.com/prisma/prisma/issues/14955
- https://github.com/prisma/prisma/issues/19325

### SQL Diff

Datamodel

```prisma
model User {
  id        Int    @id @default(autoincrement())
  firstName String

  role Role
  authorization Authorization?
}
```

Query
```graphql
mutation {
  createOneUser(data: {
    firstName: "John",
    role: User
    authorization: Authorized
  }) {
    id
  }
}
```

SQL
```sql
-- before
SELECT t.typname, t.typtype, t.typelem, r.rngsubtype, t.typbasetype, n.nspname, t.typrelid FROM pg_catalog.pg_type t LEFT OUTER JOIN pg_catalog.pg_range r ON r.rngtypid = t.oid INNER JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = $1;
SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid = $1 ORDER BY enumsortorder;
SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid = $1 ORDER BY enumsortorder;
INSERT INTO "User" ("firstName", "role", "authorization") VALUES ($1, $2, $3) RETURNING "User"."id";

-- after
SELECT t.typname, t.typtype, t.typelem, r.rngsubtype, t.typbasetype, n.nspname, t.typrelid FROM pg_catalog.pg_type t LEFT OUTER JOIN pg_catalog.pg_range r ON r.rngtypid = t.oid INNER JOIN pg_catalog.pg_namespace n ON t.typnamespace = n.oid WHERE t.oid = $1;
INSERT INTO "User" ("firstName", "role", "authorization") VALUES ($1, $2, $3) RETURNING "User"."id";
```