### PR TITLE
driver-adapters: Better result type

### DIFF
--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -1,5 +1,5 @@
 import type neon from '@neondatabase/serverless'
-import { Debug } from '@prisma/driver-adapter-utils'
+import { Debug, ok, err } from '@prisma/driver-adapter-utils'
 import type {
   DriverAdapter,
   ResultSet,
@@ -36,7 +36,7 @@ abstract class NeonQueryable implements Queryable {
       rows,
     }
 
-    return { ok: true, value: resultSet }
+    return ok(resultSet)
   }
 
   async executeRaw(query: Query): Promise<Result<number>> {
@@ -46,7 +46,7 @@ abstract class NeonQueryable implements Queryable {
     const { rowCount: rowsAffected } = await this.performIO(query)
 
     // Note: `rowsAffected` can sometimes be null (e.g., when executing `"BEGIN"`)
-    return { ok: true, value: rowsAffected ?? 0 }
+    return ok(rowsAffected ?? 0)
   }
 
   abstract performIO(query: Query): Promise<PerformIOResult>
@@ -82,14 +82,14 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
     debug(`[js::commit]`)
 
     this.client.release()
-    return Promise.resolve({ ok: true, value: undefined })
+    return Promise.resolve(ok(undefined))
   }
 
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
     this.client.release()
-    return Promise.resolve({ ok: true, value: undefined })
+    return Promise.resolve(ok(undefined))
   }
 }
 
@@ -109,7 +109,7 @@ export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdap
     debug(`${tag} options: %O`, options)
 
     const connection = await this.client.connect()
-    return { ok: true, value: new NeonTransaction(connection, options) }
+    return ok(new NeonTransaction(connection, options))
   }
 
   async close() {
@@ -117,7 +117,7 @@ export class PrismaNeon extends NeonWsQueryable<neon.Pool> implements DriverAdap
       await this.client.end()
       this.isRunning = false
     }
-    return { ok: true as const, value: undefined }
+    return ok(undefined)
   }
 }
 
@@ -139,6 +139,6 @@ export class PrismaNeonHTTP extends NeonQueryable implements DriverAdapter {
   }
 
   async close() {
-    return { ok: true as const, value: undefined }
+    return ok(undefined)
   }
 }

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
@@ -1,5 +1,5 @@
 import type planetScale from '@planetscale/database'
-import { Debug } from '@prisma/driver-adapter-utils'
+import { Debug, ok } from '@prisma/driver-adapter-utils'
 import type {
   DriverAdapter,
   ResultSet,
@@ -46,7 +46,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.
       lastInsertId,
     }
 
-    return { ok: true, value: resultSet }
+    return ok(resultSet)
   }
 
   /**
@@ -59,7 +59,7 @@ class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.
     debug(`${tag} %O`, query)
 
     const { rowsAffected } = await this.performIO(query)
-    return { ok: true, value: rowsAffected }
+    return ok(rowsAffected)
   }
 
   /**
@@ -97,14 +97,14 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
     debug(`[js::commit]`)
 
     this.txDeferred.resolve()
-    return Promise.resolve({ ok: true, value: await this.txResultPromise })
+    return Promise.resolve(ok(await this.txResultPromise))
   }
 
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
     this.txDeferred.reject(new RollbackError())
-    return Promise.resolve({ ok: true, value: await this.txResultPromise })
+    return Promise.resolve(ok(await this.txResultPromise))
   }
 }
 
@@ -127,7 +127,7 @@ export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Connecti
           const [txDeferred, deferredPromise] = createDeferred<void>()
           const txWrapper = new PlanetScaleTransaction(tx, options, txDeferred, txResultPromise)
 
-          resolve({ ok: true, value: txWrapper })
+          resolve(ok(txWrapper))
           return deferredPromise
         })
         .catch((error) => {
@@ -143,6 +143,6 @@ export class PrismaPlanetScale extends PlanetScaleQueryable<planetScale.Connecti
   }
 
   async close() {
-    return { ok: true as const, value: undefined }
+    return ok(undefined)
   }
 }

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/index.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/index.ts
@@ -1,4 +1,5 @@
 export { bindAdapter } from './binder'
 export { ColumnTypeEnum } from './const'
 export { Debug } from './debug'
+export { ok, err, type Result } from './result'
 export type * from './types'

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/result.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/result.ts
@@ -1,0 +1,41 @@
+import { Error } from './types'
+export type Result<T> = {
+  // common methods
+  map<U>(fn: (value: T) => U): Result<U>
+  flatMap<U>(fn: (value: T) => Result<U>): Result<U>
+} & (
+  | {
+      readonly ok: true
+      readonly value: T
+    }
+  | {
+      readonly ok: false
+      readonly error: Error
+    }
+)
+
+export function ok<T>(value: T): Result<T> {
+  return {
+    ok: true,
+    value,
+    map(fn) {
+      return ok(fn(value))
+    },
+    flatMap(fn) {
+      return fn(value)
+    },
+  }
+}
+
+export function err<T>(error: Error): Result<T> {
+  return {
+    ok: false,
+    error,
+    map() {
+      return err(error)
+    },
+    flatMap() {
+      return err(error)
+    },
+  }
+}

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -1,6 +1,7 @@
 import { ColumnTypeEnum } from './const'
+import { Result } from './result'
 
-export type ColumnType = typeof ColumnTypeEnum[keyof typeof ColumnTypeEnum]
+export type ColumnType = (typeof ColumnTypeEnum)[keyof typeof ColumnTypeEnum]
 
 export interface ResultSet {
   /**
@@ -33,25 +34,17 @@ export type Query = {
 }
 
 export type Error = {
-  kind: 'GenericJsError',
+  kind: 'GenericJsError'
   id: number
 }
 
-export type Result<T> = {
-  ok: true,
-  value: T
-} | {
-  ok: false,
-  error: Error
-}
-
-export interface Queryable  {
+export interface Queryable {
   readonly flavour: 'mysql' | 'postgres' | 'sqlite'
 
   /**
    * Execute a query given as SQL, interpolating the given parameters,
    * and returning the type-aware result set of the query.
-   * 
+   *
    * This is the preferred way of executing `SELECT` queries.
    */
   queryRaw(params: Query): Promise<Result<ResultSet>>
@@ -59,7 +52,7 @@ export interface Queryable  {
   /**
    * Execute a query given as SQL, interpolating the given parameters,
    * and returning the number of affected rows.
-   * 
+   *
    * This is the preferred way of executing `INSERT`, `UPDATE`, `DELETE` queries,
    * as well as transactional queries.
    */


### PR DESCRIPTION
Adds convenience functions for creating result types: `err` and `ok`,
similar to Rust ones.

Adds `map` and `flatMap` methods on `Result` type for easier way to work
with a `Result` on a happy path.

Split from #4213
