### PR TITLE
query-tests-setup: handle external process rpc thread panic

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -32,10 +32,19 @@ impl ExecutorProcess {
     fn new() -> Result<ExecutorProcess> {
         let (sender, receiver) = mpsc::channel::<ReqImpl>(300);
 
-        std::thread::spawn(|| match start_rpc_thread(receiver) {
+        let handle = std::thread::spawn(|| match start_rpc_thread(receiver) {
             Ok(()) => (),
             Err(err) => {
                 exit_with_message(1, &err.to_string());
+            }
+        });
+
+        std::thread::spawn(move || {
+            if let Err(e) = handle.join() {
+                exit_with_message(
+                    1,
+                    &format!("rpc thread panicked with: {:?}", e.downcast_ref::<String>()),
+                );
             }
         });
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -43,7 +43,10 @@ impl ExecutorProcess {
             if let Err(e) = handle.join() {
                 exit_with_message(
                     1,
-                    &format!("rpc thread panicked with: {:?}", e.downcast_ref::<String>()),
+                    &format!(
+                        "rpc thread panicked with: {}",
+                        e.downcast::<String>().unwrap_or_default()
+                    ),
                 );
             }
         });


### PR DESCRIPTION
Terminate the process if the RPC thread crashes and print the panic message instead of silently continuing.

Otherwise, every test afterwards will be failing with `SendError` trying to send requests to a closed channel in `self.task_handle.send((method_call, sender))`, e.g.: https://github.com/prisma/prisma-engines/actions/runs/6275305901/job/17042513838?pr=4229

It could also be a valid change to only print the error and let all future tests fail, but exiting the process is consistent with how other non-recoverable failures are handled in this module.