### PR TITLE
test(qe): don't crash in rpc thread if request future was dropped

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -125,7 +125,10 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
                                         let sender = pending_requests.remove(response.id()).unwrap();
                                         match response {
                                             jsonrpc_core::Output::Success(success) => {
-                                                sender.send(success.result).unwrap();
+                                                // The other end may be dropped if the whole
+                                                // request future was dropped and not polled to
+                                                // completion, so we ignore send errors here.
+                                                _ = sender.send(success.result);
                                             }
                                             jsonrpc_core::Output::Failure(err) => {
                                                 panic!("error response from jsonrpc: {err:?}")


### PR DESCRIPTION
Don't crash in the RPC thread in external process executor if the
receiver side of the oneshot channel was already dropped from the other
side. This may happen if the request future is dropped without polling
it to completion after the point in time where a `MethodCall` is already
sent over `task_handle` MPSC channel.
