### PR TITLE
tests(qe): Lenient float comparision in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3650,6 +3659,7 @@ dependencies = [
  "chrono",
  "colored",
  "enumflags2",
+ "float-cmp",
  "futures",
  "indoc",
  "insta",
@@ -5500,7 +5510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -20,9 +20,10 @@ uuid.workspace = true
 tokio.workspace = true
 user-facing-errors.workspace = true
 prisma-value = { path = "../../../libs/prisma-value" }
-query-engine-metrics = { path = "../../metrics"}
+query-engine-metrics = { path = "../../metrics" }
 once_cell = "1.15.0"
 futures = "0.3"
 
 [dev-dependencies]
 insta = "1.7.1"
+float-cmp = "0.9.0"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/floats.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/floats.rs
@@ -1,0 +1,23 @@
+#[macro_export]
+macro_rules! assert_approximate_float {
+    ($data:expr, $field:expr, $val:expr) => {{
+        let val: serde_json::Value = query_tests_setup::walk_json(
+            &serde_json::from_str::<serde_json::Value>($data.to_string().as_str()).unwrap(),
+            $field,
+        )
+        .unwrap()
+        .to_owned();
+
+        if let serde_json::Value::Number(v) = &val {
+            if let Some(v) = v.as_f64() {
+                if !float_cmp::approx_eq!(f64, v, $val) {
+                    panic!("{v} is not close enough to expected value of {}", $val.to_string());
+                }
+            } else {
+                panic!("Expected a float, got {:?}", val);
+            }
+        } else {
+            panic!("Expected a number, got {:?}", val);
+        }
+    }};
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/mod.rs
@@ -1,4 +1,5 @@
 mod bytes;
+mod floats;
 mod json;
 mod querying;
 mod raw;
@@ -6,6 +7,7 @@ mod string;
 mod time;
 
 pub use bytes::*;
+pub use floats::*;
 pub use json::*;
 pub use querying::*;
 pub use raw::*;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/typed_output.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/typed_output.rs
@@ -492,7 +492,7 @@ mod typed_output {
             string: "str",
             int: 42,
             bInt: "9223372036854775807",
-            float: 1.5432,
+            float: 10.01,
             bytes: "AQID",
             bool: true,
             dt: "1900-10-10T01:10:10.001Z",
@@ -527,7 +527,7 @@ mod typed_output {
                 },
                 "float": {
                   "prisma__type": "double",
-                  "prisma__value": 1.5432
+                  "prisma__value": 10.01
                 },
                 "bytes": {
                   "prisma__type": "bytes",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
@@ -334,9 +334,10 @@ mod atomic_number_ops {
           query_nested_number_ops(&runner, 1, "optFloat", "increment", "4.6").await?,
           @r###"{"optFloat":null}"###
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "increment", "4.6").await?,
-          @r###"{"optFloat":10.1}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "increment", "4.6").await?,
+            &["optFloat"],
+            10.1
         );
 
         // Decrement
@@ -344,9 +345,10 @@ mod atomic_number_ops {
           query_nested_number_ops(&runner, 1, "optFloat", "decrement", "4.6").await?,
           @r###"{"optFloat":null}"###
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "decrement", "4.6").await?,
-          @r###"{"optFloat":5.5}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "decrement", "4.6").await?,
+            &["optFloat"],
+            5.5
         );
 
         // Multiply
@@ -354,9 +356,10 @@ mod atomic_number_ops {
           query_nested_number_ops(&runner, 1, "optFloat", "multiply", "2").await?,
           @r###"{"optFloat":null}"###
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "multiply", "2").await?,
-          @r###"{"optFloat":11.0}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "multiply", "2").await?,
+            &["optFloat"],
+            11.0
         );
 
         // Divide
@@ -364,19 +367,22 @@ mod atomic_number_ops {
           query_nested_number_ops(&runner, 1, "optFloat", "divide", "2").await?,
           @r###"{"optFloat":null}"###
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "divide", "2").await?,
-          @r###"{"optFloat":5.5}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "divide", "2").await?,
+            &["optFloat"],
+            5.5
         );
 
         // Set
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 1, "optFloat", "set", "5.1").await?,
-          @r###"{"optFloat":5.1}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 1, "optFloat", "set", "5.1").await?,
+            &["optFloat"],
+            5.1
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "set", "5.1").await?,
-          @r###"{"optFloat":5.1}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "set", "5.1").await?,
+            &["optFloat"],
+            5.1
         );
 
         // Set null
@@ -402,9 +408,10 @@ mod atomic_number_ops {
           query_nested_number_ops(&runner, 1, "optFloat", "increment", "4.6").await?,
           @r###"{"optFloat":null}"###
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "increment", "4.6").await?,
-          @r###"{"optFloat":10.1}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "increment", "4.6").await?,
+            &["optFloat"],
+            10.1
         );
 
         // Decrement
@@ -412,9 +419,10 @@ mod atomic_number_ops {
           query_nested_number_ops(&runner, 1, "optFloat", "decrement", "4.6").await?,
           @r###"{"optFloat":null}"###
         );
-        insta::assert_snapshot!(
-          query_nested_number_ops(&runner, 2, "optFloat", "decrement", "4.6").await?,
-          @r###"{"optFloat":5.5}"###
+        assert_approximate_float!(
+            query_nested_number_ops(&runner, 2, "optFloat", "decrement", "4.6").await?,
+            &["optFloat"],
+            5.5
         );
 
         // Multiply

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update.rs
@@ -500,9 +500,10 @@ mod update {
           query_number_operation(&runner, "1", "optFloat", "increment", "4.6").await?,
           @r###"{"data":{"updateOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "increment", "4.6").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":10.1}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "increment", "4.6").await?,
+            &["data", "updateOneTestModel", "optFloat"],
+            10.1
         );
 
         // Decrement
@@ -510,9 +511,10 @@ mod update {
           query_number_operation(&runner, "1", "optFloat", "decrement", "4.6").await?,
           @r###"{"data":{"updateOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "decrement", "4.6").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.5}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "decrement", "4.6").await?,
+            &["data", "updateOneTestModel", "optFloat"],
+            5.5
         );
 
         // Multiply
@@ -520,9 +522,10 @@ mod update {
           query_number_operation(&runner, "1", "optFloat", "multiply", "2").await?,
           @r###"{"data":{"updateOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "multiply", "2").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":11.0}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "multiply", "2").await?,
+            &["data", "updateOneTestModel", "optFloat"],
+            11.0
         );
 
         // Divide
@@ -530,19 +533,22 @@ mod update {
           query_number_operation(&runner, "1", "optFloat", "divide", "2").await?,
           @r###"{"data":{"updateOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "divide", "2").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.5}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "divide", "2").await?,
+            &["data", "updateOneTestModel", "optFloat"],
+            5.5
         );
 
         // Set
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "1", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.1}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "1", "optFloat", "set", "5.1").await?,
+            &["data", "updateOneTestModel", "optFloat"],
+            5.1
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"updateOneTestModel":{"optFloat":5.1}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "set", "5.1").await?,
+            &["data", "updateOneTestModel", "optFloat"],
+            5.1
         );
 
         // Set null

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/upsert.rs
@@ -548,9 +548,10 @@ mod upsert {
           query_number_operation(&runner, "1", "optFloat", "increment", "4.6").await?,
           @r###"{"data":{"upsertOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "increment", "4.6").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":10.1}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "increment", "4.6").await?,
+            &["data", "upsertOneTestModel", "optFloat"],
+            10.1
         );
 
         // Decrement
@@ -558,9 +559,10 @@ mod upsert {
           query_number_operation(&runner, "1", "optFloat", "decrement", "4.6").await?,
           @r###"{"data":{"upsertOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "decrement", "4.6").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.5}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "decrement", "4.6").await?,
+            &["data", "upsertOneTestModel", "optFloat"],
+            5.5
         );
 
         // Multiply
@@ -568,9 +570,10 @@ mod upsert {
           query_number_operation(&runner, "1", "optFloat", "multiply", "2").await?,
           @r###"{"data":{"upsertOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "multiply", "2").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":11.0}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "multiply", "2").await?,
+            &["data", "upsertOneTestModel", "optFloat"],
+            11.0
         );
 
         // Divide
@@ -578,19 +581,22 @@ mod upsert {
           query_number_operation(&runner, "1", "optFloat", "divide", "2").await?,
           @r###"{"data":{"upsertOneTestModel":{"optFloat":null}}}"###
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "divide", "2").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.5}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "divide", "2").await?,
+            &["data", "upsertOneTestModel", "optFloat"],
+            5.5
         );
 
         // Set
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "1", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.1}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "1", "optFloat", "set", "5.1").await?,
+            &["data", "upsertOneTestModel", "optFloat"],
+            5.1
         );
-        insta::assert_snapshot!(
-          query_number_operation(&runner, "2", "optFloat", "set", "5.1").await?,
-          @r###"{"data":{"upsertOneTestModel":{"optFloat":5.1}}}"###
+        assert_approximate_float!(
+            query_number_operation(&runner, "2", "optFloat", "set", "5.1").await?,
+            &["data", "upsertOneTestModel", "optFloat"],
+            5.1
         );
 
         // Set null

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -215,11 +215,13 @@ impl TestConfig {
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                if path.metadata().is_ok_and(|md| md.permissions().mode() & 0o111 == 0) {
-                    exit_with_message(&format!(
-                        "The external test executor file `{}` must be have permissions to execute",
-                        file
-                    ));
+                if let Ok(md) = path.metadata() {
+                    if md.permissions().mode() & 0o111 == 0 {
+                        exit_with_message(&format!(
+                            "The external test executor file `{}` must be have permissions to execute",
+                            file
+                        ));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Double values suffer from rounding imprecisions due to their representation, as such we cannot rely on snapshots for comparing float values when queries execute through the driver adapters. This commit, implements a macro to approximately compare floats, and applies it to some tests.

See https://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html for a deeper rationale