### PR TITLE
fix(driver-adapters): float rounding problem

### DIFF
--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -56,10 +56,14 @@ pub fn conv_params(params: &[QuaintValue<'_>]) -> serde_json::Result<Vec<JSArg>>
                 Some(bytes) => JSArg::Buffer(bytes.to_vec()),
                 None => JsonValue::Null.into(),
             },
-            quaint_value => {
-                let json: JsonValue = quaint_value.clone().into();
-                json.into()
-            }
+            quaint_value @ QuaintValue::Numeric(bd) => match bd {
+                Some(bd) => match bd.to_string().parse::<f64>() {
+                    Ok(double) => JSArg::from(JsonValue::from(double)),
+                    Err(_) => JSArg::from(JsonValue::from(quaint_value.clone())),
+                },
+                None => JsonValue::Null.into(),
+            },
+            quaint_value => JSArg::from(JsonValue::from(quaint_value.clone())),
         };
 
         values.push(res);


### PR DESCRIPTION
Closes https://github.com/prisma/prisma-engines/pull/4284

BigDecimal values converted to json are transformed into a f64 value using the following internal conversion:

```
  fn to_f64(&self) -> Option<f64> {
        self.int_val.to_f64().map(|x| x * 10f64.powi(-self.scale as i32))
    }
```

This computation causes the rounding problem seen in driver adapters. In quaint this is not manifested, as the driver takes the string representation and not the result of `to_f64`. The string representation doesn't compute any operation transforming the original value.