### PR TITLE
driver-adapters: close tx on drop

### DIFF
--- a/query-engine/driver-adapters/js/adapter-libsql/package.json
+++ b/query-engine/driver-adapters/js/adapter-libsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-libsql",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "Prisma's driver adapter for libsql and Turso",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
@@ -104,7 +104,7 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
     return ok(undefined)
   }
 
-  discard(): Result<void> {
+  dispose(): Result<void> {
     if (!this.finished) {
       this.finished = true
       this.rollback().catch(console.error)

--- a/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
@@ -72,6 +72,8 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
 }
 
 class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Transaction {
+  finished = false
+
   constructor(
     client: TransactionClient,
     readonly options: TransactionOptions,
@@ -82,6 +84,8 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   async commit(): Promise<Result<void>> {
     debug(`[js::commit]`)
 
+    this.finished = true
+
     await this.client.commit()
     return ok(undefined)
   }
@@ -89,12 +93,22 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
+    this.finished = true
+
     try {
       await this.client.rollback()
     } catch (error) {
       debug('error in rollback:', error)
     }
 
+    return ok(undefined)
+  }
+
+  discard(): Result<void> {
+    if (!this.finished) {
+      this.finished = true
+      this.rollback().catch(console.error)
+    }
     return ok(undefined)
   }
 }

--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-neon",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Prisma's driver adapter for \"@neondatabase/serverless\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -80,7 +80,10 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
 }
 
 class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction {
-  constructor(client: neon.PoolClient, readonly options: TransactionOptions) {
+  constructor(
+    client: neon.PoolClient,
+    readonly options: TransactionOptions,
+  ) {
     super(client)
   }
 
@@ -96,6 +99,11 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
 
     this.client.release()
     return Promise.resolve(ok(undefined))
+  }
+
+  discard(): Result<void> {
+    this.client.release()
+    return ok(undefined)
   }
 }
 

--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -101,7 +101,7 @@ class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transa
     return Promise.resolve(ok(undefined))
   }
 
-  discard(): Result<void> {
+  dispose(): Result<void> {
     this.client.release()
     return ok(undefined)
   }

--- a/query-engine/driver-adapters/js/adapter-pg/package.json
+++ b/query-engine/driver-adapters/js/adapter-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-pg",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Prisma's driver adapter for \"pg\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-pg/src/pg.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/pg.ts
@@ -94,7 +94,7 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
     return ok(undefined)
   }
 
-  discard(): Result<void> {
+  dispose(): Result<void> {
     this.client.release()
     return ok(undefined)
   }

--- a/query-engine/driver-adapters/js/adapter-pg/src/pg.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/pg.ts
@@ -93,6 +93,11 @@ class PgTransaction extends PgQueryable<TransactionClient> implements Transactio
     this.client.release()
     return ok(undefined)
   }
+
+  discard(): Result<void> {
+    this.client.release()
+    return ok(undefined)
+  }
 }
 
 export class PrismaPg extends PgQueryable<StdClient> implements DriverAdapter {

--- a/query-engine/driver-adapters/js/adapter-planetscale/package.json
+++ b/query-engine/driver-adapters/js/adapter-planetscale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-planetscale",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "Prisma's driver adapter for \"@planetscale/database\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
@@ -84,6 +84,8 @@ class PlanetScaleQueryable<ClientT extends planetScale.Connection | planetScale.
 }
 
 class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transaction> implements Transaction {
+  finished = false
+
   constructor(
     tx: planetScale.Transaction,
     readonly options: TransactionOptions,
@@ -96,6 +98,7 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
   async commit(): Promise<Result<void>> {
     debug(`[js::commit]`)
 
+    this.finished = true
     this.txDeferred.resolve()
     return Promise.resolve(ok(await this.txResultPromise))
   }
@@ -103,8 +106,16 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
   async rollback(): Promise<Result<void>> {
     debug(`[js::rollback]`)
 
+    this.finished = true
     this.txDeferred.reject(new RollbackError())
     return Promise.resolve(ok(await this.txResultPromise))
+  }
+
+  discard(): Result<void> {
+    if (!this.finished) {
+      this.rollback().catch(console.error)
+    }
+    return ok(undefined)
   }
 }
 

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/planetscale.ts
@@ -111,7 +111,7 @@ class PlanetScaleTransaction extends PlanetScaleQueryable<planetScale.Transactio
     return Promise.resolve(ok(await this.txResultPromise))
   }
 
-  discard(): Result<void> {
+  dispose(): Result<void> {
     if (!this.finished) {
       this.rollback().catch(console.error)
     }

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/driver-adapter-utils",
-  "version": "0.5.0-pre.1",
+  "version": "0.5.0-pre.2",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/driver-adapter-utils",
-  "version": "0.5.0-pre.2",
+  "version": "0.5.0",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/driver-adapter-utils",
-  "version": "0.4.0",
+  "version": "0.5.0-pre.1",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
@@ -47,6 +47,7 @@ const bindTransaction = (errorRegistry: ErrorRegistryInternal, transaction: Tran
     executeRaw: wrapAsync(errorRegistry, transaction.executeRaw.bind(transaction)),
     commit: wrapAsync(errorRegistry, transaction.commit.bind(transaction)),
     rollback: wrapAsync(errorRegistry, transaction.rollback.bind(transaction)),
+    discard: wrapSync(errorRegistry, transaction.discard.bind(transaction)),
   }
 }
 
@@ -57,6 +58,20 @@ function wrapAsync<A extends unknown[], R>(
   return async (...args) => {
     try {
       return await fn(...args)
+    } catch (error) {
+      const id = registry.registerNewError(error)
+      return err({ kind: 'GenericJsError', id })
+    }
+  }
+}
+
+function wrapSync<A extends unknown[], R>(
+  registry: ErrorRegistryInternal,
+  fn: (...args: A) => Result<R>,
+): (...args: A) => Result<R> {
+  return (...args) => {
+    try {
+      return fn(...args)
     } catch (error) {
       const id = registry.registerNewError(error)
       return err({ kind: 'GenericJsError', id })

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
@@ -47,7 +47,7 @@ const bindTransaction = (errorRegistry: ErrorRegistryInternal, transaction: Tran
     executeRaw: wrapAsync(errorRegistry, transaction.executeRaw.bind(transaction)),
     commit: wrapAsync(errorRegistry, transaction.commit.bind(transaction)),
     rollback: wrapAsync(errorRegistry, transaction.rollback.bind(transaction)),
-    discard: wrapSync(errorRegistry, transaction.discard.bind(transaction)),
+    dispose: wrapSync(errorRegistry, transaction.dispose.bind(transaction)),
   }
 }
 

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -96,6 +96,13 @@ export interface Transaction extends Queryable {
    * Rolls back the transaction.
    */
   rollback(): Promise<Result<void>>
+  /**
+   * Discards and closes the transaction which may or may not have been committed or rolled back.
+   * This operation must be synchronous. If the implementation requires calling creating new
+   * asynchronous tasks on the event loop, the driver is responsible for handling the errors
+   * appropriately to ensure they don't crash the application.
+   */
+  discard(): Result<void>
 }
 
 export interface ErrorCapturingDriverAdapter extends DriverAdapter {

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -102,7 +102,7 @@ export interface Transaction extends Queryable {
    * asynchronous tasks on the event loop, the driver is responsible for handling the errors
    * appropriately to ensure they don't crash the application.
    */
-  discard(): Result<void>
+  dispose(): Result<void>
 }
 
 export interface ErrorCapturingDriverAdapter extends DriverAdapter {

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: workspace:*
         version: link:../adapter-planetscale
       '@prisma/client':
-        specifier: 5.4.0-integration-dispose-tx.1
-        version: 5.4.0-integration-dispose-tx.1(prisma@5.4.0-integration-dispose-tx.1)
+        specifier: 5.4.0-integration-dispose-tx.2
+        version: 5.4.0-integration-dispose-tx.2(prisma@5.4.0-integration-dispose-tx.2)
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
@@ -153,8 +153,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       prisma:
-        specifier: 5.4.0-integration-dispose-tx.1
-        version: 5.4.0-integration-dispose-tx.1
+        specifier: 5.4.0-integration-dispose-tx.2
+        version: 5.4.0-integration-dispose-tx.2
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -518,8 +518,8 @@ packages:
     resolution: {integrity: sha512-aWbU+D/IRHoDE9975y+Q4c+EwwAWxCPwFId+N1AhQVFXzbeJMkj6KN2iQtoi03elcLMRdfT+V3i9Z4WRw+/oIA==}
     engines: {node: '>=16'}
 
-  /@prisma/client@5.4.0-integration-dispose-tx.1(prisma@5.4.0-integration-dispose-tx.1):
-    resolution: {integrity: sha512-UDIHkK9BWksA1kBjl+Ljfen7WpwdoW5uK16e4BEAmYOs5cYDJWXo4UrLl+g417B+3y0ejCuTBcv8/WcMtcyf+A==}
+  /@prisma/client@5.4.0-integration-dispose-tx.2(prisma@5.4.0-integration-dispose-tx.2):
+    resolution: {integrity: sha512-MShiYnvIUS/5ThfLRjyGaKGrhtzj69f38EqEksph7KckbLzfPQ7VWAJ2ZwKoi5DGJXEPaeb3S0lQpXl2KyuGxA==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -529,15 +529,15 @@ packages:
         optional: true
     dependencies:
       '@prisma/engines-version': 5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4
-      prisma: 5.4.0-integration-dispose-tx.1
+      prisma: 5.4.0-integration-dispose-tx.2
     dev: false
 
   /@prisma/engines-version@5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4:
     resolution: {integrity: sha512-6yhw/P2lWJOljh3QIkqeBNgLPBLVca08YjKPTyOlQ771vnA3pH+EYpIi2VOb2+3NsIM9zlX1NvFadd4qSbtubA==}
     dev: false
 
-  /@prisma/engines@5.4.0-integration-dispose-tx.1:
-    resolution: {integrity: sha512-L7DjzF1OJm9liowIFsfseCC9QdbyfmrzOM5rJT7M2opd59t4osTuTx7WDXJLz1fQjlH0ZxA1cnuczxjR4Ud9kw==}
+  /@prisma/engines@5.4.0-integration-dispose-tx.2:
+    resolution: {integrity: sha512-3kYPptQRiyDARcJIZudak7naHlTo0qYB/8ObxlIyw9IjbKax2m4MiPZuVasVpdcspXYj+ayzomFmCDptjZrjzg==}
     requiresBuild: true
 
   /@types/debug@4.1.8:
@@ -1244,13 +1244,13 @@ packages:
   /postgres-range@1.1.3:
     resolution: {integrity: sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==}
 
-  /prisma@5.4.0-integration-dispose-tx.1:
-    resolution: {integrity: sha512-piMuW/v00urdX9LW5kPhQdAOKmPRB17w/7p0tfqi/NSRFd8MIfuwZw5uMCE8XpyossCEypI/q3DMnGxKCPt3bw==}
+  /prisma@5.4.0-integration-dispose-tx.2:
+    resolution: {integrity: sha512-FBI46emn8rBapyTN6cwM0KNtmK94D9mucnQh2g+VhjWqD1SpFwFTVLXiT25tOFwEK0M/UQQ+eBsXn65BNBoisQ==}
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.4.0-integration-dispose-tx.1
+      '@prisma/engines': 5.4.0-integration-dispose-tx.2
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -128,8 +128,8 @@ importers:
         specifier: workspace:*
         version: link:../adapter-planetscale
       '@prisma/client':
-        specifier: 5.4.0-integration-libsql-adapter.7
-        version: 5.4.0-integration-libsql-adapter.7(prisma@5.4.0-integration-libsql-adapter.7)
+        specifier: 5.4.0-integration-dispose-tx.1
+        version: 5.4.0-integration-dispose-tx.1(prisma@5.4.0-integration-dispose-tx.1)
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
@@ -153,8 +153,8 @@ importers:
         specifier: ^7.0.3
         version: 7.0.3
       prisma:
-        specifier: 5.4.0-integration-libsql-adapter.7
-        version: 5.4.0-integration-libsql-adapter.7
+        specifier: 5.4.0-integration-dispose-tx.1
+        version: 5.4.0-integration-dispose-tx.1
       tsx:
         specifier: ^3.12.7
         version: 3.12.7
@@ -518,8 +518,8 @@ packages:
     resolution: {integrity: sha512-aWbU+D/IRHoDE9975y+Q4c+EwwAWxCPwFId+N1AhQVFXzbeJMkj6KN2iQtoi03elcLMRdfT+V3i9Z4WRw+/oIA==}
     engines: {node: '>=16'}
 
-  /@prisma/client@5.4.0-integration-libsql-adapter.7(prisma@5.4.0-integration-libsql-adapter.7):
-    resolution: {integrity: sha512-0WNHV37C16IPoE0cgBtX4heYDHaLXQhq4IIB50RMw/WJyzozhigEIizaFKbBdZ4PjxpekohHvPgTH6r4QfiTrA==}
+  /@prisma/client@5.4.0-integration-dispose-tx.1(prisma@5.4.0-integration-dispose-tx.1):
+    resolution: {integrity: sha512-UDIHkK9BWksA1kBjl+Ljfen7WpwdoW5uK16e4BEAmYOs5cYDJWXo4UrLl+g417B+3y0ejCuTBcv8/WcMtcyf+A==}
     engines: {node: '>=16.13'}
     requiresBuild: true
     peerDependencies:
@@ -528,16 +528,16 @@ packages:
       prisma:
         optional: true
     dependencies:
-      '@prisma/engines-version': 5.4.0-24.libsql-adapter-8337c6b372b0f4eb2500403a7cf450885aee4cdc
-      prisma: 5.4.0-integration-libsql-adapter.7
+      '@prisma/engines-version': 5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4
+      prisma: 5.4.0-integration-dispose-tx.1
     dev: false
 
-  /@prisma/engines-version@5.4.0-24.libsql-adapter-8337c6b372b0f4eb2500403a7cf450885aee4cdc:
-    resolution: {integrity: sha512-Yr2GeXHTK2FdxF5o0lLyZk0oJC8L1QMADZyPn+wTNcG9kfMCCs3cvQwPLDdvsMUHfwJ0c31r6w0mEpM4c37Ejw==}
+  /@prisma/engines-version@5.4.0-26.4bf3cce422a49f49c661da32d4016a5be81d28b4:
+    resolution: {integrity: sha512-6yhw/P2lWJOljh3QIkqeBNgLPBLVca08YjKPTyOlQ771vnA3pH+EYpIi2VOb2+3NsIM9zlX1NvFadd4qSbtubA==}
     dev: false
 
-  /@prisma/engines@5.4.0-integration-libsql-adapter.7:
-    resolution: {integrity: sha512-QRNhAeLw4EqSE+N6tzpOSlkqW9XO1Zf3aUO4wNH3LJTjG153oIJDnGfahijF93PjuyIOSHEFGZ7mfKeAaq7FiA==}
+  /@prisma/engines@5.4.0-integration-dispose-tx.1:
+    resolution: {integrity: sha512-L7DjzF1OJm9liowIFsfseCC9QdbyfmrzOM5rJT7M2opd59t4osTuTx7WDXJLz1fQjlH0ZxA1cnuczxjR4Ud9kw==}
     requiresBuild: true
 
   /@types/debug@4.1.8:
@@ -1244,13 +1244,13 @@ packages:
   /postgres-range@1.1.3:
     resolution: {integrity: sha512-VdlZoocy5lCP0c/t66xAfclglEapXPCIVhqqJRncYpvbCgImF0w67aPKfbqUMr72tO2k5q0TdTZwCLjPTI6C9g==}
 
-  /prisma@5.4.0-integration-libsql-adapter.7:
-    resolution: {integrity: sha512-B7nkAnHFAxEMPS/o3jpUeUOp97Js3HlRThfXMfYILrVML/MMy18HwjQrVzxfF/QSq7UxbUQAyGLFrqSypTPAzw==}
+  /prisma@5.4.0-integration-dispose-tx.1:
+    resolution: {integrity: sha512-piMuW/v00urdX9LW5kPhQdAOKmPRB17w/7p0tfqi/NSRFd8MIfuwZw5uMCE8XpyossCEypI/q3DMnGxKCPt3bw==}
     engines: {node: '>=16.13'}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@prisma/engines': 5.4.0-integration-libsql-adapter.7
+      '@prisma/engines': 5.4.0-integration-dispose-tx.1
 
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}

--- a/query-engine/driver-adapters/js/smoke-test-js/package.json
+++ b/query-engine/driver-adapters/js/smoke-test-js/package.json
@@ -51,7 +51,7 @@
     "@prisma/adapter-neon": "workspace:*",
     "@prisma/adapter-pg": "workspace:*",
     "@prisma/adapter-planetscale": "workspace:*",
-    "@prisma/client": "5.4.0-integration-dispose-tx.1",
+    "@prisma/client": "5.4.0-integration-dispose-tx.2",
     "@prisma/driver-adapter-utils": "workspace:*",
     "pg": "^8.11.3",
     "superjson": "^1.13.1",
@@ -61,7 +61,7 @@
     "@types/node": "^20.5.1",
     "@types/pg": "^8.10.2",
     "cross-env": "^7.0.3",
-    "prisma": "5.4.0-integration-dispose-tx.1",
+    "prisma": "5.4.0-integration-dispose-tx.2",
     "tsx": "^3.12.7"
   }
 }

--- a/query-engine/driver-adapters/js/smoke-test-js/package.json
+++ b/query-engine/driver-adapters/js/smoke-test-js/package.json
@@ -51,7 +51,7 @@
     "@prisma/adapter-neon": "workspace:*",
     "@prisma/adapter-pg": "workspace:*",
     "@prisma/adapter-planetscale": "workspace:*",
-    "@prisma/client": "5.4.0-integration-libsql-adapter.7",
+    "@prisma/client": "5.4.0-integration-dispose-tx.1",
     "@prisma/driver-adapter-utils": "workspace:*",
     "pg": "^8.11.3",
     "superjson": "^1.13.1",
@@ -61,7 +61,7 @@
     "@types/node": "^20.5.1",
     "@types/pg": "^8.10.2",
     "cross-env": "^7.0.3",
-    "prisma": "5.4.0-integration-libsql-adapter.7",
+    "prisma": "5.4.0-integration-dispose-tx.1",
     "tsx": "^3.12.7"
   }
 }

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -392,13 +392,13 @@ impl TransactionProxy {
     pub fn new(js_transaction: &JsObject) -> napi::Result<Self> {
         let commit = js_transaction.get_named_property("commit")?;
         let rollback = js_transaction.get_named_property("rollback")?;
-        let discard = js_transaction.get_named_property("discard")?;
+        let dispose = js_transaction.get_named_property("dispose")?;
         let options = js_transaction.get_named_property("options")?;
 
         Ok(Self {
             commit,
             rollback,
-            dispose: discard,
+            dispose,
             options,
         })
     }

--- a/query-engine/driver-adapters/src/transaction.rs
+++ b/query-engine/driver-adapters/src/transaction.rs
@@ -37,6 +37,12 @@ impl JsTransaction {
     }
 }
 
+impl Drop for JsTransaction {
+    fn drop(&mut self) {
+        _ = self.tx_proxy.discard();
+    }
+}
+
 #[async_trait]
 impl QuaintTransaction for JsTransaction {
     async fn commit(&self) -> quaint::Result<()> {

--- a/query-engine/driver-adapters/src/transaction.rs
+++ b/query-engine/driver-adapters/src/transaction.rs
@@ -37,12 +37,6 @@ impl JsTransaction {
     }
 }
 
-impl Drop for JsTransaction {
-    fn drop(&mut self) {
-        _ = self.tx_proxy.discard();
-    }
-}
-
 #[async_trait]
 impl QuaintTransaction for JsTransaction {
     async fn commit(&self) -> quaint::Result<()> {


### PR DESCRIPTION
Fixes transactions not being closed after some errors on the Rust side:
* errors that happen in `<JsQueryable as TransactionCapable>::start_transaction`
* caught and unwound panics
* maybe more

It is one of the two reasons that may trigger nested transaction errors with libSQL.

It is also a prerequisite for https://github.com/prisma/prisma-engines/pull/4288 (otherwise those errors can leave the libSQL connection in locked state).