### PR TITLE
driver-adapters: libsql: serialize all operations

### DIFF
--- a/query-engine/driver-adapters/js/adapter-libsql/package.json
+++ b/query-engine/driver-adapters/js/adapter-libsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-libsql",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Prisma's driver adapter for libsql and Turso",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-libsql/package.json
+++ b/query-engine/driver-adapters/js/adapter-libsql/package.json
@@ -19,7 +19,8 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*",
+    "async-mutex": "0.4.0"
   },
   "devDependencies": {
     "@libsql/client": "0.3.5"

--- a/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
@@ -9,6 +9,7 @@ import type {
   TransactionOptions,
 } from '@prisma/driver-adapter-utils'
 import type { InStatement, Client as LibSqlClientRaw, Transaction as LibSqlTransactionRaw } from '@libsql/client'
+import { Mutex } from 'async-mutex'
 import { getColumnTypes, mapRow } from './conversion'
 
 const debug = Debug('prisma:driver-adapter:libsql')
@@ -16,8 +17,12 @@ const debug = Debug('prisma:driver-adapter:libsql')
 type StdClient = LibSqlClientRaw
 type TransactionClient = LibSqlTransactionRaw
 
+const LOCK_TAG = Symbol()
+
 class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements Queryable {
-  readonly flavour = 'sqlite'
+  readonly flavour = 'sqlite';
+
+  [LOCK_TAG] = new Mutex()
 
   constructor(protected readonly client: ClientT) {}
 
@@ -60,6 +65,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
    * marked as unhealthy.
    */
   private async performIO(query: Query) {
+    const release = await this[LOCK_TAG].acquire()
     try {
       const result = await this.client.execute(query as InStatement)
       return result
@@ -67,6 +73,8 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
       const error = e as Error
       debug('Error in performIO: %O', error)
       throw error
+    } finally {
+      release()
     }
   }
 }
@@ -77,6 +85,7 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
   constructor(
     client: TransactionClient,
     readonly options: TransactionOptions,
+    readonly unlockParent: () => void,
   ) {
     super(client)
   }
@@ -86,7 +95,12 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
 
     this.finished = true
 
-    await this.client.commit()
+    try {
+      await this.client.commit()
+    } finally {
+      this.unlockParent()
+    }
+
     return ok(undefined)
   }
 
@@ -99,6 +113,8 @@ class LibSqlTransaction extends LibSqlQueryable<TransactionClient> implements Tr
       await this.client.rollback()
     } catch (error) {
       debug('error in rollback:', error)
+    } finally {
+      this.unlockParent()
     }
 
     return ok(undefined)
@@ -126,11 +142,19 @@ export class PrismaLibSQL extends LibSqlQueryable<StdClient> implements DriverAd
     const tag = '[js::startTransaction]'
     debug(`${tag} options: %O`, options)
 
-    const tx = await this.client.transaction('deferred')
-    return ok(new LibSqlTransaction(tx, options))
+    const release = await this[LOCK_TAG].acquire()
+
+    try {
+      const tx = await this.client.transaction('deferred')
+      return ok(new LibSqlTransaction(tx, options, release))
+    } catch (e) {
+      release()
+      throw e
+    }
   }
 
   async close(): Promise<Result<void>> {
+    await this[LOCK_TAG].acquire()
     this.client.close()
     return ok(undefined)
   }

--- a/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
@@ -148,6 +148,8 @@ export class PrismaLibSQL extends LibSqlQueryable<StdClient> implements DriverAd
       const tx = await this.client.transaction('deferred')
       return ok(new LibSqlTransaction(tx, options, release))
     } catch (e) {
+      // note: we only release the lock if creating the transaction fails, it must stay locked otherwise,
+      // hence `catch` and rethrowing the error and not `finally`.
       release()
       throw e
     }

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
+      async-mutex:
+        specifier: 0.4.0
+        version: 0.4.0
     devDependencies:
       '@libsql/client':
         specifier: 0.3.5
@@ -601,6 +604,12 @@ packages:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
     dev: true
+
+  /async-mutex@0.4.0:
+    resolution: {integrity: sha512-eJFZ1YhRR8UN8eBLoNzcDPcy/jqjsg6I1AP+KvWQX80BqOSW1oJPJXDylPUEeMr2ZQvHgnQ//Lp6f3RQ1zI7HA==}
+    dependencies:
+      tslib: 2.6.2
+    dev: false
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -1408,6 +1417,10 @@ packages:
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
+
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+    dev: false
 
   /tsup@7.2.0(typescript@5.1.6):
     resolution: {integrity: sha512-vDHlczXbgUvY3rWvqFEbSqmC1L7woozbzngMqTtL2PGBODTtWlRwGDDawhvWzr5c1QjKe4OAKqJGfE1xeXUvtQ==}


### PR DESCRIPTION
Depends on https://github.com/prisma/prisma-engines/pull/4286 to prevent transaction from being stuck locked on some errors.

Since 0.3.5, all transactions in libSQL use the same connection. This may change again in the future, but right now allowing multiple transactions at the same time leads to nested transaction errors, and making queries outside of transactions concurrently with open transactions is a correctness issue as they may unexpectedly become a part of transaction (isn't something we observed yet though).

This fixes the failing `occ_update_many` test, and (together with https://github.com/prisma/prisma-engines/pull/4286) the failing bytes smoke test.