### PR TITLE
fix(driver-adapter): add support for UUID type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,6 +1068,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-core",
+ "uuid",
 ]
 
 [[package]]

--- a/query-engine/driver-adapters/Cargo.toml
+++ b/query-engine/driver-adapters/Cargo.toml
@@ -13,6 +13,7 @@ psl.workspace = true
 tracing = "0.1"
 tracing-core = "0.1"
 metrics = "0.18"
+uuid = { version = "1", feature = ["v4"] }
 
 # Note: these deps are temporarily specified here to avoid importing them from tiberius (the SQL server driver).
 # They will be imported from quaint-core instead in a future PR.

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -36,6 +36,8 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
       return ColumnTypeEnum.Text
     case PgColumnType['JSONB']:
       return ColumnTypeEnum.Json
+    case PgColumnType['UUID']:
+      return ColumnTypeEnum.Uuid
     default:
       if (fieldTypeId >= 10000) {
         // Postgres Custom Types

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/const.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/const.ts
@@ -17,8 +17,8 @@ export const ColumnTypeEnum = {
   'Json': 11,
   'Enum': 12,
   'Bytes': 13,
-  // 'Set': 14,
-  // 'Array': 15,
+  'Set': 14,
+  'Uuid': 15,
   // ...
   'UnknownNumber': 128
 } as const


### PR DESCRIPTION
This PR adds support for the UUID type in Driver Adapters.
After this PR is merged, we can stop skipping [this Prisma Client test](https://github.com/prisma/prisma/pull/21200/files#r1338467870). This PR contributes to https://github.com/prisma/team-orm/issues/374.