### PR TITLE
Fix JsonNull parsing from neon and pg drivers

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
@@ -122,6 +122,44 @@ mod json {
         Ok(())
     }
 
+    #[connector_test(capabilities(AdvancedJsonNullability))]
+    async fn json_null_must_not_be_confused_with_literal_string(runner: Runner) -> TestResult<()> {
+        create_row(&runner, r#"{ id: 1, json: "\"null\"" }"#).await?;
+
+        match runner.protocol() {
+            query_engine_tests::EngineProtocol::Graphql => {
+                let res = run_query!(runner, r#"{ findManyTestModel { json } }"#);
+
+                insta::assert_snapshot!(
+                  res,
+                  @r###"{"data":{"findManyTestModel":[{"json":"\"null\""}]}}"###
+                );
+            }
+            query_engine_tests::EngineProtocol::Json => {
+                let res = runner
+                    .query_json(
+                        r#"{
+                            "modelName": "TestModel",
+                            "action": "findMany",
+                            "query": {
+                                "selection": {
+                                    "json": true
+                                }
+                            }
+                        }"#,
+                    )
+                    .await?;
+
+                insta::assert_snapshot!(
+                  res.to_string(),
+                  @r###"{"data":{"findManyTestModel":[{"json":{"$type":"Json","value":"\"null\""}}]}}"###
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     async fn create_test_data(runner: &Runner) -> TestResult<()> {
         create_row(runner, r#"{ id: 1, json: "{}" }"#).await?;
         create_row(runner, r#"{ id: 2, json: "{\"a\":\"b\"}" }"#).await?;

--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-neon",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Prisma's driver adapter for \"@neondatabase/serverless\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -45,7 +45,23 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
   }
 }
 
+/**
+ * JsonNull are stored in json strings as the string "null", distinguishable from the `null`
+ * value. By default, JSON and JSONB columns use Json.parse to parse a JSON column value and
+ * this will lead to serde_json::Value::Null in rust.
+ *
+ * By converting "null" to the string "null", we can signal JsonNull in rust side and
+ * convert it to QuaintValue::Text("null"), which will be coerced properly in the presentation
+ * of the response document.
+ */
+function convertJson(json: string): any {
+  return (json === 'null') ? json : JSON.parse(json)
+}
+
 // return string instead of JavaScript Date object
 types.setTypeParser(NeonColumnType.DATE, date => date)
 types.setTypeParser(NeonColumnType.TIME, date => date)
 types.setTypeParser(NeonColumnType.TIMESTAMP, date => date)
+
+types.setTypeParser(NeonColumnType.JSONB, convertJson)
+types.setTypeParser(NeonColumnType.JSON, convertJson)

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
+import { ColumnTypeEnum, type ColumnType, JsonNullMarker } from '@prisma/driver-adapter-utils'
 import { types } from '@neondatabase/serverless'
 
 const NeonColumnType = types.builtins
@@ -46,16 +46,17 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
 }
 
 /**
- * JsonNull are stored in json strings as the string "null", distinguishable from the `null`
- * value. By default, JSON and JSONB columns use Json.parse to parse a JSON column value and
- * this will lead to serde_json::Value::Null in rust.
+ * JsonNull are stored in JSON strings as the string "null", distinguishable from
+ * the `null` value which is used by the driver to represent the database NULL.
+ * By default, JSON and JSONB columns use JSON.parse to parse a JSON column value
+ * and this will lead to serde_json::Value::Null in Rust, which will be interpreted
+ * as DbNull.
  *
- * By converting "null" to the string "null", we can signal JsonNull in rust side and
- * convert it to QuaintValue::Text("null"), which will be coerced properly in the presentation
- * of the response document.
+ * By converting "null" to JsonNullMarker, we can signal JsonNull in Rust side and
+ * convert it to QuaintValue::Json(Some(Null)).
  */
-function convertJson(json: string): any {
-  return (json === 'null') ? json : JSON.parse(json)
+function convertJson(json: string): unknown {
+  return (json === 'null') ? JsonNullMarker : JSON.parse(json)
 }
 
 // return string instead of JavaScript Date object

--- a/query-engine/driver-adapters/js/adapter-pg/package.json
+++ b/query-engine/driver-adapters/js/adapter-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-pg",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Prisma's driver adapter for \"pg\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -1,4 +1,4 @@
-import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
+import { ColumnTypeEnum, type ColumnType, JsonNullMarker } from '@prisma/driver-adapter-utils'
 import { types } from 'pg'
 
 const PgColumnType = types.builtins
@@ -46,16 +46,17 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
 }
 
 /**
- * JsonNull are stored in json strings as the string "null", distinguishable from the `null`
- * value. By default, JSON and JSONB columns use Json.parse to parse a JSON column value and
- * this will lead to serde_json::Value::Null in rust.
+ * JsonNull are stored in JSON strings as the string "null", distinguishable from
+ * the `null` value which is used by the driver to represent the database NULL.
+ * By default, JSON and JSONB columns use JSON.parse to parse a JSON column value
+ * and this will lead to serde_json::Value::Null in Rust, which will be interpreted
+ * as DbNull.
  *
- * By converting "null" to the string "null", we can signal JsonNull in rust side and
- * convert it to QuaintValue::Text("null"), which will be coerced properly in the presentation
- * of the response document.
+ * By converting "null" to JsonNullMarker, we can signal JsonNull in Rust side and
+ * convert it to QuaintValue::Json(Some(Null)).
  */
-function convertJson(json: string): any {
-  return (json === 'null') ? json : JSON.parse(json)
+function convertJson(json: string): unknown {
+  return (json === 'null') ? JsonNullMarker : JSON.parse(json)
 }
 
 // return string instead of JavaScript Date object

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/driver-adapter-utils",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/const.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/const.ts
@@ -21,3 +21,8 @@ export const ColumnTypeEnum = {
   // 'Array': 15,
   // ...
 } as const
+
+// This string value paired with `ColumnType.Json` will be treated as JSON `null`
+// when convering to a quaint value. This is to work around JS/JSON null values
+// already being used to represent database NULLs.
+export const JsonNullMarker = '$__prisma_null'

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/index.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/index.ts
@@ -1,5 +1,5 @@
 export { bindAdapter } from './binder'
-export { ColumnTypeEnum } from './const'
+export { ColumnTypeEnum, JsonNullMarker } from './const'
 export { Debug } from './debug'
 export { ok, err, type Result } from './result'
 export type * from './types'

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -279,10 +279,14 @@ fn js_value_to_quaint(
             serde_json::Value::Null => QuaintValue::DateTime(None),
             mismatch => panic!("Expected a string in column {}, found {}", column_name, mismatch),
         },
-        ColumnType::Json => match json_value {
-            serde_json::Value::Null => QuaintValue::Json(None),
-            json => QuaintValue::json(json),
-        },
+        ColumnType::Json => {
+            match json_value {
+                serde_json::Value::Null => QuaintValue::Json(None),
+                // JsonNull
+                serde_json::Value::String(s) if s == "null" => QuaintValue::Text(Some(s.into())),
+                json => QuaintValue::json(json),
+            }
+        }
         ColumnType::Enum => match json_value {
             serde_json::Value::String(s) => QuaintValue::enum_variant(s),
             serde_json::Value::Null => QuaintValue::Enum(None),

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -281,9 +281,10 @@ fn js_value_to_quaint(
         },
         ColumnType::Json => {
             match json_value {
+                // DbNull
                 serde_json::Value::Null => QuaintValue::Json(None),
                 // JsonNull
-                serde_json::Value::String(s) if s == "null" => QuaintValue::Text(Some(s.into())),
+                serde_json::Value::String(s) if s == "$__prisma_null" => QuaintValue::json(serde_json::Value::Null),
                 json => QuaintValue::json(json),
             }
         }


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/383

Before, some tests for neon like `writes::top_level_mutations::create_many::json_create_many::create_many_json_adv` failed because JsonNull values where not properly retrieved.

```
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    0       │-{"data":{"findManyTestModel":[{"id":1,"json":"{}"},{"id":2,"json":"null"},{"id":3,"json":null},{"id":4,"json":null}]}}
          0 │+{"data":{"findManyTestModel":[{"id":1,"json":"{}"},{"id":2,"json":null},{"id":3,"json":null},{"id":4,"json":null}]}}
────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
thread 'writes::top_level_mutations::create_many::json_create_many::create_many_json_adv' panicked at 'snapshot assertion for 'run_create_many_json_adv-2' failed in line 348', 
```

This PR fixes these tests, and should not affect other adapters suites. 

Neon [failing tests in main](https://github.com/prisma/prisma-engines/actions/runs/6327051786/job/17182023869) vs this patch:

```diff
index 484a05c..7f5b4e9 100644
--- a/before
+++ b/after
@@ -15,7 +15,6 @@ failures:
     queries::batch::transactional_batch::transactional::raw_mix
     queries::data_types::bytes::bytes::read_many
     queries::data_types::bytes::bytes::read_one
-    queries::data_types::json::json::json_null
     queries::filters::bytes_filter::bytes_filter_spec::basic_where
     queries::filters::bytes_filter::bytes_filter_spec::inclusion_filter
     queries::filters::bytes_filter::bytes_filter_spec::where_shorthands
@@ -67,9 +66,6 @@ failures:
     writes::data_types::scalar_list::json::json::create_mut_return_items_with_empty_lists
     writes::data_types::scalar_list::json::json::create_mut_work_with_list_vals
     writes::data_types::scalar_list::json::json::update_mut_push_empty_scalar_list
-    writes::top_level_mutations::create::json_create::create_json_adv
     writes::top_level_mutations::create_list::create_list::create_not_accept_null_in_set
-    writes::top_level_mutations::create_many::json_create_many::create_many_json_adv
-    writes::top_level_mutations::update::json_update::update_json_adv
 
-test result: FAILED. 1499 passed; 72 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1306.49s
\ No newline at end of file
+test result: FAILED. 1503 passed; 68 failed; 0 ignored; 0 measured; 0 filtered out; finished in 998.56s
\ No newline at end of file
```

pg failing tests went from 88 -> 84 (~5%)
neon failing tests went from 72 -> 68 (~6%)