### PR TITLE
fix(driver-adapters) libsql queries containing aggregations

### DIFF
--- a/query-engine/driver-adapters/js/adapter-libsql/package.json
+++ b/query-engine/driver-adapters/js/adapter-libsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-libsql",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Prisma's driver adapter for libsql and Turso",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-libsql/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/conversion.ts
@@ -101,19 +101,11 @@ function inferColumnType(value: NonNullable<Value>): ColumnType {
     case 'boolean':
       return ColumnTypeEnum.Boolean
     case 'number':
-      return inferNumericType(value)
+      return ColumnTypeEnum.UnknownNumber
     case 'object':
       return inferObjectType(value)
     default:
       throw new UnexpectedTypeError(value)
-  }
-}
-
-function inferNumericType(value: number): ColumnType {
-  if (Number.isInteger(value)) {
-    return ColumnTypeEnum.Int64
-  } else {
-    return ColumnTypeEnum.Double
   }
 }
 

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/driver-adapter-utils",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/const.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/const.ts
@@ -20,6 +20,7 @@ export const ColumnTypeEnum = {
   // 'Set': 14,
   // 'Array': 15,
   // ...
+  'UnknownNumber': 128
 } as const
 
 // This string value paired with `ColumnType.Json` will be treated as JSON `null`

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -92,69 +92,78 @@ pub enum ColumnType {
     /// - INT16 (SMALLINT) -> e.g. `32767`
     /// - INT24 (MEDIUMINT) -> e.g. `8388607`
     /// - INT32 (INT) -> e.g. `2147483647`
-    Int32,
+    Int32 = 0,
 
     /// The following PlanetScale type IDs are mapped into Int64:
     /// - INT64 (BIGINT) -> e.g. `"9223372036854775807"` (String-encoded)
-    Int64,
+    Int64 = 1,
 
     /// The following PlanetScale type IDs are mapped into Float:
     /// - FLOAT32 (FLOAT) -> e.g. `3.402823466`
-    Float,
+    Float = 2,
 
     /// The following PlanetScale type IDs are mapped into Double:
     /// - FLOAT64 (DOUBLE) -> e.g. `1.7976931348623157`
-    Double,
+    Double = 3,
 
     /// The following PlanetScale type IDs are mapped into Numeric:
     /// - DECIMAL (DECIMAL) -> e.g. `"99999999.99"` (String-encoded)
-    Numeric,
+    Numeric = 4,
 
     /// The following PlanetScale type IDs are mapped into Boolean:
     /// - BOOLEAN (BOOLEAN) -> e.g. `1`
-    Boolean,
+    Boolean = 5,
 
     /// The following PlanetScale type IDs are mapped into Char:
     /// - CHAR (CHAR) -> e.g. `"c"` (String-encoded)
-    Char,
+    Char = 6,
 
     /// The following PlanetScale type IDs are mapped into Text:
     /// - TEXT (TEXT) -> e.g. `"foo"` (String-encoded)
     /// - VARCHAR (VARCHAR) -> e.g. `"foo"` (String-encoded)
-    Text,
+    Text = 7,
 
     /// The following PlanetScale type IDs are mapped into Date:
     /// - DATE (DATE) -> e.g. `"2023-01-01"` (String-encoded, yyyy-MM-dd)
-    Date,
+    Date = 8,
 
     /// The following PlanetScale type IDs are mapped into Time:
     /// - TIME (TIME) -> e.g. `"23:59:59"` (String-encoded, HH:mm:ss)
-    Time,
+    Time = 9,
 
     /// The following PlanetScale type IDs are mapped into DateTime:
     /// - DATETIME (DATETIME) -> e.g. `"2023-01-01 23:59:59"` (String-encoded, yyyy-MM-dd HH:mm:ss)
     /// - TIMESTAMP (TIMESTAMP) -> e.g. `"2023-01-01 23:59:59"` (String-encoded, yyyy-MM-dd HH:mm:ss)
-    DateTime,
+    DateTime = 10,
 
     /// The following PlanetScale type IDs are mapped into Json:
     /// - JSON (JSON) -> e.g. `"{\"key\": \"value\"}"` (String-encoded)
-    Json,
+    Json = 11,
 
     /// The following PlanetScale type IDs are mapped into Enum:
     /// - ENUM (ENUM) -> e.g. `"foo"` (String-encoded)
-    Enum,
+    Enum = 12,
 
     /// The following PlanetScale type IDs are mapped into Bytes:
     /// - BLOB (BLOB) -> e.g. `"\u0012"` (String-encoded)
     /// - VARBINARY (VARBINARY) -> e.g. `"\u0012"` (String-encoded)
     /// - BINARY (BINARY) -> e.g. `"\u0012"` (String-encoded)
     /// - GEOMETRY (GEOMETRY) -> e.g. `"\u0012"` (String-encoded)
-    Bytes,
+    Bytes = 13,
 
     /// The following PlanetScale type IDs are mapped into Set:
     /// - SET (SET) -> e.g. `"foo,bar"` (String-encoded, comma-separated)
     /// This is currently unhandled, and will panic if encountered.
-    Set,
+    Set = 14,
+
+    // Below there are custom types that don't have a 1:1 translation with a quaint::Value.
+    // enum variant.
+    /// UnknownNumber is used when the type of the column is a number but of unknown particular type
+    /// and precision.
+    ///
+    /// It's used by some driver adapters, like libsql to return aggregation values like AVG, or
+    /// COUNT, and it can be mapped to either Int64, or Double
+    UnknownNumber = 128,
 }
 
 #[napi(object)]
@@ -188,11 +197,7 @@ fn js_value_to_quaint(
             mismatch => panic!("Expected an i32 number in column {}, found {}", column_name, mismatch),
         },
         ColumnType::Int64 => match json_value {
-            serde_json::Value::Number(n) => n
-                .as_i64()
-                .map(|v| QuaintValue::Int64(Some(v)))
-                .or(n.as_f64().map(|v| QuaintValue::Double(Some(v))))
-                .expect("number must be an i64 or f64"),
+            serde_json::Value::Number(n) => QuaintValue::int64(n.as_i64().expect("number must be an i64")),
             serde_json::Value::String(s) => {
                 let n = s.parse::<i64>().expect("string-encoded number must be an i64");
                 QuaintValue::int64(n)
@@ -309,6 +314,17 @@ fn js_value_to_quaint(
             serde_json::Value::Null => QuaintValue::Bytes(None),
             mismatch => panic!(
                 "Expected a string or an array in column {}, found {}",
+                column_name, mismatch
+            ),
+        },
+        ColumnType::UnknownNumber => match json_value {
+            serde_json::Value::Number(n) => n
+                .as_i64()
+                .map(|v| QuaintValue::Int64(Some(v)))
+                .or(n.as_f64().map(|v| QuaintValue::Double(Some(v))))
+                .expect("number must be an i64 or f64"),
+            mismatch => panic!(
+                "Expected a either an i64 or a f64 in column {}, found {}",
                 column_name, mismatch
             ),
         },

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -188,7 +188,11 @@ fn js_value_to_quaint(
             mismatch => panic!("Expected an i32 number in column {}, found {}", column_name, mismatch),
         },
         ColumnType::Int64 => match json_value {
-            serde_json::Value::Number(n) => QuaintValue::int64(n.as_i64().expect("number must be an i64")),
+            serde_json::Value::Number(n) => n
+                .as_i64()
+                .map(|v| QuaintValue::Int64(Some(v)))
+                .or(n.as_f64().map(|v| QuaintValue::Double(Some(v))))
+                .expect("number must be an i64 or f64"),
             serde_json::Value::String(s) => {
                 let n = s.parse::<i64>().expect("string-encoded number must be an i64");
                 QuaintValue::int64(n)


### PR DESCRIPTION
Merge after https://github.com/prisma/prisma-engines/pull/4291 
Closes https://github.com/prisma/team-orm/issues/389

Problem: the libsql driver does not include typing information from aggregation functions.

Solution: we define a new column type of unknown number that is attempted to be converted as int64, and in case it's not possible, it's converted to f64.

Alternatives considered:
* always convert as f64 -> This won't work well as prisma operates on preserving the semantics of the underlying types being aggregated. 
* keep track of the column types being aggregated when issuing the query, and assign the proper types to the aggregate column. Requires pushing down schema information to the driver adapters, which requires in turn a major re-architecture. 


Fixes the following 9 test failures:

```
    queries::aggregation::group_by::aggregation_group_by::group_by_multiple_ordering
    queries::aggregation::group_by::aggregation_group_by::group_by_ordering_avg_aggregation
    queries::aggregation::group_by::aggregation_group_by::group_by_ordering_max_aggregation
    queries::aggregation::group_by::aggregation_group_by::group_by_ordering_min_aggregation
    queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
    queries::aggregation::group_by::aggregation_group_by::group_by_relation_filters
    queries::aggregation::group_by::aggregation_group_by::group_by_rev_ordering
    queries::aggregation::group_by::aggregation_group_by::group_by_scalar_filters
    queries::aggregation::group_by::aggregation_group_by::group_by_take_skip
```