### PR TITLE
adapter-libsql: fix failing apply_number_ops_for_int test

### DIFF
--- a/query-engine/driver-adapters/js/adapter-libsql/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/conversion.ts
@@ -125,7 +125,7 @@ class UnexpectedTypeError extends Error {
   }
 }
 
-export function mapRow(row: Row): unknown[] {
+export function mapRow(row: Row, columnTypes: ColumnType[]): unknown[] {
   // `Row` doesn't have map, so we copy the array once and modify it in-place
   // to avoid allocating and copying twice if we used `Array.from(row).map(...)`.
   const result: unknown[] = Array.from(row)
@@ -144,6 +144,16 @@ export function mapRow(row: Row): unknown[] {
     // implemented for other adapters.
     if (isArrayBuffer(value)) {
       result[i] = Array.from(new Uint8Array(value))
+    }
+
+    // If an integer is required and the current number isn't one,
+    // discard the fractional part.
+    if (
+      typeof value === 'number' &&
+      (columnTypes[i] === ColumnTypeEnum.Int32 || columnTypes[i] === ColumnTypeEnum.Int64) &&
+      !Number.isInteger(value)
+    ) {
+      result[i] = Math.trunc(value)
     }
   }
 

--- a/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
+++ b/query-engine/driver-adapters/js/adapter-libsql/src/libsql.ts
@@ -40,7 +40,7 @@ class LibSqlQueryable<ClientT extends StdClient | TransactionClient> implements 
     const resultSet: ResultSet = {
       columnNames: columns,
       columnTypes,
-      rows: rows.map(mapRow),
+      rows: rows.map((row) => mapRow(row, columnTypes)),
     }
 
     return ok(resultSet)


### PR DESCRIPTION
If an integer is required by the column type, read the number as an
integer.

I added this conversion on the JS side rather than in `proxy.rs`, as per
previous request by Alberto regarding other similar conversions.
