### PR TITLE
driver-adapters: fix getLogs rpc handler in test executor

### DIFF
--- a/query-engine/driver-adapters/js/connector-test-kit-executor/src/index.ts
+++ b/query-engine/driver-adapters/js/connector-test-kit-executor/src/index.ts
@@ -67,7 +67,7 @@ async function main(): Promise<void> {
 const state: Record<number, {
     engine: engines.QueryEngineInstance,
     adapter: ErrorCapturingDriverAdapter,
-    queryLogs: string[]
+    logs: string[]
 }> = {}
 
 async function handleRequest(method: string, params: unknown): Promise<unknown> {
@@ -177,7 +177,7 @@ async function handleRequest(method: string, params: unknown): Promise<unknown> 
             }
 
             const castParams = params as GetLogsPayload
-            return state[castParams.schemaId].queryLogs ?? []
+            return state[castParams.schemaId].logs
         }
         default: {
             throw new Error(`Unknown method: \`${method}\``)


### PR DESCRIPTION
Fixes 4 tests:

* `new::native_upsert::native_upsert::should_upsert_on_compound_id`
* `new::native_upsert::native_upsert::should_upsert_on_id`
* `new::native_upsert::native_upsert::should_upsert_on_single_unique`
* `new::native_upsert::native_upsert::should_upsert_on_unique_list`
