### PR TITLE
psl: un-hide `driverAdapters` preview feature

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -45,6 +45,7 @@ features!(
     DataProxy,
     Deno,
     Distinct,
+    DriverAdapters,
     ExtendedIndexes,
     ExtendedWhereUnique,
     FieldReference,
@@ -64,7 +65,6 @@ features!(
     NamedConstraints,
     NApi,
     NativeTypes,
-    DriverAdapters,
     OrderByAggregateGroup,
     OrderByNulls,
     OrderByRelation,
@@ -82,6 +82,7 @@ features!(
 pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
         Deno
+         | DriverAdapters
          | FullTextIndex
          | FullTextSearch
          | Metrics
@@ -89,7 +90,6 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
          | PostgresqlExtensions
          | Tracing
          | Views
-         | DriverAdapters
     }),
     deprecated: enumflags2::make_bitflags!(PreviewFeature::{
         AtomicNumberOperations

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -89,6 +89,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
          | PostgresqlExtensions
          | Tracing
          | Views
+         | DriverAdapters
     }),
     deprecated: enumflags2::make_bitflags!(PreviewFeature::{
         AtomicNumberOperations
@@ -123,9 +124,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | TransactionApi
         | UncheckedScalarInputs
     }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{
-        DriverAdapters
-    }),
+    hidden: enumflags2::BitFlags::EMPTY,
 };
 
 #[derive(Debug)]

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, fullTextIndex, fullTextSearch, metrics, multiSchema, driverAdapters, postgresqlExtensions, tracing, views[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, fullTextIndex, fullTextSearch, metrics, multiSchema, postgresqlExtensions, tracing, views[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, fullTextIndex, fullTextSearch, metrics, multiSchema, postgresqlExtensions, tracing, views[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, fullTextIndex, fullTextSearch, metrics, multiSchema, driverAdapters, postgresqlExtensions, tracing, views[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"


### PR DESCRIPTION
Closes: https://github.com/prisma/team-orm/issues/406
