### PR TITLE
driver-adapters: support bytes type in pg and neon

### DIFF
--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -44,6 +44,8 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case PgColumnType['INET']:
     case PgColumnType['CIDR']:
       return ColumnTypeEnum.Text
+    case PgColumnType['BYTEA']:
+      return ColumnTypeEnum.Bytes
     default:
       if (fieldTypeId >= 10000) {
         // Postgres Custom Types
@@ -67,10 +69,29 @@ function convertJson(json: string): unknown {
   return (json === 'null') ? JsonNullMarker : JSON.parse(json)
 }
 
+// Original BYTEA parser
+const parsePgBytes = types.getTypeParser(PgColumnType.BYTEA) as (_: string) => Buffer
+
+/**
+ * Convert bytes to a JSON-encodable representation since we can't
+ * currently send a parsed Buffer or ArrayBuffer across JS to Rust
+ * boundary.
+ * TODO:
+ * 1. Check if using base64 would be more efficient than this encoding.
+ * 2. Consider the possibility of eliminating re-encoding altogether
+ *    and passing bytea hex format to the engine if that can be aligned
+ *    with other adapter flavours.
+ */
+function convertBytes(serializedBytes: string): number[] {
+  const buffer = parsePgBytes(serializedBytes)
+  return Array.from(new Uint8Array(buffer))
+}
+
 // return string instead of JavaScript Date object
 types.setTypeParser(PgColumnType.TIME, date => date)
 types.setTypeParser(PgColumnType.DATE, date => date)
 types.setTypeParser(PgColumnType.TIMESTAMP, date => date)
 types.setTypeParser(PgColumnType.JSONB, convertJson)
 types.setTypeParser(PgColumnType.JSON, convertJson)
-types.setTypeParser(PgColumnType.MONEY, (money: string) => money.slice(1))
+types.setTypeParser(PgColumnType.MONEY, money => money.slice(1))
+types.setTypeParser(PgColumnType.BYTEA, convertBytes)

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -32,10 +32,9 @@ impl ToNapiValue for JSArg {
         match value {
             JSArg::RawString(s) => ToNapiValue::to_napi_value(env, s),
             JSArg::Value(v) => ToNapiValue::to_napi_value(env, v),
-            JSArg::Buffer(bytes) => ToNapiValue::to_napi_value(
-                env,
-                napi::Env::from_raw(env).create_arraybuffer_with_data(bytes)?.into_raw(),
-            ),
+            JSArg::Buffer(bytes) => {
+                ToNapiValue::to_napi_value(env, napi::Env::from_raw(env).create_buffer_with_data(bytes)?.into_raw())
+            }
         }
     }
 }


### PR DESCRIPTION
The minimal approach to supporting Bytes type in pg and Neon adapters.

Fixes the "unsupported column type 17" error and failing tests related to `Bytes` Prisma type.

There are two changes here.

#### 1. Writing

This PR makes the engine pass bytes to JS from Rust as Node.js `Buffer` and not
as JavaScript `ArrayBuffer`.

Neon and pg only recognise `Buffer` and write garbage data by calling
`toString()` when an `ArrayBuffer` is passed. Turso supports both
(tested with both local libSQL and remote Turso).

An alternative would've been to keep sending `ArrayBuffer`s and map them on JavaScript side:

```ts
  private async performIO(query: Query) {
    const { sql, args } = query

    const values = args.map((value) => {
      if (utils.isArrayBuffer(value)) {
        return Buffer.from(value)
      }
      return value
    })

    // ...
```

Note that `Buffer.from(arrayBuffer)` is cheap as it doesn't copy data, `Buffer`
is essentially a wrapper on top of `ArrayBuffer` in modern Node.js.

Ideally I'd prefer to keep using `ArrayBuffer` as it is a native JavaScript type
(which didn't exist when `Buffer` was introduced in Node.js, otherwise there
would be no need in the latter), and it would likely match what we'd send from
WebAssembly, but I also didn't want to introduce re-mapping of query arguments
when it could've been avoided. Generally I'm fine with either solution, so let
me know what you think.

#### 2. Reading

I reused the temporary format introduced for libSQL adapter for now to make tests pass.
It's probably not the most optimal option (though maybe it's good enough if we
don't actually encode the results to JSON and just use `serde_json::Value` as
an abstraction and convert N-API values to "JSON" values &mdash; I'm not
completely sure which of the two is the case here).

But if it's actually real JSON encoded as string, then base64 would be better.

Another option which would be especially efficient for pg and neon (but maybe
less so for other adapters) is passing the string with hex-encoded values
directly without re-encoding, i.e., use `value => value` (or `value => value.slice(2)`
to strip leading `\x`) as the type parser for `PgColumnType.BYTEA`.

---

Refs: https://github.com/prisma/team-orm/issues/374