### PR TITLE
driver-adapters: support XML columns in pg and neon

### DIFF
--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -43,6 +43,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case NeonColumnType['VARBIT']:
     case NeonColumnType['INET']:
     case NeonColumnType['CIDR']:
+    case NeonColumnType['XML']:
       return ColumnTypeEnum.Text
     default:
       if (fieldTypeId >= 10000) {

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -43,6 +43,7 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case PgColumnType['VARBIT']:
     case PgColumnType['INET']:
     case PgColumnType['CIDR']:
+    case PgColumnType['XML']:
       return ColumnTypeEnum.Text
     default:
       if (fieldTypeId >= 10000) {


### PR DESCRIPTION
Fixes the "unsupported column type 142" error.

Refs: https://github.com/prisma/team-orm/issues/374