### PR TITLE
fix: to-one filter should reference the related model

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/one_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/one_relation.rs
@@ -9,26 +9,26 @@ mod one_relation {
         let schema = indoc! {
             r#"
             model Blog {
-                #id(id, String, @id, @default(cuid()))
+                #id(blogId, String, @id, @default(cuid()))
                 name String
                 post Post?
             }
 
             model Post {
-                #id(id, String, @id, @default(cuid()))
+                #id(postId, String, @id, @default(cuid()))
                 title      String
                 popularity Int
                 blogId     String? @unique
-                blog       Blog?    @relation(fields: [blogId], references: [id])
+                blog       Blog?    @relation(fields: [blogId], references: [blogId])
                 comment    Comment?
             }
 
             model Comment {
-                #id(id, String, @id, @default(cuid()))
+                #id(commentId, String, @id, @default(cuid()))
                 text   String
                 likes  Int
                 postId String? @unique
-                post   Post?   @relation(fields: [postId], references: [id])
+                post   Post?   @relation(fields: [postId], references: [postId])
             }
             "#
         };

--- a/query-engine/connectors/sql-query-connector/src/filter/visitor.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter/visitor.rs
@@ -364,7 +364,6 @@ impl FilterVisitorExt for FilterVisitor {
                 let alias = self.next_alias(AliasMode::Join);
 
                 let linking_fields_not_null: Vec<_> =
-                    // ModelProjection::from(filter.field.model().primary_identifier())
                     ModelProjection::from(filter.field.related_model().primary_identifier())
                         .as_columns(ctx)
                         .map(|c| c.aliased_col(Some(alias), ctx))

--- a/query-engine/connectors/sql-query-connector/src/filter/visitor.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter/visitor.rs
@@ -330,12 +330,13 @@ impl FilterVisitorExt for FilterVisitor {
             RelationCondition::NoRelatedRecord if self.can_render_join() && !filter.field.is_list() => {
                 let alias = self.next_alias(AliasMode::Join);
 
-                let linking_fields_null: Vec<_> = ModelProjection::from(filter.field.model().primary_identifier())
-                    .as_columns(ctx)
-                    .map(|c| c.aliased_col(Some(alias), ctx))
-                    .map(|c| c.is_null())
-                    .map(Expression::from)
-                    .collect();
+                let linking_fields_null: Vec<_> =
+                    ModelProjection::from(filter.field.related_model().primary_identifier())
+                        .as_columns(ctx)
+                        .map(|c| c.aliased_col(Some(alias), ctx))
+                        .map(|c| c.is_null())
+                        .map(Expression::from)
+                        .collect();
                 let null_filter = ConditionTree::And(linking_fields_null);
 
                 let join = compute_one2m_join(
@@ -362,12 +363,14 @@ impl FilterVisitorExt for FilterVisitor {
             RelationCondition::ToOneRelatedRecord if self.can_render_join() && !filter.field.is_list() => {
                 let alias = self.next_alias(AliasMode::Join);
 
-                let linking_fields_not_null: Vec<_> = ModelProjection::from(filter.field.model().primary_identifier())
-                    .as_columns(ctx)
-                    .map(|c| c.aliased_col(Some(alias), ctx))
-                    .map(|c| c.is_not_null())
-                    .map(Expression::from)
-                    .collect();
+                let linking_fields_not_null: Vec<_> =
+                    // ModelProjection::from(filter.field.model().primary_identifier())
+                    ModelProjection::from(filter.field.related_model().primary_identifier())
+                        .as_columns(ctx)
+                        .map(|c| c.aliased_col(Some(alias), ctx))
+                        .map(|c| c.is_not_null())
+                        .map(Expression::from)
+                        .collect();
                 let not_null_filter = ConditionTree::And(linking_fields_not_null);
 
                 let join = compute_one2m_join(


### PR DESCRIPTION
## Overview

fixes prisma/prisma#21352

hotfix cherry picked from https://github.com/prisma/prisma-engines/pull/4315