### PR TITLE
fix(fmt): add missing quotation mark for `add_schema_to_schemas`

### DIFF
--- a/prisma-fmt/src/code_actions/multi_schema.rs
+++ b/prisma-fmt/src/code_actions/multi_schema.rs
@@ -136,7 +136,7 @@ pub(super) fn add_schema_to_schemas(
 
     let edit = match datasource.schemas_span {
         Some(span) => {
-            let formatted_attribute = format!(r#", "{}""#, model.schema_name().unwrap());
+            let formatted_attribute = format!(r#"", "{}""#, model.schema_name().unwrap());
             super::create_text_edit(
                 schema,
                 formatted_attribute,

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas/result.json
@@ -32,7 +32,7 @@
                 "character": 28
               }
             },
-            "newText": ", \"base\""
+            "newText": "\", \"base\""
           }
         ]
       }


### PR DESCRIPTION
fixes https://github.com/prisma/language-tools/issues/1551