### PR TITLE
adapter-planetscale: handle NULL column type

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/raw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/raw.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset};
 use prisma_value::encode_bytes;
 use query_tests_setup::{TestError, TestResult};
 
-pub fn fmt_query_raw(query: &str, params: Vec<RawParam>) -> String {
+pub fn fmt_query_raw(query: &str, params: impl IntoIterator<Item = RawParam>) -> String {
     let params = params_to_json(params);
     let params = serde_json::to_string(&params).unwrap();
 
@@ -13,7 +13,7 @@ pub fn fmt_query_raw(query: &str, params: Vec<RawParam>) -> String {
     )
 }
 
-pub fn fmt_execute_raw(query: &str, params: Vec<RawParam>) -> String {
+pub fn fmt_execute_raw(query: &str, params: impl IntoIterator<Item = RawParam>) -> String {
     let params = params_to_json(params);
     let params = serde_json::to_string(&params).unwrap();
 
@@ -66,7 +66,7 @@ impl RawParam {
     }
 }
 
-fn params_to_json(params: Vec<RawParam>) -> Vec<serde_json::Value> {
+fn params_to_json(params: impl IntoIterator<Item = RawParam>) -> Vec<serde_json::Value> {
     params.into_iter().map(serde_json::Value::from).collect::<Vec<_>>()
 }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -19,6 +19,7 @@ mod prisma_16760;
 mod prisma_17103;
 mod prisma_18517;
 mod prisma_20799;
+mod prisma_21369;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21369.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21369.rs
@@ -1,0 +1,17 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(generic), exclude(MongoDb))]
+mod prisma_21369 {
+    #[connector_test]
+    async fn select_null_works(runner: Runner) -> TestResult<()> {
+        let query = fmt_query_raw("SELECT null as result", []);
+        let result = run_query!(runner, query);
+
+        assert_eq!(
+            result,
+            r#"{"data":{"queryRaw":[{"result":{"prisma__type":"null","prisma__value":null}}]}}"#
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21369.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21369.rs
@@ -4,7 +4,7 @@ use query_engine_tests::*;
 mod prisma_21369 {
     #[connector_test]
     async fn select_null_works(runner: Runner) -> TestResult<()> {
-        let query = fmt_query_raw("SELECT null as result", []);
+        let query = fmt_query_raw("SELECT NULL AS result", []);
         let result = run_query!(runner, query);
 
         assert_eq!(

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/conversion.ts
@@ -2,7 +2,7 @@ import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
 
 // See: https://github.com/planetscale/vitess-types/blob/06235e372d2050b4c0fff49972df8111e696c564/src/vitess/query/v16/query.proto#L108-L218
 export type PlanetScaleColumnType
-  = 'NULL_TYPE' // unsupported
+  = 'NULL'
   | 'INT8'
   | 'UINT8'
   | 'INT16'
@@ -89,6 +89,9 @@ export function fieldToColumnType(field: PlanetScaleColumnType): ColumnType {
     case 'HEXVAL':
     case 'GEOMETRY':
       return ColumnTypeEnum.Bytes
+    case 'NULL':
+      // Fall back to Int32 for consistency with quaint.
+      return ColumnTypeEnum.Int32
     default:
       throw new Error(`Unsupported column type: ${field}`)
   }


### PR DESCRIPTION
When a column type is NULL, mark it as `ColumnType.Int32` in JS to
eventually convert it to `quaint::ValueType::Int32(None)`, just like
quaint does in its own MySQL connector.

Fixes: https://github.com/prisma/prisma/issues/21369
