### PR TITLE
Backport adapter-planetscale NULL column fix (#4320) to 5.4.x

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/raw.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/raw.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, FixedOffset};
 use prisma_value::encode_bytes;
 use query_tests_setup::{TestError, TestResult};
 
-pub fn fmt_query_raw(query: &str, params: Vec<RawParam>) -> String {
+pub fn fmt_query_raw(query: &str, params: impl IntoIterator<Item = RawParam>) -> String {
     let params = params_to_json(params);
     let params = serde_json::to_string(&params).unwrap();
 
@@ -13,7 +13,7 @@ pub fn fmt_query_raw(query: &str, params: Vec<RawParam>) -> String {
     )
 }
 
-pub fn fmt_execute_raw(query: &str, params: Vec<RawParam>) -> String {
+pub fn fmt_execute_raw(query: &str, params: impl IntoIterator<Item = RawParam>) -> String {
     let params = params_to_json(params);
     let params = serde_json::to_string(&params).unwrap();
 
@@ -66,7 +66,7 @@ impl RawParam {
     }
 }
 
-fn params_to_json(params: Vec<RawParam>) -> Vec<serde_json::Value> {
+fn params_to_json(params: impl IntoIterator<Item = RawParam>) -> Vec<serde_json::Value> {
     params.into_iter().map(serde_json::Value::from).collect::<Vec<_>>()
 }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -19,6 +19,7 @@ mod prisma_16760;
 mod prisma_17103;
 mod prisma_18517;
 mod prisma_20799;
+mod prisma_21369;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21369.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21369.rs
@@ -1,0 +1,17 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(generic), exclude(MongoDb))]
+mod prisma_21369 {
+    #[connector_test]
+    async fn select_null_works(runner: Runner) -> TestResult<()> {
+        let query = fmt_query_raw("SELECT NULL AS result", []);
+        let result = run_query!(runner, query);
+
+        assert_eq!(
+            result,
+            r#"{"data":{"queryRaw":[{"result":{"prisma__type":"null","prisma__value":null}}]}}"#
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/driver-adapters/js/adapter-libsql/package.json
+++ b/query-engine/driver-adapters/js/adapter-libsql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-libsql",
-  "version": "0.5.0",
+  "version": "5.4.0",
   "description": "Prisma's driver adapter for libSQL and Turso",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-neon/README.md
+++ b/query-engine/driver-adapters/js/adapter-neon/README.md
@@ -1,3 +1,5 @@
 # @prisma/adapter-neon
 
-**INTERNAL PACKAGE, DO NOT USE**
+Prisma driver adapter for [Neon Serverless Driver](https://github.com/neondatabase/serverless).
+
+See https://github.com/prisma/prisma/releases/tag/5.4.0 for details.

--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-neon",
-  "version": "0.6.0",
+  "version": "5.4.0",
   "description": "Prisma's driver adapter for \"@neondatabase/serverless\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-pg/package.json
+++ b/query-engine/driver-adapters/js/adapter-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-pg",
-  "version": "0.6.0",
+  "version": "5.4.0",
   "description": "Prisma's driver adapter for \"pg\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-planetscale/README.md
+++ b/query-engine/driver-adapters/js/adapter-planetscale/README.md
@@ -1,3 +1,6 @@
 # @prisma/adapter-planetscale
 
-**INTERNAL PACKAGE, DO NOT USE**
+Prisma driver adapter for [PlanetScale Serverless Driver](https://github.com/planetscale/database-js).
+
+See https://github.com/prisma/prisma/releases/tag/5.4.0 for details.
+

--- a/query-engine/driver-adapters/js/adapter-planetscale/package.json
+++ b/query-engine/driver-adapters/js/adapter-planetscale/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/adapter-planetscale",
-  "version": "0.5.0",
+  "version": "5.4.0",
   "description": "Prisma's driver adapter for \"@planetscale/database\"",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/adapter-planetscale/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-planetscale/src/conversion.ts
@@ -2,7 +2,7 @@ import { ColumnTypeEnum, type ColumnType } from '@prisma/driver-adapter-utils'
 
 // See: https://github.com/planetscale/vitess-types/blob/06235e372d2050b4c0fff49972df8111e696c564/src/vitess/query/v16/query.proto#L108-L218
 export type PlanetScaleColumnType
-  = 'NULL_TYPE' // unsupported
+  = 'NULL'
   | 'INT8'
   | 'UINT8'
   | 'INT16'
@@ -89,6 +89,9 @@ export function fieldToColumnType(field: PlanetScaleColumnType): ColumnType {
     case 'HEXVAL':
     case 'GEOMETRY':
       return ColumnTypeEnum.Bytes
+    case 'NULL':
+      // Fall back to Int32 for consistency with quaint.
+      return ColumnTypeEnum.Int32
     default:
       throw new Error(`Unsupported column type: ${field}`)
   }

--- a/query-engine/driver-adapters/js/connector-test-kit-executor/package.json
+++ b/query-engine/driver-adapters/js/connector-test-kit-executor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connector-test-kit-executor",
-  "version": "1.0.0",
+  "version": "5.4.0",
   "description": "",
   "main": "dist/index.js",
   "private": true,

--- a/query-engine/driver-adapters/js/driver-adapter-utils/package.json
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prisma/driver-adapter-utils",
-  "version": "0.9.0",
+  "version": "5.4.0",
   "description": "Internal set of utilities and types for Prisma's driver adapters.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/query-engine/driver-adapters/js/smoke-test-js/package.json
+++ b/query-engine/driver-adapters/js/smoke-test-js/package.json
@@ -2,7 +2,7 @@
   "name": "@prisma/driver-adapters-smoke-tests-js",
   "private": true,
   "type": "module",
-  "version": "0.0.0",
+  "version": "5.4.0",
   "description": "",
   "scripts": {
     "prisma:db:push:postgres": "prisma db push --schema ./prisma/postgres/schema.prisma --force-reset",

--- a/query-engine/driver-adapters/js/version.sh
+++ b/query-engine/driver-adapters/js/version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Usage: `./version.sh x.y.z` will set the `x.y.z` to every package in the monorepo.
+
+target_version=$1
+package_dirs=$(pnpm -r list -r --depth -1 --json | jq -r '.[] | .path' | tail -n +2)
+
+# Iterate through each package directory
+for package_dir in $package_dirs; do
+  # Check if the directory exists
+  if [ -d "$package_dir" ]; then
+    # Set the target version using pnpm
+    (cd "$package_dir" && pnpm version "$target_version" --no-git-tag-version --allow-same-version)
+  fi
+done


### PR DESCRIPTION
Since driver adapters packages version 5.4.1 weren't released together with Prisma 5.4.1 because we didn't have this automated yet, we decided to retroactively release them and include the PlanetScale adapter patch as a driver adapters counterpart of 5.4.1.