### PR TITLE
qe: always create a span for `prisma:engine` regardless of iTX

### DIFF
--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -15,7 +15,7 @@ use serde::Deserialize;
 use serde_json::json;
 use std::{collections::HashMap, future::Future, marker::PhantomData, panic::AssertUnwindSafe, sync::Arc};
 use tokio::sync::RwLock;
-use tracing::{field, instrument::WithSubscriber, Instrument, Span};
+use tracing::{field, instrument::WithSubscriber, Instrument};
 use tracing_subscriber::filter::LevelFilter;
 use user_facing_errors::Error;
 
@@ -319,12 +319,7 @@ impl QueryEngine {
 
             let query = RequestBody::try_from_str(&body, engine.engine_protocol())?;
 
-            let span = if tx_id.is_none() {
-                tracing::info_span!("prisma:engine", user_facing = true)
-            } else {
-                Span::none()
-            };
-
+            let span = tracing::info_span!("prisma:engine", user_facing = true);
             let trace_id = telemetry::helpers::set_parent_context_from_json_str(&span, &trace);
 
             async move {

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -21,7 +21,7 @@ use request_handlers::{load_executor, RequestBody, RequestHandler};
 use serde_json::json;
 use std::{marker::PhantomData, sync::Arc};
 use tokio::sync::RwLock;
-use tracing::{field, instrument::WithSubscriber, Instrument, Level, Span};
+use tracing::{field, instrument::WithSubscriber, Instrument, Level};
 use tracing_subscriber::filter::LevelFilter;
 use wasm_bindgen::prelude::wasm_bindgen;
 

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
-use tracing::{field, Instrument, Span};
+use tracing::{field, Instrument};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Starts up the graphql query engine server
@@ -116,13 +116,8 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
     let tx_id = transaction_id(headers);
     let tracing_cx = get_parent_span_context(headers);
 
-    let span = if tx_id.is_none() {
-        let span = info_span!("prisma:engine", user_facing = true);
-        span.set_parent(tracing_cx);
-        span
-    } else {
-        Span::none()
-    };
+    let span = info_span!("prisma:engine", user_facing = true);
+    span.set_parent(tracing_cx);
 
     let mut traceparent = traceparent(headers);
     let mut trace_id = get_trace_id_from_traceparent(traceparent.as_deref());


### PR DESCRIPTION
Prevent `prisma:engine:response_json_serialization` span from being orphan when using interactive transactions.

This check made sense in the past in principle when there were no child spans outside of the iTX runner so this span wouldn't have any children (although arguably it might have been been useful regardless), but now after https://github.com/prisma/prisma-engines/pull/4154 and https://github.com/prisma/prisma-engines/pull/4339 it is not the case anymore and we should definitely always create it.

**Before:**
<img width="332" alt="image" src="https://github.com/prisma/prisma/assets/4923335/b86660cf-0338-4492-b84e-86539954fa53">

**After:**
<img width="327" alt="image" src="https://github.com/prisma/prisma-engines/assets/4923335/32c64f7b-e632-46ed-9671-e55eb10c6b2c">

Fixes: https://github.com/prisma/prisma/issues/21402
