### PR TITLE
fix(smoke-test): add assertion for expected error

### DIFF
--- a/query-engine/driver-adapters/js/smoke-test-js/README.md
+++ b/query-engine/driver-adapters/js/smoke-test-js/README.md
@@ -58,7 +58,7 @@ In the current directory:
 
 ### Pg
 
-Start `docker compose up postgrest15` in `/docker`.
+Start database via `docker compose up postgres15` in `/docker`.
 
 In the current directory:
 - Run `pnpm prisma:pg` to push the Prisma schema and insert the test data.

--- a/query-engine/driver-adapters/js/smoke-test-js/README.md
+++ b/query-engine/driver-adapters/js/smoke-test-js/README.md
@@ -66,3 +66,12 @@ In the current directory:
   For more fine-grained control:
   - Run `pnpm pg:libquery` to test using `libquery`
   - Run `pnpm pg:client` to test using `@prisma/client`
+
+### Libsql
+
+In the current directory:
+- Run `pnpm prisma:libsql` to push the Prisma schema and insert the test data.
+- Run `pnpm libsql` to run smoke tests using `libquery` against the SQLite database, using `libSQL`
+  For more fine-grained control:
+  - Run `pnpm libsql:libquery` to test using `libquery`
+  - Run `pnpm libsql:client` to test using `@prisma/client`

--- a/query-engine/driver-adapters/js/smoke-test-js/README.md
+++ b/query-engine/driver-adapters/js/smoke-test-js/README.md
@@ -55,3 +55,14 @@ In the current directory:
   For more fine-grained control:
   - Run `pnpm neon:ws:http` to test using `libquery`
   - Run `pnpm neon:ws:http` to test using `@prisma/client`
+
+### Pg
+
+Start `docker compose up postgrest15` in `/docker`.
+
+In the current directory:
+- Run `pnpm prisma:pg` to push the Prisma schema and insert the test data.
+- Run `pnpm pg` to run smoke tests using `libquery` against the PostgreSQL database, using `pg`
+  For more fine-grained control:
+  - Run `pnpm pg:libquery` to test using `libquery`
+  - Run `pnpm pg:client` to test using `@prisma/client`

--- a/query-engine/driver-adapters/js/smoke-test-js/package.json
+++ b/query-engine/driver-adapters/js/smoke-test-js/package.json
@@ -35,8 +35,8 @@
     "planetscale:client": "DATABASE_URL=\"${JS_PLANETSCALE_DATABASE_URL}\" node --test --test-reporter spec --loader=tsx ./src/client/planetscale.test.ts",
     "planetscale": "pnpm planetscale:libquery && pnpm planetscale:client",
     "prisma:libsql": "cross-env-shell DATABASE_URL=\"${JS_LIBSQL_DATABASE_URL}\" \"pnpm prisma:db:push:sqlite && pnpm prisma:db:execute:sqlite\"",
-    "libsql:libquery": "cross-env-shell DATABASE_URL=\"${JS_LIBSQL_DATABASE_URL}\" node --test --loader=tsx ./src/libquery/libsql.test.ts",
-    "libsql:client": "cross-env-shell DATABASE_URL=\"${JS_LIBSQL_DATABASE_URL}\" node --test --loader=tsx ./src/client/libsql.test.ts",
+    "libsql:libquery": "cross-env-shell DATABASE_URL=\"${JS_LIBSQL_DATABASE_URL}\" node --test --test-reporter spec --loader=tsx ./src/libquery/libsql.test.ts",
+    "libsql:client": "cross-env-shell DATABASE_URL=\"${JS_LIBSQL_DATABASE_URL}\" node --test --test-reporter spec --loader=tsx ./src/client/libsql.test.ts",
     "libsql": "pnpm libsql:libquery && pnpm libsql:client"
   },
   "keywords": [],

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/sqlite/migrations/20230915202554_init/migration.sql
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/sqlite/migrations/20230915202554_init/migration.sql
@@ -64,6 +64,11 @@ CREATE TABLE "Product" (
     "properties_null" TEXT
 );
 
+-- CreateTable
+CREATE TABLE "Unique" (
+    "email" TEXT NOT NULL PRIMARY KEY,
+);
+
 -- CreateIndex
 CREATE UNIQUE INDEX "Child_c_key" ON "Child"("c");
 

--- a/query-engine/driver-adapters/js/smoke-test-js/prisma/sqlite/schema.prisma
+++ b/query-engine/driver-adapters/js/smoke-test-js/prisma/sqlite/schema.prisma
@@ -73,3 +73,7 @@ model Product {
   properties      String
   properties_null String?
 }
+
+model Unique {
+  email String @id
+}

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -289,10 +289,22 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
           async () => {
             const result = await doQuery({
               modelName: 'Unique',
-              action: 'createMany',
+              action: 'createOne',
               query: {
                 arguments: {
-                  data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
+                  data: { email: 'duplicate@example.com' },
+                },
+                selection: {
+                  $scalars: true,
+                },
+              },
+            })
+            const result2 = await doQuery({
+              modelName: 'Unique',
+              action: 'createOne',
+              query: {
+                arguments: {
+                  data: { email: 'duplicate@example.com' }
                 },
                 selection: {
                   $scalars: true,

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -284,7 +284,7 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
 
     it('expected error', async () => {
 
-      assert.throws(function () {
+      assert.throws( async () => {
         const result = await doQuery({
           modelName: 'Unique',
           action: 'createMany',

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -283,20 +283,29 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
     })
 
     it('expected error', async () => {
-      const result = await doQuery({
-        modelName: 'Unique',
-        action: 'createMany',
-        query: {
-          arguments: {
-            data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
-          },
-          selection: {
-            $scalars: true,
-          },
-        },
-      })
 
-      console.log('[nodejs] error result', JSON.stringify(result, null, 2))
+      assert.throws(function () {
+        const result = await doQuery({
+          modelName: 'Unique',
+          action: 'createMany',
+          query: {
+            arguments: {
+              data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
+            },
+            selection: {
+              $scalars: true,
+            },
+          },
+        })
+  
+        console.log('[nodejs] error result', JSON.stringify(result, null, 2))
+      },
+      {
+        message: /unique/i,
+      }
+      );
+
+      
     })
 
     describe('read scalar and non scalar types', () => {
@@ -396,7 +405,7 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
           selection: {
             bytes: true,
           },
-          arguments:  {
+          arguments: {
             data: {
               bytes: {
                 $type: 'Bytes',

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -285,24 +285,22 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
     it('expected error', async () => {
 
       assert.throws( async () => {
-        const result = await doQuery({
-          modelName: 'Unique',
-          action: 'createMany',
-          query: {
-            arguments: {
-              data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
+          const result = await doQuery({
+            modelName: 'Unique',
+            action: 'createMany',
+            query: {
+              arguments: {
+                data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
+              },
+              selection: {
+                $scalars: true,
+              },
             },
-            selection: {
-              $scalars: true,
-            },
-          },
-        })
-  
-        console.log('[nodejs] error result', JSON.stringify(result, null, 2))
-      },
-      {
-        message: /unique/i,
-      }
+          })
+    
+          console.log('[nodejs] error result', JSON.stringify(result, null, 2))
+        },
+        /unique/i,
       );
 
       

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -284,25 +284,28 @@ export function smokeTestLibquery(adapter: ErrorCapturingDriverAdapter, prismaSc
 
     it('expected error', async () => {
 
-      assert.throws( async () => {
-          const result = await doQuery({
-            modelName: 'Unique',
-            action: 'createMany',
-            query: {
-              arguments: {
-                data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
-              },
-              selection: {
-                $scalars: true,
-              },
-            },
-          })
-    
-          console.log('[nodejs] error result', JSON.stringify(result, null, 2))
-        },
-        /unique/i,
-      );
 
+        await assert.rejects(
+          async () => {
+            const result = await doQuery({
+              modelName: 'Unique',
+              action: 'createMany',
+              query: {
+                arguments: {
+                  data: [{ email: 'duplicate@example.com' }, { email: 'duplicate@example.com' }],
+                },
+                selection: {
+                  $scalars: true,
+                },
+              },
+            })
+            console.log('[nodejs] error result', JSON.stringify(result, null, 2))
+          },
+          (err) => {
+            assert.match(err.message, /unique/i);
+            return true;
+          },
+        );
       
     })
 


### PR DESCRIPTION
LibSQL, Pg and PlanetScale properly throw the error and pass this test now.
Neon:ws does not, and Neon:http a different one.