### PR TITLE
Driver adapters phase 1 correctness: implement flavor-specific driver adapter conversions for postgres dates

### DIFF
--- a/quaint/src/ast/values.rs
+++ b/quaint/src/ast/values.rs
@@ -33,13 +33,37 @@ where
     }
 }
 
+/// A native-column type, i.e. the connector-specific type of the column.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NativeColumnType<'a>(Cow<'a, str>);
+
+impl<'a> std::ops::Deref for NativeColumnType<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<'a> From<&'a str> for NativeColumnType<'a> {
+    fn from(s: &'a str) -> Self {
+        Self(s.into())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Value<'a> {
     pub typed: ValueType<'a>,
-    pub native_column_type: Option<Cow<'a, str>>,
+    pub native_column_type: Option<NativeColumnType<'a>>,
 }
 
 impl<'a> Value<'a> {
+    /// Changes the value to include information about the native column type
+    pub fn with_native_column_type<T: Into<NativeColumnType<'a>>>(mut self, column_type: Option<T>) -> Self {
+        self.native_column_type = column_type.map(|ct| ct.into());
+        self
+    }
+
     /// Creates a new 32-bit signed integer.
     pub fn int32<I>(value: I) -> Self
     where

--- a/quaint/src/ast/values.rs
+++ b/quaint/src/ast/values.rs
@@ -47,7 +47,7 @@ impl<'a> std::ops::Deref for NativeColumnType<'a> {
 
 impl<'a> From<&'a str> for NativeColumnType<'a> {
     fn from(s: &'a str) -> Self {
-        Self(s.into())
+        Self(Cow::Owned(s.to_uppercase()))
     }
 }
 
@@ -58,6 +58,12 @@ pub struct Value<'a> {
 }
 
 impl<'a> Value<'a> {
+    /// Returns the native column type of the value, if any, in the form
+    /// of an UPCASE string. ex: "VARCHAR, BYTEA, DATE, TIMEZ"  
+    pub fn native_column_type_name(&'a self) -> Option<&'a str> {
+        self.native_column_type.as_deref()
+    }
+
     /// Changes the value to include information about the native column type
     pub fn with_native_column_type<T: Into<NativeColumnType<'a>>>(mut self, column_type: Option<T>) -> Self {
         self.native_column_type = column_type.map(|ct| ct.into());

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
@@ -14,7 +14,7 @@ pub(crate) trait ScalarFieldExt {
 
 impl ScalarFieldExt for ScalarField {
     fn value<'a>(&self, pv: PrismaValue, ctx: &Context<'_>) -> Value<'a> {
-        match (pv, self.type_identifier()) {
+        let value = match (pv, self.type_identifier()) {
             (PrismaValue::String(s), _) => s.into(),
             (PrismaValue::Float(f), _) => f.into(),
             (PrismaValue::Boolean(b), _) => b.into(),
@@ -76,7 +76,9 @@ impl ScalarFieldExt for ScalarField {
                 TypeIdentifier::Bytes => Value::null_bytes(),
                 TypeIdentifier::Unsupported => unreachable!("No unsupported field should reach that path"),
             },
-        }
+        };
+
+        value.with_native_column_type(self.native_type().map(|nt| nt.name()))
     }
 
     fn type_family(&self) -> TypeFamily {

--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -25,7 +25,6 @@
     "postgres-array": "^3.0.2"
   },
   "peerDependencies": {
-    "@neondatabase/serverless": "^0.6.0",
-    "postgres-array": "^3.0.2"
+    "@neondatabase/serverless": "^0.6.0"
   }
 }

--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -21,9 +21,11 @@
     "@prisma/driver-adapter-utils": "workspace:*"
   },
   "devDependencies": {
-    "@neondatabase/serverless": "^0.6.0"
+    "@neondatabase/serverless": "^0.6.0",
+    "postgres-array": "^3.0.2"
   },
   "peerDependencies": {
-    "@neondatabase/serverless": "^0.6.0"
+    "@neondatabase/serverless": "^0.6.0",
+    "postgres-array": "^3.0.2"
   }
 }

--- a/query-engine/driver-adapters/js/adapter-neon/package.json
+++ b/query-engine/driver-adapters/js/adapter-neon/package.json
@@ -18,11 +18,11 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*",
+    "postgres-array": "^3.0.2"
   },
   "devDependencies": {
-    "@neondatabase/serverless": "^0.6.0",
-    "postgres-array": "^3.0.2"
+    "@neondatabase/serverless": "^0.6.0"
   },
   "peerDependencies": {
     "@neondatabase/serverless": "^0.6.0"

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -136,9 +136,7 @@ function normalize_timestampz(time: string): string {
 }
 
 function normalize_array(element_normalizer: (string) => string): (string) => string[] {
-  return function(str: string): string[] {
-    return parseArray(str, element_normalizer)
-  }
+  return (str) => parseArray(str, element_normalizer)
 }
 
 /*

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -118,6 +118,21 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
   }
 }
 
+function normalize_array(element_normalizer: (string) => string): (string) => string[] {
+  return (str) => parseArray(str, element_normalizer)
+}
+
+/****************************/
+/* Time-related data-types  */
+/****************************/
+
+function normalize_numeric(numeric: string): string {
+  return numeric
+}
+
+types.setTypeParser(ScalarColumnType.NUMERIC, normalize_numeric)
+types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, normalize_array(normalize_numeric))
+
 /****************************/
 /* Time-related data-types  */
 /****************************/
@@ -133,10 +148,6 @@ function normalize_timestamp(time: string): string {
 
 function normalize_timestampz(time: string): string {
   return time.split("+")[0]
-}
-
-function normalize_array(element_normalizer: (string) => string): (string) => string[] {
-  return (str) => parseArray(str, element_normalizer)
 }
 
 /*
@@ -249,6 +260,3 @@ types.setTypeParser(ArrayColumnType.BYTEA_ARRAY, (serializedBytesArray) => {
   const buffers = parseBytesArray(serializedBytesArray)
   return buffers.map(encodeBuffer)
 })
-
-
-

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -1,5 +1,6 @@
 import { ColumnTypeEnum, type ColumnType, JsonNullMarker } from '@prisma/driver-adapter-utils'
 import { types } from '@neondatabase/serverless'
+import { parse as parseArray } from 'postgres-array'
 
 const NeonColumnType = types.builtins
 
@@ -49,8 +50,10 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
     case NeonColumnType['DATE']:
       return ColumnTypeEnum.Date
     case NeonColumnType['TIME']:
+    case NeonColumnType['TIMETZ']:
       return ColumnTypeEnum.Time
     case NeonColumnType['TIMESTAMP']:
+    case NeonColumnType['TIMESTAMPTZ']:
       return ColumnTypeEnum.DateTime
     case NeonColumnType['NUMERIC']:
     case NeonColumnType['MONEY']:
@@ -73,7 +76,6 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
       return ColumnTypeEnum.Text
     case NeonColumnType['BYTEA']:
       return ColumnTypeEnum.Bytes
-
     case ArrayColumnType.INT2_ARRAY:
     case ArrayColumnType.INT4_ARRAY:
       return ColumnTypeEnum.Int32Array
@@ -116,6 +118,79 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
   }
 }
 
+/****************************/
+/* Time-related data-types  */
+/****************************/
+
+
+function normalize_date(date: string): string {
+  return date
+}
+
+function normalize_timestamp(time: string): string {
+  return time
+}
+
+function normalize_timestampz(time: string): string {
+  return time.split("+")[0]
+}
+
+function normalize_array(element_normalizer: (string) => string): (string) => string[] {
+  return function(str: string): string[] {
+    return parseArray(str, element_normalizer)
+  }
+}
+
+/*
+ * TIME, TIMETZ, TIME_ARRAY - converts value (or value elements) to a string in the format HH:mm:ss.f
+ */
+
+function normalize_time(time: string): string {
+  return time
+}
+
+function normalize_timez(time: string): string {
+  // Although it might be controversial, UTC is assumed in consistency with the behavior of rust postgres driver
+  // in quaint. See quaint/src/connector/postgres/conversion.rs
+  return time.split("+")[0]
+}
+
+types.setTypeParser(NeonColumnType.TIME, normalize_time)
+types.setTypeParser(ArrayColumnType.TIME_ARRAY, normalize_array(normalize_time))
+types.setTypeParser(NeonColumnType.TIMETZ, normalize_timez)
+
+/*
+ * DATE, DATE_ARRAY - converts value (or value elements) to a string in the format YYYY-MM-DD
+ */
+
+types.setTypeParser(NeonColumnType.DATE, normalize_date)
+types.setTypeParser(ArrayColumnType.DATE_ARRAY, normalize_array(normalize_date))
+
+
+/*
+ * TIMESTAMP, TIMESTAMP_ARRAY - converts value (or value elements) to a string in the rfc3339 format
+ * ex: 1996-12-19T16:39:57-08:00
+ */
+types.setTypeParser(NeonColumnType.TIMESTAMP, normalize_timestamp)
+types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, normalize_array(normalize_timestamp))
+types.setTypeParser(NeonColumnType.TIMESTAMPTZ, normalize_timestampz)
+
+/******************/
+/* Money handling */
+/******************/
+
+function normalize_money(money: string): string {
+  return money.slice(1)
+}
+
+types.setTypeParser(NeonColumnType.MONEY, normalize_money)
+types.setTypeParser(ArrayColumnType.MONEY_ARRAY, normalize_array(normalize_money))
+
+
+/*****************/
+/* JSON handling */
+/*****************/
+
 /**
  * JsonNull are stored in JSON strings as the string "null", distinguishable from
  * the `null` value which is used by the driver to represent the database NULL.
@@ -126,22 +201,17 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
  * By converting "null" to JsonNullMarker, we can signal JsonNull in Rust side and
  * convert it to QuaintValue::Json(Some(Null)).
  */
-function convertJson(json: string): unknown {
+function toJson(json: string): unknown {
   return (json === 'null') ? JsonNullMarker : JSON.parse(json)
 }
 
-// Original BYTEA parser
-const parsePgBytes = types.getTypeParser(NeonColumnType.BYTEA) as (_: string) => Buffer
 
-/**
- * Convert bytes to a JSON-encodable representation since we can't
- * currently send a parsed Buffer or ArrayBuffer across JS to Rust
- * boundary.
- */
-function convertBytes(serializedBytes: string): number[] {
-  const buffer = parsePgBytes(serializedBytes)
-  return encodeBuffer(buffer)
-}
+types.setTypeParser(NeonColumnType.JSONB, toJson)
+types.setTypeParser(NeonColumnType.JSON, toJson)
+
+/************************/
+/* Binary data handling */
+/************************/
 
 /**
  * TODO:
@@ -154,14 +224,26 @@ function encodeBuffer(buffer: Buffer) {
   return Array.from(new Uint8Array(buffer))
 }
 
-// return string instead of JavaScript Date object
-types.setTypeParser(NeonColumnType.TIME, date => date)
-types.setTypeParser(NeonColumnType.DATE, date => date)
-types.setTypeParser(NeonColumnType.TIMESTAMP, date => date)
-types.setTypeParser(NeonColumnType.JSONB, convertJson)
-types.setTypeParser(NeonColumnType.JSON, convertJson)
-types.setTypeParser(NeonColumnType.MONEY, money => money.slice(1))
+/*
+ * BYTEA - arbitrary raw binary strings
+ */
+
+const parsePgBytes = types.getTypeParser(NeonColumnType.BYTEA) as (_: string) => Buffer
+/**
+ * Convert bytes to a JSON-encodable representation since we can't
+ * currently send a parsed Buffer or ArrayBuffer across JS to Rust
+ * boundary.
+ */
+function convertBytes(serializedBytes: string): number[] {
+  const buffer = parsePgBytes(serializedBytes)
+  return encodeBuffer(buffer)
+}
+
 types.setTypeParser(NeonColumnType.BYTEA, convertBytes)
+
+/*
+ * BYTEA_ARRAYS - arrays of arbitrary raw binary strings
+ */
 
 const parseBytesArray = types.getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
 
@@ -170,12 +252,5 @@ types.setTypeParser(ArrayColumnType.BYTEA_ARRAY, (serializedBytesArray) => {
   return buffers.map(encodeBuffer)
 })
 
-const parseTextArray = types.getTypeParser(ArrayColumnType.TEXT_ARRAY) as (_: string) => string[]
 
-types.setTypeParser(ArrayColumnType.TIME_ARRAY, parseTextArray)
-types.setTypeParser(ArrayColumnType.DATE_ARRAY, parseTextArray)
-types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, parseTextArray)
 
-types.setTypeParser(ArrayColumnType.MONEY_ARRAY, (moneyArray) =>
-  parseTextArray(moneyArray).map((money) => money.slice(1)),
-)

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -2,7 +2,7 @@ import { ColumnTypeEnum, type ColumnType, JsonNullMarker } from '@prisma/driver-
 import { types } from '@neondatabase/serverless'
 import { parse as parseArray } from 'postgres-array'
 
-const NeonColumnType = types.builtins
+const ScalarColumnType = types.builtins
 
 /**
  * PostgreSQL array column types (not defined in NeonColumnType).
@@ -36,45 +36,45 @@ const ArrayColumnType = {
  */
 export function fieldToColumnType(fieldTypeId: number): ColumnType {
   switch (fieldTypeId) {
-    case NeonColumnType['INT2']:
-    case NeonColumnType['INT4']:
+    case ScalarColumnType['INT2']:
+    case ScalarColumnType['INT4']:
       return ColumnTypeEnum.Int32
-    case NeonColumnType['INT8']:
+    case ScalarColumnType['INT8']:
       return ColumnTypeEnum.Int64
-    case NeonColumnType['FLOAT4']:
+    case ScalarColumnType['FLOAT4']:
       return ColumnTypeEnum.Float
-    case NeonColumnType['FLOAT8']:
+    case ScalarColumnType['FLOAT8']:
       return ColumnTypeEnum.Double
-    case NeonColumnType['BOOL']:
+    case ScalarColumnType['BOOL']:
       return ColumnTypeEnum.Boolean
-    case NeonColumnType['DATE']:
+    case ScalarColumnType['DATE']:
       return ColumnTypeEnum.Date
-    case NeonColumnType['TIME']:
-    case NeonColumnType['TIMETZ']:
+    case ScalarColumnType['TIME']:
+    case ScalarColumnType['TIMETZ']:
       return ColumnTypeEnum.Time
-    case NeonColumnType['TIMESTAMP']:
-    case NeonColumnType['TIMESTAMPTZ']:
+    case ScalarColumnType['TIMESTAMP']:
+    case ScalarColumnType['TIMESTAMPTZ']:
       return ColumnTypeEnum.DateTime
-    case NeonColumnType['NUMERIC']:
-    case NeonColumnType['MONEY']:
+    case ScalarColumnType['NUMERIC']:
+    case ScalarColumnType['MONEY']:
       return ColumnTypeEnum.Numeric
-    case NeonColumnType['JSON']:
-    case NeonColumnType['JSONB']:
+    case ScalarColumnType['JSON']:
+    case ScalarColumnType['JSONB']:
       return ColumnTypeEnum.Json
-    case NeonColumnType['UUID']:
+    case ScalarColumnType['UUID']:
       return ColumnTypeEnum.Uuid
-    case NeonColumnType['OID']:
+    case ScalarColumnType['OID']:
       return ColumnTypeEnum.Int64
-    case NeonColumnType['BPCHAR']:
-    case NeonColumnType['TEXT']:
-    case NeonColumnType['VARCHAR']:
-    case NeonColumnType['BIT']:
-    case NeonColumnType['VARBIT']:
-    case NeonColumnType['INET']:
-    case NeonColumnType['CIDR']:
-    case NeonColumnType['XML']:
+    case ScalarColumnType['BPCHAR']:
+    case ScalarColumnType['TEXT']:
+    case ScalarColumnType['VARCHAR']:
+    case ScalarColumnType['BIT']:
+    case ScalarColumnType['VARBIT']:
+    case ScalarColumnType['INET']:
+    case ScalarColumnType['CIDR']:
+    case ScalarColumnType['XML']:
       return ColumnTypeEnum.Text
-    case NeonColumnType['BYTEA']:
+    case ScalarColumnType['BYTEA']:
       return ColumnTypeEnum.Bytes
     case ArrayColumnType.INT2_ARRAY:
     case ArrayColumnType.INT4_ARRAY:
@@ -155,15 +155,15 @@ function normalize_timez(time: string): string {
   return time.split("+")[0]
 }
 
-types.setTypeParser(NeonColumnType.TIME, normalize_time)
+types.setTypeParser(ScalarColumnType.TIME, normalize_time)
 types.setTypeParser(ArrayColumnType.TIME_ARRAY, normalize_array(normalize_time))
-types.setTypeParser(NeonColumnType.TIMETZ, normalize_timez)
+types.setTypeParser(ScalarColumnType.TIMETZ, normalize_timez)
 
 /*
  * DATE, DATE_ARRAY - converts value (or value elements) to a string in the format YYYY-MM-DD
  */
 
-types.setTypeParser(NeonColumnType.DATE, normalize_date)
+types.setTypeParser(ScalarColumnType.DATE, normalize_date)
 types.setTypeParser(ArrayColumnType.DATE_ARRAY, normalize_array(normalize_date))
 
 
@@ -171,9 +171,9 @@ types.setTypeParser(ArrayColumnType.DATE_ARRAY, normalize_array(normalize_date))
  * TIMESTAMP, TIMESTAMP_ARRAY - converts value (or value elements) to a string in the rfc3339 format
  * ex: 1996-12-19T16:39:57-08:00
  */
-types.setTypeParser(NeonColumnType.TIMESTAMP, normalize_timestamp)
+types.setTypeParser(ScalarColumnType.TIMESTAMP, normalize_timestamp)
 types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, normalize_array(normalize_timestamp))
-types.setTypeParser(NeonColumnType.TIMESTAMPTZ, normalize_timestampz)
+types.setTypeParser(ScalarColumnType.TIMESTAMPTZ, normalize_timestampz)
 
 /******************/
 /* Money handling */
@@ -183,7 +183,7 @@ function normalize_money(money: string): string {
   return money.slice(1)
 }
 
-types.setTypeParser(NeonColumnType.MONEY, normalize_money)
+types.setTypeParser(ScalarColumnType.MONEY, normalize_money)
 types.setTypeParser(ArrayColumnType.MONEY_ARRAY, normalize_array(normalize_money))
 
 
@@ -206,8 +206,8 @@ function toJson(json: string): unknown {
 }
 
 
-types.setTypeParser(NeonColumnType.JSONB, toJson)
-types.setTypeParser(NeonColumnType.JSON, toJson)
+types.setTypeParser(ScalarColumnType.JSONB, toJson)
+types.setTypeParser(ScalarColumnType.JSON, toJson)
 
 /************************/
 /* Binary data handling */
@@ -228,7 +228,7 @@ function encodeBuffer(buffer: Buffer) {
  * BYTEA - arbitrary raw binary strings
  */
 
-const parsePgBytes = types.getTypeParser(NeonColumnType.BYTEA) as (_: string) => Buffer
+const parsePgBytes = types.getTypeParser(ScalarColumnType.BYTEA) as (_: string) => Buffer
 /**
  * Convert bytes to a JSON-encodable representation since we can't
  * currently send a parsed Buffer or ArrayBuffer across JS to Rust
@@ -239,7 +239,7 @@ function convertBytes(serializedBytes: string): number[] {
   return encodeBuffer(buffer)
 }
 
-types.setTypeParser(NeonColumnType.BYTEA, convertBytes)
+types.setTypeParser(ScalarColumnType.BYTEA, convertBytes)
 
 /*
  * BYTEA_ARRAYS - arrays of arbitrary raw binary strings

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -5,7 +5,7 @@ import { parse as parseArray } from 'postgres-array'
 const ScalarColumnType = types.builtins
 
 /**
- * PostgreSQL array column types (not defined in NeonColumnType).
+ * PostgreSQL array column types (not defined in ScalarColumnType).
  */
 const ArrayColumnType = {
   BOOL_ARRAY: 1000,

--- a/query-engine/driver-adapters/js/adapter-pg/package.json
+++ b/query-engine/driver-adapters/js/adapter-pg/package.json
@@ -18,7 +18,8 @@
   "license": "Apache-2.0",
   "sideEffects": false,
   "dependencies": {
-    "@prisma/driver-adapter-utils": "workspace:*"
+    "@prisma/driver-adapter-utils": "workspace:*",
+    "postgres-array": "^3.0.2"
   },
   "devDependencies": {
     "pg": "^8.11.3",

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -118,6 +118,21 @@ export function fieldToColumnType(fieldTypeId: number): ColumnType {
   }
 }
 
+function normalize_array(element_normalizer: (string) => string): (string) => string[] {
+  return (str) => parseArray(str, element_normalizer)
+}
+
+/****************************/
+/* Time-related data-types  */
+/****************************/
+
+function normalize_numeric(numeric: string): string {
+  return numeric
+}
+
+types.setTypeParser(ScalarColumnType.NUMERIC, normalize_numeric)
+types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, normalize_array(normalize_numeric))
+
 /****************************/
 /* Time-related data-types  */
 /****************************/
@@ -133,12 +148,6 @@ function normalize_timestamp(time: string): string {
 
 function normalize_timestampz(time: string): string {
   return time.split("+")[0]
-}
-
-function normalize_array(element_normalizer: (string) => string): (string) => string[] {
-  return function(str: string): string[] {
-    return parseArray(str, element_normalizer)
-  }
 }
 
 /*
@@ -251,6 +260,3 @@ types.setTypeParser(ArrayColumnType.BYTEA_ARRAY, (serializedBytesArray) => {
   const buffers = parseBytesArray(serializedBytesArray)
   return buffers.map(encodeBuffer)
 })
-
-
-

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -1,7 +1,7 @@
 import { ColumnTypeEnum, type ColumnType, JsonNullMarker } from '@prisma/driver-adapter-utils'
 import { types } from 'pg'
 
-const PgColumnType = types.builtins
+const ScalarColumnType = types.builtins
 
 /**
  * PostgreSQL array column types (not defined in PgColumnType).
@@ -35,43 +35,43 @@ const ArrayColumnType = {
  */
 export function fieldToColumnType(fieldTypeId: number): ColumnType {
   switch (fieldTypeId) {
-    case PgColumnType['INT2']:
-    case PgColumnType['INT4']:
+    case ScalarColumnType['INT2']:
+    case ScalarColumnType['INT4']:
       return ColumnTypeEnum.Int32
-    case PgColumnType['INT8']:
+    case ScalarColumnType['INT8']:
       return ColumnTypeEnum.Int64
-    case PgColumnType['FLOAT4']:
+    case ScalarColumnType['FLOAT4']:
       return ColumnTypeEnum.Float
-    case PgColumnType['FLOAT8']:
+    case ScalarColumnType['FLOAT8']:
       return ColumnTypeEnum.Double
-    case PgColumnType['BOOL']:
+    case ScalarColumnType['BOOL']:
       return ColumnTypeEnum.Boolean
-    case PgColumnType['DATE']:
+    case ScalarColumnType['DATE']:
       return ColumnTypeEnum.Date
-    case PgColumnType['TIME']:
+    case ScalarColumnType['TIME']:
       return ColumnTypeEnum.Time
-    case PgColumnType['TIMESTAMP']:
+    case ScalarColumnType['TIMESTAMP']:
       return ColumnTypeEnum.DateTime
-    case PgColumnType['NUMERIC']:
-    case PgColumnType['MONEY']:
+    case ScalarColumnType['NUMERIC']:
+    case ScalarColumnType['MONEY']:
       return ColumnTypeEnum.Numeric
-    case PgColumnType['JSON']:
-    case PgColumnType['JSONB']:
+    case ScalarColumnType['JSON']:
+    case ScalarColumnType['JSONB']:
       return ColumnTypeEnum.Json
-    case PgColumnType['UUID']:
+    case ScalarColumnType['UUID']:
       return ColumnTypeEnum.Uuid
-    case PgColumnType['OID']:
+    case ScalarColumnType['OID']:
       return ColumnTypeEnum.Int64
-    case PgColumnType['BPCHAR']:
-    case PgColumnType['TEXT']:
-    case PgColumnType['VARCHAR']:
-    case PgColumnType['BIT']:
-    case PgColumnType['VARBIT']:
-    case PgColumnType['INET']:
-    case PgColumnType['CIDR']:
-    case PgColumnType['XML']:
+    case ScalarColumnType['BPCHAR']:
+    case ScalarColumnType['TEXT']:
+    case ScalarColumnType['VARCHAR']:
+    case ScalarColumnType['BIT']:
+    case ScalarColumnType['VARBIT']:
+    case ScalarColumnType['INET']:
+    case ScalarColumnType['CIDR']:
+    case ScalarColumnType['XML']:
       return ColumnTypeEnum.Text
-    case PgColumnType['BYTEA']:
+    case ScalarColumnType['BYTEA']:
       return ColumnTypeEnum.Bytes
 
     case ArrayColumnType.INT2_ARRAY:
@@ -131,7 +131,7 @@ function convertJson(json: string): unknown {
 }
 
 // Original BYTEA parser
-const parsePgBytes = types.getTypeParser(PgColumnType.BYTEA) as (_: string) => Buffer
+const parsePgBytes = types.getTypeParser(ScalarColumnType.BYTEA) as (_: string) => Buffer
 
 /**
  * Convert bytes to a JSON-encodable representation since we can't
@@ -155,13 +155,13 @@ function encodeBuffer(buffer: Buffer) {
 }
 
 // return string instead of JavaScript Date object
-types.setTypeParser(PgColumnType.TIME, date => date)
-types.setTypeParser(PgColumnType.DATE, date => date)
-types.setTypeParser(PgColumnType.TIMESTAMP, date => date)
-types.setTypeParser(PgColumnType.JSONB, convertJson)
-types.setTypeParser(PgColumnType.JSON, convertJson)
-types.setTypeParser(PgColumnType.MONEY, money => money.slice(1))
-types.setTypeParser(PgColumnType.BYTEA, convertBytes)
+types.setTypeParser(ScalarColumnType.TIME, date => date)
+types.setTypeParser(ScalarColumnType.DATE, date => date)
+types.setTypeParser(ScalarColumnType.TIMESTAMP, date => date)
+types.setTypeParser(ScalarColumnType.JSONB, convertJson)
+types.setTypeParser(ScalarColumnType.JSON, convertJson)
+types.setTypeParser(ScalarColumnType.MONEY, money => money.slice(1))
+types.setTypeParser(ScalarColumnType.BYTEA, convertBytes)
 
 const parseBytesArray = types.getTypeParser(ArrayColumnType.BYTEA_ARRAY) as (_: string) => Buffer[]
 

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -39,13 +39,13 @@ importers:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
+      postgres-array:
+        specifier: ^3.0.2
+        version: 3.0.2
     devDependencies:
       '@neondatabase/serverless':
         specifier: ^0.6.0
         version: 0.6.0
-      postgres-array:
-        specifier: ^3.0.2
-        version: 3.0.2
 
   adapter-pg:
     dependencies:

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@prisma/driver-adapter-utils':
         specifier: workspace:*
         version: link:../driver-adapter-utils
+      postgres-array:
+        specifier: ^3.0.2
+        version: 3.0.2
     devDependencies:
       '@types/pg':
         specifier: ^8.10.2

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@neondatabase/serverless':
         specifier: ^0.6.0
         version: 0.6.0
+      postgres-array:
+        specifier: ^3.0.2
+        version: 3.0.2
 
   adapter-pg:
     dependencies:

--- a/query-engine/driver-adapters/package-lock.json
+++ b/query-engine/driver-adapters/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "driver-adapters",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/query-engine/driver-adapters/package-lock.json
+++ b/query-engine/driver-adapters/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "driver-adapters",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -1,0 +1,55 @@
+use crate::conversion::JSArg;
+use chrono::format::StrftimeItems;
+use once_cell::sync::Lazy;
+use serde_json::value::Value as JsonValue;
+
+const TIME_FMT: Lazy<StrftimeItems> = Lazy::new(|| StrftimeItems::new("%H:%M:%S%.f"));
+
+pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec<JSArg>> {
+    let mut args = Vec::with_capacity(values.len());
+
+    for qv in values {
+        let res = match (&qv.typed, qv.native_column_type.as_deref()) {
+            (quaint::ValueType::DateTime(value), Some("Date")) => match value {
+                Some(value) => JSArg::RawString(value.date_naive().to_string()),
+                None => JsonValue::Null.into(),
+            },
+            (quaint::ValueType::DateTime(value), Some("Time")) => match value {
+                Some(value) => JSArg::RawString(value.time().to_string()),
+                None => JsonValue::Null.into(),
+            },
+            (quaint::ValueType::DateTime(value), Some("Timetz")) => match value {
+                Some(value) => JSArg::RawString(value.time().format_with_items(TIME_FMT.clone()).to_string()),
+                None => JsonValue::Null.into(),
+            },
+            (quaint::ValueType::DateTime(value), _) => match value {
+                Some(value) => JSArg::RawString(value.naive_utc().to_string()),
+                None => JsonValue::Null.into(),
+            },
+            (quaint::ValueType::Json(s), _) => match s {
+                Some(ref s) => {
+                    let json_str = serde_json::to_string(s)?;
+                    JSArg::RawString(json_str)
+                }
+                None => JsonValue::Null.into(),
+            },
+            (quaint::ValueType::Bytes(bytes), _) => match bytes {
+                Some(bytes) => JSArg::Buffer(bytes.to_vec()),
+                None => JsonValue::Null.into(),
+            },
+            (quaint_value @ quaint::ValueType::Numeric(bd), _) => match bd {
+                Some(bd) => match bd.to_string().parse::<f64>() {
+                    Ok(double) => JSArg::from(JsonValue::from(double)),
+                    Err(_) => JSArg::from(JsonValue::from(quaint_value.clone())),
+                },
+                None => JsonValue::Null.into(),
+            },
+            (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(values_to_js_args(items)?),
+            (quaint_value, _) => JSArg::from(JsonValue::from(quaint_value.clone())),
+        };
+
+        args.push(res);
+    }
+
+    Ok(args)
+}

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -3,7 +3,7 @@ use chrono::format::StrftimeItems;
 use once_cell::sync::Lazy;
 use serde_json::value::Value as JsonValue;
 
-const TIME_FMT: Lazy<StrftimeItems> = Lazy::new(|| StrftimeItems::new("%H:%M:%S%.f"));
+static TIME_FMT: Lazy<StrftimeItems> = Lazy::new(|| StrftimeItems::new("%H:%M:%S%.f"));
 
 pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec<JSArg>> {
     let mut args = Vec::with_capacity(values.len());

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -9,16 +9,16 @@ pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec
     let mut args = Vec::with_capacity(values.len());
 
     for qv in values {
-        let res = match (&qv.typed, qv.native_column_type.as_deref()) {
-            (quaint::ValueType::DateTime(value), Some("Date")) => match value {
+        let res = match (&qv.typed, qv.native_column_type_name()) {
+            (quaint::ValueType::DateTime(value), Some("DATE")) => match value {
                 Some(value) => JSArg::RawString(value.date_naive().to_string()),
                 None => JsonValue::Null.into(),
             },
-            (quaint::ValueType::DateTime(value), Some("Time")) => match value {
+            (quaint::ValueType::DateTime(value), Some("TIME")) => match value {
                 Some(value) => JSArg::RawString(value.time().to_string()),
                 None => JsonValue::Null.into(),
             },
-            (quaint::ValueType::DateTime(value), Some("Timetz")) => match value {
+            (quaint::ValueType::DateTime(value), Some("TIMETZ")) => match value {
                 Some(value) => JSArg::RawString(value.time().format_with_items(TIME_FMT.clone()).to_string()),
                 None => JsonValue::Null.into(),
             },

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -947,7 +947,7 @@ mod proxy_test {
 
         assert_eq!(
             quaint_value.err().unwrap().to_string(),
-            "Conversion failed: expected an i32 number in column column_name[2], found {}"
+            "Conversion failed: expected an i32 number in column 'column_name[2]', found {}"
         );
     }
 
@@ -969,7 +969,7 @@ mod proxy_test {
 
         assert_eq!(
             quaint_value.err().unwrap().to_string(),
-            "Conversion failed: expected a string in column column_name[0], found 10"
+            "Conversion failed: expected a string in column 'column_name[0]', found 10"
         );
     }
 }

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -10,7 +10,6 @@ use quaint::{
     error::{Error, ErrorKind},
     prelude::{Query as QuaintQuery, Queryable as QuaintQueryable, ResultSet, TransactionCapable},
     visitor::{self, Visitor},
-    Value,
 };
 use tracing::{info_span, Instrument};
 
@@ -38,8 +37,8 @@ impl JsBaseQueryable {
         Self { proxy, flavour }
     }
 
-    /// visit a query according to the flavour of the JS connector
-    pub fn visit_query<'a>(&self, q: QuaintQuery<'a>) -> quaint::Result<(String, Vec<Value<'a>>)> {
+    /// visit a quaint query AST according to the flavour of the JS connector
+    fn visit_quaint_query<'a>(&self, q: QuaintQuery<'a>) -> quaint::Result<(String, Vec<quaint::Value<'a>>)> {
         match self.flavour {
             Flavour::Mysql => visitor::Mysql::build(q),
             Flavour::Postgres => visitor::Postgres::build(q),
@@ -47,39 +46,48 @@ impl JsBaseQueryable {
             _ => unimplemented!("Unsupported flavour for JS connector {:?}", self.flavour),
         }
     }
+
+    async fn build_query(&self, sql: &str, values: &[quaint::Value<'_>]) -> quaint::Result<Query> {
+        let sql: String = sql.to_string();
+        let args = match self.flavour {
+            Flavour::Postgres => conversion::postgres::values_to_js_args(values),
+            _ => conversion::values_to_js_args(values),
+        }?;
+        Ok(Query { sql, args })
+    }
 }
 
 #[async_trait]
 impl QuaintQueryable for JsBaseQueryable {
     async fn query(&self, q: QuaintQuery<'_>) -> quaint::Result<ResultSet> {
-        let (sql, params) = self.visit_query(q)?;
+        let (sql, params) = self.visit_quaint_query(q)?;
         self.query_raw(&sql, &params).await
     }
 
-    async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
+    async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<ResultSet> {
         metrics::query("js.query_raw", sql, params, move || async move {
             self.do_query_raw(sql, params).await
         })
         .await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
+    async fn query_raw_typed(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<ResultSet> {
         self.query_raw(sql, params).await
     }
 
     async fn execute(&self, q: QuaintQuery<'_>) -> quaint::Result<u64> {
-        let (sql, params) = self.visit_query(q)?;
+        let (sql, params) = self.visit_quaint_query(q)?;
         self.execute_raw(&sql, &params).await
     }
 
-    async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
+    async fn execute_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<u64> {
         metrics::query("js.execute_raw", sql, params, move || async move {
             self.do_execute_raw(sql, params).await
         })
         .await
     }
 
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
+    async fn execute_raw_typed(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<u64> {
         self.execute_raw(sql, params).await
     }
 
@@ -134,16 +142,10 @@ impl JsBaseQueryable {
         format!(r#"-- Implicit "{}" query via underlying driver"#, stmt)
     }
 
-    async fn build_query(sql: &str, values: &[quaint::Value<'_>]) -> quaint::Result<Query> {
-        let sql: String = sql.to_string();
-        let args = conversion::conv_params(values)?;
-        Ok(Query { sql, args })
-    }
-
-    async fn do_query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
+    async fn do_query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<ResultSet> {
         let len = params.len();
         let serialization_span = info_span!("js:query:args", user_facing = true, "length" = %len);
-        let query = Self::build_query(sql, params).instrument(serialization_span).await?;
+        let query = self.build_query(sql, params).instrument(serialization_span).await?;
 
         let sql_span = info_span!("js:query:sql", user_facing = true, "db.statement" = %sql);
         let result_set = self.proxy.query_raw(query).instrument(sql_span).await?;
@@ -154,10 +156,10 @@ impl JsBaseQueryable {
         result_set.try_into()
     }
 
-    async fn do_execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
+    async fn do_execute_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<u64> {
         let len = params.len();
         let serialization_span = info_span!("js:query:args", user_facing = true, "length" = %len);
-        let query = Self::build_query(sql, params).instrument(serialization_span).await?;
+        let query = self.build_query(sql, params).instrument(serialization_span).await?;
 
         let sql_span = info_span!("js:query:sql", user_facing = true, "db.statement" = %sql);
         let affected_rows = self.proxy.execute_raw(query).instrument(sql_span).await?;
@@ -202,11 +204,11 @@ impl QuaintQueryable for JsQueryable {
         self.inner.query(q).await
     }
 
-    async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
+    async fn query_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<ResultSet> {
         self.inner.query_raw(sql, params).await
     }
 
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
+    async fn query_raw_typed(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<ResultSet> {
         self.inner.query_raw_typed(sql, params).await
     }
 
@@ -214,11 +216,11 @@ impl QuaintQueryable for JsQueryable {
         self.inner.execute(q).await
     }
 
-    async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
+    async fn execute_raw(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<u64> {
         self.inner.execute_raw(sql, params).await
     }
 
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
+    async fn execute_raw_typed(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<u64> {
         self.inner.execute_raw_typed(sql, params).await
     }
 


### PR DESCRIPTION
Fixes https://github.com/prisma/team-orm/issues/403
Fixes https://github.com/prisma/team-orm/issues/435

It also fixes these engine tests:

```
writes::data_types::native_types::postgres::postgres::native_date
new::regressions::prisma_15581::prisma_15581::create_one_model_with_low_precision_datetime_in_id
```