### PR TITLE
fix(tracing): quote traceparent value in sql comment

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/sql_trace.rs
+++ b/query-engine/connectors/sql-query-connector/src/sql_trace.rs
@@ -8,7 +8,7 @@ pub fn trace_parent_to_string(context: &SpanContext) -> String {
     let span_id = context.span_id();
 
     // see https://www.w3.org/TR/trace-context/#traceparent-header-field-values
-    format!("traceparent=00-{trace_id:032x}-{span_id:032x}-01")
+    format!("traceparent='00-{trace_id:032x}-{span_id:032x}-01'")
 }
 
 pub trait SqlTraceComment: Sized {
@@ -34,7 +34,7 @@ macro_rules! sql_trace {
             fn add_trace_id(self, trace_id: Option<&str>) -> Self {
                 if let Some(traceparent) = trace_id {
                     if should_sample(&traceparent) {
-                        self.comment(format!("traceparent={}", traceparent))
+                        self.comment(format!("traceparent='{}'", traceparent))
                     } else {
                         self
                     }


### PR DESCRIPTION
I noticed that the traceparent value isn't quoted when tracing is enabled, which can affect some parsers. Looking at the opentelemetry spec for sql comments, we can see all values including traceparent are single-quoted

https://open-telemetry.github.io/opentelemetry-sqlcommenter/#sample