### PR TITLE
ci: add ignored paths & skip running Buildkite tests when git diff is empty

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -19,7 +19,8 @@ if [[ "$2" == "test" ]]; then
         echo "No changes found for the previous commit in paths that are not ignored, this run will now be skipped."
         exit 0
     else
-        echo "Changes found for the previous commit in paths that are not ignored: \n\n${GIT_DIFF}\n\nThis run will continue..."
+        # Note that printf works better for displaying line returns in CI
+        printf "Changes found for the previous commit in paths that are not ignored: \n\n${GIT_DIFF}\n\nThis run will continue...\n"
     fi
 else
     echo "We are in the build pipeline."

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -2,6 +2,13 @@
 
 set -e
 
+if [[ -z "$2"  ]]; then
+    printf "Error: the name of the pipeline must be provided.\nExample: './engineer pipeline test'" 1>&2
+    exit 1
+else
+    echo "We are in the $2 pipeline."
+fi
+
 # Checks what's the diff with the previous commit, 
 # excluding some paths that do not need a run, 
 # because they do not affect tests running in Buildkite.
@@ -11,7 +18,6 @@ GIT_DIFF=$(git diff --name-only HEAD HEAD~1 -- . ':!.github' ':!query-engine/dri
 # Example: ./.buildkite/engineer pipeline test
 # We only want to check for changes and skip in the test pipeline.
 if [[ "$2" == "test" ]]; then
-    echo "We are in the test pipeline."
     # Checking if GIT_DIFF is empty
     # If it's empty then it's most likely that there are changes but they are in ignored paths.
     # So we do not start Buildkite
@@ -22,8 +28,6 @@ if [[ "$2" == "test" ]]; then
         # Note that printf works better for displaying line returns in CI
         printf "Changes found for the previous commit in paths that are not ignored: \n\n${GIT_DIFF}\n\nThis run will continue...\n"
     fi
-else
-    echo "We are in the build pipeline."
 fi
 
 # Check OS

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -5,7 +5,7 @@ set -e
 # Checks what's the diff with the previous commit, 
 # excluding some paths that do not need a run, 
 # because they do not affect tests running in Buildkite.
-GIT_DIFF=$(git diff --name-only -- . ':!.github' ':!query-engine/driver-adapters/js' ':!renovate.json' ':!*.md' ':!LICENSE' ':!CODEOWNERS';)
+GIT_DIFF=$(git diff --name-only HEAD HEAD~1 -- . ':!.github' ':!query-engine/driver-adapters/js' ':!renovate.json' ':!*.md' ':!LICENSE' ':!CODEOWNERS';)
 
 # $2 is either "test" or "build", depending on the pipeline
 # Example: ./.buildkite/engineer pipeline test

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -1,5 +1,27 @@
 #!/usr/bin/env bash
 
+set -ex
+
+node -v
+npm -v
+
+git clone https://github.com/timsuchanek/last-git-changes.git
+cd last-git-changes
+npm install
+npm run build
+cd ..
+node last-git-changes/bin.js --exclude='docs,examples,scripts,README.md,LICENSE,CONTRIBUTING.md,.github,.prettierrc.yml' 
+export CHANGED_COUNT=$(node last-git-changes/bin.js --exclude='docs,examples,scripts,README.md,LICENSE,CONTRIBUTING.md,.github,.prettierrc.yml' | wc -l)
+
+echo $CHANGED_COUNT
+
+if [ $CHANGED_COUNT -gt 0 ]; then
+  echo "Something changed, TODO"
+else
+  echo "Nothing changed, this run will be skipped now."
+fi
+
+
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     OS=linux-amzn
 elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -1,27 +1,31 @@
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
-node -v
-npm -v
+# Checks what's the diff with the previous commit, 
+# excluding some paths that do not need a run, 
+# because they do not affect tests running in Buildkite.
+GIT_DIFF=$(git diff --name-only -- . ':!.github' ':!query-engine/driver-adapters/js' ':!renovate.json' ':!*.md' ':!LICENSE' ':!CODEOWNERS';)
 
-git clone https://github.com/timsuchanek/last-git-changes.git
-cd last-git-changes
-npm install
-npm run build
-cd ..
-node last-git-changes/bin.js --exclude='docs,examples,scripts,README.md,LICENSE,CONTRIBUTING.md,.github,.prettierrc.yml' 
-export CHANGED_COUNT=$(node last-git-changes/bin.js --exclude='docs,examples,scripts,README.md,LICENSE,CONTRIBUTING.md,.github,.prettierrc.yml' | wc -l)
-
-echo $CHANGED_COUNT
-
-if [ $CHANGED_COUNT -gt 0 ]; then
-  echo "Something changed, TODO"
+# $2 is either "test" or "build", depending on the pipeline
+# Example: ./.buildkite/engineer pipeline test
+# We only want to check for changes and skip in the test pipeline.
+if [[ "$2" == "test" ]]; then
+    echo "We are in the test pipeline."
+    # Checking if GIT_DIFF is empty
+    # If it's empty then it's most likely that there are changes but they are in ignored paths.
+    # So we do not start Buildkite
+    if [ -z "${GIT_DIFF}" ]; then
+        echo "No changes found for the previous commit in paths that are not ignored, this run will now be skipped."
+        exit 0
+    else
+        echo "Changes found for the previous commit in paths that are not ignored: \n\n${GIT_DIFF}\n\nThis run will continue..."
+    fi
 else
-  echo "Nothing changed, this run will be skipped now."
+    echo "We are in the build pipeline."
 fi
 
-
+# Check OS
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
     OS=linux-amzn
 elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -34,7 +38,6 @@ fi
 # Check if the system has engineer installed, if not, use a local copy.
 if ! type "engineer" &> /dev/null; then
     # Setup Prisma engine build & test tool (engineer).
-    set -e
     curl --fail -sSL "https://prisma-engineer.s3-eu-west-1.amazonaws.com/1.59/latest/$OS/engineer.gz" --output engineer.gz
     gzip -d engineer.gz
     chmod +x engineer
@@ -44,6 +47,5 @@ if ! type "engineer" &> /dev/null; then
     rm -rf ./engineer
 else
     # Already installed on the system
-    set -e
     engineer "$@"
 fi


### PR DESCRIPTION
It breaks the infinite loop of releases and makes our Buildkite setup better by avoiding testing and building engines when it’s not needed.

See example run
https://buildkite.com/prisma/test-prisma-engines/builds/21127#018b1e2a-d699-4d44-980e-90b8a738c8e0/130-131

<img width="923" alt="Screenshot 2023-10-11 at 12 04 13" src="https://github.com/prisma/prisma-engines/assets/1328733/c711f879-4477-4414-9eac-c5be396c9776">
