### PR TITLE
driver-adapters: parse decimals as strings in arrays in neon and pg

### DIFF
--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -175,8 +175,8 @@ const parseTextArray = types.getTypeParser(ArrayColumnType.TEXT_ARRAY) as (_: st
 types.setTypeParser(ArrayColumnType.TIME_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.DATE_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, parseTextArray)
-types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, parseTextArray)
 
+types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.MONEY_ARRAY, (moneyArray) =>
   parseTextArray(moneyArray).map((money) => money.slice(1)),
 )

--- a/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/conversion.ts
@@ -175,6 +175,7 @@ const parseTextArray = types.getTypeParser(ArrayColumnType.TEXT_ARRAY) as (_: st
 types.setTypeParser(ArrayColumnType.TIME_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.DATE_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, parseTextArray)
+types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, parseTextArray)
 
 types.setTypeParser(ArrayColumnType.MONEY_ARRAY, (moneyArray) =>
   parseTextArray(moneyArray).map((money) => money.slice(1)),

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -175,8 +175,8 @@ const parseTextArray = types.getTypeParser(ArrayColumnType.TEXT_ARRAY) as (_: st
 types.setTypeParser(ArrayColumnType.TIME_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.DATE_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, parseTextArray)
-types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, parseTextArray)
 
+types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.MONEY_ARRAY, (moneyArray) =>
   parseTextArray(moneyArray).map((money) => money.slice(1)),
 )

--- a/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
+++ b/query-engine/driver-adapters/js/adapter-pg/src/conversion.ts
@@ -175,6 +175,7 @@ const parseTextArray = types.getTypeParser(ArrayColumnType.TEXT_ARRAY) as (_: st
 types.setTypeParser(ArrayColumnType.TIME_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.DATE_ARRAY, parseTextArray)
 types.setTypeParser(ArrayColumnType.TIMESTAMP_ARRAY, parseTextArray)
+types.setTypeParser(ArrayColumnType.NUMERIC_ARRAY, parseTextArray)
 
 types.setTypeParser(ArrayColumnType.MONEY_ARRAY, (moneyArray) =>
   parseTextArray(moneyArray).map((money) => money.slice(1)),


### PR DESCRIPTION
Fixes the following test: `writes::data_types::scalar_list::defaults::decimal::basic_write`.

Fixes: https://github.com/prisma/team-orm/issues/435
