### PR TITLE
.buildkite/engineer: fix shellcheck error

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -26,7 +26,7 @@ if [[ "$2" == "test" ]]; then
         exit 0
     else
         # Note that printf works better for displaying line returns in CI
-        printf "Changes found for the previous commit in paths that are not ignored: \n\n${GIT_DIFF}\n\nThis run will continue...\n"
+        printf "Changes found for the previous commit in paths that are not ignored: \n\n%s\n\nThis run will continue...\n" "${GIT_DIFF}"
     fi
 fi
 


### PR DESCRIPTION
Fix the following shellcheck error:

```
./.buildkite/engineer:29:16: note: Don't use variables in the printf format string. Use printf '..%s..' "$foo". [SC2059]
```

This is currently failing on CI: https://github.com/prisma/prisma-engines/actions/runs/6483571164/job/17605483589?pr=4358
