### PR TITLE
driver-adapters: Map libsql errors to Prisma errors

### DIFF
--- a/quaint/src/connector/sqlite.rs
+++ b/quaint/src/connector/sqlite.rs
@@ -1,6 +1,8 @@
 mod conversion;
 mod error;
 
+pub use error::SqliteError;
+
 pub use rusqlite::{params_from_iter, version as sqlite_version};
 
 use super::IsolationLevel;

--- a/quaint/src/connector/sqlite/error.rs
+++ b/quaint/src/connector/sqlite/error.rs
@@ -1,6 +1,157 @@
+use std::fmt;
+
 use crate::error::*;
 use rusqlite::ffi;
 use rusqlite::types::FromSqlError;
+
+#[derive(Debug)]
+pub struct SqliteError {
+    pub extended_code: i32,
+    pub message: Option<String>,
+}
+
+impl fmt::Display for SqliteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Error code {}: {}",
+            self.extended_code,
+            ffi::code_to_str(self.extended_code)
+        )
+    }
+}
+
+impl std::error::Error for SqliteError {}
+
+impl SqliteError {
+    pub fn new(extended_code: i32, message: Option<String>) -> Self {
+        Self { extended_code, message }
+    }
+
+    pub fn primary_code(&self) -> i32 {
+        self.extended_code & 0xFF
+    }
+}
+
+impl From<SqliteError> for Error {
+    fn from(error: SqliteError) -> Self {
+        match error {
+            SqliteError {
+                extended_code: ffi::SQLITE_CONSTRAINT_UNIQUE | ffi::SQLITE_CONSTRAINT_PRIMARYKEY,
+                message: Some(description),
+            } => {
+                let constraint = description
+                    .split(": ")
+                    .nth(1)
+                    .map(|s| s.split(", "))
+                    .map(|i| i.flat_map(|s| s.split('.').last()))
+                    .map(DatabaseConstraint::fields)
+                    .unwrap_or(DatabaseConstraint::CannotParse);
+
+                let kind = ErrorKind::UniqueConstraintViolation { constraint };
+                let mut builder = Error::builder(kind);
+
+                builder.set_original_code(error.extended_code.to_string());
+                builder.set_original_message(description);
+
+                builder.build()
+            }
+
+            SqliteError {
+                extended_code: ffi::SQLITE_CONSTRAINT_NOTNULL,
+                message: Some(description),
+            } => {
+                let constraint = description
+                    .split(": ")
+                    .nth(1)
+                    .map(|s| s.split(", "))
+                    .map(|i| i.flat_map(|s| s.split('.').last()))
+                    .map(DatabaseConstraint::fields)
+                    .unwrap_or(DatabaseConstraint::CannotParse);
+
+                let kind = ErrorKind::NullConstraintViolation { constraint };
+                let mut builder = Error::builder(kind);
+
+                builder.set_original_code(error.extended_code.to_string());
+                builder.set_original_message(description);
+
+                builder.build()
+            }
+
+            SqliteError {
+                extended_code: ffi::SQLITE_CONSTRAINT_FOREIGNKEY | ffi::SQLITE_CONSTRAINT_TRIGGER,
+                message: Some(description),
+            } => {
+                let mut builder = Error::builder(ErrorKind::ForeignKeyConstraintViolation {
+                    constraint: DatabaseConstraint::ForeignKey,
+                });
+
+                builder.set_original_code(error.extended_code.to_string());
+                builder.set_original_message(description);
+
+                builder.build()
+            }
+
+            SqliteError { extended_code, message } if error.primary_code() == ffi::SQLITE_BUSY => {
+                let mut builder = Error::builder(ErrorKind::SocketTimeout);
+                builder.set_original_code(format!("{extended_code}"));
+
+                if let Some(description) = message {
+                    builder.set_original_message(description);
+                }
+
+                builder.build()
+            }
+
+            SqliteError {
+                extended_code,
+                ref message,
+            } => match message {
+                Some(d) if d.starts_with("no such table") => {
+                    let table = d.split(": ").last().into();
+                    let kind = ErrorKind::TableDoesNotExist { table };
+
+                    let mut builder = Error::builder(kind);
+                    builder.set_original_code(format!("{extended_code}"));
+                    builder.set_original_message(d);
+
+                    builder.build()
+                }
+                Some(d) if d.contains("has no column named") => {
+                    let column = d.split(" has no column named ").last().into();
+                    let kind = ErrorKind::ColumnNotFound { column };
+
+                    let mut builder = Error::builder(kind);
+                    builder.set_original_code(format!("{extended_code}"));
+                    builder.set_original_message(d);
+
+                    builder.build()
+                }
+                Some(d) if d.starts_with("no such column: ") => {
+                    let column = d.split("no such column: ").last().into();
+                    let kind = ErrorKind::ColumnNotFound { column };
+
+                    let mut builder = Error::builder(kind);
+                    builder.set_original_code(format!("{extended_code}"));
+                    builder.set_original_message(d);
+
+                    builder.build()
+                }
+                _ => {
+                    let description = message.as_ref().map(|d| d.to_string());
+                    let mut builder = Error::builder(ErrorKind::QueryError(error.into()));
+                    builder.set_original_code(format!("{extended_code}"));
+
+                    if let Some(description) = description {
+                        builder.set_original_message(description);
+                    }
+
+                    builder.build()
+                }
+            },
+        }
+    }
+}
 
 impl From<rusqlite::Error> for Error {
     fn from(e: rusqlite::Error) -> Error {
@@ -33,197 +184,15 @@ impl From<rusqlite::Error> for Error {
 
             rusqlite::Error::QueryReturnedNoRows => Error::builder(ErrorKind::NotFound).build(),
 
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    code: ffi::ErrorCode::ConstraintViolation,
-                    extended_code: 2067,
-                },
-                Some(description),
-            ) => {
-                let constraint = description
-                    .split(": ")
-                    .nth(1)
-                    .map(|s| s.split(", "))
-                    .map(|i| i.flat_map(|s| s.split('.').last()))
-                    .map(DatabaseConstraint::fields)
-                    .unwrap_or(DatabaseConstraint::CannotParse);
-
-                let kind = ErrorKind::UniqueConstraintViolation { constraint };
-                let mut builder = Error::builder(kind);
-
-                builder.set_original_code("2067");
-                builder.set_original_message(description);
-
-                builder.build()
+            rusqlite::Error::SqliteFailure(ffi::Error { code: _, extended_code }, message) => {
+                SqliteError::new(extended_code, message).into()
             }
-
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    code: ffi::ErrorCode::ConstraintViolation,
-                    extended_code: 1555,
-                },
-                Some(description),
-            ) => {
-                let constraint = description
-                    .split(": ")
-                    .nth(1)
-                    .map(|s| s.split(", "))
-                    .map(|i| i.flat_map(|s| s.split('.').last()))
-                    .map(DatabaseConstraint::fields)
-                    .unwrap_or(DatabaseConstraint::CannotParse);
-
-                let kind = ErrorKind::UniqueConstraintViolation { constraint };
-                let mut builder = Error::builder(kind);
-
-                builder.set_original_code("1555");
-                builder.set_original_message(description);
-
-                builder.build()
-            }
-
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    code: ffi::ErrorCode::ConstraintViolation,
-                    extended_code: 1299,
-                },
-                Some(description),
-            ) => {
-                let constraint = description
-                    .split(": ")
-                    .nth(1)
-                    .map(|s| s.split(", "))
-                    .map(|i| i.flat_map(|s| s.split('.').last()))
-                    .map(DatabaseConstraint::fields)
-                    .unwrap_or(DatabaseConstraint::CannotParse);
-
-                let kind = ErrorKind::NullConstraintViolation { constraint };
-                let mut builder = Error::builder(kind);
-
-                builder.set_original_code("1299");
-                builder.set_original_message(description);
-
-                builder.build()
-            }
-
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    code: ffi::ErrorCode::ConstraintViolation,
-                    extended_code: 787,
-                },
-                Some(description),
-            ) => {
-                let mut builder = Error::builder(ErrorKind::ForeignKeyConstraintViolation {
-                    constraint: DatabaseConstraint::ForeignKey,
-                });
-
-                builder.set_original_code("787");
-                builder.set_original_message(description);
-
-                builder.build()
-            }
-
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    code: ffi::ErrorCode::ConstraintViolation,
-                    extended_code: 1811,
-                },
-                Some(description),
-            ) => {
-                let mut builder = Error::builder(ErrorKind::ForeignKeyConstraintViolation {
-                    constraint: DatabaseConstraint::ForeignKey,
-                });
-
-                builder.set_original_code("1811");
-                builder.set_original_message(description);
-
-                builder.build()
-            }
-
-            rusqlite::Error::SqliteFailure(
-                ffi::Error {
-                    code: ffi::ErrorCode::DatabaseBusy,
-                    extended_code,
-                },
-                description,
-            ) => {
-                let mut builder = Error::builder(ErrorKind::SocketTimeout);
-                builder.set_original_code(format!("{extended_code}"));
-
-                if let Some(description) = description {
-                    builder.set_original_message(description);
-                }
-
-                builder.build()
-            }
-
-            rusqlite::Error::SqliteFailure(ffi::Error { extended_code, .. }, ref description) => match description {
-                Some(d) if d.starts_with("no such table") => {
-                    let table = d.split(": ").last().into();
-                    let kind = ErrorKind::TableDoesNotExist { table };
-
-                    let mut builder = Error::builder(kind);
-                    builder.set_original_code(format!("{extended_code}"));
-                    builder.set_original_message(d);
-
-                    builder.build()
-                }
-                Some(d) if d.contains("has no column named") => {
-                    let column = d.split(" has no column named ").last().into();
-                    let kind = ErrorKind::ColumnNotFound { column };
-
-                    let mut builder = Error::builder(kind);
-                    builder.set_original_code(format!("{extended_code}"));
-                    builder.set_original_message(d);
-
-                    builder.build()
-                }
-                Some(d) if d.starts_with("no such column: ") => {
-                    let column = d.split("no such column: ").last().into();
-                    let kind = ErrorKind::ColumnNotFound { column };
-
-                    let mut builder = Error::builder(kind);
-                    builder.set_original_code(format!("{extended_code}"));
-                    builder.set_original_message(d);
-
-                    builder.build()
-                }
-                _ => {
-                    let description = description.as_ref().map(|d| d.to_string());
-                    let mut builder = Error::builder(ErrorKind::QueryError(e.into()));
-                    builder.set_original_code(format!("{extended_code}"));
-
-                    if let Some(description) = description {
-                        builder.set_original_message(description);
-                    }
-
-                    builder.build()
-                }
-            },
 
             rusqlite::Error::SqlInputError {
                 error: ffi::Error { extended_code, .. },
-                ref msg,
+                msg,
                 ..
-            } => match msg {
-                d if d.starts_with("no such column: ") => {
-                    let column = d.split("no such column: ").last().into();
-                    let kind = ErrorKind::ColumnNotFound { column };
-
-                    let mut builder = Error::builder(kind);
-                    builder.set_original_code(extended_code.to_string());
-                    builder.set_original_message(d);
-
-                    builder.build()
-                }
-                _ => {
-                    let description = msg.clone();
-                    let mut builder = Error::builder(ErrorKind::QueryError(e.into()));
-                    builder.set_original_code(extended_code.to_string());
-                    builder.set_original_message(description);
-
-                    builder.build()
-                }
-            },
+            } => SqliteError::new(extended_code, Some(msg)).into(),
 
             e => Error::builder(ErrorKind::QueryError(e.into())).build(),
         }

--- a/quaint/src/error.rs
+++ b/quaint/src/error.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 pub use crate::connector::mysql::MysqlError;
 pub use crate::connector::postgres::PostgresError;
+pub use crate::connector::sqlite::SqliteError;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DatabaseConstraint {

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -53,6 +53,14 @@ export type Error =
       message: string
       state: string
     }
+  | {
+      kind: 'Sqlite'
+      /**
+       * Sqlite extended error code: https://www.sqlite.org/rescode.html
+       */
+      extendedCode: number
+      message: string
+    }
 
 export interface Queryable {
   readonly flavour: 'mysql' | 'postgres' | 'sqlite'

--- a/query-engine/driver-adapters/js/pnpm-lock.yaml
+++ b/query-engine/driver-adapters/js/pnpm-lock.yaml
@@ -435,21 +435,21 @@ packages:
     dependencies:
       '@libsql/hrana-client': 0.5.5
       js-base64: 3.7.5
-      libsql: 0.1.23
+      libsql: 0.1.28
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - utf-8-validate
 
-  /@libsql/darwin-arm64@0.1.23:
-    resolution: {integrity: sha512-+V9aoOrZ47iYbY5NrcS0F2bDOCH407QI0wxAtss0CLOcFxlz/T6Nw0ryLK31GabklJQAmOXIyqkumLfz5HT64w==}
+  /@libsql/darwin-arm64@0.1.28:
+    resolution: {integrity: sha512-p4nldHUOhcl9ibnH1F6oiXV5Dl3PAcPB9VIjdjVvO3/URo5J7mhqRMuwJMKO5DZJJGtkKJ5IO0gu0hc90rnKIg==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     optional: true
 
-  /@libsql/darwin-x64@0.1.23:
-    resolution: {integrity: sha512-toHo7s0HiMl4VCIfjhGXDe9bGWWo78eP8fxIbwU6RlaLO6MNV9fjHY/GjTWccWOwyxcT+q6X/kUc957HnoW3bg==}
+  /@libsql/darwin-x64@0.1.28:
+    resolution: {integrity: sha512-WaEK+Z+wP5sr0h8EcusSGHv4Mqc3smYICeG4P/wsbRDKQ2WUMWqZrpgqaBsm+WPbXogU2vpf+qGc8BnpFZ0ggw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
@@ -484,22 +484,29 @@ packages:
       - bufferutil
       - utf-8-validate
 
-  /@libsql/linux-x64-gnu@0.1.23:
-    resolution: {integrity: sha512-U11LdjayakOj0lQCHDYkTgUfe4Q+7AjZZh8MzgEDF/9l0bmKNI3eFLWA3JD2Xm98yz65lUx95om0WKOKu5VW/w==}
+  /@libsql/linux-arm64-gnu@0.1.28:
+    resolution: {integrity: sha512-a17ANBuOqH2L8gdyET4Kg3XggQvxWnoA+7x7sDEX5NyWNyvr7P04WzNPAT0xAOWLclC1fDD6jM5sh/fbJk/7NA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    optional: true
+
+  /@libsql/linux-x64-gnu@0.1.28:
+    resolution: {integrity: sha512-dkg+Ou7ApV0PHpZWd9c6NrYyc/WSNn5h/ScKotaMTLWlLL96XAMNwrYLpZpUj61I2y7QzU98XtMfiSD1Ux+VaA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@libsql/linux-x64-musl@0.1.23:
-    resolution: {integrity: sha512-8UcCK2sPVzcafHsEmcU5IDp/NxjD6F6JFS5giijsMX5iGgxYQiiwTUMOmSxW0AWBeT4VY5U7G6rG5PC8JSFtfg==}
+  /@libsql/linux-x64-musl@0.1.28:
+    resolution: {integrity: sha512-ZuOxCDYlG+f1IDsxstmaxLtgG9HvlLuUKs0X3um4f5F5V+P+PF8qr08gSdD1IP2pj+JBOiwhQffaEpR1wupxhQ==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     optional: true
 
-  /@libsql/win32-x64-msvc@0.1.23:
-    resolution: {integrity: sha512-HAugD66jTmRRRGNMLKRiaFeMOC3mgUsAiuO6NRdRz3nM6saf9e5QqN/Ppuu9yqHHcZfv7VhQ9UGlAvzVK64Itg==}
+  /@libsql/win32-x64-msvc@0.1.28:
+    resolution: {integrity: sha512-2cmUiMIsJLHpetebGeeYqUYaCPWEnwMjqxwu1ZEEbA5x8r+DNmIhLrc0QSQ29p7a5u14vbZnShNOtT/XG7vKew==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
@@ -971,19 +978,20 @@ packages:
   /js-base64@3.7.5:
     resolution: {integrity: sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==}
 
-  /libsql@0.1.23:
-    resolution: {integrity: sha512-Nf/1B2Glxvcnba4jYFhXcaYmicyBA3RRm0LVwBkTl8UWCIDbX+Ad7c1ecrQwixPLPffWOVxKIqyCNTuUHUkVgA==}
+  /libsql@0.1.28:
+    resolution: {integrity: sha512-yCKlT0ntV8ZIWTPGNClhQQeH/LNAzLjbbEgBvgLb+jfQwAuTbyvPpVVLwkZzesqja1nbkWApztW0pX81Jp0pkw==}
     cpu: [x64, arm64]
     os: [darwin, linux, win32]
     dependencies:
       '@neon-rs/load': 0.0.4
       detect-libc: 2.0.2
     optionalDependencies:
-      '@libsql/darwin-arm64': 0.1.23
-      '@libsql/darwin-x64': 0.1.23
-      '@libsql/linux-x64-gnu': 0.1.23
-      '@libsql/linux-x64-musl': 0.1.23
-      '@libsql/win32-x64-msvc': 0.1.23
+      '@libsql/darwin-arm64': 0.1.28
+      '@libsql/darwin-x64': 0.1.28
+      '@libsql/linux-arm64-gnu': 0.1.28
+      '@libsql/linux-x64-gnu': 0.1.28
+      '@libsql/linux-x64-musl': 0.1.28
+      '@libsql/win32-x64-msvc': 0.1.28
 
   /lilconfig@2.1.0:
     resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}

--- a/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
+++ b/query-engine/driver-adapters/js/smoke-test-js/src/libquery/libquery.ts
@@ -290,13 +290,13 @@ export function smokeTestLibquery(
     })
 
     it('expected error (on duplicate insert) as json result (not throwing error)', async () => {
-      // clean up first
       await doQuery({
         modelName: 'Unique',
         action: 'deleteMany',
         query: {
+          arguments: {},
           selection: {
-            count: true,
+            $scalars: true,
           },
         },
       })
@@ -327,17 +327,9 @@ export function smokeTestLibquery(
         },
       })
 
-      if (flavour === 'postgres' || flavour === 'mysql') {
-        const result = await promise
-        console.log('[nodejs] error result', JSON.stringify(result, null, 2))
-        assert.equal(result?.errors?.[0]?.['user_facing_error']?.['error_code'], 'P2002')
-      } else {
-        await assert.rejects(promise, (err) => {
-          assert(typeof err === 'object' && err !== null)
-          assert.match(err['message'], /unique/i)
-          return true
-        })
-      }
+      const result = await promise
+      console.log('[nodejs] error result', JSON.stringify(result, null, 2))
+      assert.equal(result?.errors?.[0]?.['user_facing_error']?.['error_code'], 'P2002')
     })
 
     describe('read scalar and non scalar types', () => {


### PR DESCRIPTION
Similar approach to what we did with Neon: raw error data is returned
from driver adapter in case of DB error, which then reuses Quaint's
error handling code for adapter too.

At the moment, this works with local database only. Cloud portion of that requires some adjustments from Turso's side and they are working on it, but I don't exepect any changes to our code would be needed after it's done.

Close prisma/team-orm#393
