### PR TITLE
driver-adapters: Common code for libsql/mysql error handling

### DIFF
--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -8,7 +8,6 @@ use crate::{
     visitor::{self, Visitor},
 };
 use async_trait::async_trait;
-pub use error::PostgresError;
 use futures::{future::FutureExt, lock::Mutex};
 use lru_cache::LruCache;
 use native_tls::{Certificate, Identity, TlsConnector};
@@ -27,6 +26,8 @@ use tokio_postgres::{
     Client, Config, Statement,
 };
 use url::{Host, Url};
+
+pub use error::PostgresError;
 
 pub(crate) const DEFAULT_SCHEMA: &str = "public";
 

--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -1,5 +1,5 @@
 mod conversion;
-pub mod error;
+mod error;
 
 use crate::{
     ast::{Query, Value},
@@ -8,6 +8,7 @@ use crate::{
     visitor::{self, Visitor},
 };
 use async_trait::async_trait;
+pub use error::PostgresError;
 use futures::{future::FutureExt, lock::Mutex};
 use lru_cache::LruCache;
 use native_tls::{Certificate, Identity, TlsConnector};

--- a/quaint/src/error.rs
+++ b/quaint/src/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 #[cfg(feature = "pooled")]
 use std::time::Duration;
 
-pub use crate::connector::postgres::error::PostgresError;
+pub use crate::connector::postgres::PostgresError;
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum DatabaseConstraint {

--- a/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
+++ b/query-engine/driver-adapters/js/adapter-neon/src/neon.ts
@@ -67,7 +67,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
       debug('Error in performIO: %O', e)
       if (e && e.code) {
         return err({
-          kind: 'PostgresError',
+          kind: 'Postgres',
           code: e.code,
           severity: e.severity,
           message: e.message,
@@ -84,10 +84,7 @@ class NeonWsQueryable<ClientT extends neon.Pool | neon.PoolClient> extends NeonQ
 class NeonTransaction extends NeonWsQueryable<neon.PoolClient> implements Transaction {
   finished = false
 
-  constructor(
-    client: neon.PoolClient,
-    readonly options: TransactionOptions,
-  ) {
+  constructor(client: neon.PoolClient, readonly options: TransactionOptions) {
     super(client)
   }
 

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/binder.ts
@@ -60,7 +60,7 @@ function wrapAsync<A extends unknown[], R>(
       return await fn(...args)
     } catch (error) {
       const id = registry.registerNewError(error)
-      return err({ kind: 'GenericJsError', id })
+      return err({ kind: 'GenericJs', id })
     }
   }
 }
@@ -74,7 +74,7 @@ function wrapSync<A extends unknown[], R>(
       return fn(...args)
     } catch (error) {
       const id = registry.registerNewError(error)
-      return err({ kind: 'GenericJsError', id })
+      return err({ kind: 'GenericJs', id })
     }
   }
 }

--- a/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
+++ b/query-engine/driver-adapters/js/driver-adapter-utils/src/types.ts
@@ -33,18 +33,20 @@ export type Query = {
   args: Array<unknown>
 }
 
-export type Error = {
-  kind: 'GenericJsError'
-  id: number
-} | {
-  kind: 'PostgresError'
-  code: string,
-  severity: string
-  message: string
-  detail: string | undefined
-  column: string | undefined
-  hint: string | undefined
-}
+export type Error =
+  | {
+      kind: 'GenericJs'
+      id: number
+    }
+  | {
+      kind: 'Postgres'
+      code: string
+      severity: string
+      message: string
+      detail: string | undefined
+      column: string | undefined
+      hint: string | undefined
+    }
 
 export interface Queryable {
   readonly flavour: 'mysql' | 'postgres' | 'sqlite'

--- a/query-engine/driver-adapters/src/result.rs
+++ b/query-engine/driver-adapters/src/result.rs
@@ -19,11 +19,11 @@ pub struct PostgresErrorDef {
 /// See driver-adapters/js/adapter-utils/src/types.ts file for example
 pub(crate) enum DriverAdapterError {
     /// Unexpected JS exception
-    GenericJsError {
+    GenericJs {
         id: i32,
     },
 
-    PostgresError(#[serde(with = "PostgresErrorDef")] PostgresError),
+    Postgres(#[serde(with = "PostgresErrorDef")] PostgresError),
     // in the future, expected errors that map to known user errors with PXXX codes will also go here
 }
 
@@ -38,8 +38,8 @@ impl FromNapiValue for DriverAdapterError {
 impl From<DriverAdapterError> for QuaintError {
     fn from(value: DriverAdapterError) -> Self {
         match value {
-            DriverAdapterError::GenericJsError { id } => QuaintError::external_error(id),
-            DriverAdapterError::PostgresError(e) => e.into(),
+            DriverAdapterError::GenericJs { id } => QuaintError::external_error(id),
+            DriverAdapterError::Postgres(e) => e.into(),
             // in future, more error types would be added and we'll need to convert them to proper QuaintErrors here
         }
     }


### PR DESCRIPTION
Splits part of the code that are common between #4364 and #4362 into
it's own PR so it could be reviewd and merged separately and
aforementioned PR stop conflicting with each other.

Also implements error handling for PG since it is necessary for modified
smoke test to pass.
