### PR TITLE
chore(docs): Add "how to" README sections to public-facing Driver Adapters

### DIFF
--- a/query-engine/driver-adapters/js/adapter-libsql/README.md
+++ b/query-engine/driver-adapters/js/adapter-libsql/README.md
@@ -3,3 +3,93 @@
 Prisma driver adapter for Turso and libSQL.
 
 See https://prisma.io/turso for details.
+
+The following usage tutorial is valid for Prisma 5.4.2 and later versions.
+
+## How to install
+
+After [getting started with Turso](https://www.prisma.io/blog/prisma-turso-ea-support-rXGd_Tmy3UXX#create-a-database-on-turso), you can use the Turso serverless driver to connect to your database. You will need to install the `@prisma/adapter-libsql` driver adapter and the `@libsql/client` serverless driver.
+
+```sh
+npm install @prisma/adapter-libsql
+npm install @libsql/client
+```
+
+Make sure your Turso database connection string and authentication token is copied over to your `.env` file. The connection string will start with `libsql://`.
+
+```env
+# .env
+TURSO_AUTH_TOKEN="eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9..."
+TURSO_DATABASE_URL="libsql://turso-prisma-random-user.turso.io"
+```
+
+You can now reference this environment variable in your `schema.prisma` datasource. Make sure you also include the `driverAdapters` Preview feature.
+
+```prisma
+// schema.prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+```
+
+Now run `npx prisma generate` to re-generate Prisma Client.
+
+## How to setup migrations
+
+As Turso needs to sync between a local sqlite database and another one hosted on Turso Cloud, an additional migration setup is needed. In particular, anytime you modify models and relations in your `schema.prisma` file, you should:
+
+1. Create a baseline migration
+
+```sh
+npx prisma migrate diff --from-empty \
+  --to-schema-datamodel prisma/schema.prisma \
+  --script > baseline.sql
+```
+
+2. Apply the migration to your Turso database
+
+```sh
+turso db shell turso-prisma < baseline.sql 
+```
+
+## How to use
+
+In TypeScript, you will need to:
+
+1. Import packages
+2. Set up the libSQL serverless database driver
+3. Instantiate the Prisma libSQL adapter with the libSQL serverless database driver
+4. Pass the driver adapter to the Prisma Client instance
+
+```typescript
+// Import needed packages
+import { PrismaClient } from '@prisma/client';
+import { PrismaLibSQL } from '@prisma/adapter-libsql';
+import { createClient } from '@libsql/client';
+
+// Setup
+const connectionString = `${process.env.TURSO_DATABASE_URL}`;
+const authToken = `${process.env.TURSO_AUTH_TOKEN}`;
+
+// Init prisma client
+const libsql = createClient({
+  url: connectionString,
+  authToken,
+});
+const adapter = new PrismaLibSQL(libsql);
+const prisma = new PrismaClient({ adapter });
+
+// Use Prisma Client as normal
+```
+
+Your Prisma Client instance now uses a **single** remote Turso database.
+You can take it a step further by setting up database replicas. Turso automatically picks the closest replica to your app for read queries when you create replicas. No additional logic is required to define how the routing of the read queries should be handled. Write queries will be forwarded to the primary database.
+We encourage you to create an issue if you find something missing or run into a bug.
+
+If you have any feedback about our libSQL Serverless Driver support, please leave a comment on our [dedicated GitHub issue](https://github.com/prisma/prisma/discussions/21345) and we'll use it as we continue development.

--- a/query-engine/driver-adapters/js/adapter-neon/README.md
+++ b/query-engine/driver-adapters/js/adapter-neon/README.md
@@ -2,4 +2,70 @@
 
 Prisma driver adapter for [Neon Serverless Driver](https://github.com/neondatabase/serverless).
 
-See https://github.com/prisma/prisma/releases/tag/5.4.0 for details.
+See https://github.com/prisma/prisma/releases/tag/5.4.0 and https://www.prisma.io/blog/serverless-database-drivers-KML1ehXORxZV for details.
+
+The following usage tutorial is valid for Prisma 5.4.2 and later versions.
+
+## How to install
+
+After [creating your database on Neon](https://neon.tech/docs/get-started-with-neon/setting-up-a-project), you'll need to install the `@prisma/adapter-neon` driver adapter, Neon’s serverless database driver `@neondatabase/serverless`, and `ws` to set up a WebSocket connection for use by Neon.
+
+```sh
+npm install @prisma/adapter-neon
+npm install @neondatabase/serverless
+npm install ws
+```
+
+Make sure your [Neon database connection string](https://neon.tech/docs/connect/connect-from-any-app) is copied over to your `.env` file. The connection string will start with `postgres://`.
+
+```env
+# .env
+DATABASE_URL="postgres://..."
+```
+
+You can now reference this environment variable in your `schema.prisma` datasource. Make sure you also include the `driverAdapters` Preview feature.
+
+```prisma
+// schema.prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+```
+
+Now run `npx prisma generate` to re-generate Prisma Client.
+
+## How to use
+
+In TypeScript, you will need to:
+
+1. Import packages
+2. Set up the Neon serverless database driver
+3. Instantiate the Prisma Neon adapter with the Neon serverless database driver
+4. Pass the driver adapter to the Prisma Client instance
+
+```typescript
+// Import needed packages
+import { Pool, neonConfig } from '@neondatabase/serverless';
+import { PrismaNeon } from '@prisma/adapter-neon';
+import { PrismaClient } from '@prisma/client';
+import ws from 'ws';
+
+// Setup
+neonConfig.webSocketConstructor = ws;
+const connectionString = `${process.env.DATABASE_URL}`;
+
+// Init prisma client
+const pool = new Pool({ connectionString });
+const adapter = new PrismaNeon(pool);
+const prisma = new PrismaClient({ adapter });
+
+// Use Prisma Client as normal
+```
+
+Now your code has built-in benefits of the Neon serverless driver, such as WebSocket connections and [message pipelining](https://neon.tech/blog/quicker-serverless-postgres), while Prisma covers connection creation and destruction, error handling, and type safety. If you have any feedback about our Neon Serverless Driver support, please leave a comment on our [dedicated GitHub issue](https://github.com/prisma/prisma/discussions/21346) and we'll use it as we continue development.

--- a/query-engine/driver-adapters/js/adapter-neon/README.md
+++ b/query-engine/driver-adapters/js/adapter-neon/README.md
@@ -23,7 +23,7 @@ Make sure your [Neon database connection string](https://neon.tech/docs/connect/
 DATABASE_URL="postgres://..."
 ```
 
-You can now reference this environment variable in your `schema.prisma` datasource. Make sure you also include the `driverAdapters` Preview feature.
+Make sure you also include the `driverAdapters` Preview feature in your `schema.prisma`.
 
 ```prisma
 // schema.prisma

--- a/query-engine/driver-adapters/js/adapter-planetscale/README.md
+++ b/query-engine/driver-adapters/js/adapter-planetscale/README.md
@@ -2,5 +2,70 @@
 
 Prisma driver adapter for [PlanetScale Serverless Driver](https://github.com/planetscale/database-js).
 
-See https://github.com/prisma/prisma/releases/tag/5.4.0 for details.
+See https://github.com/prisma/prisma/releases/tag/5.4.0 and https://www.prisma.io/blog/serverless-database-drivers-KML1ehXORxZV for details.
 
+The following usage tutorial is valid for Prisma 5.4.2 and later versions.
+
+## How to install
+
+After [getting started with PlanetScale](https://neon.tech/docs/get-started-with-neon/setting-up-a-project), you can use the PlanetScale serverless driver to connect to your database. You will need to install the `@prisma/adapter-planetscale` driver adapter, the `@planetscale/database` serverless driver, and `undici` to provide a `fetch` function to the PlanetScale driver.
+
+```sh
+npm install @prisma/adapter-planetscale
+npm install @planetscale/database
+npm install undici
+```
+
+Make sure your [PlanetScale database connection string](https://planetscale.com/docs/concepts/connection-strings) is copied over to your `.env` file. The connection string will start with `mysql://`.
+
+```env
+# .env
+DATABASE_URL="mysql://..."
+```
+
+You can now reference this environment variable in your `schema.prisma` datasource. Make sure you also include the `driverAdapters` Preview feature.
+
+```prisma
+// schema.prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["driverAdapters"]
+}
+
+datasource db {
+  provider     = "mysql"
+  url          = env("DATABASE_URL")
+  relationMode = "prisma"
+}
+```
+
+Now run `npx prisma generate` to re-generate Prisma Client.
+
+## How to use
+
+In TypeScript, you will need to:
+
+1. Import packages
+2. Set up the PlanetScale serverless database driver
+3. Instantiate the Prisma PlanetScale adapter with the PlanetScale serverless database driver
+4. Pass the driver adapter to the Prisma Client instance
+
+```typescript
+// Import needed packages
+import { connect } from '@planetscale/database';
+import { PrismaPlanetScale } from '@prisma/adapter-planetscale';
+import { PrismaClient } from '@prisma/client';
+import { fetch as undiciFetch } from 'undici';
+
+// Setup
+const connectionString = `${process.env.DATABASE_URL}`;
+
+// Init prisma client
+const connection = connect({ url: connectionString, fetch: undiciFetch });
+const adapter = new PrismaPlanetScale(connection);
+const prisma = new PrismaClient({ adapter });
+
+// Use Prisma Client as normal
+```
+
+Your Prisma Client instance now uses PlanetScale's [`database-js`](https://github.com/planetscale/database-js), which can improve [`connection reliability and performance`](https://planetscale.com/blog/faster-mysql-with-http3). It uses HTTP requests instead of Prisma’s connection pool, but Prisma will continue to handle error handling and type safety. If you have any feedback about our PlanetScale Serverless Driver support, please leave a comment on our [dedicated GitHub issue](https://github.com/prisma/prisma/discussions/21347) and we'll use it as we continue development.


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/387.

This PR adds instructions about how to install and use the following Driver Adapters:
- [x] PlanetScale
- [x] Neon
- [x] libSQL (Turso)