### PR TITLE
Bump commit hash for 5.5.2

### DIFF
--- a/.buildkite/engineer
+++ b/.buildkite/engineer
@@ -9,26 +9,26 @@ else
     echo "We are in the $2 pipeline."
 fi
 
-# Checks what's the diff with the previous commit, 
-# excluding some paths that do not need a run, 
-# because they do not affect tests running in Buildkite.
-GIT_DIFF=$(git diff --name-only HEAD HEAD~1 -- . ':!.github' ':!query-engine/driver-adapters/js' ':!renovate.json' ':!*.md' ':!LICENSE' ':!CODEOWNERS';)
+# # Checks what's the diff with the previous commit, 
+# # excluding some paths that do not need a run, 
+# # because they do not affect tests running in Buildkite.
+# GIT_DIFF=$(git diff --name-only HEAD HEAD~1 -- . ':!.github' ':!query-engine/driver-adapters/js' ':!renovate.json' ':!*.md' ':!LICENSE' ':!CODEOWNERS';)
 
-# $2 is either "test" or "build", depending on the pipeline
-# Example: ./.buildkite/engineer pipeline test
-# We only want to check for changes and skip in the test pipeline.
-if [[ "$2" == "test" ]]; then
-    # Checking if GIT_DIFF is empty
-    # If it's empty then it's most likely that there are changes but they are in ignored paths.
-    # So we do not start Buildkite
-    if [ -z "${GIT_DIFF}" ]; then
-        echo "No changes found for the previous commit in paths that are not ignored, this run will now be skipped."
-        exit 0
-    else
-        # Note that printf works better for displaying line returns in CI
-        printf "Changes found for the previous commit in paths that are not ignored: \n\n%s\n\nThis run will continue...\n" "${GIT_DIFF}"
-    fi
-fi
+# # $2 is either "test" or "build", depending on the pipeline
+# # Example: ./.buildkite/engineer pipeline test
+# # We only want to check for changes and skip in the test pipeline.
+# if [[ "$2" == "test" ]]; then
+#     # Checking if GIT_DIFF is empty
+#     # If it's empty then it's most likely that there are changes but they are in ignored paths.
+#     # So we do not start Buildkite
+#     if [ -z "${GIT_DIFF}" ]; then
+#         echo "No changes found for the previous commit in paths that are not ignored, this run will now be skipped."
+#         exit 0
+#     else
+#         # Note that printf works better for displaying line returns in CI
+#         printf "Changes found for the previous commit in paths that are not ignored: \n\n%s\n\nThis run will continue...\n" "${GIT_DIFF}"
+#     fi
+# fi
 
 # Check OS
 if [[ "$OSTYPE" == "linux-gnu" ]]; then


### PR DESCRIPTION
Bump commit hash with an empty commit for 5.5.2 patch to work around the
problem with local engine cache.
