### PR TITLE
ci: fix yml files for GitHub Actions workflow for DOCKERHUB login

### DIFF
--- a/.github/workflows/query-engine-black-box.yml
+++ b/.github/workflows/query-engine-black-box.yml
@@ -50,7 +50,10 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         continue-on-error: true
-        if: "${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}"
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -68,7 +68,10 @@ jobs:
       - name: 'Login to Docker Hub'
         uses: docker/login-action@v3
         continue-on-error: true
-        if: "${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}"
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -80,7 +80,10 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         continue-on-error: true
-        if: "${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}"
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/schema-engine.yml
+++ b/.github/workflows/schema-engine.yml
@@ -113,7 +113,10 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         continue-on-error: true
-        if: "${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}"
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Failed with this before:

Invalid workflow file: .github/workflows/schema-engine.yml#L116
The workflow is not valid. .github/workflows/schema-engine.yml (Line: 116, Col: 13): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''

https://github.com/prisma/prisma-engines/actions/runs/6662939086