### PR TITLE
fix(psl): composite type validation in indices

### DIFF
--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -123,7 +123,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
             indexes::supports_clustering_setting(index, ctx);
             indexes::clustering_can_be_defined_only_once(index, ctx);
             indexes::opclasses_are_not_allowed_with_other_than_normal_indices(index, ctx);
-            indexes::composite_types_non_conjunctive_in_indexes(index, ctx);
+            indexes::composite_type_in_compound_index(index, ctx);
 
             for field_attribute in index.scalar_field_attributes() {
                 let span = index.ast_attribute().span;

--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -123,7 +123,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
             indexes::supports_clustering_setting(index, ctx);
             indexes::clustering_can_be_defined_only_once(index, ctx);
             indexes::opclasses_are_not_allowed_with_other_than_normal_indices(index, ctx);
-            indexes::composite_types_are_not_allowed_in_index(index, ctx);
+            indexes::composite_types_non_conjunctive_in_indexes(index, ctx);
 
             for field_attribute in index.scalar_field_attributes() {
                 let span = index.ast_attribute().span;

--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -123,7 +123,7 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
             indexes::supports_clustering_setting(index, ctx);
             indexes::clustering_can_be_defined_only_once(index, ctx);
             indexes::opclasses_are_not_allowed_with_other_than_normal_indices(index, ctx);
-            indexes::composite_type_in_compound_index(index, ctx);
+            indexes::composite_type_in_compound_unique_index(index, ctx);
 
             for field_attribute in index.scalar_field_attributes() {
                 let span = index.ast_attribute().span;

--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -386,14 +386,16 @@ pub(crate) fn opclasses_are_not_allowed_with_other_than_normal_indices(index: In
     }
 }
 
-pub(crate) fn composite_types_non_conjunctive_in_indexes(index: IndexWalker<'_>, ctx: &mut Context<'_>) {
+pub(crate) fn composite_type_in_compound_index(index: IndexWalker<'_>, ctx: &mut Context<'_>) {
     let composite_type = index
         .fields()
         .find(|f| f.scalar_field_type().as_composite_type().is_some());
 
     if index.fields().len() > 1 && composite_type.is_some() {
+        
         let message = format!(
-            "Prisma currently does not composite types in indexes when used in conjunction with other fields.",
+            "Prisma does not currently support composite types in compound indices. Please remove {:?} from the index.",
+            composite_type.unwrap().name()
         );
         ctx.push_error(DatamodelError::new_attribute_validation_error(
             &message,

--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -393,7 +393,7 @@ pub(crate) fn composite_type_in_compound_index(index: IndexWalker<'_>, ctx: &mut
 
     if index.fields().len() > 1 && composite_type.is_some() {
         let message = format!(
-            "Prisma does not currently support composite types in compound indices. Please remove {:?} from the index.",
+            "Prisma does not currently support composite types in compound indices, please remove {:?} from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details",
             composite_type.unwrap().name()
         );
         ctx.push_error(DatamodelError::new_attribute_validation_error(

--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -392,7 +392,6 @@ pub(crate) fn composite_type_in_compound_index(index: IndexWalker<'_>, ctx: &mut
         .find(|f| f.scalar_field_type().as_composite_type().is_some());
 
     if index.fields().len() > 1 && composite_type.is_some() {
-        
         let message = format!(
             "Prisma does not currently support composite types in compound indices. Please remove {:?} from the index.",
             composite_type.unwrap().name()
@@ -402,7 +401,6 @@ pub(crate) fn composite_type_in_compound_index(index: IndexWalker<'_>, ctx: &mut
             index.attribute_name(),
             index.ast_attribute().span,
         ));
-        return;
     }
 }
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -386,14 +386,18 @@ pub(crate) fn opclasses_are_not_allowed_with_other_than_normal_indices(index: In
     }
 }
 
-pub(crate) fn composite_type_in_compound_index(index: IndexWalker<'_>, ctx: &mut Context<'_>) {
+pub(crate) fn composite_type_in_compound_unique_index(index: IndexWalker<'_>, ctx: &mut Context<'_>) {
+    if !index.is_unique() {
+        return;
+    }
+
     let composite_type = index
         .fields()
         .find(|f| f.scalar_field_type().as_composite_type().is_some());
 
     if index.fields().len() > 1 && composite_type.is_some() {
         let message = format!(
-            "Prisma does not currently support composite types in compound indices, please remove {:?} from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details",
+            "Prisma does not currently support composite types in compound unique indices, please remove {:?} from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details",
             composite_type.unwrap().name()
         );
         ctx.push_error(DatamodelError::new_attribute_validation_error(

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -90,10 +90,8 @@ impl ScalarField {
         };
 
         match scalar_field_type {
-            // TODO: Fix message -- composite types do work?
-            // ? Is this message not validated anywhere ?
             ScalarFieldType::CompositeType(_) => {
-                unreachable!("Cannot convert a composite type to a type identifier. This error is typically caused by mistakenly using a composite type within a composite index.",)
+                unreachable!("This shouldn't be reached; composite types are not supported in unique indices.",)
             }
             ScalarFieldType::Enum(x) => TypeIdentifier::Enum(x),
             ScalarFieldType::BuiltInScalar(scalar) => scalar.into(),

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -90,6 +90,8 @@ impl ScalarField {
         };
 
         match scalar_field_type {
+            // TODO: Fix message -- composite types do work?
+            // ? Is this message not validated anywhere ?
             ScalarFieldType::CompositeType(_) => {
                 unreachable!("Cannot convert a composite type to a type identifier. This error is typically caused by mistakenly using a composite type within a composite index.",)
             }

--- a/query-engine/prisma-models/src/field/scalar.rs
+++ b/query-engine/prisma-models/src/field/scalar.rs
@@ -91,7 +91,7 @@ impl ScalarField {
 
         match scalar_field_type {
             ScalarFieldType::CompositeType(_) => {
-                unreachable!("This shouldn't be reached; composite types are not supported in unique indices.",)
+                unreachable!("This shouldn't be reached; composite types are not supported in compound unique indices.",)
             }
             ScalarFieldType::Enum(x) => TypeIdentifier::Enum(x),
             ScalarFieldType::BuiltInScalar(scalar) => scalar.into(),

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -74,7 +74,7 @@ fn converting_composite_types_compound() {
 
     assert!(res
         .unwrap_err()
-        .contains(r#"Prisma does not currently support composite types in compound indices. Please remove "attributes" from the index."#));
+        .contains(r#"Prisma does not currently support composite types in compound indices, please remove "attributes" from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details"#));
 }
 
 #[test]

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -84,33 +84,33 @@ fn converting_composite_types_nested() {
         datasource db { 
             provider = "mongodb"
             url      = "mongodb://localhost:27017/hello"
-          }
+        }
           
-          type TheatersLocation {
+        type TheatersLocation {
             address TheatersLocationAddress
             geo     TheatersLocationGeo
-          }
+        }
           
-          type TheatersLocationAddress {
+        type TheatersLocationAddress {
             city    String
             state   String
             street1 String
             street2 String?
             zipcode String
-          }
+        }
           
-          type TheatersLocationGeo {
+        type TheatersLocationGeo {
             coordinates Float[]
             type        String
-          }
+        }
           
-          model theaters {
+        model theaters {
             id        String           @id @default(auto()) @map("_id") @db.ObjectId
             location  TheatersLocation
             theaterId Int
           
             @@index([location.geo], map: "geo index")
-          }
+        }
         "#,
     );
 
@@ -124,33 +124,33 @@ fn converting_composite_types_nested_scalar() {
         datasource db { 
             provider = "mongodb"
             url      = "mongodb://localhost:27017/hello"
-          }
+        }
           
-          type TheatersLocation {
+        type TheatersLocation {
             address TheatersLocationAddress
             geo     TheatersLocationGeo
-          }
+        }
           
-          type TheatersLocationAddress {
+        type TheatersLocationAddress {
             city    String
             state   String
             street1 String
             street2 String?
             zipcode String
-          }
+        }
           
-          type TheatersLocationGeo {
+        type TheatersLocationGeo {
             coordinates Float[]
             type        String
-          }
+        }
           
-          model theaters {
+        model theaters {
             id        String           @id @default(auto()) @map("_id") @db.ObjectId
             location  TheatersLocation
             theaterId Int
           
             @@index([location.geo.type], map: "geo index")
-          }
+        }
         "#,
     );
 

--- a/query-engine/prisma-models/tests/datamodel_converter_tests.rs
+++ b/query-engine/prisma-models/tests/datamodel_converter_tests.rs
@@ -54,9 +54,43 @@ fn converting_composite_types_compound() {
             authorId   String      @db.ObjectId
             attributes Attribute[]
       
+            @@index([authorId, attributes])
+        }
+
+        type Attribute {
+            name  String
+            value String
+            group String
+        }
+      
+        model User {
+            id   String @id @default(auto()) @map("_id") @db.ObjectId
+            Post Post[]
+        }
+    "#,
+    );
+
+    assert!(res.is_ok());
+}
+
+#[test]
+fn converting_composite_types_compound_unique() {
+    let res = psl::parse_schema(
+        r#"
+        datasource db {
+            provider = "mongodb"
+            url      = "mongodb://localhost:27017/hello"
+        }
+
+        model Post {
+            id         String      @id @default(auto()) @map("_id") @db.ObjectId
+            author     User        @relation(fields: [authorId], references: [id])
+            authorId   String      @db.ObjectId
+            attributes Attribute[]
+      
             @@unique([authorId, attributes])
             //       ^^^^^^^^^^^^^^^^^^^^^^
-            // Prisma does not currently support composite types in compound indices
+            // Prisma does not currently support composite types in compound unique indices...
         }
 
         type Attribute {
@@ -74,7 +108,7 @@ fn converting_composite_types_compound() {
 
     assert!(res
         .unwrap_err()
-        .contains(r#"Prisma does not currently support composite types in compound indices, please remove "attributes" from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details"#));
+        .contains(r#"Prisma does not currently support composite types in compound unique indices, please remove "attributes" from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details"#));
 }
 
 #[test]


### PR DESCRIPTION
Updated the composite type validation introduced [here](https://github.com/onichandame/prisma-engines/blob/697d52d15cddee276af3bf41cd81cb4fa31d135a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs#L389-L404) to only throw a validation error when encountering composite types in compound indices.
(Specifically _unique_ indices as I can't reproduce this using either _normal_ or _fulltext_ indices)

fixes https://github.com/prisma/prisma/issues/21441
contributes https://github.com/prisma/prisma/issues/21723

related discovery page: [notion](https://www.notion.so/prismaio/Regression-for-MongoDB-in-5-4-0-3a8040b3a2544ec1b9db72a3a47fb1c7)
