### PR TITLE
driver-adapters: Rename ColumnType::Char to Character

### DIFF
--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -117,9 +117,7 @@ pub enum ColumnType {
     /// - BOOLEAN (BOOLEAN) -> e.g. `1`
     Boolean = 5,
 
-    /// The following PlanetScale type IDs are mapped into Char:
-    /// - CHAR (CHAR) -> e.g. `"c"` (String-encoded)
-    Char = 6,
+    Character = 6,
 
     /// The following PlanetScale type IDs are mapped into Text:
     /// - TEXT (TEXT) -> e.g. `"foo"` (String-encoded)
@@ -346,7 +344,7 @@ fn js_value_to_quaint(
                 "expected a boolean in column '{column_name}', found {mismatch}"
             )),
         },
-        ColumnType::Char => match json_value {
+        ColumnType::Character => match json_value {
             serde_json::Value::String(s) => match s.chars().next() {
                 Some(c) => Ok(QuaintValue::character(c)),
                 None => Ok(QuaintValue::null_character()),
@@ -452,7 +450,7 @@ fn js_value_to_quaint(
         ColumnType::DoubleArray => js_array_to_quaint(ColumnType::Double, json_value, column_name),
         ColumnType::NumericArray => js_array_to_quaint(ColumnType::Numeric, json_value, column_name),
         ColumnType::BooleanArray => js_array_to_quaint(ColumnType::Boolean, json_value, column_name),
-        ColumnType::CharArray => js_array_to_quaint(ColumnType::Char, json_value, column_name),
+        ColumnType::CharArray => js_array_to_quaint(ColumnType::Character, json_value, column_name),
         ColumnType::TextArray => js_array_to_quaint(ColumnType::Text, json_value, column_name),
         ColumnType::DateArray => js_array_to_quaint(ColumnType::Date, json_value, column_name),
         ColumnType::TimeArray => js_array_to_quaint(ColumnType::Time, json_value, column_name),
@@ -790,7 +788,7 @@ mod proxy_test {
 
     #[test]
     fn js_value_char_to_quaint() {
-        let column_type = ColumnType::Char;
+        let column_type = ColumnType::Character;
 
         // null
         test_null(QuaintValue::null_character(), column_type);

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -182,7 +182,7 @@ pub enum ColumnType {
     BooleanArray = 69,
 
     /// Char array (CHAR_ARRAY in PostgreSQL)
-    CharArray = 70,
+    CharacterArray = 70,
 
     /// Text array (TEXT_ARRAY in PostgreSQL)
     TextArray = 71,
@@ -450,7 +450,7 @@ fn js_value_to_quaint(
         ColumnType::DoubleArray => js_array_to_quaint(ColumnType::Double, json_value, column_name),
         ColumnType::NumericArray => js_array_to_quaint(ColumnType::Numeric, json_value, column_name),
         ColumnType::BooleanArray => js_array_to_quaint(ColumnType::Boolean, json_value, column_name),
-        ColumnType::CharArray => js_array_to_quaint(ColumnType::Character, json_value, column_name),
+        ColumnType::CharacterArray => js_array_to_quaint(ColumnType::Character, json_value, column_name),
         ColumnType::TextArray => js_array_to_quaint(ColumnType::Text, json_value, column_name),
         ColumnType::DateArray => js_array_to_quaint(ColumnType::Date, json_value, column_name),
         ColumnType::TimeArray => js_array_to_quaint(ColumnType::Time, json_value, column_name),


### PR DESCRIPTION
To avoid confusion with SQL's CHAR type that is a fixed-length string,
not single character.
