### PR TITLE
feat: add support for nested transaction rollbacks via savepoints in sql

### DIFF
--- a/quaint/src/connector/mssql.rs
+++ b/quaint/src/connector/mssql.rs
@@ -11,6 +11,7 @@ use crate::{
 use async_trait::async_trait;
 use connection_string::JdbcString;
 use futures::lock::Mutex;
+use std::sync::Arc;
 use std::{
     convert::TryFrom,
     fmt,
@@ -22,7 +23,6 @@ use std::{
 use tiberius::*;
 use tokio::net::TcpStream;
 use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
-use std::sync::Arc;
 
 /// The underlying SQL Server driver. Only available with the `expose-drivers` Cargo feature.
 #[cfg(feature = "expose-drivers")]
@@ -116,17 +116,14 @@ impl TransactionCapable for Mssql {
         let rollback_stmt = self.rollback_statement(st_depth).await;
 
         let opts = TransactionOptions::new(
-            isolation, 
+            isolation,
             self.requires_isolation_first(),
             self.transaction_depth.clone(),
             commit_stmt,
             rollback_stmt,
         );
 
-
-        Ok(Box::new(
-            DefaultTransaction::new(self, &begin_statement, opts).await?,
-        ))
+        Ok(Box::new(DefaultTransaction::new(self, &begin_statement, opts).await?))
     }
 }
 
@@ -470,12 +467,12 @@ impl Queryable for Mssql {
             "BEGIN TRAN".to_string()
         };
 
-        return ret
+        return ret;
     }
 
     /// Statement to commit a transaction
     async fn commit_statement(&self, depth: i32) -> String {
-        // MSSQL doesn't have a "RELEASE SAVEPOINT" equivalent, so in a nested 
+        // MSSQL doesn't have a "RELEASE SAVEPOINT" equivalent, so in a nested
         // transaction we just continue onwards
         let ret = if depth > 1 {
             " ".to_string()
@@ -483,7 +480,7 @@ impl Queryable for Mssql {
             "COMMIT".to_string()
         };
 
-        return ret
+        return ret;
     }
 
     /// Statement to rollback a transaction
@@ -495,7 +492,7 @@ impl Queryable for Mssql {
             "ROLLBACK".to_string()
         };
 
-        return ret
+        return ret;
     }
 
     fn requires_isolation_first(&self) -> bool {

--- a/quaint/src/connector/mssql.rs
+++ b/quaint/src/connector/mssql.rs
@@ -109,7 +109,7 @@ impl TransactionCapable for Mssql {
 
         let mut transaction_depth = self.transaction_depth.lock().await;
         *transaction_depth += 1;
-        let st_depth = *transaction_depth + 0;
+        let st_depth = *transaction_depth;
 
         let begin_statement = self.begin_statement(st_depth).await;
         let commit_stmt = self.commit_statement(st_depth).await;

--- a/quaint/src/connector/mysql.rs
+++ b/quaint/src/connector/mysql.rs
@@ -23,6 +23,7 @@ use std::{
 };
 use tokio::sync::Mutex;
 use url::{Host, Url};
+use std::sync::Arc;
 
 pub use error::MysqlError;
 
@@ -41,6 +42,7 @@ pub struct Mysql {
     socket_timeout: Option<Duration>,
     is_healthy: AtomicBool,
     statement_cache: Mutex<LruCache<String, my::Statement>>,
+    transaction_depth: Arc<futures::lock::Mutex<i32>>,
 }
 
 /// Wraps a connection url and exposes the parsing logic used by quaint, including default values.
@@ -376,6 +378,7 @@ impl Mysql {
             statement_cache: Mutex::new(url.cache()),
             url,
             is_healthy: AtomicBool::new(true),
+            transaction_depth: Arc::new(futures::lock::Mutex::new(0)),
         })
     }
 
@@ -582,6 +585,42 @@ impl Queryable for Mysql {
 
     fn requires_isolation_first(&self) -> bool {
         true
+    }
+
+    /// Statement to begin a transaction
+    async fn begin_statement(&self, depth: i32) -> String {
+        let savepoint_stmt = format!("SAVEPOINT savepoint{}", depth);
+        let ret = if depth > 1 {
+            savepoint_stmt
+        } else {
+            "BEGIN".to_string()
+        };
+
+        return ret
+    }
+
+    /// Statement to commit a transaction
+    async fn commit_statement(&self, depth: i32) -> String {
+        let savepoint_stmt = format!("RELEASE SAVEPOINT savepoint{}", depth);
+        let ret = if depth > 1 {
+            savepoint_stmt
+        } else {
+            "COMMIT".to_string()
+        };
+
+        return ret
+    }
+
+    /// Statement to rollback a transaction
+    async fn rollback_statement(&self, depth: i32) -> String {
+        let savepoint_stmt = format!("ROLLBACK TO savepoint{}", depth);
+        let ret = if depth > 1 {
+            savepoint_stmt
+        } else {
+            "ROLLBACK".to_string()
+        };
+
+        return ret
     }
 }
 

--- a/quaint/src/connector/mysql.rs
+++ b/quaint/src/connector/mysql.rs
@@ -14,6 +14,7 @@ use mysql_async::{
     prelude::{Query as _, Queryable as _},
 };
 use percent_encoding::percent_decode;
+use std::sync::Arc;
 use std::{
     borrow::Cow,
     future::Future,
@@ -23,7 +24,6 @@ use std::{
 };
 use tokio::sync::Mutex;
 use url::{Host, Url};
-use std::sync::Arc;
 
 pub use error::MysqlError;
 
@@ -590,13 +590,9 @@ impl Queryable for Mysql {
     /// Statement to begin a transaction
     async fn begin_statement(&self, depth: i32) -> String {
         let savepoint_stmt = format!("SAVEPOINT savepoint{}", depth);
-        let ret = if depth > 1 {
-            savepoint_stmt
-        } else {
-            "BEGIN".to_string()
-        };
+        let ret = if depth > 1 { savepoint_stmt } else { "BEGIN".to_string() };
 
-        return ret
+        return ret;
     }
 
     /// Statement to commit a transaction
@@ -608,7 +604,7 @@ impl Queryable for Mysql {
             "COMMIT".to_string()
         };
 
-        return ret
+        return ret;
     }
 
     /// Statement to rollback a transaction
@@ -620,7 +616,7 @@ impl Queryable for Mysql {
             "ROLLBACK".to_string()
         };
 
-        return ret
+        return ret;
     }
 }
 

--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -13,6 +13,7 @@ use lru_cache::LruCache;
 use native_tls::{Certificate, Identity, TlsConnector};
 use percent_encoding::percent_decode;
 use postgres_native_tls::MakeTlsConnector;
+use std::sync::Arc;
 use std::{
     borrow::{Borrow, Cow},
     fmt::{Debug, Display},
@@ -26,7 +27,6 @@ use tokio_postgres::{
     Client, Config, Statement,
 };
 use url::{Host, Url};
-use std::sync::Arc;
 
 pub use error::PostgresError;
 
@@ -939,13 +939,9 @@ impl Queryable for PostgreSql {
     /// Statement to begin a transaction
     async fn begin_statement(&self, depth: i32) -> String {
         let savepoint_stmt = format!("SAVEPOINT savepoint{}", depth);
-        let ret = if depth > 1 {
-            savepoint_stmt
-        } else {
-            "BEGIN".to_string()
-        };
+        let ret = if depth > 1 { savepoint_stmt } else { "BEGIN".to_string() };
 
-        return ret
+        return ret;
     }
 
     /// Statement to commit a transaction
@@ -957,7 +953,7 @@ impl Queryable for PostgreSql {
             "COMMIT".to_string()
         };
 
-        return ret
+        return ret;
     }
 
     /// Statement to rollback a transaction
@@ -969,7 +965,7 @@ impl Queryable for PostgreSql {
             "ROLLBACK".to_string()
         };
 
-        return ret
+        return ret;
     }
 }
 

--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -26,6 +26,7 @@ use tokio_postgres::{
     Client, Config, Statement,
 };
 use url::{Host, Url};
+use std::sync::Arc;
 
 pub use error::PostgresError;
 
@@ -63,6 +64,7 @@ pub struct PostgreSql {
     socket_timeout: Option<Duration>,
     statement_cache: Mutex<LruCache<String, Statement>>,
     is_healthy: AtomicBool,
+    transaction_depth: Arc<Mutex<i32>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -652,6 +654,7 @@ impl PostgreSql {
             pg_bouncer: url.query_params.pg_bouncer,
             statement_cache: Mutex::new(url.cache()),
             is_healthy: AtomicBool::new(true),
+            transaction_depth: Arc::new(Mutex::new(0)),
         })
     }
 
@@ -931,6 +934,42 @@ impl Queryable for PostgreSql {
 
     fn requires_isolation_first(&self) -> bool {
         false
+    }
+
+    /// Statement to begin a transaction
+    async fn begin_statement(&self, depth: i32) -> String {
+        let savepoint_stmt = format!("SAVEPOINT savepoint{}", depth);
+        let ret = if depth > 1 {
+            savepoint_stmt
+        } else {
+            "BEGIN".to_string()
+        };
+
+        return ret
+    }
+
+    /// Statement to commit a transaction
+    async fn commit_statement(&self, depth: i32) -> String {
+        let savepoint_stmt = format!("RELEASE SAVEPOINT savepoint{}", depth);
+        let ret = if depth > 1 {
+            savepoint_stmt
+        } else {
+            "COMMIT".to_string()
+        };
+
+        return ret
+    }
+
+    /// Statement to rollback a transaction
+    async fn rollback_statement(&self, depth: i32) -> String {
+        let savepoint_stmt = format!("ROLLBACK TO SAVEPOINT savepoint{}", depth);
+        let ret = if depth > 1 {
+            savepoint_stmt
+        } else {
+            "ROLLBACK".to_string()
+        };
+
+        return ret
     }
 }
 

--- a/quaint/src/connector/queryable.rs
+++ b/quaint/src/connector/queryable.rs
@@ -137,10 +137,8 @@ macro_rules! impl_default_TransactionCapable {
                 let commit_stmt = self.commit_statement(st_depth).await;
                 let rollback_stmt = self.rollback_statement(st_depth).await;
 
-
-
                 let opts = crate::connector::TransactionOptions::new(
-                    isolation, 
+                    isolation,
                     self.requires_isolation_first(),
                     depth,
                     commit_stmt,

--- a/quaint/src/connector/sqlite.rs
+++ b/quaint/src/connector/sqlite.rs
@@ -13,9 +13,9 @@ use crate::{
     visitor::{self, Visitor},
 };
 use async_trait::async_trait;
+use std::sync::Arc;
 use std::{convert::TryFrom, path::Path, time::Duration};
 use tokio::sync::Mutex;
-use std::sync::Arc;
 
 pub(crate) const DEFAULT_SQLITE_SCHEMA_NAME: &str = "main";
 
@@ -143,7 +143,7 @@ impl TryFrom<&str> for Sqlite {
 
         let client = Mutex::new(conn);
 
-        Ok(Sqlite { 
+        Ok(Sqlite {
             client,
             transaction_depth: Arc::new(futures::lock::Mutex::new(0)),
         })
@@ -262,13 +262,9 @@ impl Queryable for Sqlite {
     /// Statement to begin a transaction
     async fn begin_statement(&self, depth: i32) -> String {
         let savepoint_stmt = format!("SAVEPOINT savepoint{}", depth);
-        let ret = if depth > 1 {
-            savepoint_stmt
-        } else {
-            "BEGIN".to_string()
-        };
+        let ret = if depth > 1 { savepoint_stmt } else { "BEGIN".to_string() };
 
-        return ret
+        return ret;
     }
 
     /// Statement to commit a transaction
@@ -280,7 +276,7 @@ impl Queryable for Sqlite {
             "COMMIT".to_string()
         };
 
-        return ret
+        return ret;
     }
 
     /// Statement to rollback a transaction
@@ -292,7 +288,7 @@ impl Queryable for Sqlite {
             "ROLLBACK".to_string()
         };
 
-        return ret
+        return ret;
     }
 }
 

--- a/quaint/src/connector/transaction.rs
+++ b/quaint/src/connector/transaction.rs
@@ -4,10 +4,10 @@ use crate::{
     error::{Error, ErrorKind},
 };
 use async_trait::async_trait;
-use metrics::{decrement_gauge, increment_gauge};
-use std::{fmt, str::FromStr};
 use futures::lock::Mutex;
+use metrics::{decrement_gauge, increment_gauge};
 use std::sync::Arc;
+use std::{fmt, str::FromStr};
 
 extern crate metrics as metrics;
 
@@ -58,8 +58,8 @@ impl<'a> DefaultTransaction<'a> {
         begin_stmt: &str,
         tx_opts: TransactionOptions,
     ) -> crate::Result<DefaultTransaction<'a>> {
-        let this = Self { 
-            inner, 
+        let this = Self {
+            inner,
             depth: tx_opts.depth,
             commit_stmt: tx_opts.commit_stmt,
             rollback_stmt: tx_opts.rollback_stmt,
@@ -222,7 +222,7 @@ impl FromStr for IsolationLevel {
 }
 impl TransactionOptions {
     pub fn new(
-        isolation_level: Option<IsolationLevel>, 
+        isolation_level: Option<IsolationLevel>,
         isolation_first: bool,
         depth: Arc<Mutex<i32>>,
         commit_stmt: String,

--- a/quaint/src/pooled.rs
+++ b/quaint/src/pooled.rs
@@ -500,7 +500,10 @@ impl Quaint {
             }
         };
 
-        Ok(PooledConnection { inner })
+        Ok(PooledConnection { 
+            inner, 
+            transaction_depth: Arc::new(futures::lock::Mutex::new(0))
+        })
     }
 
     /// Info about the connection and underlying database.

--- a/quaint/src/pooled.rs
+++ b/quaint/src/pooled.rs
@@ -500,9 +500,9 @@ impl Quaint {
             }
         };
 
-        Ok(PooledConnection { 
-            inner, 
-            transaction_depth: Arc::new(futures::lock::Mutex::new(0))
+        Ok(PooledConnection {
+            inner,
+            transaction_depth: Arc::new(futures::lock::Mutex::new(0)),
         })
     }
 

--- a/quaint/src/pooled/manager.rs
+++ b/quaint/src/pooled/manager.rs
@@ -11,11 +11,14 @@ use crate::{
 };
 use async_trait::async_trait;
 use mobc::{Connection as MobcPooled, Manager};
+use futures::lock::Mutex;
+use std::sync::Arc;
 
 /// A connection from the pool. Implements
 /// [Queryable](connector/trait.Queryable.html).
 pub struct PooledConnection {
     pub(crate) inner: MobcPooled<QuaintManager>,
+    pub transaction_depth: Arc<Mutex<i32>>,
 }
 
 impl_default_TransactionCapable!(PooledConnection);
@@ -62,8 +65,16 @@ impl Queryable for PooledConnection {
         self.inner.server_reset_query(tx).await
     }
 
-    fn begin_statement(&self) -> &'static str {
-        self.inner.begin_statement()
+    async fn begin_statement(&self, depth: i32) -> String {
+        self.inner.begin_statement(depth).await
+    }
+
+    async fn commit_statement(&self, depth: i32) -> String {
+        self.inner.commit_statement(depth).await
+    }
+
+    async fn rollback_statement(&self, depth: i32) -> String {
+        self.inner.rollback_statement(depth).await
     }
 
     async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> crate::Result<()> {

--- a/quaint/src/pooled/manager.rs
+++ b/quaint/src/pooled/manager.rs
@@ -10,8 +10,8 @@ use crate::{
     error::Error,
 };
 use async_trait::async_trait;
-use mobc::{Connection as MobcPooled, Manager};
 use futures::lock::Mutex;
+use mobc::{Connection as MobcPooled, Manager};
 use std::sync::Arc;
 
 /// A connection from the pool. Implements

--- a/quaint/src/single.rs
+++ b/quaint/src/single.rs
@@ -7,8 +7,8 @@ use crate::{
     connector::{self, impl_default_TransactionCapable, ConnectionInfo, IsolationLevel, Queryable, TransactionCapable},
 };
 use async_trait::async_trait;
-use std::{fmt, sync::Arc};
 use futures::lock::Mutex;
+use std::{fmt, sync::Arc};
 
 #[cfg(feature = "sqlite")]
 use std::convert::TryFrom;
@@ -165,7 +165,11 @@ impl Quaint {
         let connection_info = Arc::new(ConnectionInfo::from_url(url_str)?);
         Self::log_start(&connection_info);
 
-        Ok(Self { inner, connection_info, transaction_depth: Arc::new(Mutex::new(0)) })
+        Ok(Self {
+            inner,
+            connection_info,
+            transaction_depth: Arc::new(Mutex::new(0)),
+        })
     }
 
     #[cfg(feature = "sqlite")]

--- a/quaint/src/tests/query.rs
+++ b/quaint/src/tests/query.rs
@@ -64,7 +64,7 @@ async fn select_star_from(api: &mut dyn TestApi) -> crate::Result<()> {
 async fn transactions(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_temp_table("value int").await?;
 
-    let tx = api.conn().start_transaction(None).await?;
+    let mut tx = api.conn().start_transaction(None).await?;
     let insert = Insert::single_into(&table).value("value", 10);
 
     let rows_affected = tx.execute(insert.into()).await?;
@@ -74,6 +74,20 @@ async fn transactions(api: &mut dyn TestApi) -> crate::Result<()> {
     let res = api.conn().select(select).await?.into_single()?;
 
     assert_eq!(Value::int32(10), res[0]);
+
+    // Check that nested transactions are also rolled back, even at multiple levels deep
+    let mut tx_inner = api.conn().start_transaction(None).await?;
+    let inner_insert1 = Insert::single_into(&table).value("value", 20);
+    let inner_rows_affected1 = tx.execute(inner_insert1.into()).await?;
+    assert_eq!(1, inner_rows_affected1);
+
+    let mut tx_inner2 = api.conn().start_transaction(None).await?;
+    let inner_insert2 = Insert::single_into(&table).value("value", 20);
+    let inner_rows_affected2 = tx.execute(inner_insert2.into()).await?;
+    assert_eq!(1, inner_rows_affected2);
+    tx_inner2.commit().await?;
+
+    tx_inner.commit().await?;
 
     tx.rollback().await?;
 

--- a/quaint/src/tests/query/error.rs
+++ b/quaint/src/tests/query/error.rs
@@ -456,7 +456,7 @@ async fn concurrent_transaction_conflict(api: &mut dyn TestApi) -> crate::Result
     let conn1 = api.create_additional_connection().await?;
     let conn2 = api.create_additional_connection().await?;
 
-    let tx1 = conn1.start_transaction(Some(IsolationLevel::Serializable)).await?;
+    let mut tx1 = conn1.start_transaction(Some(IsolationLevel::Serializable)).await?;
     let tx2 = conn2.start_transaction(Some(IsolationLevel::Serializable)).await?;
 
     tx1.query(Select::from_table(&table).into()).await?;

--- a/query-engine/core/src/executor/mod.rs
+++ b/query-engine/core/src/executor/mod.rs
@@ -72,7 +72,6 @@ pub struct TransactionOptions {
 
     /// An optional pre-defined transaction id. Some value might be provided in case we want to generate
     /// a new id at the beginning of the transaction
-    #[serde(skip)]
     pub new_tx_id: Option<TxId>,
 }
 

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -1,6 +1,6 @@
 use crate::CoreError;
 use connector::Transaction;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 use tokio::time::{Duration, Instant};
 
@@ -38,7 +38,7 @@ pub(crate) use messages::*;
 /// the TransactionActorManager can reply with a helpful error message which explains that no operation can be performed on a closed transaction
 /// rather than an error message stating that the transaction does not exist.
 
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize, Serialize)]
 pub struct TxId(String);
 
 const MINIMUM_TX_ID_LENGTH: usize = 24;

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -3,6 +3,7 @@ use crate::{
     proxy::{CommonProxy, DriverProxy, Query},
 };
 use async_trait::async_trait;
+use futures::lock::Mutex;
 use napi::JsObject;
 use psl::datamodel_connector::Flavour;
 use quaint::{
@@ -11,6 +12,7 @@ use quaint::{
     prelude::{Query as QuaintQuery, Queryable as QuaintQueryable, ResultSet, TransactionCapable},
     visitor::{self, Visitor},
 };
+use std::sync::Arc;
 use tracing::{info_span, Instrument};
 
 /// A JsQueryable adapts a Proxy to implement quaint's Queryable interface. It has the
@@ -185,6 +187,7 @@ impl JsBaseQueryable {
 pub struct JsQueryable {
     inner: JsBaseQueryable,
     driver_proxy: DriverProxy,
+    pub transaction_depth: Arc<Mutex<i32>>,
 }
 
 impl std::fmt::Display for JsQueryable {
@@ -262,14 +265,19 @@ impl TransactionCapable for JsQueryable {
             }
         }
 
-        let begin_stmt = tx.begin_statement();
+        let mut depth_guard = self.transaction_depth.lock().await;
+        *depth_guard += 1;
+
+        let st_depth = *depth_guard;
+
+        let begin_stmt = tx.begin_statement(st_depth).await;
 
         let tx_opts = tx.options();
         if tx_opts.use_phantom_query {
-            let begin_stmt = JsBaseQueryable::phantom_query_message(begin_stmt);
+            let begin_stmt = JsBaseQueryable::phantom_query_message(&begin_stmt);
             tx.raw_phantom_cmd(begin_stmt.as_str()).await?;
         } else {
-            tx.raw_cmd(begin_stmt).await?;
+            tx.raw_cmd(&begin_stmt).await?;
         }
 
         if !isolation_first {
@@ -291,5 +299,6 @@ pub fn from_napi(driver: JsObject) -> JsQueryable {
     JsQueryable {
         inner: JsBaseQueryable::new(common),
         driver_proxy,
+        transaction_depth: Arc::new(futures::lock::Mutex::new(0)),
     }
 }

--- a/query-engine/driver-adapters/src/transaction.rs
+++ b/query-engine/driver-adapters/src/transaction.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures::lock::Mutex;
 use metrics::decrement_gauge;
 use napi::{bindgen_prelude::FromNapiValue, JsObject};
 use quaint::{
@@ -6,6 +7,7 @@ use quaint::{
     prelude::{Query as QuaintQuery, Queryable, ResultSet},
     Value,
 };
+use std::sync::Arc;
 
 use crate::{
     proxy::{CommonProxy, TransactionOptions, TransactionProxy},
@@ -18,11 +20,20 @@ use crate::{
 pub(crate) struct JsTransaction {
     tx_proxy: TransactionProxy,
     inner: JsBaseQueryable,
+    pub depth: Arc<Mutex<i32>>,
+    pub commit_stmt: String,
+    pub rollback_stmt: String,
 }
 
 impl JsTransaction {
     pub(crate) fn new(inner: JsBaseQueryable, tx_proxy: TransactionProxy) -> Self {
-        Self { inner, tx_proxy }
+        Self {
+            inner,
+            tx_proxy,
+            commit_stmt: "COMMIT".to_string(),
+            rollback_stmt: "ROLLBACK".to_string(),
+            depth: Arc::new(futures::lock::Mutex::new(0)),
+        }
     }
 
     pub fn options(&self) -> &TransactionOptions {
@@ -37,11 +48,12 @@ impl JsTransaction {
 
 #[async_trait]
 impl QuaintTransaction for JsTransaction {
-    async fn commit(&self) -> quaint::Result<()> {
+    async fn commit(&mut self) -> quaint::Result<()> {
         // increment of this gauge is done in DriverProxy::startTransaction
         decrement_gauge!("prisma_client_queries_active", 1.0);
 
-        let commit_stmt = "COMMIT";
+        let mut depth_guard = self.depth.lock().await;
+        let commit_stmt = &self.commit_stmt;
 
         if self.options().use_phantom_query {
             let commit_stmt = JsBaseQueryable::phantom_query_message(commit_stmt);
@@ -50,14 +62,18 @@ impl QuaintTransaction for JsTransaction {
             self.inner.raw_cmd(commit_stmt).await?;
         }
 
+        // Modify the depth value through the MutexGuard
+        *depth_guard -= 1;
+
         self.tx_proxy.commit().await
     }
 
-    async fn rollback(&self) -> quaint::Result<()> {
+    async fn rollback(&mut self) -> quaint::Result<()> {
         // increment of this gauge is done in DriverProxy::startTransaction
         decrement_gauge!("prisma_client_queries_active", 1.0);
 
-        let rollback_stmt = "ROLLBACK";
+        let mut depth_guard = self.depth.lock().await;
+        let rollback_stmt = &self.rollback_stmt;
 
         if self.options().use_phantom_query {
             let rollback_stmt = JsBaseQueryable::phantom_query_message(rollback_stmt);
@@ -65,6 +81,9 @@ impl QuaintTransaction for JsTransaction {
         } else {
             self.inner.raw_cmd(rollback_stmt).await?;
         }
+
+        // Modify the depth value through the MutexGuard
+        *depth_guard -= 1;
 
         self.tx_proxy.rollback().await
     }


### PR DESCRIPTION
Same as https://github.com/prisma/prisma-engines/pull/4375 but in our repo to trigger Buildkite