### PR TITLE
driver-adapters: convert Decimals to Strings when calling JS

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mysql.rs
@@ -198,6 +198,35 @@ mod mysql {
         Ok(())
     }
 
+    fn schema_decimal_vitess() -> String {
+        let schema = indoc! {
+            r#"model Model {
+            #id(id, String, @id, @default(cuid()))
+            decLarge Decimal @test.Decimal(20, 10)
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(only(Vitess), schema(schema_decimal_vitess))]
+    async fn native_decimal_vitess_precision(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation {
+            createOneModel(
+              data: {
+                decLarge: "131603421.38724228"
+              }
+            ) {
+              decLarge
+            }
+          }"#),
+          @r###"{"data":{"createOneModel":{"decLarge":"131603421.38724228"}}}"###
+        );
+
+        Ok(())
+    }
+
     fn schema_string() -> String {
         let schema = indoc! {
             r#"model Model {

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -75,11 +75,8 @@ pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec
                 Some(bytes) => JSArg::Buffer(bytes.to_vec()),
                 None => JsonValue::Null.into(),
             },
-            quaint_value @ quaint::ValueType::Numeric(bd) => match bd {
-                Some(bd) => match bd.to_string().parse::<f64>() {
-                    Ok(double) => JSArg::from(JsonValue::from(double)),
-                    Err(_) => JSArg::from(JsonValue::from(quaint_value.clone())),
-                },
+            quaint::ValueType::Numeric(bd) => match bd {
+                Some(bd) => JSArg::RawString(bd.to_string()),
                 None => JsonValue::Null.into(),
             },
             quaint::ValueType::Array(Some(items)) => JSArg::Array(values_to_js_args(items)?),

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -1,4 +1,5 @@
 pub(crate) mod postgres;
+pub(crate) mod sqlite;
 
 use napi::bindgen_prelude::{FromNapiValue, ToNapiValue};
 use napi::NapiValue;
@@ -59,33 +60,31 @@ impl ToNapiValue for JSArg {
     }
 }
 
+pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
+    let res = match &value.typed {
+        quaint::ValueType::Json(s) => match s {
+            Some(ref s) => {
+                let json_str = serde_json::to_string(s)?;
+                JSArg::RawString(json_str)
+            }
+            None => JsonValue::Null.into(),
+        },
+        quaint::ValueType::Bytes(bytes) => match bytes {
+            Some(bytes) => JSArg::Buffer(bytes.to_vec()),
+            None => JsonValue::Null.into(),
+        },
+        quaint::ValueType::Numeric(bd) => match bd {
+            // converting decimal to string to preserve the precision
+            Some(bd) => JSArg::RawString(bd.to_string()),
+            None => JsonValue::Null.into(),
+        },
+        quaint::ValueType::Array(Some(ref items)) => JSArg::Array(values_to_js_args(items)?),
+        quaint_value => JSArg::from(JsonValue::from(quaint_value.clone())),
+    };
+
+    Ok(res)
+}
+
 pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec<JSArg>> {
-    let mut args = Vec::with_capacity(values.len());
-
-    for qv in values {
-        let res = match &qv.typed {
-            quaint::ValueType::Json(s) => match s {
-                Some(ref s) => {
-                    let json_str = serde_json::to_string(s)?;
-                    JSArg::RawString(json_str)
-                }
-                None => JsonValue::Null.into(),
-            },
-            quaint::ValueType::Bytes(bytes) => match bytes {
-                Some(bytes) => JSArg::Buffer(bytes.to_vec()),
-                None => JsonValue::Null.into(),
-            },
-            quaint::ValueType::Numeric(bd) => match bd {
-                // converting decimal to string to preserve the precision
-                Some(bd) => JSArg::RawString(bd.to_string()),
-                None => JsonValue::Null.into(),
-            },
-            quaint::ValueType::Array(Some(items)) => JSArg::Array(values_to_js_args(items)?),
-            quaint_value => JSArg::from(JsonValue::from(quaint_value.clone())),
-        };
-
-        args.push(res);
-    }
-
-    Ok(args)
+    values.iter().map(value_to_js_arg).collect()
 }

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -76,6 +76,7 @@ pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec
                 None => JsonValue::Null.into(),
             },
             quaint::ValueType::Numeric(bd) => match bd {
+                // converting decimal to string to preserve the precision
                 Some(bd) => JSArg::RawString(bd.to_string()),
                 None => JsonValue::Null.into(),
             },

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -5,48 +5,31 @@ use serde_json::value::Value as JsonValue;
 
 static TIME_FMT: Lazy<StrftimeItems> = Lazy::new(|| StrftimeItems::new("%H:%M:%S%.f"));
 
+pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
+    let res = match (&value.typed, value.native_column_type_name()) {
+        (quaint::ValueType::DateTime(value), Some("DATE")) => match value {
+            Some(value) => JSArg::RawString(value.date_naive().to_string()),
+            None => JsonValue::Null.into(),
+        },
+        (quaint::ValueType::DateTime(value), Some("TIME")) => match value {
+            Some(value) => JSArg::RawString(value.time().to_string()),
+            None => JsonValue::Null.into(),
+        },
+        (quaint::ValueType::DateTime(value), Some("TIMETZ")) => match value {
+            Some(value) => JSArg::RawString(value.time().format_with_items(TIME_FMT.clone()).to_string()),
+            None => JsonValue::Null.into(),
+        },
+        (quaint::ValueType::DateTime(value), _) => match value {
+            Some(value) => JSArg::RawString(value.naive_utc().to_string()),
+            None => JsonValue::Null.into(),
+        },
+        (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(values_to_js_args(items)?),
+        _ => super::value_to_js_arg(value)?,
+    };
+
+    Ok(res)
+}
+
 pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec<JSArg>> {
-    let mut args = Vec::with_capacity(values.len());
-
-    for qv in values {
-        let res = match (&qv.typed, qv.native_column_type_name()) {
-            (quaint::ValueType::DateTime(value), Some("DATE")) => match value {
-                Some(value) => JSArg::RawString(value.date_naive().to_string()),
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::DateTime(value), Some("TIME")) => match value {
-                Some(value) => JSArg::RawString(value.time().to_string()),
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::DateTime(value), Some("TIMETZ")) => match value {
-                Some(value) => JSArg::RawString(value.time().format_with_items(TIME_FMT.clone()).to_string()),
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::DateTime(value), _) => match value {
-                Some(value) => JSArg::RawString(value.naive_utc().to_string()),
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::Json(s), _) => match s {
-                Some(ref s) => {
-                    let json_str = serde_json::to_string(s)?;
-                    JSArg::RawString(json_str)
-                }
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::Bytes(bytes), _) => match bytes {
-                Some(bytes) => JSArg::Buffer(bytes.to_vec()),
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::Numeric(bd), _) => match bd {
-                Some(bd) => JSArg::RawString(bd.to_string()),
-                None => JsonValue::Null.into(),
-            },
-            (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(values_to_js_args(items)?),
-            (quaint_value, _) => JSArg::from(JsonValue::from(quaint_value.clone())),
-        };
-
-        args.push(res);
-    }
-
-    Ok(args)
+    values.iter().map(value_to_js_arg).collect()
 }

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -37,6 +37,10 @@ pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec
                 Some(bytes) => JSArg::Buffer(bytes.to_vec()),
                 None => JsonValue::Null.into(),
             },
+            (quaint::ValueType::Numeric(bd), _) => match bd {
+                Some(bd) => JSArg::RawString(bd.to_string()),
+                None => JsonValue::Null.into(),
+            },
             (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(values_to_js_args(items)?),
             (quaint_value, _) => JSArg::from(JsonValue::from(quaint_value.clone())),
         };

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -37,10 +37,6 @@ pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec
                 Some(bytes) => JSArg::Buffer(bytes.to_vec()),
                 None => JsonValue::Null.into(),
             },
-            (quaint::ValueType::Numeric(bd), _) => match bd {
-                Some(bd) => JSArg::RawString(bd.to_string()),
-                None => JsonValue::Null.into(),
-            },
             (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(values_to_js_args(items)?),
             (quaint_value, _) => JSArg::from(JsonValue::from(quaint_value.clone())),
         };

--- a/query-engine/driver-adapters/src/conversion/sqlite.rs
+++ b/query-engine/driver-adapters/src/conversion/sqlite.rs
@@ -1,0 +1,23 @@
+use crate::conversion::JSArg;
+use serde_json::value::Value as JsonValue;
+
+pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
+    let res = match &value.typed {
+        quaint::ValueType::Numeric(bd) => match bd {
+            // converting decimal to string to preserve the precision
+            Some(bd) => match bd.to_string().parse::<f64>() {
+                Ok(double) => JSArg::from(JsonValue::from(double)),
+                Err(_) => JSArg::from(JsonValue::from(value.clone())),
+            },
+            None => JsonValue::Null.into(),
+        },
+        quaint::ValueType::Array(Some(ref items)) => JSArg::Array(values_to_js_args(items)?),
+        _ => super::value_to_js_arg(value)?,
+    };
+
+    Ok(res)
+}
+
+pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec<JSArg>> {
+    values.iter().map(value_to_js_arg).collect()
+}

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -51,6 +51,7 @@ impl JsBaseQueryable {
         let sql: String = sql.to_string();
         let args = match self.flavour {
             Flavour::Postgres => conversion::postgres::values_to_js_args(values),
+            Flavour::Sqlite => conversion::sqlite::values_to_js_args(values),
             _ => conversion::values_to_js_args(values),
         }?;
         Ok(Query { sql, args })


### PR DESCRIPTION
When forwarding the input to the driver adapter, we used to convert
decimal values to f64. On a large numbers, that lost some precision.
Changing this to convert them to strings instead.

Fix prisma/team-orm#497

TODO: after this gets to the client, unskip `decimal/presion` test
there.
