### PR TITLE
Handle MySQL zero date as NULL if opted in

### DIFF
--- a/quaint/src/connector/queryable.rs
+++ b/quaint/src/connector/queryable.rs
@@ -7,7 +7,7 @@ pub trait GetRow {
 }
 
 pub trait TakeRow {
-    fn take_result_row(&mut self) -> crate::Result<Vec<Value<'static>>>;
+    fn take_result_row(&mut self, mysql_zero_date_as_null: bool) -> crate::Result<Vec<Value<'static>>>;
 }
 
 pub trait ToColumnNames {


### PR DESCRIPTION
This pull request introduces a significant enhancement for users working with legacy MySQL databases that contain zero dates, which are often a blocker when adopting Prisma. By incorporating the ability to opt-in for treating MySQL zero dates as `null`, we aim to provide a more flexible and backward-compatible solution for our users.

### Usage Example

To enable this feature, users can simply append the mysql_zero_date_as_null=true parameter to their MySQL connection string as shown below:

```
mysql://username:password@localhost:3306/mydb?mysql_zero_date_as_null=true
```

### Impact

This change is fully backward compatible, as it requires explicit opt-in via the connection string. Users who do not require this functionality will experience no change in behavior, ensuring a seamless experience for the existing user base.