### PR TITLE
ci(renovate): Group Driver Adapters + Pin dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,7 @@
     "before 5am every weekday",
     "every weekend"
   ],
+  "rangeStrategy": "pin",
   "separateMinorPatch": true,
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base"
-  ],s
+  ],
   "cargo": {
     "enabled": false
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base"
-  ],
+  ],s
   "cargo": {
     "enabled": false
   },
@@ -24,6 +24,12 @@
       "groupName": "Weekly vitess docker image version update",
       "packageNames": ["vitess/vttestserver"],
       "schedule": ["before 7am on Wednesday"]
+    },
+    {
+      "groupName": ["Prisma Driver Adapters"],
+      "matchPackageNames": ["@prisma/driver-adapter-utils"],
+      "matchPackagePrefixes": ["@prisma/adapter"],
+      "schedule": ["at any time"]
     }
   ]
 }


### PR DESCRIPTION
To avoid:
https://github.com/prisma/prisma-engines/pull/4397
https://github.com/prisma/prisma-engines/pull/4396
https://github.com/prisma/prisma-engines/pull/4349
https://github.com/prisma/prisma-engines/pull/4348

Same code as was in use over at https://github.com/prisma/prisma/blob/main/.github/renovate.json

Also, make renovate pin the dependencies in `package.json`.