### PR TITLE
fix(driver-adapters): Ensure transaction metrics do not get negative

### DIFF
--- a/query-engine/driver-adapters/src/transaction.rs
+++ b/query-engine/driver-adapters/src/transaction.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use metrics::{decrement_gauge, increment_gauge};
+use metrics::decrement_gauge;
 use napi::{bindgen_prelude::FromNapiValue, JsObject};
 use quaint::{
     connector::{IsolationLevel, Transaction as QuaintTransaction},

--- a/query-engine/driver-adapters/src/transaction.rs
+++ b/query-engine/driver-adapters/src/transaction.rs
@@ -22,8 +22,6 @@ pub(crate) struct JsTransaction {
 
 impl JsTransaction {
     pub(crate) fn new(inner: JsBaseQueryable, tx_proxy: TransactionProxy) -> Self {
-        increment_gauge!("prisma_client_queries_active", 1.0);
-
         Self { inner, tx_proxy }
     }
 
@@ -40,6 +38,7 @@ impl JsTransaction {
 #[async_trait]
 impl QuaintTransaction for JsTransaction {
     async fn commit(&self) -> quaint::Result<()> {
+        // increment of this gauge is done in DriverProxy::startTransaction
         decrement_gauge!("prisma_client_queries_active", 1.0);
 
         let commit_stmt = "COMMIT";
@@ -55,6 +54,7 @@ impl QuaintTransaction for JsTransaction {
     }
 
     async fn rollback(&self) -> quaint::Result<()> {
+        // increment of this gauge is done in DriverProxy::startTransaction
         decrement_gauge!("prisma_client_queries_active", 1.0);
 
         let rollback_stmt = "ROLLBACK";


### PR DESCRIPTION
Current dispatcher for a thread gets lost somewhere within napi-rs/napi
`ThreadsafeFunction` nad thearfore, gauge increment in `Transaction::new` is not registered. That in turn means that when the same gauge is decremented in `commit`/`rollback`, it's value will get negative.

Moving increment to proxy fixes the problem.

Note: that does not add any tests for the fix, since metrics testing story in engines is more complicated and postponed until phase 2.

Unblocks prisma/prisma#21746
