### PR TITLE
ci(renovate): Enable config migration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
   ],
@@ -15,6 +16,7 @@
   ],
   "rangeStrategy": "pin",
   "separateMinorPatch": true,
+  "configMigration": true,
   "packageRules": [
     {
       "matchFiles": ["docker-compose.yml"],


### PR DESCRIPTION
With this configuration Renovate should open PRs to improve the configuration itself, so that we never use outdated keys or similar (as we do right now with packageNames, which was migrated to matchPackageNames)

see docs.renovatebot.com/configuration-options/#configmigration