### PR TITLE
Fix DATE / TIME argument parsing for planetscale (Rust side)

### DIFF
--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -46,7 +46,7 @@ jobs:
       QUERY_BATCH_SIZE: '10'
       WORKSPACE_ROOT: ${{ github.workspace }}
 
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2004
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -46,7 +46,7 @@ jobs:
       QUERY_BATCH_SIZE: '10'
       WORKSPACE_ROOT: ${{ github.workspace }}
 
-    runs-on: buildjet-8vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -10,7 +10,6 @@ use serde_json::value::Value as JsonValue;
 #[derive(Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum JSArg {
-    RawString(String),
     Value(serde_json::Value),
     Buffer(Vec<u8>),
     Array(Vec<JSArg>),
@@ -35,7 +34,6 @@ impl FromNapiValue for JSArg {
 impl ToNapiValue for JSArg {
     unsafe fn to_napi_value(env: napi::sys::napi_env, value: Self) -> napi::Result<napi::sys::napi_value> {
         match value {
-            JSArg::RawString(s) => ToNapiValue::to_napi_value(env, s),
             JSArg::Value(v) => ToNapiValue::to_napi_value(env, v),
             JSArg::Buffer(bytes) => {
                 ToNapiValue::to_napi_value(env, napi::Env::from_raw(env).create_buffer_with_data(bytes)?.into_raw())

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -1,3 +1,4 @@
+pub(crate) mod mysql;
 pub(crate) mod postgres;
 pub(crate) mod sqlite;
 
@@ -58,33 +59,4 @@ impl ToNapiValue for JSArg {
             }
         }
     }
-}
-
-pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
-    let res = match &value.typed {
-        quaint::ValueType::Json(s) => match s {
-            Some(ref s) => {
-                let json_str = serde_json::to_string(s)?;
-                JSArg::RawString(json_str)
-            }
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Bytes(bytes) => match bytes {
-            Some(bytes) => JSArg::Buffer(bytes.to_vec()),
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Numeric(bd) => match bd {
-            // converting decimal to string to preserve the precision
-            Some(bd) => JSArg::RawString(bd.to_string()),
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Array(Some(ref items)) => JSArg::Array(values_to_js_args(items)?),
-        quaint_value => JSArg::from(JsonValue::from(quaint_value.clone())),
-    };
-
-    Ok(res)
-}
-
-pub fn values_to_js_args(values: &[quaint::Value<'_>]) -> serde_json::Result<Vec<JSArg>> {
-    values.iter().map(value_to_js_arg).collect()
 }

--- a/query-engine/driver-adapters/src/conversion.rs
+++ b/query-engine/driver-adapters/src/conversion.rs
@@ -7,7 +7,7 @@ use napi::NapiValue;
 use serde::Serialize;
 use serde_json::value::Value as JsonValue;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(untagged)]
 pub enum JSArg {
     RawString(String),

--- a/query-engine/driver-adapters/src/conversion/mysql.rs
+++ b/query-engine/driver-adapters/src/conversion/mysql.rs
@@ -1,35 +1,18 @@
 use crate::conversion::JSArg;
 use serde_json::value::Value as JsonValue;
 
-const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
+const DATETIME_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
+const DATE_FORMAT: &str = "%Y-%m-%d";
 const TIME_FORMAT: &str = "%H:%M:%S";
 
 pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
     let res = match &value.typed {
-        quaint::ValueType::Json(s) => match s {
-            Some(ref s) => {
-                let json_str = serde_json::to_string(s)?;
-                JSArg::RawString(json_str)
-            }
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Bytes(bytes) => match bytes {
-            Some(bytes) => JSArg::Buffer(bytes.to_vec()),
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Numeric(bd) => match bd {
-            // converting decimal to string to preserve the precision
-            Some(bd) => JSArg::RawString(bd.to_string()),
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::DateTime(dt) => match dt {
-            Some(dt) => JSArg::RawString(dt.format(DATE_FORMAT).to_string()),
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Time(dt) => match dt {
-            Some(dt) => JSArg::RawString(dt.format(TIME_FORMAT).to_string()),
-            None => JsonValue::Null.into(),
-        },
+        quaint::ValueType::Numeric(Some(bd)) => JSArg::RawString(bd.to_string()),
+        quaint::ValueType::Json(Some(ref s)) => JSArg::RawString(serde_json::to_string(s)?),
+        quaint::ValueType::Bytes(Some(bytes)) => JSArg::Buffer(bytes.to_vec()),
+        quaint::ValueType::Date(Some(d)) => JSArg::RawString(d.format(DATE_FORMAT).to_string()),
+        quaint::ValueType::DateTime(Some(dt)) => JSArg::RawString(dt.format(DATETIME_FORMAT).to_string()),
+        quaint::ValueType::Time(Some(t)) => JSArg::RawString(t.format(TIME_FORMAT).to_string()),
         quaint::ValueType::Array(Some(ref items)) => JSArg::Array(
             items
                 .iter()
@@ -39,4 +22,87 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
         quaint_value => JSArg::from(JsonValue::from(quaint_value.clone())),
     };
     Ok(res)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bigdecimal::BigDecimal;
+    use chrono::*;
+    use quaint::ValueType;
+    use std::str::FromStr;
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_value_to_js_arg() {
+            let test_cases = vec![
+            (
+                ValueType::Numeric(Some(1.into())), 
+                JSArg::RawString("1".to_string())
+            ),
+            (
+                ValueType::Numeric(Some(BigDecimal::from_str("-1.1").unwrap())),
+                JSArg::RawString("-1.1".to_string()),
+            ),
+            (
+                ValueType::Numeric(None),
+                JSArg::Value(serde_json::Value::Null)
+            ),
+            (
+                ValueType::Json(Some(serde_json::json!({"a": 1}))),
+                JSArg::RawString(r#"{"a":1}"#.to_string()),
+            ),
+            (
+                ValueType::Json(None),
+                JSArg::Value(serde_json::Value::Null)
+            ),
+            (
+                ValueType::Date(Some(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap())),
+                JSArg::RawString("2020-02-29".to_string()),
+            ),
+            (
+                ValueType::Date(None),
+                JSArg::Value(serde_json::Value::Null)
+            ),
+            (
+                ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())),
+                JSArg::RawString("2020-01-01 23:13:01".to_string()),
+            ),
+            (
+                ValueType::DateTime(None),
+                JSArg::Value(serde_json::Value::Null)
+            ),
+            (
+                ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())),
+                JSArg::RawString("23:13:01".to_string()),
+            ),
+            (
+                ValueType::Time(None),
+                JSArg::Value(serde_json::Value::Null)
+            ),
+            (
+                ValueType::Array(Some(vec!(
+                    ValueType::Numeric(Some(1.into())).into_value(),
+                    ValueType::Numeric(None).into_value(),
+                    ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())).into_value(),
+                    ValueType::Time(None).into_value(),
+                ))),
+                JSArg::Array(vec!(
+                    JSArg::RawString("1".to_string()),
+                    JSArg::Value(serde_json::Value::Null),
+                    JSArg::RawString("23:13:01".to_string()),
+                    JSArg::Value(serde_json::Value::Null),
+                ))
+            ),
+        ];
+
+        let mut errors: Vec<String> = vec![];
+        for (val, expected) in test_cases {
+            let actual = value_to_js_arg(&val.clone().into_value()).unwrap();
+            if actual != expected {
+                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", &val, expected, actual));
+            }
+        }
+        assert_eq!(errors.len(), 0, "{}", errors.join("\n"));
+    }
 }

--- a/query-engine/driver-adapters/src/conversion/mysql.rs
+++ b/query-engine/driver-adapters/src/conversion/mysql.rs
@@ -1,16 +1,11 @@
 use crate::conversion::JSArg;
 use serde_json::value::Value as JsonValue;
 
+const DATE_FORMAT: &str = "%Y-%m-%d %H:%M:%S";
+const TIME_FORMAT: &str = "%H:%M:%S";
+
 pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
     let res = match &value.typed {
-        quaint::ValueType::Numeric(bd) => match bd {
-            // converting decimal to string to preserve the precision
-            Some(bd) => match bd.to_string().parse::<f64>() {
-                Ok(double) => JSArg::from(JsonValue::from(double)),
-                Err(_) => JSArg::from(JsonValue::from(value.clone())),
-            },
-            None => JsonValue::Null.into(),
-        },
         quaint::ValueType::Json(s) => match s {
             Some(ref s) => {
                 let json_str = serde_json::to_string(s)?;
@@ -22,6 +17,19 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
             Some(bytes) => JSArg::Buffer(bytes.to_vec()),
             None => JsonValue::Null.into(),
         },
+        quaint::ValueType::Numeric(bd) => match bd {
+            // converting decimal to string to preserve the precision
+            Some(bd) => JSArg::RawString(bd.to_string()),
+            None => JsonValue::Null.into(),
+        },
+        quaint::ValueType::DateTime(dt) => match dt {
+            Some(dt) => JSArg::RawString(dt.format(DATE_FORMAT).to_string()),
+            None => JsonValue::Null.into(),
+        },
+        quaint::ValueType::Time(dt) => match dt {
+            Some(dt) => JSArg::RawString(dt.format(TIME_FORMAT).to_string()),
+            None => JsonValue::Null.into(),
+        },
         quaint::ValueType::Array(Some(ref items)) => JSArg::Array(
             items
                 .iter()
@@ -30,6 +38,5 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
         ),
         quaint_value => JSArg::from(JsonValue::from(quaint_value.clone())),
     };
-
     Ok(res)
 }

--- a/query-engine/driver-adapters/src/conversion/mysql.rs
+++ b/query-engine/driver-adapters/src/conversion/mysql.rs
@@ -9,7 +9,7 @@ const TIME_FORMAT: &str = "%H:%M:%S";
 pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
     let res = match &value.typed {
         quaint::ValueType::Numeric(Some(bd)) => JSArg::Value(JsonValue::String(bd.to_string())),
-        quaint::ValueType::Json(Some(s)) => JSArg::Value(s.to_owned()),
+        quaint::ValueType::Json(Some(s)) => JSArg::Value(JsonValue::String(serde_json::to_string(s)?)),
         quaint::ValueType::Bytes(Some(bytes)) => JSArg::Buffer(bytes.to_vec()),
         quaint::ValueType::Date(Some(d)) => JSArg::Value(JsonValue::String(d.format(DATE_FORMAT).to_string())),
         quaint::ValueType::DateTime(Some(dt)) => JSArg::Value(JsonValue::String(dt.format(DATETIME_FORMAT).to_string())),
@@ -47,15 +47,15 @@ mod test {
             ),
             (
                 ValueType::Numeric(None),
-                JSArg::Value(serde_json::Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Json(Some(serde_json::json!({"a": 1}))),
-                JSArg::Value(serde_json::json!({"a": 1}))
+                JSArg::Value(JsonValue::String("{\"a\":1}".to_string()))
             ),
             (
                 ValueType::Json(None),
-                JSArg::Value(serde_json::Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Date(Some(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap())),
@@ -63,7 +63,7 @@ mod test {
             ),
             (
                 ValueType::Date(None),
-                JSArg::Value(serde_json::Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())),
@@ -71,7 +71,7 @@ mod test {
             ),
             (
                 ValueType::DateTime(None),
-                JSArg::Value(serde_json::Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())),
@@ -79,7 +79,7 @@ mod test {
             ),
             (
                 ValueType::Time(None),
-                JSArg::Value(serde_json::Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Array(Some(vec!(
@@ -89,7 +89,7 @@ mod test {
                 ))),
                 JSArg::Array(vec!(
                     JSArg::Value(JsonValue::String("1".to_string())),
-                    JSArg::Value(serde_json::Value::Null),
+                    JSArg::Value(JsonValue::Null),
                     JSArg::Value(JsonValue::String("23:13:01".to_string()))
                 ))
             ),

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -50,3 +50,95 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
 
     Ok(res)
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bigdecimal::BigDecimal;
+    use chrono::*;
+    use quaint::ValueType;
+    use serde_json::Value;
+    use std::str::FromStr;
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_value_to_js_arg() {
+        let test_cases: Vec<(quaint::Value, JSArg)> = vec![
+            (
+                ValueType::Numeric(Some(1.into())).into_value(),
+                JSArg::RawString("1".to_string())
+            ),
+            (
+                ValueType::Numeric(Some(BigDecimal::from_str("-1.1").unwrap())).into_value(),
+                JSArg::RawString("-1.1".to_string()),
+            ),
+            (
+                ValueType::Numeric(None).into_value(),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Json(Some(serde_json::json!({"a": 1}))).into_value(),
+                JSArg::RawString(r#"{"a":1}"#.to_string()),
+            ),
+            (
+                ValueType::Json(None).into_value(),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Date(Some(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap())).into_value(),
+                JSArg::Value(Value::String("2020-02-29".to_string())),
+            ),
+            (
+                ValueType::Date(None).into_value(),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("DATE")),
+                JSArg::RawString("2020-01-01".to_string()),
+            ),
+            (
+                ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("TIME")),
+                JSArg::RawString("23:13:01".to_string()),
+            ),
+            (
+                ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("TIMETZ")),
+                JSArg::RawString("23:13:01".to_string()),
+            ),
+            (
+                ValueType::DateTime(None).into_value(),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())).into_value(),
+                JSArg::Value(Value::String("23:13:01".to_string())),
+            ),
+            (
+                ValueType::Time(None).into_value(),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Array(Some(vec!(
+                    ValueType::Numeric(Some(1.into())).into_value(),
+                    ValueType::Numeric(None).into_value(),
+                    ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())).into_value(),
+                    ValueType::Time(None).into_value(),
+                ))).into_value(),
+                JSArg::Array(vec!(
+                    JSArg::RawString("1".to_string()),
+                    JSArg::Value(Value::Null),
+                    JSArg::Value(Value::String("23:13:01".to_string())),
+                    JSArg::Value(Value::Null),
+                ))
+            ),
+        ];
+
+        let mut errors: Vec<String> = vec![];
+        for (val, expected) in test_cases {
+            let actual = value_to_js_arg(&val).unwrap();
+            if actual != expected {
+                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", &val, expected, actual));
+            }
+        }
+        assert_eq!(errors.len(), 0, "{}", errors.join("\n"));
+    }
+}

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -5,40 +5,16 @@ use serde_json::value::Value as JsonValue;
 
 static TIME_FMT: Lazy<StrftimeItems> = Lazy::new(|| StrftimeItems::new("%H:%M:%S%.f"));
 
+#[rustfmt::skip]
 pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
     let res = match (&value.typed, value.native_column_type_name()) {
-        (quaint::ValueType::DateTime(value), Some("DATE")) => match value {
-            Some(value) => JSArg::RawString(value.date_naive().to_string()),
-            None => JsonValue::Null.into(),
-        },
-        (quaint::ValueType::DateTime(value), Some("TIME")) => match value {
-            Some(value) => JSArg::RawString(value.time().to_string()),
-            None => JsonValue::Null.into(),
-        },
-        (quaint::ValueType::DateTime(value), Some("TIMETZ")) => match value {
-            Some(value) => JSArg::RawString(value.time().format_with_items(TIME_FMT.clone()).to_string()),
-            None => JsonValue::Null.into(),
-        },
-        (quaint::ValueType::DateTime(value), _) => match value {
-            Some(value) => JSArg::RawString(value.naive_utc().to_string()),
-            None => JsonValue::Null.into(),
-        },
-        (quaint::ValueType::Json(s), _) => match s {
-            Some(ref s) => {
-                let json_str = serde_json::to_string(s)?;
-                JSArg::RawString(json_str)
-            }
-            None => JsonValue::Null.into(),
-        },
-        (quaint::ValueType::Bytes(bytes), _) => match bytes {
-            Some(bytes) => JSArg::Buffer(bytes.to_vec()),
-            None => JsonValue::Null.into(),
-        },
-        (quaint::ValueType::Numeric(bd), _) => match bd {
-            // converting decimal to string to preserve the precision
-            Some(bd) => JSArg::RawString(bd.to_string()),
-            None => JsonValue::Null.into(),
-        },
+        (quaint::ValueType::DateTime(Some(dt)), Some("DATE")) => JSArg::Value(JsonValue::String(dt.date_naive().to_string())),
+        (quaint::ValueType::DateTime(Some(dt)), Some("TIME")) =>  JSArg::Value(JsonValue::String(dt.time().to_string())),
+        (quaint::ValueType::DateTime(Some(dt)), Some("TIMETZ")) => JSArg::Value(JsonValue::String(dt.time().format_with_items(TIME_FMT.clone()).to_string())),
+        (quaint::ValueType::DateTime(Some(dt)), _) => JSArg::Value(JsonValue::String(dt.naive_utc().to_string())),
+        (quaint::ValueType::Json(Some(s)), _) => JSArg::Value(s.to_owned()),
+        (quaint::ValueType::Bytes(Some(bytes)), _) => JSArg::Buffer(bytes.to_vec()),
+        (quaint::ValueType::Numeric(Some(bd)), _) =>  JSArg::Value(JsonValue::String(bd.to_string())),
         (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(
             items
                 .iter()
@@ -66,11 +42,11 @@ mod test {
         let test_cases: Vec<(quaint::Value, JSArg)> = vec![
             (
                 ValueType::Numeric(Some(1.into())).into_value(),
-                JSArg::RawString("1".to_string())
+                JSArg::Value(JsonValue::String("1".to_string()))
             ),
             (
                 ValueType::Numeric(Some(BigDecimal::from_str("-1.1").unwrap())).into_value(),
-                JSArg::RawString("-1.1".to_string()),
+                JSArg::Value(JsonValue::String("-1.1".to_string()))
             ),
             (
                 ValueType::Numeric(None).into_value(),
@@ -78,7 +54,7 @@ mod test {
             ),
             (
                 ValueType::Json(Some(serde_json::json!({"a": 1}))).into_value(),
-                JSArg::RawString(r#"{"a":1}"#.to_string()),
+                JSArg::Value(serde_json::json!({"a": 1}))
             ),
             (
                 ValueType::Json(None).into_value(),
@@ -86,7 +62,7 @@ mod test {
             ),
             (
                 ValueType::Date(Some(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap())).into_value(),
-                JSArg::Value(Value::String("2020-02-29".to_string())),
+                JSArg::Value(Value::String("2020-02-29".to_string()))
             ),
             (
                 ValueType::Date(None).into_value(),
@@ -94,15 +70,15 @@ mod test {
             ),
             (
                 ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("DATE")),
-                JSArg::RawString("2020-01-01".to_string()),
+                JSArg::Value(JsonValue::String("2020-01-01".to_string()))
             ),
             (
                 ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("TIME")),
-                JSArg::RawString("23:13:01".to_string()),
+                JSArg::Value(JsonValue::String("23:13:01".to_string()))
             ),
             (
                 ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("TIMETZ")),
-                JSArg::RawString("23:13:01".to_string()),
+                JSArg::Value(JsonValue::String("23:13:01".to_string()))
             ),
             (
                 ValueType::DateTime(None).into_value(),
@@ -110,7 +86,7 @@ mod test {
             ),
             (
                 ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())).into_value(),
-                JSArg::Value(Value::String("23:13:01".to_string())),
+                JSArg::Value(Value::String("23:13:01".to_string()))
             ),
             (
                 ValueType::Time(None).into_value(),
@@ -124,7 +100,7 @@ mod test {
                     ValueType::Time(None).into_value(),
                 ))).into_value(),
                 JSArg::Array(vec!(
-                    JSArg::RawString("1".to_string()),
+                    JSArg::Value(JsonValue::String("1".to_string())),
                     JSArg::Value(Value::Null),
                     JSArg::Value(Value::String("23:13:01".to_string())),
                     JSArg::Value(Value::Null),

--- a/query-engine/driver-adapters/src/conversion/postgres.rs
+++ b/query-engine/driver-adapters/src/conversion/postgres.rs
@@ -12,7 +12,7 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
         (quaint::ValueType::DateTime(Some(dt)), Some("TIME")) =>  JSArg::Value(JsonValue::String(dt.time().to_string())),
         (quaint::ValueType::DateTime(Some(dt)), Some("TIMETZ")) => JSArg::Value(JsonValue::String(dt.time().format_with_items(TIME_FMT.clone()).to_string())),
         (quaint::ValueType::DateTime(Some(dt)), _) => JSArg::Value(JsonValue::String(dt.naive_utc().to_string())),
-        (quaint::ValueType::Json(Some(s)), _) => JSArg::Value(s.to_owned()),
+        (quaint::ValueType::Json(Some(s)), _) => JSArg::Value(JsonValue::String(serde_json::to_string(s)?)),
         (quaint::ValueType::Bytes(Some(bytes)), _) => JSArg::Buffer(bytes.to_vec()),
         (quaint::ValueType::Numeric(Some(bd)), _) =>  JSArg::Value(JsonValue::String(bd.to_string())),
         (quaint::ValueType::Array(Some(items)), _) => JSArg::Array(
@@ -33,7 +33,6 @@ mod test {
     use bigdecimal::BigDecimal;
     use chrono::*;
     use quaint::ValueType;
-    use serde_json::Value;
     use std::str::FromStr;
 
     #[test]
@@ -50,23 +49,23 @@ mod test {
             ),
             (
                 ValueType::Numeric(None).into_value(),
-                JSArg::Value(Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Json(Some(serde_json::json!({"a": 1}))).into_value(),
-                JSArg::Value(serde_json::json!({"a": 1}))
+                JSArg::Value(JsonValue::String("{\"a\":1}".to_string()))
             ),
             (
                 ValueType::Json(None).into_value(),
-                JSArg::Value(Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Date(Some(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap())).into_value(),
-                JSArg::Value(Value::String("2020-02-29".to_string()))
+                JSArg::Value(JsonValue::String("2020-02-29".to_string()))
             ),
             (
                 ValueType::Date(None).into_value(),
-                JSArg::Value(Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())).into_value().with_native_column_type(Some("DATE")),
@@ -82,15 +81,15 @@ mod test {
             ),
             (
                 ValueType::DateTime(None).into_value(),
-                JSArg::Value(Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())).into_value(),
-                JSArg::Value(Value::String("23:13:01".to_string()))
+                JSArg::Value(JsonValue::String("23:13:01".to_string()))
             ),
             (
                 ValueType::Time(None).into_value(),
-                JSArg::Value(Value::Null)
+                JSArg::Value(JsonValue::Null)
             ),
             (
                 ValueType::Array(Some(vec!(
@@ -101,9 +100,9 @@ mod test {
                 ))).into_value(),
                 JSArg::Array(vec!(
                     JSArg::Value(JsonValue::String("1".to_string())),
-                    JSArg::Value(Value::Null),
-                    JSArg::Value(Value::String("23:13:01".to_string())),
-                    JSArg::Value(Value::Null),
+                    JSArg::Value(JsonValue::Null),
+                    JSArg::Value(JsonValue::String("23:13:01".to_string())),
+                    JSArg::Value(JsonValue::Null),
                 ))
             ),
         ];

--- a/query-engine/driver-adapters/src/conversion/sqlite.rs
+++ b/query-engine/driver-adapters/src/conversion/sqlite.rs
@@ -7,10 +7,7 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
             Ok(double) => JSArg::from(JsonValue::from(double)),
             Err(_) => JSArg::from(JsonValue::from(value.clone())),
         },
-        quaint::ValueType::Json(Some(ref s)) => {
-            let json_str = serde_json::to_string(s)?;
-            JSArg::RawString(json_str)
-        }
+        quaint::ValueType::Json(Some(s)) => JSArg::Value(s.to_owned()),
         quaint::ValueType::Bytes(Some(bytes)) => JSArg::Buffer(bytes.to_vec()),
         quaint::ValueType::Array(Some(ref items)) => JSArg::Array(
             items
@@ -39,6 +36,7 @@ mod test {
     fn test_value_to_js_arg() {
         let test_cases = vec![
            (
+                // This is different than how mysql or postgres processes integral BigInt values.
                 ValueType::Numeric(Some(1.into())),
                 JSArg::Value(Value::Number("1.0".parse().unwrap()))
             ),
@@ -52,7 +50,7 @@ mod test {
             ),
             (
                 ValueType::Json(Some(serde_json::json!({"a": 1}))),
-                JSArg::RawString(r#"{"a":1}"#.to_string()),
+                JSArg::Value(serde_json::json!({"a": 1})),
             ),
             (
                 ValueType::Json(None),

--- a/query-engine/driver-adapters/src/conversion/sqlite.rs
+++ b/query-engine/driver-adapters/src/conversion/sqlite.rs
@@ -3,25 +3,15 @@ use serde_json::value::Value as JsonValue;
 
 pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
     let res = match &value.typed {
-        quaint::ValueType::Numeric(bd) => match bd {
-            // converting decimal to string to preserve the precision
-            Some(bd) => match bd.to_string().parse::<f64>() {
-                Ok(double) => JSArg::from(JsonValue::from(double)),
-                Err(_) => JSArg::from(JsonValue::from(value.clone())),
-            },
-            None => JsonValue::Null.into(),
+        quaint::ValueType::Numeric(Some(bd)) => match bd.to_string().parse::<f64>() {
+            Ok(double) => JSArg::from(JsonValue::from(double)),
+            Err(_) => JSArg::from(JsonValue::from(value.clone())),
         },
-        quaint::ValueType::Json(s) => match s {
-            Some(ref s) => {
-                let json_str = serde_json::to_string(s)?;
-                JSArg::RawString(json_str)
-            }
-            None => JsonValue::Null.into(),
-        },
-        quaint::ValueType::Bytes(bytes) => match bytes {
-            Some(bytes) => JSArg::Buffer(bytes.to_vec()),
-            None => JsonValue::Null.into(),
-        },
+        quaint::ValueType::Json(Some(ref s)) => {
+            let json_str = serde_json::to_string(s)?;
+            JSArg::RawString(json_str)
+        }
+        quaint::ValueType::Bytes(Some(bytes)) => JSArg::Buffer(bytes.to_vec()),
         quaint::ValueType::Array(Some(ref items)) => JSArg::Array(
             items
                 .iter()
@@ -32,4 +22,89 @@ pub fn value_to_js_arg(value: &quaint::Value) -> serde_json::Result<JSArg> {
     };
 
     Ok(res)
+}
+
+// unit tests for value_to_js_arg
+#[cfg(test)]
+mod test {
+    use super::*;
+    use bigdecimal::BigDecimal;
+    use chrono::*;
+    use quaint::ValueType;
+    use serde_json::Value;
+    use std::str::FromStr;
+
+    #[test]
+    #[rustfmt::skip]
+    fn test_value_to_js_arg() {
+        let test_cases = vec![
+           (
+                ValueType::Numeric(Some(1.into())),
+                JSArg::Value(Value::Number("1.0".parse().unwrap()))
+            ),
+            (
+                ValueType::Numeric(Some(BigDecimal::from_str("-1.1").unwrap())),
+                JSArg::Value(Value::Number("-1.1".parse().unwrap())),
+            ),
+            (
+                ValueType::Numeric(None),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Json(Some(serde_json::json!({"a": 1}))),
+                JSArg::RawString(r#"{"a":1}"#.to_string()),
+            ),
+            (
+                ValueType::Json(None),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Date(Some(NaiveDate::from_ymd_opt(2020, 2, 29).unwrap())),
+                JSArg::Value(Value::String("2020-02-29".to_string())),
+            ),
+            (
+                ValueType::Date(None),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::DateTime(Some(Utc.with_ymd_and_hms(2020, 1, 1, 23, 13, 1).unwrap())),
+                JSArg::Value(Value::String("2020-01-01T23:13:01+00:00".to_string())),
+            ),
+            (
+                ValueType::DateTime(None),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())),
+                JSArg::Value(Value::String("23:13:01".to_string())),
+            ),
+            (
+                ValueType::Time(None),
+                JSArg::Value(Value::Null)
+            ),
+            (
+                ValueType::Array(Some(vec!(
+                    ValueType::Numeric(Some(1.into())).into_value(),
+                    ValueType::Numeric(None).into_value(),
+                    ValueType::Time(Some(NaiveTime::from_hms_opt(23, 13, 1).unwrap())).into_value(),
+                    ValueType::Time(None).into_value(),
+                ))),
+                JSArg::Array(vec!(
+                    JSArg::Value(Value::Number("1.0".parse().unwrap())),
+                    JSArg::Value(Value::Null),
+                    JSArg::Value(Value::String("23:13:01".to_string())),
+                    JSArg::Value(Value::Null),
+                ))
+            ),
+        ];
+
+        let mut errors: Vec<String> = vec![];
+        for (val, expected) in test_cases {
+            let actual = value_to_js_arg(&val.clone().into_value()).unwrap();
+            if actual != expected {
+                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", &val, expected, actual));
+            }
+        }
+        assert_eq!(errors.len(), 0, "{}", errors.join("\n"));
+    }
 }


### PR DESCRIPTION
Server side changes for https://github.com/prisma/team-orm/issues/517

```
 PASS  tests/functional/issues/6578/tests.ts
  issues.6578 (provider=sqlite)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=sqlite, js_libsql)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=postgresql)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=postgresql, js_pg)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=postgresql, js_neon)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=mysql)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=mysql, js_planetscale)
    ✓ should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable (144 ms)
  issues.6578 (provider=cockroachdb)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable
  issues.6578 (provider=sqlserver)
    ○ skipped should assert Dates, DateTimes, Times and UUIDs are wrapped in quotes and are deserializable

Test Suites: 1 passed, 1 total
Tests:       8 skipped, 1 passed, 9 total
Snapshots:   0 total
Time:        4.982 s, estimated 6 s
Ran all test suites matching /6578/i.
```