### PR TITLE
fix(docker): fix MySQL 5.7 definition in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,7 +187,6 @@ services:
     restart: unless-stopped
     platform: linux/x86_64
     environment:
-      MYSQL_USER: root
       MYSQL_ROOT_PASSWORD: prisma
       MYSQL_DATABASE: prisma
     ports:


### PR DESCRIPTION
Before this PR, running

```
docker compose -f docker-compose.yml up --remove-orphans mysql-5-7
```

resulted in the `mysql-5-7` container continuously restarting with the following error:

```
prisma-engines-mysql-5-7-1  | 2023-11-09 15:58:30+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
prisma-engines-mysql-5-7-1  |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
prisma-engines-mysql-5-7-1  |     - MYSQL_ROOT_PASSWORD
prisma-engines-mysql-5-7-1  |     - MYSQL_ALLOW_EMPTY_PASSWORD
prisma-engines-mysql-5-7-1  |     - MYSQL_RANDOM_ROOT_PASSWORD
prisma-engines-mysql-5-7-1 exited with code 1
```

This caused Schema Engine tests targeting MySQL 5.7 to fail in `main`.

Removing the `MYSQL_USER: root` env var from the docker-compose definition fixed the problem locally. Let's run this on the CI.