### PR TITLE
ci(github): Trigger run of prisma-engines-builds

### DIFF
--- a/.github/workflows/send-main-push-event.yml
+++ b/.github/workflows/send-main-push-event.yml
@@ -1,14 +1,13 @@
 name: Trigger prisma-engines-builds run
 run-name: Trigger prisma-engines-builds run for ${{ github.sha }}
 
-
 on:
   push:
     branches:
       - main
 
 jobs:
-  send-tag-event:
+  send-commit-hash:
     runs-on: ubuntu-22.04
     steps:
       - run: echo "Sending event for commit $GITHUB_SHA"

--- a/.github/workflows/send-main-push-event.yml
+++ b/.github/workflows/send-main-push-event.yml
@@ -1,0 +1,19 @@
+name: Trigger prisma-engines-builds run
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  send-tag-event:
+    runs-on: ubuntu-22.04
+    steps:
+      - run: echo "Sending event for commit $GITHUB_SHA"
+      - name: Workflow dispatch to prisma/prisma-engines-builds
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: .github/workflows/build-engines.yml
+          repo: prisma/prisma-engines-builds
+          token: ${{ secrets.BOT_TOKEN }}
+          inputs: '{ "commit": "${{ github.event.client_payload.commit }}" }'

--- a/.github/workflows/send-main-push-event.yml
+++ b/.github/workflows/send-main-push-event.yml
@@ -18,4 +18,4 @@ jobs:
           workflow: .github/workflows/build-engines.yml
           repo: prisma/prisma-engines-builds
           token: ${{ secrets.BOT_TOKEN }}
-          inputs: '{ "commit": "${{ github.event.client_payload.commit }}" }'
+          inputs: '{ "commit": "${{ github.sha }}" }'

--- a/.github/workflows/send-main-push-event.yml
+++ b/.github/workflows/send-main-push-event.yml
@@ -17,5 +17,5 @@ jobs:
         with:
           workflow: .github/workflows/build-engines.yml
           repo: prisma/prisma-engines-builds
-          token: ${{ secrets.BOT_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN_PRISMA_ENGINES_BUILD }}
           inputs: '{ "commit": "${{ github.sha }}" }'

--- a/.github/workflows/send-main-push-event.yml
+++ b/.github/workflows/send-main-push-event.yml
@@ -1,4 +1,6 @@
 name: Trigger prisma-engines-builds run
+run-name: Trigger prisma-engines-builds run for ${{ github.sha }}
+
 
 on:
   push:


### PR DESCRIPTION
On push to `main` this triggers a GH Action run over in https://github.com/prisma/prisma-engines-builds - which then builds the engines via GH Actions.