### PR TITLE
fix: crdb enum casting error when executing the same prepared statement twice

### DIFF
--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -78,33 +78,28 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         variants: Vec<EnumVariant<'a>>,
         name: Option<EnumName<'a>>,
     ) -> visitor::Result {
-        let len = variants.len();
-
         // Since enums are user-defined custom types, tokio-postgres fires an additional query
         // when parameterizing values of type enum to know which custom type the value refers to.
         // Casting the enum value to `TEXT` avoid this roundtrip since `TEXT` is a builtin type.
         if let Some(enum_name) = name.clone() {
-            self.surround_with("ARRAY[", "]", |s| {
-                for (i, variant) in variants.into_iter().enumerate() {
-                    s.add_parameter(variant.into_text());
-                    s.parameter_substitution()?;
-                    s.write("::text")?;
+            self.add_parameter(Value::array(variants.into_iter().map(|v| v.into_text())));
 
-                    if i < (len - 1) {
-                        s.write(", ")?;
-                    }
+            self.surround_with("CAST(", ")", |s| {
+                s.parameter_substitution()?;
+                s.write("::text[]")?;
+                s.write(" AS ")?;
+
+                if let Some(schema_name) = enum_name.schema_name {
+                    s.surround_with_backticks(schema_name.deref())?;
+                    s.write(".")?
                 }
+
+                s.surround_with_backticks(enum_name.name.deref())?;
+                s.write("[]")?;
 
                 Ok(())
             })?;
 
-            self.write("::")?;
-            if let Some(schema_name) = enum_name.schema_name {
-                self.surround_with_backticks(schema_name.deref())?;
-                self.write(".")?
-            }
-            self.surround_with_backticks(enum_name.name.deref())?;
-            self.write("[]")?;
         } else {
             self.visit_parameterized(Value::array(
                 variants.into_iter().map(|variant| variant.into_enum(name.clone())),

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -99,7 +99,6 @@ impl<'a> Visitor<'a> for Postgres<'a> {
 
                 Ok(())
             })?;
-
         } else {
             self.visit_parameterized(Value::array(
                 variants.into_iter().map(|variant| variant.into_enum(name.clone())),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -20,6 +20,7 @@ mod prisma_17103;
 mod prisma_18517;
 mod prisma_20799;
 mod prisma_21369;
+mod prisma_21901;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
@@ -1,14 +1,13 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema))]
+#[test_suite(schema(schema), capabilities(Enums))]
 mod prisma_21901 {
     fn schema() -> String {
         let schema = indoc! {
             r#"model Test {
               #id(id, Int, @id)
               colors Color[]
-              color Color?
             }
             
             enum Color {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
@@ -1,0 +1,51 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod prisma_21901 {
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model Test {
+              #id(id, Int, @id)
+              colors Color[]
+              color Color?
+            }
+            
+            enum Color {
+              red
+              blue
+              green
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    // fixes https://github.com/prisma/prisma/issues/21901
+    #[connector_test]
+    async fn test(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(
+            runner,
+            r#"mutation { createOneTest(data: { id: 1, colors: ["red"] }) { colors } }"#
+          ), 
+          @r###"{"data":{"createOneTest":{"colors":["red"]}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(runner, fmt_execute_raw(r#"TRUNCATE TABLE "prisma_21901_test"."Test" CASCADE;"#, [])),
+          @r###"{"data":{"executeRaw":0}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(
+            runner,
+            r#"mutation { createOneTest(data: { id: 2, colors: ["blue"] }) { colors } }"#
+          ),
+          @r###"{"data":{"createOneTest":{"colors":["blue"]}}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
@@ -29,7 +29,7 @@ mod prisma_21901 {
           run_query!(
             runner,
             r#"mutation { createOneTest(data: { id: 1, colors: ["red"] }) { colors } }"#
-          ), 
+          ),
           @r###"{"data":{"createOneTest":{"colors":["red"]}}}"###
         );
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), capabilities(Enums), exclude(MongoDb))]
+#[test_suite(schema(schema), capabilities(Enums, ScalarLists), exclude(MongoDb))]
 mod prisma_21901 {
     fn schema() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21901.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), capabilities(Enums))]
+#[test_suite(schema(schema), capabilities(Enums), exclude(MongoDb))]
 mod prisma_21901 {
     fn schema() -> String {
         let schema = indoc! {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/21901

I'm honestly unsure why exactly this fixes the issue as I'm still unsure why we had this error in the first place. There seemed to be an issue _only_ on CRDB when executing the same prepared statement twice and truncating in the middle. The error was:

```sql
PREPARE s1 AS INSERT INTO "Test" ("id", "colors") VALUES ($1, ARRAY[$2::text]::"Color"[]);

EXECUTE s1(1, 'red');
TRUNCATE TABLE "Test" CASCADE;
EXECUTE s1(1, 'red');
```

```
ERROR:  placeholder $2 already has type string, cannot assign Color
```

The PR changes how we cast enum arrays:

```sql
PREPARE s1 AS INSERT INTO "Test" ("id", "colors") VALUES ($1, CAST($2::text[] AS "Color"[]));
```

Which seems to be fixing the CRDB error.