### PR TITLE
schema-wasm: optimize for `-Oz` with LLVM and Binaryen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,10 @@ lto = "fat"
 codegen-units = 1
 opt-level = 's'   # Optimize for size.
 
+[profile.wasm-release]
+inherits = "release"
+opt-level = 'z'   # Aggressively optimize for size
+
 [profile.profiling]
 inherits = "release"
 debug = true

--- a/nix/prisma-schema-wasm.nix
+++ b/nix/prisma-schema-wasm.nix
@@ -9,10 +9,10 @@ in
 {
   packages.prisma-schema-wasm = stdenv.mkDerivation {
     name = "prisma-schema-wasm";
-    nativeBuildInputs = with pkgs; [ git wasm-bindgen-cli toolchain ];
+    nativeBuildInputs = with pkgs; [ git wasm-bindgen-cli toolchain binaryen ];
     inherit (self'.packages.prisma-engines) configurePhase src;
 
-    buildPhase = "cargo build --release --target=wasm32-unknown-unknown -p prisma-schema-build";
+    buildPhase = "cargo build --profile=wasm-release --target=wasm32-unknown-unknown -p prisma-schema-build";
     installPhase = readFile "${scriptsDir}/install.sh";
   };
 

--- a/prisma-schema-wasm/scripts/install.sh
+++ b/prisma-schema-wasm/scripts/install.sh
@@ -14,8 +14,13 @@ cp ./prisma-schema-wasm/package.json "$out"/
 printf '%s\n' " -> Copying README.md"
 cp ./prisma-schema-wasm/README.md "$out"/
 
+printf '%s\n' " -> Optimizing WASM binary for size"
+wasm-opt -Oz \
+    target/wasm32-unknown-unknown/wasm-release/prisma_schema_build.wasm \
+    -o target/prisma_schema_build.wasm
+
 printf '%s\n' " -> Generating node package"
 wasm-bindgen \
   --target nodejs \
   --out-dir "$out"/src \
-  target/wasm32-unknown-unknown/release/prisma_schema_build.wasm
+  target/prisma_schema_build.wasm


### PR DESCRIPTION
This PR explores how much size can be trivially saved in WASM binaries
compared to how we currently build them, using `prisma-schema-wasm` as
the example. This is not necessarily useful for `prisma-schema-wasm`
but could be useful for the QE.

- Enable more aggressive size optimization level in LLVM (`z` instead of
  `s`) at some runtime performance cost.
- Further optimize the WASM binary for size using `wasm-opt` from
  Binaryen.

| optimization level     | size    | ratio  |
| ---------------------- | ------- | ------ |
| `-Os` (baseline)       | 2742189 | 100%   |
| `-Oz`                  | 2558271 | 93.29% |
| `-Oz` + `wasm-opt -Oz` | 2081699 | 75.91% |
