### PR TITLE
Use revert-esm prisma/prisma branch by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CONFIG_PATH = ./query-engine/connector-test-kit-rs/test-configs
 CONFIG_FILE = .test_config
 SCHEMA_EXAMPLES_PATH = ./query-engine/example_schemas
 DEV_SCHEMA_FILE = dev_datamodel.prisma
-DRIVER_ADAPTERS_BRANCH ?= main
+DRIVER_ADAPTERS_BRANCH ?= revert-esm
 
 LIBRARY_EXT := $(shell                            \
     case "$$(uname -s)" in                        \


### PR DESCRIPTION
Uses https://github.com/prisma/prisma/compare/revert-esm until we figure out the problem with ESM export maps.