### PR TITLE
chore: Remove Vitess 5.7

### DIFF
--- a/.github/workflows/query-engine.yml
+++ b/.github/workflows/query-engine.yml
@@ -25,10 +25,6 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          - name: 'vitess_5_7'
-            single_threaded: true
-            connector: 'vitess'
-            version: '5.7'
           - name: 'vitess_8_0'
             single_threaded: true
             connector: 'vitess'

--- a/.github/workflows/schema-engine.yml
+++ b/.github/workflows/schema-engine.yml
@@ -94,11 +94,6 @@ jobs:
             url: 'postgresql://prisma@localhost:26257'
           - name: sqlite
             url: sqlite
-          - name: vitess_5_7
-            url: 'mysql://root:prisma@localhost:33577/test'
-            shadow_database_url: 'mysql://root:prisma@localhost:33578/shadow'
-            is_vitess: true
-            single_threaded: true
           - name: vitess_8_0
             url: 'mysql://root:prisma@localhost:33807/test'
             shadow_database_url: 'mysql://root:prisma@localhost:33808/shadow'

--- a/.test_database_urls/vitess_5_7
+++ b/.test_database_urls/vitess_5_7
@@ -1,2 +1,0 @@
-export TEST_DATABASE_URL="mysql://root:prisma@localhost:33577/test"
-export TEST_SHADOW_DATABASE_URL="mysql://root:prisma@localhost:33578/shadow"

--- a/Makefile
+++ b/Makefile
@@ -256,12 +256,6 @@ dev-mongodb_5: start-mongodb_5
 dev-mongodb_4_2: start-mongodb_4_2
 	cp $(CONFIG_PATH)/mongodb42 $(CONFIG_FILE)
 
-start-vitess_5_7:
-	docker compose -f docker-compose.yml up --wait -d --remove-orphans vitess-test-5_7 vitess-shadow-5_7
-
-dev-vitess_5_7: start-vitess_5_7
-	cp $(CONFIG_PATH)/vitess_5_7 $(CONFIG_FILE)
-
 start-vitess_8_0:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans vitess-test-8_0 vitess-shadow-8_0
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,26 +222,6 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
-  vitess-test-5_7:
-    image: vitess/vttestserver:mysql57@sha256:23863a518b34330109c502ac61a396008f5f023e96263bcb2bb1b0f7f7d5dc7f
-    restart: unless-stopped
-    ports:
-      - 33577:33577
-    environment:
-      PORT: 33574
-      KEYSPACES: 'test'
-      NUM_SHARDS: '1'
-      MYSQL_BIND_HOST: '0.0.0.0'
-      FOREIGN_KEY_MODE: 'disallow'
-      ENABLE_ONLINE_DDL: false
-      MYSQL_MAX_CONNECTIONS: 100000
-      TABLET_REFRESH_INTERVAL: '500ms'
-    healthcheck:
-      test: ['CMD', 'mysqladmin', 'ping', '-h127.0.0.1', '-P33577']
-      interval: 5s
-      timeout: 2s
-      retries: 20
-
   vitess-test-8_0:
     image: vitess/vttestserver:mysql80@sha256:8bec2644d83cb322eb2cdd596d33c0f858243ba6ade9164c95dfcc519643094e
     restart: unless-stopped
@@ -258,26 +238,6 @@ services:
       TABLET_REFRESH_INTERVAL: '500ms'
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h127.0.0.1', '-P33807']
-      interval: 5s
-      timeout: 2s
-      retries: 20
-
-  vitess-shadow-5_7:
-    image: vitess/vttestserver:mysql57@sha256:23863a518b34330109c502ac61a396008f5f023e96263bcb2bb1b0f7f7d5dc7f
-    restart: unless-stopped
-    ports:
-      - 33578:33577
-    environment:
-      PORT: 33574
-      KEYSPACES: 'shadow'
-      NUM_SHARDS: '1'
-      MYSQL_BIND_HOST: '0.0.0.0'
-      FOREIGN_KEY_MODE: 'disallow'
-      ENABLE_ONLINE_DDL: false
-      MYSQL_MAX_CONNECTIONS: 100000
-      TABLET_REFRESH_INTERVAL: '500ms'
-    healthcheck:
-      test: ['CMD', 'mysqladmin', 'ping', '-h127.0.0.1', '-P33577']
       interval: 5s
       timeout: 2s
       retries: 20

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -196,7 +196,6 @@ pub(crate) fn connection_string(
                 None => unreachable!("A versioned connector must have a concrete version to run."),
             }
         }
-        ConnectorVersion::Vitess(Some(VitessVersion::V5_7)) => "mysql://root@localhost:33577/test".into(),
         ConnectorVersion::Vitess(Some(VitessVersion::V8_0)) => "mysql://root@localhost:33807/test".into(),
         ConnectorVersion::Vitess(None) => unreachable!("A versioned connector must have a concrete version to run."),
     }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/vitess.rs
@@ -33,7 +33,6 @@ impl ConnectorTagInterface for VitessConnectorTag {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum VitessVersion {
-    V5_7,
     V8_0,
 }
 
@@ -42,7 +41,6 @@ impl FromStr for VitessVersion {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let version = match s {
-            "5.7" => Self::V5_7,
             "8.0" => Self::V8_0,
             _ => return Err(TestError::parse_error(format!("Unknown Vitess version `{s}`"))),
         };
@@ -54,7 +52,6 @@ impl FromStr for VitessVersion {
 impl Display for VitessVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::V5_7 => write!(f, "5.7"),
             Self::V8_0 => write!(f, "8.0"),
         }
     }

--- a/query-engine/connector-test-kit-rs/test-configs/vitess_5_7
+++ b/query-engine/connector-test-kit-rs/test-configs/vitess_5_7
@@ -1,3 +1,0 @@
-{
-    "connector": "vitess",
-    "version": "5.7"}

--- a/schema-engine/sql-introspection-tests/tests/mysql/constraints.rs
+++ b/schema-engine/sql-introspection-tests/tests/mysql/constraints.rs
@@ -4,7 +4,7 @@ use indoc::indoc;
 use sql_introspection_tests::test_api::*;
 use test_macros::test_connector;
 
-// Note: MySQL 5.6 ad 5.7 do not support check constraints, so this test is only run on MySQL 8.0.
+// Note: MySQL 5.6 and 5.7 do not support check constraints, so this test is only run on MySQL 8.0.
 #[test_connector(tags(Mysql8), exclude(Vitess))]
 async fn check_constraints_stopgap(api: &mut TestApi) -> TestResult {
     let raw_sql = indoc! {r#"


### PR DESCRIPTION
PlanetScale [runs on MySQL 8](https://planetscale.com/docs/reference/mysql-compatibility). We care about Vitess mostly in context of that.