### PR TITLE
chore: update to Rust 1.74

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6010,9 +6010,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "7daec296f25a1bae309c0cd5c29c4b260e510e6d813c286b19eaadf409d40fce"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6020,9 +6020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "e397f4664c0e4e428e8313a469aaa58310d302159845980fd23b0f22a847f217"
 dependencies = [
  "bumpalo",
  "log",
@@ -6047,9 +6047,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "5961017b3b08ad5f3fe39f1e79877f8ee7c23c5e5fd5eb80de95abc41f1f16b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6057,9 +6057,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "c5353b8dab669f5e10f5bd76df26a9360c748f054f862ff5f3f8aae0c7fb3907"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6070,9 +6070,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "0d046c5d029ba91a1ed14da14dca44b68bf2f124cfbaf741c54151fdb3e0750b"
 
 [[package]]
 name = "wasm-logger"

--- a/flake.lock
+++ b/flake.lock
@@ -2,44 +2,21 @@
   "nodes": {
     "crane": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": [
-          "flake-utils"
-        ],
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "rust-overlay": [
-          "rust-overlay"
         ]
       },
       "locked": {
-        "lastModified": 1696384830,
-        "narHash": "sha256-j8ZsVqzmj5sOm5MW9cqwQJUZELFFwOislDmqDDEMl6k=",
+        "lastModified": 1699548976,
+        "narHash": "sha256-xnpxms0koM8mQpxIup9JnT0F7GrKdvv0QvtxvRuOYR4=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f2143cd27f8bd09ee4f0121336c65015a2a0a19c",
+        "rev": "6849911446e18e520970cc6b7a691e64ee90d649",
         "type": "github"
       },
       "original": {
         "owner": "ipetkov",
         "repo": "crane",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696267196,
-        "narHash": "sha256-AAQ/2sD+0D18bb8hKuEEVpHUYD1GmO2Uh/taFamn6XQ=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "4f910c9827911b1ec2bf26b5a062cd09f8d89f85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
         "type": "github"
       }
     },
@@ -50,11 +27,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696343447,
-        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
         "type": "github"
       },
       "original": {
@@ -105,11 +82,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696193975,
-        "narHash": "sha256-mnQjUcYgp9Guu3RNVAB2Srr1TqKcPpRXmJf4LJk6KRY=",
+        "lastModified": 1699963925,
+        "narHash": "sha256-LE7OV/SwkIBsCpAlIPiFhch/J+jBDGEZjNfdnzCnCrY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdd898f8f79e8d2f99ed2ab6b3751811ef683242",
+        "rev": "bf744fe90419885eefced41b3e5ae442d732712d",
         "type": "github"
       },
       "original": {
@@ -139,11 +116,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1696558324,
-        "narHash": "sha256-TnnP4LGwDB8ZGE7h2n4nA9Faee8xPkMdNcyrzJ57cbw=",
+        "lastModified": 1700187354,
+        "narHash": "sha256-RRIVKv+tiI1yn1PqZiVGQ9YlQGZ+/9iEkA4rst1QiNk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fdb37574a04df04aaa8cf7708f94a9309caebe2b",
+        "rev": "e3ebc177291f5de627d6dfbac817b4a661b15d1c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,6 @@
     crane = {
       url = "github:ipetkov/crane";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.rust-overlay.follows = "rust-overlay";
-      inputs.flake-utils.follows = "flake-utils";
     };
     flake-utils = {
       url = "github:numtide/flake-utils";

--- a/prisma-schema-wasm/Cargo.toml
+++ b/prisma-schema-wasm/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = "=0.2.87"
+wasm-bindgen = "=0.2.88"
 wasm-logger = { version = "0.2.0", optional = true }
 prisma-fmt = { path = "../prisma-fmt" }

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -17,7 +17,7 @@ mod smoke_tests {
 
     fn assert_value_in_range(metrics: &str, metric: &str, low: f64, high: f64) {
         let regex = Regex::new(format!(r"{metric}\s+([+-]?\d+(\.\d+)?)").as_str()).unwrap();
-        match regex.captures(&metrics) {
+        match regex.captures(metrics) {
             Some(capture) => {
                 let value = capture.get(1).unwrap().as_str().parse::<f64>().unwrap();
                 assert!(

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -853,7 +853,7 @@ mod proxy_test {
         let s = "13:02:20.321";
         let json_value = serde_json::Value::String(s.to_string());
         let quaint_value = js_value_to_quaint(json_value, column_type, "column_name").unwrap();
-        let time: NaiveTime = NaiveTime::from_hms_milli_opt(13, 02, 20, 321).unwrap();
+        let time: NaiveTime = NaiveTime::from_hms_milli_opt(13, 2, 20, 321).unwrap();
         assert_eq!(quaint_value, QuaintValue::time(time));
     }
 

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -22,7 +22,7 @@ serde_json.workspace = true
 serde.workspace = true
 tokio = { version = "1.25", features = ["macros", "sync", "io-util", "time"] }
 futures = "0.3"
-wasm-bindgen = "=0.2.87"
+wasm-bindgen = "=0.2.88"
 wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.5"
 js-sys = "0.3"

--- a/schema-engine/sql-migration-tests/tests/native_types/mysql.rs
+++ b/schema-engine/sql-migration-tests/tests/native_types/mysql.rs
@@ -697,8 +697,8 @@ fn filter_from_types(api: &TestApi, cases: Cases) -> Cow<'static, [Case]> {
         return Cow::Owned(
             cases
                 .iter()
+                .filter(|&(ty, _, _)| !type_is_unsupported_mariadb(ty))
                 .cloned()
-                .filter(|(ty, _, _)| !type_is_unsupported_mariadb(ty))
                 .collect(),
         );
     }
@@ -707,8 +707,8 @@ fn filter_from_types(api: &TestApi, cases: Cases) -> Cow<'static, [Case]> {
         return Cow::Owned(
             cases
                 .iter()
+                .filter(|&(ty, _, _)| !type_is_unsupported_mysql_5_6(ty))
                 .cloned()
-                .filter(|(ty, _, _)| !type_is_unsupported_mysql_5_6(ty))
                 .collect(),
         );
     }


### PR DESCRIPTION
https://blog.rust-lang.org/2023/11/16/Rust-1.74.0.html

Changes in this commit:

* Update Nix flake, including nixpkgs and rust-overlay:

  - Rust 1.74
  - Node.js 21.1.0
  - wasm-bindgen 0.2.88
  - etc

* Bump `wasm-bindgen` dependency in `Cargo.toml` to match the new
  version of external `wasm-bindgen` binary installed on CI via Nix.
  Their versions must always match for the build to succeed.

* Fix the clippy warnings.
