### PR TITLE
test(qe): update expected error in SQLite tests with driver adapters

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15204.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15204.rs
@@ -46,7 +46,7 @@ mod conversion_error {
             runner,
             r#"query { findManyTestModel { field } }"#,
             2023,
-            "Inconsistent column data: Conversion failed: number must be an integer in column 'field'"
+            "Inconsistent column data: Conversion failed: number must be an integer in column 'field', got '1.84467440724388e19'"
         );
 
         Ok(())
@@ -74,7 +74,7 @@ mod conversion_error {
             runner,
             r#"query { findManyTestModel { field } }"#,
             2023,
-            "Inconsistent column data: Conversion failed: number must be an i64 in column 'field'"
+            "Inconsistent column data: Conversion failed: number must be an integer in column 'field', got '1.84467440724388e19'"
         );
 
         Ok(())


### PR DESCRIPTION
The error message was changed in https://github.com/prisma/prisma-engines/pull/4429 but wasn't updated in the tests which resulted in them failing on main.
