### PR TITLE
chore(driver-adapters): fix conflicting library name warning on "cargo build"

### DIFF
--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [lib]
 doc = false
 crate-type = ["cdylib"]
-name = "query_engine"
+name = "query_engine_wasm"
 
 [dependencies]
 anyhow = "1"

--- a/query-engine/query-engine-wasm/example.js
+++ b/query-engine/query-engine-wasm/example.js
@@ -6,7 +6,7 @@
 import { Pool } from '@neondatabase/serverless'
 import { PrismaNeon } from '@prisma/adapter-neon'
 import { bindAdapter } from '@prisma/driver-adapter-utils'
-import { init, QueryEngine, getBuildTimeInfo } from './pkg/query_engine.js'
+import { init, QueryEngine, getBuildTimeInfo } from './pkg/query_engine_wasm.js'
 
 async function main() {
   // Always initialize the Wasm library before using it.

--- a/query-engine/query-engine-wasm/package.json
+++ b/query-engine/query-engine-wasm/package.json
@@ -1,9 +1,12 @@
 {
   "type": "module",
   "main": "./example.js",
+  "scripts": {
+    "dev": "node --experimental-wasm-modules ./example.js"
+  },
   "dependencies": {
     "@neondatabase/serverless": "0.6.0",
-    "@prisma/adapter-neon": "5.5.2",
-    "@prisma/driver-adapter-utils": "5.5.2"
+    "@prisma/adapter-neon": "5.6.0",
+    "@prisma/driver-adapter-utils": "5.6.0"
   }
 }


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/594, and was extracted by https://github.com/prisma/prisma-engines/pull/4456.