### PR TITLE
qe: Allow to run query engine test suite against wasm engines

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -23,7 +23,7 @@ export QE_LOG_LEVEL=debug # Set it to "trace" to enable query-graph debugging lo
 # export FMT_SQL=1 # Uncomment it to enable logging formatted SQL queries
 
 ### Uncomment to run driver adapters tests. See query-engine-driver-adapters.yml workflow for how tests run in CI.
-# export EXTERNAL_TEST_EXECUTOR="$(pwd)/query-engine/driver-adapters/js/connector-test-kit-executor/script/start_node.sh"
+# export EXTERNAL_TEST_EXECUTOR="napi"
 # export DRIVER_ADAPTER=pg # Set to pg, neon or planetscale
 # export PRISMA_DISABLE_QUAINT_EXECUTORS=1 # Disable quaint executors for driver adapters
 # export DRIVER_ADAPTER_URL_OVERRIDE ="postgres://USER:PASSWORD@DATABASExxxx" # Override the database url for the driver adapter tests

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -25,12 +25,18 @@ jobs:
       fail-fast: false
       matrix:
         adapter:
-          - name: 'pg'
+          - name: 'pg (napi)'
             setup_task: 'dev-pg-postgres13'
-          - name: 'neon:ws'
+          - name: 'neon:ws (napi)'
             setup_task: 'dev-neon-ws-postgres13'
-          - name: 'libsql'
+          - name: 'libsql (napi)'
             setup_task: 'dev-libsql-sqlite'
+          - name: 'pg (wasm)'
+            setup_task: 'dev-pg-postgres13-wasm'
+          - name: 'neon:ws (wasm)'
+            setup_task: 'dev-neon-ws-postgres13-wasm'
+          - name: 'libsql (wasm)'
+            setup_task: 'dev-libsql-sqlite-wasm'
         node_version: ['18']
     env:
       LOG_LEVEL: 'info' # Set to "debug" to trace the query engine and node process running the driver adapter

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -31,15 +31,16 @@ jobs:
             setup_task: 'dev-neon-ws-postgres13'
           - name: 'libsql (napi)'
             setup_task: 'dev-libsql-sqlite'
-          - name: 'pg (wasm)'
-            setup_task: 'dev-pg-postgres13-wasm'
-            needs_wasm_pack: true
-          - name: 'neon:ws (wasm)'
-            setup_task: 'dev-neon-ws-postgres13-wasm'
-            needs_wasm_pack: true
-          - name: 'libsql (wasm)'
-            setup_task: 'dev-libsql-sqlite-wasm'
-            needs_wasm_pack: true
+          # TODO: uncomment when WASM engine is functional
+          # - name: 'pg (wasm)'
+          #   setup_task: 'dev-pg-postgres13-wasm'
+          #   needs_wasm_pack: true
+          # - name: 'neon:ws (wasm)'
+          #   setup_task: 'dev-neon-ws-postgres13-wasm'
+          #   needs_wasm_pack: true
+          # - name: 'libsql (wasm)'
+          #   setup_task: 'dev-libsql-sqlite-wasm'
+          #   needs_wasm_pack: true
         node_version: ['18']
     env:
       LOG_LEVEL: 'info' # Set to "debug" to trace the query engine and node process running the driver adapter

--- a/.github/workflows/query-engine-driver-adapters.yml
+++ b/.github/workflows/query-engine-driver-adapters.yml
@@ -33,10 +33,13 @@ jobs:
             setup_task: 'dev-libsql-sqlite'
           - name: 'pg (wasm)'
             setup_task: 'dev-pg-postgres13-wasm'
+            needs_wasm_pack: true
           - name: 'neon:ws (wasm)'
             setup_task: 'dev-neon-ws-postgres13-wasm'
+            needs_wasm_pack: true
           - name: 'libsql (wasm)'
             setup_task: 'dev-libsql-sqlite-wasm'
+            needs_wasm_pack: true
         node_version: ['18']
     env:
       LOG_LEVEL: 'info' # Set to "debug" to trace the query engine and node process running the driver adapter
@@ -91,9 +94,13 @@ jobs:
             echo "DRIVER_ADAPTERS_BRANCH=$branch" >> "$GITHUB_ENV"
           fi
 
-      - run: make ${{ matrix.adapter.setup_task }}
-
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: 'Install wasm-pack'
+        if: ${{ matrix.adapter.needs_wasm_pack }}
+        run: cargo install wasm-pack
+
+      - run: make ${{ matrix.adapter.setup_task }}
 
       - name: 'Run tests'
         run: cargo test --package query-engine-tests -- --test-threads=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,6 +3827,7 @@ dependencies = [
  "quaint",
  "query-connector",
  "query-core",
+ "request-handlers",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3827,7 +3827,6 @@ dependencies = [
  "quaint",
  "query-connector",
  "query-core",
- "request-handlers",
  "serde",
  "serde-wasm-bindgen",
  "serde_json",

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ test-libsql-sqlite: dev-libsql-sqlite test-qe-st
 
 test-driver-adapter-libsql: test-libsql-sqlite
 
+dev-libsql-sqlite-wasm: build-qe-napi build-connector-kit-js
+	cp $(CONFIG_PATH)/libsql-sqlite-wasm $(CONFIG_FILE)
+
+test-libsql-sqlite-wasm: dev-libsql-sqlite-wasm test-qe-st
+
 start-postgres9:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans postgres9
 
@@ -128,6 +133,11 @@ dev-pg-postgres13: start-pg-postgres13
 
 test-pg-postgres13: dev-pg-postgres13 test-qe-st
 
+dev-pg-postgres13-wasm: start-pg-postgres13
+	cp $(CONFIG_PATH)/pg-postgres13-wasm $(CONFIG_FILE)
+
+test-pg-postgres13-wasm: dev-pg-postgres13-wasm test-qe-st
+
 test-driver-adapter-pg: test-pg-postgres13
 
 start-neon-postgres13:
@@ -137,6 +147,11 @@ dev-neon-ws-postgres13: start-neon-postgres13 build-qe-napi build-connector-kit-
 	cp $(CONFIG_PATH)/neon-ws-postgres13 $(CONFIG_FILE)
 
 test-neon-ws-postgres13: dev-neon-ws-postgres13 test-qe-st
+
+dev-neon-ws-postgres13-wasm: start-neon-postgres13 build-qe-napi build-connector-kit-js
+	cp $(CONFIG_PATH)/neon-ws-postgres13-wasm $(CONFIG_FILE)
+
+test-neon-ws-postgres13-wasm: dev-neon-ws-postgres13-wasm test-qe-st
 
 test-driver-adapter-neon: test-neon-ws-postgres13
 
@@ -269,6 +284,11 @@ dev-planetscale-vitess8: start-planetscale-vitess8 build-qe-napi build-connector
 	cp $(CONFIG_PATH)/planetscale-vitess8 $(CONFIG_FILE)
 
 test-planetscale-vitess8: dev-planetscale-vitess8 test-qe-st
+
+dev-planetscale-vitess8-wasm: start-planetscale-vitess8 build-qe-napi build-connector-kit-js
+	cp $(CONFIG_PATH)/planetscale-vitess8-wasm $(CONFIG_FILE)
+
+test-planetscale-vitess8-wasm: dev-planetscale-vitess8-wasm test-qe-st
 
 test-driver-adapter-planetscale: test-planetscale-vitess8
 

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ test-libsql-sqlite: dev-libsql-sqlite test-qe-st
 
 test-driver-adapter-libsql: test-libsql-sqlite
 
-dev-libsql-sqlite-wasm: build-qe-napi build-connector-kit-js
+dev-libsql-sqlite-wasm: build-qe-wasm build-connector-kit-js
 	cp $(CONFIG_PATH)/libsql-sqlite-wasm $(CONFIG_FILE)
 
 test-libsql-sqlite-wasm: dev-libsql-sqlite-wasm test-qe-st
@@ -126,14 +126,14 @@ start-postgres13:
 dev-postgres13: start-postgres13
 	cp $(CONFIG_PATH)/postgres13 $(CONFIG_FILE)
 
-start-pg-postgres13: build-qe-napi build-connector-kit-js start-postgres13
+start-pg-postgres13: start-postgres13
 
-dev-pg-postgres13: start-pg-postgres13
+dev-pg-postgres13: start-pg-postgres13 build-qe-napi build-connector-kit-js
 	cp $(CONFIG_PATH)/pg-postgres13 $(CONFIG_FILE)
 
 test-pg-postgres13: dev-pg-postgres13 test-qe-st
 
-dev-pg-postgres13-wasm: start-pg-postgres13
+dev-pg-postgres13-wasm: start-pg-postgres13 build-qe-wasm build-connector-kit-js
 	cp $(CONFIG_PATH)/pg-postgres13-wasm $(CONFIG_FILE)
 
 test-pg-postgres13-wasm: dev-pg-postgres13-wasm test-qe-st
@@ -148,7 +148,7 @@ dev-neon-ws-postgres13: start-neon-postgres13 build-qe-napi build-connector-kit-
 
 test-neon-ws-postgres13: dev-neon-ws-postgres13 test-qe-st
 
-dev-neon-ws-postgres13-wasm: start-neon-postgres13 build-qe-napi build-connector-kit-js
+dev-neon-ws-postgres13-wasm: start-neon-postgres13 build-qe-wasm build-connector-kit-js
 	cp $(CONFIG_PATH)/neon-ws-postgres13-wasm $(CONFIG_FILE)
 
 test-neon-ws-postgres13-wasm: dev-neon-ws-postgres13-wasm test-qe-st
@@ -285,7 +285,7 @@ dev-planetscale-vitess8: start-planetscale-vitess8 build-qe-napi build-connector
 
 test-planetscale-vitess8: dev-planetscale-vitess8 test-qe-st
 
-dev-planetscale-vitess8-wasm: start-planetscale-vitess8 build-qe-napi build-connector-kit-js
+dev-planetscale-vitess8-wasm: start-planetscale-vitess8 build-qe-wasm build-connector-kit-js
 	cp $(CONFIG_PATH)/planetscale-vitess8-wasm $(CONFIG_FILE)
 
 test-planetscale-vitess8-wasm: dev-planetscale-vitess8-wasm test-qe-st
@@ -298,6 +298,9 @@ test-driver-adapter-planetscale: test-planetscale-vitess8
 
 build-qe-napi:
 	cargo build --package query-engine-node-api
+
+build-qe-wasm:
+	cd query-engine/query-engine-wasm && ./build.sh
 
 build-connector-kit-js: build-driver-adapters
 	cd query-engine/driver-adapters && pnpm i && pnpm build

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,11 @@ ifndef DRIVER_ADAPTER
 	cargo test --package query-engine-tests
 else
 	@echo "Executing query engine tests with $(DRIVER_ADAPTER) driver adapter"; \
-	# Add your actual command for the "test-driver-adapter" task here
-	$(MAKE) test-driver-adapter-$(DRIVER_ADAPTER);
+	if [ "$(ENGINE)" = "wasm" ]; then \
+		$(MAKE) test-driver-adapter-$(DRIVER_ADAPTER)-wasm; \
+	else \
+		$(MAKE) test-driver-adapter-$(DRIVER_ADAPTER); \
+	fi
 endif
 
 test-qe-verbose:
@@ -95,6 +98,7 @@ dev-libsql-sqlite-wasm: build-qe-wasm build-connector-kit-js
 	cp $(CONFIG_PATH)/libsql-sqlite-wasm $(CONFIG_FILE)
 
 test-libsql-sqlite-wasm: dev-libsql-sqlite-wasm test-qe-st
+test-driver-adapter-libsql-sqlite-wasm: test-libsql-sqlite-wasm
 
 start-postgres9:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans postgres9
@@ -139,6 +143,7 @@ dev-pg-postgres13-wasm: start-pg-postgres13 build-qe-wasm build-connector-kit-js
 test-pg-postgres13-wasm: dev-pg-postgres13-wasm test-qe-st
 
 test-driver-adapter-pg: test-pg-postgres13
+test-driver-adapter-pg-wasm: test-pg-postgres13-wasm
 
 start-neon-postgres13:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans neon-postgres13
@@ -154,6 +159,7 @@ dev-neon-ws-postgres13-wasm: start-neon-postgres13 build-qe-wasm build-connector
 test-neon-ws-postgres13-wasm: dev-neon-ws-postgres13-wasm test-qe-st
 
 test-driver-adapter-neon: test-neon-ws-postgres13
+test-driver-adapter-neon-wasm: test-neon-ws-postgres13-wasm
 
 start-postgres14:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans postgres14
@@ -291,6 +297,7 @@ dev-planetscale-vitess8-wasm: start-planetscale-vitess8 build-qe-wasm build-conn
 test-planetscale-vitess8-wasm: dev-planetscale-vitess8-wasm test-qe-st
 
 test-driver-adapter-planetscale: test-planetscale-vitess8
+test-driver-adapter-planetscale-wasm: test-planetscale-vitess8-wasm
 
 ######################
 # Local dev commands #

--- a/query-engine/connector-test-kit-rs/README.md
+++ b/query-engine/connector-test-kit-rs/README.md
@@ -82,15 +82,16 @@ drivers the code that actually communicates with the databases. See [`adapter-*`
 
 To run tests through a driver adapters, you should also configure the following environment variables:
 
-* `EXTERNAL_TEST_EXECUTOR`: tells the query engine test kit to use an external process to run the queries, this is a node process running a program that will read the queries to run from STDIN, and return responses to STDOUT. The connector kit follows a protocol over JSON RPC for this communication.
 * `DRIVER_ADAPTER`: tells the test executor to use a particular driver adapter. Set to `neon`, `planetscale` or any other supported adapter.
 * `DRIVER_ADAPTER_CONFIG`: a json string with the configuration for the driver adapter. This is adapter specific. See the [github workflow for driver adapter tests](.github/workflows/query-engine-driver-adapters.yml) for examples on how to configure the driver adapters.
+* `ENGINE`: can be used to run either `wasm` or `napi` version of the engine.
 
 Example:
 
 ```shell
 export EXTERNAL_TEST_EXECUTOR="$WORKSPACE_ROOT/query-engine/driver-adapters/connector-test-kit-executor/script/start_node.sh"
 export DRIVER_ADAPTER=neon
+export ENGINE=wasm
 export DRIVER_ADAPTER_CONFIG ='{ "proxyUrl": "127.0.0.1:5488/v1" }'
 ````
 
@@ -98,7 +99,7 @@ We have provided helpers to run the query-engine tests with driver adapters, the
 variables for you:
 
 ```shell
-DRIVER_ADAPTER=$adapter make test-qe
+DRIVER_ADAPTER=$adapter ENGINE=$engine make test-qe
 ```
 
 Where `$adapter` is one of the supported adapters: `neon`, `planetscale`, `libsql`.

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -8,17 +8,17 @@ use std::{convert::TryFrom, env, fmt::Display, fs::File, io::Read, path::PathBuf
 static TEST_CONFIG_FILE_NAME: &str = ".test_config";
 
 #[derive(Debug, Default, Deserialize, Clone)]
-enum TestExecutorEngine {
+pub enum TestExecutorEngine {
     #[default]
-    NAPI,
-    WASM,
+    Napi,
+    Wasm,
 }
 
 impl Display for TestExecutorEngine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TestExecutorEngine::NAPI => f.write_str("NAPI"),
-            TestExecutorEngine::WASM => f.write_str("WASM"),
+            TestExecutorEngine::Napi => f.write_str("Napi"),
+            TestExecutorEngine::Wasm => f.write_str("Wasm"),
         }
     }
 }
@@ -130,7 +130,7 @@ impl TestConfig {
         println!("* CI? {}", self.is_ci);
         if self.external_test_executor.as_ref().is_some() {
             println!("* External test executor: {}", self.external_test_executor().unwrap_or_default());
-            println!("* External test executor engine: {:?}", self.external_test_executor().unwrap_or_default());
+            println!("* External test executor engine: {:?}", self.external_test_executor_engine().unwrap_or_default());
             println!("* Driver adapter: {}", self.driver_adapter().unwrap_or_default());
             println!("* Driver adapter url override: {}", self.json_stringify_driver_adapter_config());
         }
@@ -294,6 +294,10 @@ impl TestConfig {
 
     pub fn external_test_executor(&self) -> Option<&str> {
         self.external_test_executor.as_deref()
+    }
+
+    pub fn external_test_executor_engine(&self) -> Option<TestExecutorEngine> {
+        self.external_test_executor_engine.clone()
     }
 
     pub fn driver_adapter(&self) -> Option<&str> {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -7,18 +7,17 @@ use std::{convert::TryFrom, env, fmt::Display, fs::File, io::Read, path::PathBuf
 
 static TEST_CONFIG_FILE_NAME: &str = ".test_config";
 
-#[derive(Debug, Default, Deserialize, Clone)]
-pub enum TestExecutorEngine {
-    #[default]
+#[derive(Debug, Deserialize, Clone)]
+pub enum TestExecutor {
     Napi,
     Wasm,
 }
 
-impl Display for TestExecutorEngine {
+impl Display for TestExecutor {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TestExecutorEngine::Napi => f.write_str("Napi"),
-            TestExecutorEngine::Wasm => f.write_str("Wasm"),
+            TestExecutor::Napi => f.write_str("Napi"),
+            TestExecutor::Wasm => f.write_str("Wasm"),
         }
     }
 }
@@ -40,13 +39,9 @@ pub struct TestConfig {
     /// Used when testing driver adapters, this process is expected to be a javascript process
     /// loading the library engine (as a library, or WASM modules) and providing it with a
     /// driver adapter.
+    /// Possible values: Napi, Wasm
     /// Env key: `EXTERNAL_TEST_EXECUTOR`
-    external_test_executor: Option<String>,
-
-    /// Specifies which engine to use within external test executor.
-    /// If omitted, NAPI engine will be used.
-    /// Env key: `EXTERNAL_TEST_EXECUTOR_ENGINE`
-    external_test_executor_engine: Option<TestExecutorEngine>,
+    external_test_executor: Option<TestExecutor>,
 
     /// The driver adapter to use when running tests, will be forwarded to the external test
     /// executor by setting the `DRIVER_ADAPTER` env var when spawning the executor process
@@ -106,12 +101,11 @@ fn exit_with_message(msg: &str) -> ! {
 impl TestConfig {
     /// Loads a configuration. File-based config has precedence over env config.
     pub(crate) fn load() -> Self {
-        let mut config = match Self::from_file().or_else(Self::from_env) {
+        let config = match Self::from_file().or_else(Self::from_env) {
             Some(config) => config,
             None => exit_with_message(CONFIG_LOAD_FAILED),
         };
 
-        config.fill_defaults();
         config.validate();
         config.log_info();
 
@@ -128,9 +122,8 @@ impl TestConfig {
             self.connector_version().unwrap_or_default()
         );
         println!("* CI? {}", self.is_ci);
-        if self.external_test_executor.as_ref().is_some() {
-            println!("* External test executor: {}", self.external_test_executor().unwrap_or_default());
-            println!("* External test executor engine: {:?}", self.external_test_executor_engine().unwrap_or_default());
+        if let Some(external_test_executor) = self.external_test_executor.as_ref() {
+            println!("* External test executor: {}", external_test_executor);
             println!("* Driver adapter: {}", self.driver_adapter().unwrap_or_default());
             println!("* Driver adapter url override: {}", self.json_stringify_driver_adapter_config());
         }
@@ -140,9 +133,8 @@ impl TestConfig {
     fn from_env() -> Option<Self> {
         let connector = std::env::var("TEST_CONNECTOR").ok();
         let connector_version = std::env::var("TEST_CONNECTOR_VERSION").ok();
-        let external_test_executor = std::env::var("EXTERNAL_TEST_EXECUTOR").ok();
-        let external_test_executor_engine = std::env::var("EXTERNAL_TEST_EXECUTOR_ENGINE")
-            .map(|value| serde_json::from_str::<TestExecutorEngine>(&value).ok())
+        let external_test_executor = std::env::var("EXTERNAL_TEST_EXECUTOR")
+            .map(|value| serde_json::from_str::<TestExecutor>(&value).ok())
             .unwrap_or_default();
 
         let driver_adapter = std::env::var("DRIVER_ADAPTER").ok();
@@ -160,7 +152,6 @@ impl TestConfig {
             external_test_executor,
             driver_adapter,
             driver_adapter_config,
-            external_test_executor_engine,
         })
     }
 
@@ -182,31 +173,23 @@ impl TestConfig {
         })
     }
 
-    /// if the loaded value for external_test_executor is "default" (case insensitive),
-    /// and the workspace_root is set, then use the default external test executor.
-    fn fill_defaults(&mut self) {
-        const DEFAULT_TEST_EXECUTOR: &str =
-            "query-engine/driver-adapters/connector-test-kit-executor/script/start_node.sh";
-
-        if self
-            .external_test_executor
-            .as_ref()
-            .filter(|s| s.eq_ignore_ascii_case("default"))
-            .is_some()
-        {
-            self.external_test_executor = Self::workspace_root()
-                .map(|path| path.join(DEFAULT_TEST_EXECUTOR))
-                .or_else(|| {
-                    exit_with_message(
-                        "WORKSPACE_ROOT needs to be correctly set to the root of the prisma-engines repository",
-                    )
-                })
-                .and_then(|path| path.to_str().map(|s| s.to_owned()));
-        }
-    }
-
     fn workspace_root() -> Option<PathBuf> {
         env::var("WORKSPACE_ROOT").ok().map(PathBuf::from)
+    }
+
+    pub fn external_test_executor_path(&self) -> Option<String> {
+        const DEFAULT_TEST_EXECUTOR: &str =
+            "query-engine/driver-adapters/connector-test-kit-executor/script/start_node.sh";
+        self.external_test_executor
+            .as_ref()
+            .and_then(|_| Self::workspace_root())
+            .map(|path| path.join(DEFAULT_TEST_EXECUTOR))
+            .or_else(|| {
+                exit_with_message(
+                    "WORKSPACE_ROOT needs to be correctly set to the root of the prisma-engines repository",
+                )
+            })
+            .and_then(|path| path.to_str().map(|s| s.to_owned()))
     }
 
     fn validate(&self) {
@@ -233,7 +216,7 @@ impl TestConfig {
             Err(err) => exit_with_message(&err.to_string()),
         }
 
-        if let Some(file) = self.external_test_executor.as_ref() {
+        if let Some(file) = self.external_test_executor_path().as_ref() {
             let path = PathBuf::from(file);
             let md = path.metadata();
             if !path.exists() || md.is_err() || !md.unwrap().is_file() {
@@ -258,12 +241,6 @@ impl TestConfig {
         if self.external_test_executor.is_some() && self.driver_adapter.is_none() {
             exit_with_message(
                 "When using an external test executor, the driver adapter (DRIVER_ADAPTER env var) must be set.",
-            );
-        }
-
-        if self.external_test_executor_engine.is_some() && self.external_test_executor.is_none() {
-            exit_with_message(
-                "External test executor engine can be used only if EXTERNAL_TEST_EXECUTOR env var is set.",
             );
         }
 
@@ -292,12 +269,8 @@ impl TestConfig {
         self.is_ci
     }
 
-    pub fn external_test_executor(&self) -> Option<&str> {
-        self.external_test_executor.as_deref()
-    }
-
-    pub fn external_test_executor_engine(&self) -> Option<TestExecutorEngine> {
-        self.external_test_executor_engine.clone()
+    pub fn external_test_executor(&self) -> Option<TestExecutor> {
+        self.external_test_executor.clone()
     }
 
     pub fn driver_adapter(&self) -> Option<&str> {
@@ -338,8 +311,8 @@ impl TestConfig {
                 self.json_stringify_driver_adapter_config()
             ),
             (
-                "EXTERNAL_TEST_EXECUTOR_ENGINE".to_string(),
-                self.external_test_executor_engine.clone().unwrap_or_default().to_string(),
+                "EXTERNAL_TEST_EXECUTOR".to_string(),
+                self.external_test_executor.clone().unwrap_or(TestExecutor::Napi).to_string(),
             ),
             (
                 "PRISMA_DISABLE_QUAINT_EXECUTORS".to_string(),

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -182,13 +182,14 @@ impl TestConfig {
             "query-engine/driver-adapters/connector-test-kit-executor/script/start_node.sh";
         self.external_test_executor
             .as_ref()
-            .and_then(|_| Self::workspace_root())
-            .map(|path| path.join(DEFAULT_TEST_EXECUTOR))
-            .or_else(|| {
-                exit_with_message(
-                    "WORKSPACE_ROOT needs to be correctly set to the root of the prisma-engines repository",
-                )
+            .and_then(|_| {
+                Self::workspace_root().or_else(|| {
+                    exit_with_message(
+                        "WORKSPACE_ROOT needs to be correctly set to the root of the prisma-engines repository",
+                    )
+                })
             })
+            .map(|path| path.join(DEFAULT_TEST_EXECUTOR))
             .and_then(|path| path.to_str().map(|s| s.to_owned()))
     }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -101,7 +101,7 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
     use tokio::process::Command;
 
     let path = crate::CONFIG
-        .external_test_executor()
+        .external_test_executor_path()
         .unwrap_or_else(|| exit_with_message(1, "start_rpc_thread() error: external test executor is not set"));
 
     tokio::runtime::Builder::new_current_thread()
@@ -109,7 +109,7 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
         .build()
         .unwrap()
         .block_on(async move {
-            let process = match Command::new(path)
+            let process = match Command::new(&path)
                 .envs(CONFIG.for_external_executor())
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -74,7 +74,7 @@ impl ExecutorProcess {
         };
 
         self.task_handle.send((method_call, sender)).await?;
-        let raw_response = receiver.await?;
+        let raw_response = receiver.await??;
         tracing::debug!(%raw_response);
         let response = serde_json::from_value(raw_response)?;
         Ok(response)
@@ -91,7 +91,10 @@ pub(super) static EXTERNAL_PROCESS: Lazy<ExecutorProcess> =
         }
     });
 
-type ReqImpl = (jsonrpc_core::MethodCall, oneshot::Sender<serde_json::value::Value>);
+type ReqImpl = (
+    jsonrpc_core::MethodCall,
+    oneshot::Sender<Result<serde_json::value::Value>>,
+);
 
 fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
     use std::process::Stdio;
@@ -119,7 +122,7 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
 
             let mut stdout = BufReader::new(process.stdout.unwrap()).lines();
             let mut stdin = process.stdin.unwrap();
-            let mut pending_requests: HashMap<jsonrpc_core::Id, oneshot::Sender<serde_json::value::Value>> =
+            let mut pending_requests: HashMap<jsonrpc_core::Id, oneshot::Sender<Result<serde_json::value::Value>>> =
                 HashMap::new();
 
             loop {
@@ -140,10 +143,11 @@ fn start_rpc_thread(mut receiver: mpsc::Receiver<ReqImpl>) -> Result<()> {
                                                 // The other end may be dropped if the whole
                                                 // request future was dropped and not polled to
                                                 // completion, so we ignore send errors here.
-                                                _ = sender.send(success.result);
+                                                _ = sender.send(Ok(success.result));
                                             }
                                             jsonrpc_core::Output::Failure(err) => {
-                                                panic!("error response from jsonrpc: {err:?}")
+                                                tracing::error!("error response from jsonrpc: {err:?}");
+                                                _ = sender.send(Err(Box::new(err.error)));
                                             }
                                         }
                                     }

--- a/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite
+++ b/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite
@@ -2,5 +2,5 @@
     "connector": "sqlite",
     "driver_adapter": "libsql",
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite
+++ b/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite
@@ -1,6 +1,5 @@
 {
     "connector": "sqlite",
     "driver_adapter": "libsql",
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Napi"
+    "external_test_executor": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite-wasm
@@ -1,6 +1,5 @@
 {
     "connector": "sqlite",
     "driver_adapter": "libsql",
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Wasm"
+    "external_test_executor": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite-wasm
@@ -2,5 +2,5 @@
     "connector": "sqlite",
     "driver_adapter": "libsql",
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "WASM"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/libsql-sqlite-wasm
@@ -2,5 +2,5 @@
     "connector": "sqlite",
     "driver_adapter": "libsql",
     "external_test_executor": "default",
-    "external_test_executor_engine": "WASM"
+    "external_test_executor_engine": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13
@@ -3,6 +3,5 @@
     "version": "13",
     "driver_adapter": "neon:ws",
     "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Napi"
+    "external_test_executor": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13
@@ -4,5 +4,5 @@
     "driver_adapter": "neon:ws",
     "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13-wasm
@@ -3,6 +3,5 @@
     "version": "13",
     "driver_adapter": "neon:ws",
     "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Wasm"
+    "external_test_executor": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13-wasm
@@ -4,5 +4,5 @@
     "driver_adapter": "neon:ws",
     "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "WASM"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/neon-ws-postgres13-wasm
@@ -4,5 +4,5 @@
     "driver_adapter": "neon:ws",
     "driver_adapter_config": { "proxyUrl": "127.0.0.1:5488/v1" },
     "external_test_executor": "default",
-    "external_test_executor_engine": "WASM"
+    "external_test_executor_engine": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/pg-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/pg-postgres13
@@ -2,6 +2,5 @@
     "connector": "postgres",
     "version": "13",
     "driver_adapter": "pg",
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Napi"
+    "external_test_executor": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/pg-postgres13
+++ b/query-engine/connector-test-kit-rs/test-configs/pg-postgres13
@@ -3,5 +3,5 @@
     "version": "13",
     "driver_adapter": "pg",
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/pg-postgres13-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/pg-postgres13-wasm
@@ -2,6 +2,5 @@
     "connector": "postgres",
     "version": "13",
     "driver_adapter": "pg",
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Wasm"
+    "external_test_executor": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/pg-postgres13-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/pg-postgres13-wasm
@@ -3,5 +3,5 @@
     "version": "13",
     "driver_adapter": "pg",
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "WASM"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/pg-postgres13-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/pg-postgres13-wasm
@@ -3,5 +3,5 @@
     "version": "13",
     "driver_adapter": "pg",
     "external_test_executor": "default",
-    "external_test_executor_engine": "WASM"
+    "external_test_executor_engine": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8
+++ b/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8
@@ -3,6 +3,5 @@
     "version": "8.0",
     "driver_adapter": "planetscale",
     "driver_adapter_config": { "proxyUrl": "http://root:root@127.0.0.1:8085" },
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Napi"
+    "external_test_executor": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8
+++ b/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8
@@ -4,5 +4,5 @@
     "driver_adapter": "planetscale",
     "driver_adapter_config": { "proxyUrl": "http://root:root@127.0.0.1:8085" },
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "Napi"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8-wasm
@@ -3,6 +3,5 @@
     "version": "8.0",
     "driver_adapter": "planetscale",
     "driver_adapter_config": { "proxyUrl": "http://root:root@127.0.0.1:8085" },
-    "external_test_executor": "default",
-    "external_test_executor_engine": "Wasm"
+    "external_test_executor": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8-wasm
@@ -4,5 +4,5 @@
     "driver_adapter": "planetscale",
     "driver_adapter_config": { "proxyUrl": "http://root:root@127.0.0.1:8085" },
     "external_test_executor": "default",
-    "external_test_executor_engine": "WASM"
+    "external_test_executor_engine": "Wasm"
 }

--- a/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8-wasm
+++ b/query-engine/connector-test-kit-rs/test-configs/planetscale-vitess8-wasm
@@ -4,5 +4,5 @@
     "driver_adapter": "planetscale",
     "driver_adapter_config": { "proxyUrl": "http://root:root@127.0.0.1:8085" },
     "external_test_executor": "default",
-    "external_test_executor_engine": "NAPI"
+    "external_test_executor_engine": "WASM"
 }

--- a/query-engine/driver-adapters/connector-test-kit-executor/package.json
+++ b/query-engine/driver-adapters/connector-test-kit-executor/package.json
@@ -12,6 +12,11 @@
   "scripts": {
     "build": "tsup ./src/index.ts --format esm --dts"
   },
+  "tsup": {
+    "external": [
+      "../../../query-engine-wasm/pkg/query_engine_bg.js"
+    ]
+  },
   "keywords": [],
   "author": "",
   "sideEffects": false,

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/index.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/index.ts
@@ -1,5 +1,4 @@
 import * as qe from './qe'
-import * as engines from './engines/Library'
 import * as readline from 'node:readline'
 import * as jsonRpc from './jsonRpc'
 
@@ -76,7 +75,7 @@ async function main(): Promise<void> {
 }
 
 const state: Record<number, {
-    engine: engines.QueryEngineInstance,
+    engine: qe.QueryEngine,
     adapter: ErrorCapturingDriverAdapter,
     logs: string[]
 }> = {}
@@ -215,7 +214,7 @@ function respondOk(requestId: number, payload: unknown) {
     console.log(JSON.stringify(msg))
 }
 
-async function initQe(url: string, prismaSchema: string, logCallback: qe.QueryLogCallback): Promise<[engines.QueryEngineInstance, ErrorCapturingDriverAdapter]> {
+async function initQe(url: string, prismaSchema: string, logCallback: qe.QueryLogCallback): Promise<[qe.QueryEngine, ErrorCapturingDriverAdapter]> {
     const adapter = await adapterFromEnv(url) as DriverAdapter
     const errorCapturingAdapter = bindAdapter(adapter)
     const engineInstance = qe.initQueryEngine(errorCapturingAdapter, prismaSchema, logCallback, debug)

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/index.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/index.ts
@@ -217,7 +217,7 @@ function respondOk(requestId: number, payload: unknown) {
 async function initQe(url: string, prismaSchema: string, logCallback: qe.QueryLogCallback): Promise<[qe.QueryEngine, ErrorCapturingDriverAdapter]> {
     const adapter = await adapterFromEnv(url) as DriverAdapter
     const errorCapturingAdapter = bindAdapter(adapter)
-    const engineInstance = qe.initQueryEngine(errorCapturingAdapter, prismaSchema, logCallback, debug)
+    const engineInstance = await qe.initQueryEngine(errorCapturingAdapter, prismaSchema, logCallback, debug)
     return [engineInstance, errorCapturingAdapter];
 }
 

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/qe.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/qe.ts
@@ -1,22 +1,25 @@
 import type { ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
-import * as lib from './engines/Library'
+import { WasmQueryEngine } from './wasm'
+import * as napi from './engines/Library'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
+export interface QueryEngine {
+  connect(trace: string): Promise<void>
+  disconnect(trace: string): Promise<void>;
+  query(body: string, trace: string, tx_id?: string): Promise<string>;
+  startTransaction(input: string, trace: string): Promise<string>;
+  commitTransaction(tx_id: string, trace: string): Promise<string>;
+  rollbackTransaction(tx_id: string, trace: string): Promise<string>;
+}
 
 export type QueryLogCallback = (log: string) => void
 
-export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel: string, queryLogCallback: QueryLogCallback, debug: (...args: any[]) => void): lib.QueryEngineInstance {
-    // I assume nobody will run this on Windows ¯\_(ツ)_/¯
-    const libExt = os.platform() === 'darwin' ? 'dylib' : 'so'
-    const dirname = path.dirname(new URL(import.meta.url).pathname)
 
-    const libQueryEnginePath = path.join(dirname, `../../../../target/debug/libquery_engine.${libExt}`)
-
-    const libqueryEngine = { exports: {} as unknown as lib.Library }
-    // @ts-ignore
-    process.dlopen(libqueryEngine, libQueryEnginePath)
-
-    const QueryEngine = libqueryEngine.exports.QueryEngine
+export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel: string, queryLogCallback: QueryLogCallback, debug: (...args: any[]) => void): QueryEngine {
 
     const queryEngineOptions = {
         datamodel,
@@ -37,5 +40,28 @@ export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel:
         debug(parsed)
     }
 
-    return new QueryEngine(queryEngineOptions, logCallback, adapter)
+    const engineFromEnv = process.env.EXTERNAL_TEST_EXECUTOR_ENGINE ?? 'napi'
+    if (engineFromEnv === 'WASM') {
+        return  new WasmQueryEngine(queryEngineOptions, logCallback, adapter)
+    } else if (engineFromEnv === 'NAPI') {
+        const { QueryEngine } = loadNapiEngine()
+        return new QueryEngine(queryEngineOptions, logCallback, adapter)
+    } else {
+        throw new TypeError(`Invalid EXTERNAL_TEST_EXECUTOR_ENGINE value: ${engineFromEnv}. Expected NAPI or WASM`)
+    }
+
+
+}
+
+function loadNapiEngine(): napi.Library {
+    // I assume nobody will run this on Windows ¯\_(ツ)_/¯
+    const libExt = os.platform() === 'darwin' ? 'dylib' : 'so'
+
+    const libQueryEnginePath = path.join(dirname, `../../../../target/debug/libquery_engine.${libExt}`)
+
+    const libqueryEngine = { exports: {} as unknown as napi.Library }
+    // @ts-ignore
+    process.dlopen(libqueryEngine, libQueryEnginePath)
+
+    return libqueryEngine.exports
 }

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/qe.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/qe.ts
@@ -1,5 +1,4 @@
 import type { ErrorCapturingDriverAdapter } from '@prisma/driver-adapter-utils'
-import { WasmQueryEngine } from './wasm'
 import * as napi from './engines/Library'
 import * as os from 'node:os'
 import * as path from 'node:path'
@@ -19,7 +18,7 @@ export interface QueryEngine {
 export type QueryLogCallback = (log: string) => void
 
 
-export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel: string, queryLogCallback: QueryLogCallback, debug: (...args: any[]) => void): QueryEngine {
+export async function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel: string, queryLogCallback: QueryLogCallback, debug: (...args: any[]) => void): QueryEngine {
 
     const queryEngineOptions = {
         datamodel,
@@ -40,14 +39,15 @@ export function initQueryEngine(adapter: ErrorCapturingDriverAdapter, datamodel:
         debug(parsed)
     }
 
-    const engineFromEnv = process.env.EXTERNAL_TEST_EXECUTOR_ENGINE ?? 'napi'
-    if (engineFromEnv === 'WASM') {
+    const engineFromEnv = process.env.EXTERNAL_TEST_EXECUTOR_ENGINE ?? 'Napi'
+    if (engineFromEnv === 'Wasm') {
+        const { WasmQueryEngine } = await import('./wasm')
         return  new WasmQueryEngine(queryEngineOptions, logCallback, adapter)
-    } else if (engineFromEnv === 'NAPI') {
+    } else if (engineFromEnv === 'Napi') {
         const { QueryEngine } = loadNapiEngine()
         return new QueryEngine(queryEngineOptions, logCallback, adapter)
     } else {
-        throw new TypeError(`Invalid EXTERNAL_TEST_EXECUTOR_ENGINE value: ${engineFromEnv}. Expected NAPI or WASM`)
+        throw new TypeError(`Invalid EXTERNAL_TEST_EXECUTOR_ENGINE value: ${engineFromEnv}. Expected Napi or Wasm`)
     }
 
 

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/qe.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/qe.ts
@@ -39,7 +39,7 @@ export async function initQueryEngine(adapter: ErrorCapturingDriverAdapter, data
         debug(parsed)
     }
 
-    const engineFromEnv = process.env.EXTERNAL_TEST_EXECUTOR_ENGINE ?? 'Napi'
+    const engineFromEnv = process.env.EXTERNAL_TEST_EXECUTOR ?? 'Napi'
     if (engineFromEnv === 'Wasm') {
         const { WasmQueryEngine } = await import('./wasm')
         return  new WasmQueryEngine(queryEngineOptions, logCallback, adapter)
@@ -47,7 +47,7 @@ export async function initQueryEngine(adapter: ErrorCapturingDriverAdapter, data
         const { QueryEngine } = loadNapiEngine()
         return new QueryEngine(queryEngineOptions, logCallback, adapter)
     } else {
-        throw new TypeError(`Invalid EXTERNAL_TEST_EXECUTOR_ENGINE value: ${engineFromEnv}. Expected Napi or Wasm`)
+        throw new TypeError(`Invalid EXTERNAL_TEST_EXECUTOR value: ${engineFromEnv}. Expected Napi or Wasm`)
     }
 
 

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/wasm.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/wasm.ts
@@ -1,0 +1,14 @@
+import * as wasm from '../../../query-engine-wasm/pkg/query_engine_bg.js'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
+
+const bytes = await fs.readFile(path.resolve(dirname, '..', '..', '..', 'query-engine-wasm', 'pkg', 'query_engine_bg.wasm'))
+const module = new WebAssembly.Module(bytes) 
+const instance = new WebAssembly.Instance(module, { './query_engine_bg.js': wasm })
+wasm.__wbg_set_wasm(instance.exports);
+wasm.init()
+
+export const WasmQueryEngine = wasm.QueryEngine

--- a/query-engine/driver-adapters/connector-test-kit-executor/tsconfig.json
+++ b/query-engine/driver-adapters/connector-test-kit-executor/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "ESNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "moduleResolution": "Bundler",
     "esModuleInterop": false,
     "isolatedModules": true,
@@ -17,7 +17,7 @@
     "skipDefaultLibCheck": true,
     "skipLibCheck": true,
     "emitDeclarationOnly": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
   },
   "exclude": ["**/dist", "**/declaration", "**/node_modules", "**/src/__tests__"]
 }

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -15,7 +15,10 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 psl.workspace = true
 prisma-models = { path = "../prisma-models" }
 quaint = { path = "../../quaint" }
-# request-handlers = { path = "../request-handlers", default-features = false, features = ["sql", "driver-adapters"] }
+request-handlers = { path = "../request-handlers", default-features = false, features = [
+    "sql",
+    "driver-adapters",
+] }
 connector = { path = "../connectors/query-connector", package = "query-connector" }
 sql-query-connector = { path = "../connectors/sql-query-connector" }
 query-core = { path = "../core" }

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -15,13 +15,13 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 psl.workspace = true
 prisma-models = { path = "../prisma-models" }
 quaint = { path = "../../quaint" }
-request-handlers = { path = "../request-handlers", default-features = false, features = ["sql", "driver-adapters"] }
+# request-handlers = { path = "../request-handlers", default-features = false, features = ["sql", "driver-adapters"] }
 connector = { path = "../connectors/query-connector", package = "query-connector" }
 sql-query-connector = { path = "../connectors/sql-query-connector" }
 query-core = { path = "../core" }
 
 thiserror = "1"
-connection-string.workspace = true 
+connection-string.workspace = true
 url = "2"
 serde_json.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Intoroduces new environment variable/test config option,
`EXTERNAL_TEST_EXECUTOR_ENGINE` that can be either `NAPI` (default) or
`WASM` that affects which engine external test executor will start with.

Adds a bunch of additional test configs for driver adapters that
duplicate existing ones, but run against WASM engine.

Close prisma/team-orm#551
