### PR TITLE
query-engine-wasm: Fix build & ensure it stays fixed

### DIFF
--- a/.github/workflows/qe-wasm-check.yml
+++ b/.github/workflows/qe-wasm-check.yml
@@ -22,5 +22,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install wasm-pack
         run: cargo install wasm-pack
-      - run: ./build.sh
+      - name: Build wasm query engine
+        run: ./build.sh
         working-directory: ./query-engine/query-engine-wasm

--- a/.github/workflows/qe-wasm-check.yml
+++ b/.github/workflows/qe-wasm-check.yml
@@ -1,0 +1,26 @@
+name: WASM engine compile check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/build-wasm.yml'
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
+      - 'renovate.json'
+
+jobs:
+  build:
+    name: 'Compilation check for query-engine-wasm'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
+      - run: ./build.sh
+        working-directory: ./query-engine/query-engine-wasm

--- a/.github/workflows/qe-wasm-check.yml
+++ b/.github/workflows/qe-wasm-check.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/build-wasm.yml'
+      - '!.github/workflows/qe-wasm-check.yml'
       - '.buildkite/**'
       - '*.md'
       - 'LICENSE'

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 prisma-models = { path = "../prisma-models" }
-query-core = { path = "../core", features = ["metrics"] }
+query-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 quaint = { path = "../../quaint" }
 psl.workspace = true


### PR DESCRIPTION
Current version in main does not compile to wasm correctly. This PR
fixes the error and adds CI check to ensure it compiles before it is
merged.
