### PR TITLE
driver-adapters: remove dispose method for JS transaction interface

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -27,3 +27,4 @@ mod prisma_7010;
 mod prisma_7072;
 mod prisma_7434;
 mod prisma_8265;
+mod prisma_engines_4286;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
@@ -1,0 +1,24 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(generic), only(Sqlite))]
+mod sqlite {
+    #[connector_test]
+    async fn close_tx_on_error(runner: Runner) -> TestResult<()> {
+        // Try to open a transaction with unsupported isolation error in SQLite.
+        let result = runner.start_tx(2000, 5000, Some("ReadUncommitted".to_owned())).await;
+        assert!(result.is_err());
+
+        // Without the changes from https://github.com/prisma/prisma-engines/pull/4286 or
+        // https://github.com/prisma/prisma-engines/pull/4489 this second `start_tx` call will
+        // either hang infinitely with libSQL driver adapter, or fail with a "cannot start a
+        // transaction within a transaction" error.
+        // A more future proof way to check this would be to make both transactions EXCLUSIVE or
+        // IMMEDIATE if we had control over SQLite transaction type here, as that would not rely on
+        // both transactions using the same connection if we were to pool multiple SQLite
+        // connections in the future.
+        let tx = runner.start_tx(2000, 5000, None).await?;
+        runner.rollback_tx(tx).await?.unwrap();
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(generic), only(JS, Sqlite))]
+#[test_suite(schema(generic), only(Sqlite('libsql.js')))]
 mod sqlite {
     #[connector_test]
     async fn close_tx_on_error(runner: Runner) -> TestResult<()> {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(generic), only(Sqlite('libsql.js')))]
+#[test_suite(schema(generic), only(Sqlite("libsql.js")))]
 mod sqlite {
     #[connector_test]
     async fn close_tx_on_error(runner: Runner) -> TestResult<()> {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_engines_4286.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(generic), only(Sqlite))]
+#[test_suite(schema(generic), only(JS, Sqlite))]
 mod sqlite {
     #[connector_test]
     async fn close_tx_on_error(runner: Runner) -> TestResult<()> {

--- a/query-engine/driver-adapters/src/async_js_function.rs
+++ b/query-engine/driver-adapters/src/async_js_function.rs
@@ -55,6 +55,10 @@ where
         .map_err(into_quaint_error)?;
         js_result.into()
     }
+
+    pub(crate) fn as_raw(&self) -> &ThreadsafeFunction<ArgType, ErrorStrategy::Fatal> {
+        &self.threadsafe_fn
+    }
 }
 
 impl<ArgType, ReturnType> FromNapiValue for AsyncJsFunction<ArgType, ReturnType>

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -610,7 +610,7 @@ impl TransactionProxy {
     ///   will not attempt rolling the transaction back even if the `commit` future was dropped while
     ///   waiting on the JavaScript call to complete and deliver response.
     pub async fn commit(&self) -> quaint::Result<()> {
-        self.closed.store(true, Ordering::Release);
+        self.closed.store(true, Ordering::Relaxed);
         self.commit.call(()).await
     }
 
@@ -630,14 +630,14 @@ impl TransactionProxy {
     ///   will not attempt rolling back again even if the `rollback` future was dropped while waiting
     ///   on the JavaScript call to complete and deliver response.
     pub async fn rollback(&self) -> quaint::Result<()> {
-        self.closed.store(true, Ordering::Release);
+        self.closed.store(true, Ordering::Relaxed);
         self.rollback.call(()).await
     }
 }
 
 impl Drop for TransactionProxy {
     fn drop(&mut self) {
-        if self.closed.swap(true, Ordering::Acquire) {
+        if self.closed.swap(true, Ordering::Relaxed) {
             return;
         }
 

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -608,7 +608,7 @@ impl TransactionProxy {
     /// - If it is polled at least once, `true` will be stored in [`TransactionProxy::closed`] and
     ///   the underlying FFI call will be delivered to JavaScript side in lockstep, so the destructor
     ///   will not attempt rolling the transaction back even if the `commit` future was dropped while
-    ///   waiting on the JavaScript call.
+    ///   waiting on the JavaScript call to complete and deliver response.
     pub async fn commit(&self) -> quaint::Result<()> {
         self.closed.store(true, Ordering::Release);
         self.commit.call(()).await
@@ -628,7 +628,7 @@ impl TransactionProxy {
     /// - If it is polled at least once, `true` will be stored in [`TransactionProxy::closed`] and
     ///   the underlying FFI call will be delivered to JavaScript side in lockstep, so the destructor
     ///   will not attempt rolling back again even if the `rollback` future was dropped while waiting
-    ///   on the JavaScript call.
+    ///   on the JavaScript call to complete and deliver response.
     pub async fn rollback(&self) -> quaint::Result<()> {
         self.closed.store(true, Ordering::Release);
         self.rollback.call(()).await

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -600,7 +600,7 @@ impl TransactionProxy {
     /// so the destructor will ensure the transaction is closed even if the future is dropped.
     pub async fn commit(&self) -> quaint::Result<()> {
         let result = self.commit.call(()).await;
-        self.closed.swap(true, Ordering::Release);
+        self.closed.store(true, Ordering::Release);
         result
     }
 
@@ -610,7 +610,7 @@ impl TransactionProxy {
     /// so the destructor will ensure the transaction is closed even if the future is dropped.
     pub async fn rollback(&self) -> quaint::Result<()> {
         let result = self.rollback.call(()).await;
-        self.closed.swap(true, Ordering::Release);
+        self.closed.store(true, Ordering::Release);
         result
     }
 }


### PR DESCRIPTION
Remove the boilerplate `Transaction.dispose` method from the public
driver adapter interface and move the corresponding functionality
directly to the destructor of `TransactionProxy`.

Refs: https://github.com/prisma/prisma-engines/pull/4286
Closes: https://github.com/prisma/team-orm/issues/391
