### PR TITLE
tech-debt(schema-engine-tests): Reduce vitess flakeyness

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,7 +294,7 @@ services:
       FOREIGN_KEY_MODE: 'disallow'
       ENABLE_ONLINE_DDL: false
       MYSQL_MAX_CONNECTIONS: 100000
-      TABLET_REFRESH_INTERVAL: '500ms'
+      TABLET_REFRESH_INTERVAL: '100ms'
     healthcheck:
       test: ['CMD', 'mysqladmin', 'ping', '-h127.0.0.1', '-P33807']
       interval: 5s

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -25,6 +25,9 @@ Example usage:
 source .test_database_urls/mysql_5_6
 "#;
 
+/// How long to wait for a schema change to propagate in Vitess.
+const VITESS_MAX_REFRESH_DELAY_MS: u64 = 1000;
+
 static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
     let database_url = std::env::var("TEST_DATABASE_URL").map_err(|_| MISSING_TEST_DATABASE_URL_MSG.to_owned())?;
     let shadow_database_url = std::env::var("TEST_SHADOW_DATABASE_URL").ok();
@@ -57,7 +60,7 @@ static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
                 //
                 // For schema changes that do not alter the table column names, the schema is not
                 // required to be reloaded.
-                max_refresh_delay = Some(Duration::from_millis(500));
+                max_refresh_delay = Some(Duration::from_millis(VITESS_MAX_REFRESH_DELAY_MS));
             }
 
             Ok(DbUnderTest {

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -207,7 +207,7 @@ impl TestApiArgs {
     }
 
     pub fn max_ddl_refresh_delay(&self) -> Option<Duration> {
-        self.db.max_ddl_refresh_delay.clone()
+        self.db.max_ddl_refresh_delay
     }
 }
 

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -2,6 +2,7 @@ use crate::{logging, mssql, mysql, postgres, Capabilities, Tags};
 use enumflags2::BitFlags;
 use once_cell::sync::Lazy;
 use quaint::single::Quaint;
+use std::time::Duration;
 use std::{fmt::Display, io::Write as _};
 
 #[derive(Debug)]
@@ -11,6 +12,7 @@ pub(crate) struct DbUnderTest {
     shadow_database_url: Option<String>,
     provider: &'static str,
     pub(crate) tags: BitFlags<Tags>,
+    pub(crate) max_ddl_refresh_delay: Option<std::time::Duration>,
 }
 
 const MISSING_TEST_DATABASE_URL_MSG: &str = r#"
@@ -40,13 +42,22 @@ static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
             capabilities: Capabilities::CreateDatabase.into(),
             provider: "sqlite",
             shadow_database_url,
+            max_ddl_refresh_delay: None,
         }),
         "mysql" => {
             let tags = mysql::get_mysql_tags(&database_url)?;
             let mut capabilities = Capabilities::Enums | Capabilities::Json;
+            let mut max_refresh_delay = None;
 
             if tags.contains(Tags::Vitess) {
                 capabilities |= Capabilities::CreateDatabase;
+                // Vitess is an eventually consistent system that propagates schema changes
+                // from vttablet to vtgate asynchronously. We might need to wait for a while before
+                // start querying the database after a schema change is made.
+                //
+                // For schema changes that do not alter the table column names, the schema is not
+                // required to be reloaded.
+                max_refresh_delay = Some(Duration::from_millis(500));
             }
 
             Ok(DbUnderTest {
@@ -55,6 +66,7 @@ static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
                 capabilities,
                 provider: "mysql",
                 shadow_database_url,
+                max_ddl_refresh_delay: max_refresh_delay,
             })
         }
         "postgresql" | "postgres" => Ok({
@@ -75,6 +87,7 @@ static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
                     | Capabilities::CreateDatabase,
                 provider,
                 shadow_database_url,
+                max_ddl_refresh_delay: None,
             }
         }),
         "sqlserver" => Ok(DbUnderTest {
@@ -83,6 +96,7 @@ static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
             capabilities: Capabilities::CreateDatabase.into(),
             provider: "sqlserver",
             shadow_database_url,
+            max_ddl_refresh_delay: None,
         }),
         _ => Err("Unknown database URL".into()),
     }
@@ -190,6 +204,10 @@ impl TestApiArgs {
 
     pub fn tags(&self) -> BitFlags<Tags> {
         self.db.tags
+    }
+
+    pub fn max_ddl_refresh_delay(&self) -> Option<Duration> {
+        self.db.max_ddl_refresh_delay.clone()
     }
 }
 

--- a/schema-engine/sql-migration-tests/src/commands/schema_push.rs
+++ b/schema-engine/sql-migration-tests/src/commands/schema_push.rs
@@ -2,6 +2,7 @@ use colored::Colorize;
 use schema_core::{
     commands::schema_push, json_rpc::types::*, schema_connector::SchemaConnector, CoreError, CoreResult,
 };
+use std::time::Duration;
 use std::{borrow::Cow, fmt::Debug};
 use tracing_futures::Instrument;
 
@@ -11,15 +12,18 @@ pub struct SchemaPush<'a> {
     force: bool,
     /// Purely for logging diagnostics.
     migration_id: Option<&'a str>,
+    // In eventually-consistent systems, we might need to wait for a while before the system refreshes
+    max_ddl_refresh_delay: Option<Duration>,
 }
 
 impl<'a> SchemaPush<'a> {
-    pub fn new(api: &'a mut dyn SchemaConnector, schema: String) -> Self {
+    pub fn new(api: &'a mut dyn SchemaConnector, schema: String, max_refresh_delay: Option<Duration>) -> Self {
         SchemaPush {
             api,
             schema,
             force: false,
             migration_id: None,
+            max_ddl_refresh_delay: max_refresh_delay,
         }
     }
 
@@ -43,6 +47,10 @@ impl<'a> SchemaPush<'a> {
             .instrument(tracing::info_span!("SchemaPush", migration_id = ?self.migration_id));
 
         let output = test_setup::runtime::run_with_thread_local_runtime(fut)?;
+
+        if let Some(delay) = self.max_ddl_refresh_delay {
+            std::thread::sleep(delay);
+        }
 
         Ok(SchemaPushAssertion {
             result: output,

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -21,6 +21,7 @@ use schema_core::{
 };
 use sql_schema_connector::SqlSchemaConnector;
 use sql_schema_describer::SqlSchema;
+use std::time::Duration;
 use std::{
     borrow::Cow,
     fmt::{Display, Write},
@@ -189,6 +190,12 @@ impl TestApi {
         self.root.is_vitess()
     }
 
+    /// Returns a duration that is guaranteed to be larger than the maximum refresh rate after a
+    /// DDL statement
+    pub fn max_ddl_refresh_delay(&self) -> Option<Duration> {
+        self.root.max_ddl_refresh_delay()
+    }
+
     /// Insert test values
     pub fn insert<'a>(&'a mut self, table_name: &'a str) -> SingleRowInsert<'a> {
         SingleRowInsert {
@@ -316,12 +323,13 @@ impl TestApi {
     /// Plan a `schemaPush` command adding the datasource
     pub fn schema_push_w_datasource(&mut self, dm: impl Into<String>) -> SchemaPush<'_> {
         let schema = self.datamodel_with_provider(&dm.into());
-        SchemaPush::new(&mut self.connector, schema)
+        self.schema_push(schema)
     }
 
     /// Plan a `schemaPush` command
     pub fn schema_push(&mut self, dm: impl Into<String>) -> SchemaPush<'_> {
-        SchemaPush::new(&mut self.connector, dm.into())
+        let max_ddl_refresh_delay = self.max_ddl_refresh_delay();
+        SchemaPush::new(&mut self.connector, dm.into(), max_ddl_refresh_delay)
     }
 
     pub fn tags(&self) -> BitFlags<Tags> {

--- a/schema-engine/sql-migration-tests/tests/migrations/sqlite.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/sqlite.rs
@@ -182,13 +182,9 @@ fn unique_constraint_errors_in_migrations(api: TestApi) {
         .send_unwrap_err()
         .to_user_facing();
 
-    let expected_json = expect![[r#"
-        {
-          "is_panic": false,
-          "message": "SQLite database error\nUNIQUE constraint failed: Fruit.name\n   0: sql_schema_connector::apply_migration::apply_migration\n             at schema-engine/connectors/sql-schema-connector/src/apply_migration.rs:10\n   1: sql_migration_tests::commands::schema_push::SchemaPush\n           with \u001b[3mmigration_id\u001b[0m\u001b[2m=\u001b[0mSome(\"the-migration\")\n             at schema-engine/sql-migration-tests/src/commands/schema_push.rs:43",
-          "backtrace": null
-        }"#]];
-    expected_json.assert_eq(&serde_json::to_string_pretty(&res).unwrap())
+    assert!(serde_json::to_string_pretty(&res)
+        .unwrap()
+        .contains("UNIQUE constraint failed: Fruit.name"));
 }
 
 #[test]


### PR DESCRIPTION
Vitess DDL is eventually consistent. When DDL is applied, there's a delay until that's reflected on vtgate. That delay is equal to the `TABLET_REFRESH_INTERVAL` setting in vttestserver + the time it takes for the refresh operation to complete. 

What I did to fix this was:
- Add an optional field to the `DBUnderTest`abstraction, called `max_ddl_refresh_delay` which is None for all databaes where DDL is applied atomically, and has a value for vitess of 1000 ms.
- I provided access to that setting in `SchemaPush`, and in case it had a value, make the schema push operation sleep after being applied.

Effects:
- Experiments yield that 1000 ms seems big enough to remove the flakeyness. I tried with lower wait times, such as 100, 200 and 500ms but some times one of the tests failed.
- The wait time increased substantially for this check, from 2m to 8m. Still this is less than the test feedback from other checks, so it's acceptable.
- In the future if the number of schema tests in vitess grew substantially, the runtime will grow by 1s times the number of schema loads. This might be unnacceptable.
- A longer term solution would be to:
  1. Do not apply the sleep strategy on all tests, and instead run tests normally.
  2. In case the test fails retry with some sleep time, up to x (eg. 3) times.
- I don't have the appetite to implement the long-term solution now, the reason is that `connector_test` macros used in schema tests require a big overhaul, which takes more time than what's now considered a priority for solving the flakeyness, compared to other team priorities.
