### PR TITLE
ci: update prisma-schema-wasm slack notification message

### DIFF
--- a/.github/workflows/publish-prisma-schema-wasm.yml
+++ b/.github/workflows/publish-prisma-schema-wasm.yml
@@ -58,6 +58,6 @@ jobs:
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2.2.1
         env:
-          SLACK_TITLE: 'Build and publish prisma-schema-wasm failed :x:'
+          SLACK_TITLE: 'Building and publishing prisma-schema-wasm failed :x:'
           SLACK_COLOR: '#FF0000'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_WASM_FAILING }}

--- a/.github/workflows/publish-prisma-schema-wasm.yml
+++ b/.github/workflows/publish-prisma-schema-wasm.yml
@@ -58,6 +58,6 @@ jobs:
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2.2.1
         env:
-          SLACK_TITLE: 'Building and publishing prisma-schema-wasm failed :x:'
+          SLACK_TITLE: 'Building and publishing @prisma/prisma-schema-wasm failed :x:'
           SLACK_COLOR: '#FF0000'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_WASM_FAILING }}

--- a/.github/workflows/publish-prisma-schema-wasm.yml
+++ b/.github/workflows/publish-prisma-schema-wasm.yml
@@ -58,6 +58,6 @@ jobs:
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2.2.1
         env:
-          SLACK_TITLE: 'prisma-schema-wasm publishing failed :x:'
+          SLACK_TITLE: 'Build and publish prisma-schema-wasm failed :x:'
           SLACK_COLOR: '#FF0000'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_WASM_FAILING }}

--- a/.github/workflows/publish-query-engine-wasm.yml
+++ b/.github/workflows/publish-query-engine-wasm.yml
@@ -64,6 +64,6 @@ jobs:
         if: ${{ failure() }}
         uses: rtCamp/action-slack-notify@v2.2.1
         env:
-          SLACK_TITLE: 'Build and publish @prisma/query-engine-wasm failed :x:'
+          SLACK_TITLE: 'Building and publishing @prisma/query-engine-wasm failed :x:'
           SLACK_COLOR: '#FF0000'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_WASM_FAILING }}


### PR DESCRIPTION
Update the wording of the slack notification on build error in
`@prisma/prisma-schema-wasm` to mirror the changes suggested by @Jolg42
for the `@prisma/query-engine-wasm` workflow in
<https://github.com/prisma/prisma-engines/pull/4491#discussion_r1406325039>.
