### PR TITLE
ci: fix validation errors in publish-prisma-schema-wasm.yml

### DIFF
--- a/.github/workflows/publish-prisma-schema-wasm.yml
+++ b/.github/workflows/publish-prisma-schema-wasm.yml
@@ -9,11 +9,14 @@ on:
     inputs:
       enginesWrapperVersion:
         required: true
+        description: 'New @prisma/prisma-schema-wasm package version'
       enginesHash:
         required: true
+        description: 'prisma-engines commit to build'
       npmDistTag:
         required: true
         default: 'latest'
+        description: 'npm dist-tag (e.g. latest or integration)'
 
 jobs:
   build:


### PR DESCRIPTION
The descriptions of inputs are required in the workflow schema, it is
highlighed as errors in the editor that they are currently missing in
`publish-prisma-schema-wasm.yml`.

<img width="637" alt="Screenshot 2023-11-27 at 17 02 07" src="https://github.com/prisma/prisma-engines/assets/4923335/3f450104-12bb-482a-b6b3-dbc9936e9c85">

