### PR TITLE
ci: fix undefined variable in `run-name` in publish-query-engine-wasm

### DIFF
--- a/.github/workflows/publish-query-engine-wasm.yml
+++ b/.github/workflows/publish-query-engine-wasm.yml
@@ -1,5 +1,5 @@
 name: Build and publish @prisma/query-engine-wasm
-run-name: npm - release @prisma/query-engine-wasm@${{ github.event.inputs.enginesWrapperVersion }} from ${{ github.event.inputs.enginesHash }} on ${{ github.event.inputs.npmDistTag }}
+run-name: npm - release @prisma/query-engine-wasm@${{ github.event.inputs.packageVersion }} from ${{ github.event.inputs.enginesHash }} on ${{ github.event.inputs.npmDistTag }}
 
 concurrency: publish-query-engine-wasm
 


### PR DESCRIPTION
A copy-paste artifact, the actual input name is `packageVersion` in this
workflow. This led to titles like this:

```
npm - release @prisma/query-engine-wasm@ from 01aad9b63c8d574cc270d2b09461e920d19986e6 on latest
```

After this fix they'll look like this:

```
npm - release @prisma/query-engine-wasm@5.7.0-20.01aad9b63c8d574cc270d2b09461e920d19986e6 from 01aad9b63c8d574cc270d2b09461e920d19986e6 on latest
```

Fixup for https://github.com/prisma/prisma-engines/pull/4491