### PR TITLE
qe-wasm: Partially fix tests

### DIFF
--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 
 # Call this script as `./build.sh <npm_version>`
 set -euo pipefail

--- a/query-engine/query-engine-wasm/example/prisma/schema.prisma
+++ b/query-engine/query-engine-wasm/example/prisma/schema.prisma
@@ -4,8 +4,8 @@ datasource db {
 }
 
 generator client {
-    provider = "prisma-client-js"
-    previewFeatures = ["driverAdapters"]
+    provider        = "prisma-client-js"
+    previewFeatures = ["driverAdapters", "tracing"]
 }
 
 model User {

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use driver_adapters::JsObject;
 use js_sys::Function as JsFunction;
-use psl::PreviewFeature;
 use query_core::{
     protocol::EngineProtocol,
     schema::{self, QuerySchema},
@@ -180,7 +179,8 @@ impl QueryEngine {
             .validate_that_one_datasource_is_provided()
             .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
 
-        let enable_tracing = config.preview_features().contains(PreviewFeature::Tracing);
+        // Telemetry panics on timings if preview feature is enabled
+        let enable_tracing = false; // config.preview_features().contains(PreviewFeature::Tracing);
         let engine_protocol = engine_protocol.unwrap_or(EngineProtocol::Json);
 
         let builder = EngineBuilder {


### PR DESCRIPTION
1. Bash script for build did not abort on error, hence sed error on
   linux went unnoticed.
2. We don't actually need sed trickery sincce `wasm-pack` has a flag for
   changing binary name.
3. `tracing` feature does not actually work on WASM even partially: it panics on
   `Instant` invokation as soon as first span is created. Since we are
   running tests with all preview features enabled, that means that
   practically any test panics now. Disabled it again.

A lot of tests are still failing on ThreadRng invocation and stacktrace
is not really helpful, but I still think it's better if we get it
working.