### PR TITLE
ci: fix wasm build script

### DIFF
--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Call this script as `./build.sh <npm_version>`
 
 OUT_VERSION="$1"
@@ -12,7 +14,7 @@ OUT_NPM_NAME="@prisma/query-engine-wasm"
 # to avoid conflicts with libquery's `name = "query_engine"` library name declaration.
 # This little `sed -i` trick below is a hack to publish "@prisma/query-engine-wasm"
 # with the same binding filenames currently expected by the Prisma Client.
-sed -i '' 's/name = "query_engine_wasm"/name = "query_engine"/g' Cargo.toml
+sed -i 's/name = "query_engine_wasm"/name = "query_engine"/g' Cargo.toml
 
 # use `wasm-pack build --release` on CI only
 if [[ -z "$BUILDKITE" ]] && [[ -z "$GITHUB_ACTIONS" ]]; then
@@ -23,7 +25,7 @@ fi
 
 wasm-pack build $BUILD_PROFILE --target $OUT_TARGET
 
-sed -i '' 's/name = "query_engine"/name = "query_engine_wasm"/g' Cargo.toml
+sed -i 's/name = "query_engine"/name = "query_engine_wasm"/g' Cargo.toml
 
 sleep 1
 


### PR DESCRIPTION
The build script had an invalid `sed` command with an extra `''`
argument that caused it to fail with

```
sed: can't read s/name = "query_engine_wasm"/name = "query_engine"/g: No such file or directory
```

Example: https://github.com/prisma/prisma-engines/actions/runs/7090582268/job/19297872413

<img width="779" alt="image" src="https://github.com/prisma/prisma-engines/assets/4923335/b3fbdf78-e8d9-4de8-acf1-b0a82fb714fe">
<img width="883" alt="image" src="https://github.com/prisma/prisma-engines/assets/4923335/a7382bce-1d5e-45c0-bf5d-58d4fd2b9409">

<p></p>

This is reproducible both on CI and locally for me. Perhaps it was
written for BSD sed and doesn't work with GNU sed (so it always fails on
Linux and also fails on macOS inside prisma-engines Nix flake but maybe
it works on macOS without Nix)?

Because of this, a broken package was published from CI.

The commit fixes the `sed` command and adds `set -e` so that errors like
this would fail CI instead of silently continuing and doing wrong
things.
