### PR TITLE
query-engine-wasm: fix build.sh with BSD sed

### DIFF
--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -14,7 +14,7 @@ OUT_NPM_NAME="@prisma/query-engine-wasm"
 # to avoid conflicts with libquery's `name = "query_engine"` library name declaration.
 # This little `sed -i` trick below is a hack to publish "@prisma/query-engine-wasm"
 # with the same binding filenames currently expected by the Prisma Client.
-sed -i 's/name = "query_engine_wasm"/name = "query_engine"/g' Cargo.toml
+sed -i.bak 's/name = "query_engine_wasm"/name = "query_engine"/g' Cargo.toml
 
 # use `wasm-pack build --release` on CI only
 if [[ -z "$BUILDKITE" ]] && [[ -z "$GITHUB_ACTIONS" ]]; then
@@ -25,7 +25,12 @@ fi
 
 wasm-pack build $BUILD_PROFILE --target $OUT_TARGET
 
-sed -i 's/name = "query_engine"/name = "query_engine_wasm"/g' Cargo.toml
+sed -i.bak 's/name = "query_engine"/name = "query_engine_wasm"/g' Cargo.toml
+
+# Remove the backup file created by sed. We only created it because there's no
+# cross-platform way to specify we don't need one (it's just `-i` in GNU sed
+# but `-i ""` in BSD sed).
+rm Cargo.toml.bak
 
 sleep 1
 


### PR DESCRIPTION
https://github.com/prisma/prisma-engines/pull/4519 fixed the `build.sh` script being broken with GNU sed (e.g. on Linux, including on CI) but broke it with BSD sed (e.g. on vanilla macOS with out-of-the box BSD sed, without GNU sed installed via Homebrew or Nix). This commit makes the script cross-platform.
