### PR TITLE
fix: handle native types for joined queries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,8 @@ dependencies = [
 name = "builtin-psl-connectors"
 version = "0.1.0"
 dependencies = [
+ "bigdecimal",
+ "chrono",
  "connection-string",
  "either",
  "enumflags2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,6 @@ dependencies = [
 name = "builtin-psl-connectors"
 version = "0.1.0"
 dependencies = [
- "bigdecimal",
  "chrono",
  "connection-string",
  "either",

--- a/psl/builtin-connectors/Cargo.toml
+++ b/psl/builtin-connectors/Cargo.toml
@@ -14,4 +14,4 @@ lsp-types = "0.91.1"
 once_cell = "1.3"
 regex = "1"
 chrono = { version = "0.4.6", default_features = false }
-bigdecimal = "0.3"
+

--- a/psl/builtin-connectors/Cargo.toml
+++ b/psl/builtin-connectors/Cargo.toml
@@ -13,3 +13,5 @@ indoc.workspace = true
 lsp-types = "0.91.1"
 once_cell = "1.3"
 regex = "1"
+chrono = { version = "0.4.6", default_features = false }
+bigdecimal = "0.3"

--- a/psl/builtin-connectors/Cargo.toml
+++ b/psl/builtin-connectors/Cargo.toml
@@ -13,5 +13,5 @@ indoc.workspace = true
 lsp-types = "0.91.1"
 once_cell = "1.3"
 regex = "1"
-chrono = { version = "0.4.6", default_features = false }
+chrono = { version = "0.4.6", default-features = false }
 

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -1,7 +1,6 @@
 mod native_types;
 mod validations;
 
-use bigdecimal::{BigDecimal, ParseBigDecimalError};
 pub use native_types::CockroachType;
 
 use chrono::*;
@@ -329,25 +328,6 @@ impl Connector for CockroachDatamodelConnector {
             None => self.parse_json_datetime(
                 str,
                 Some(self.default_native_type_for_scalar_type(&ScalarType::DateTime)),
-            ),
-        }
-    }
-
-    fn parse_json_decimal(
-        &self,
-        str: &str,
-        nt: Option<NativeTypeInstance>,
-    ) -> Result<BigDecimal, ParseBigDecimalError> {
-        let native_type: Option<&CockroachType> = nt.as_ref().map(|nt| nt.downcast_ref());
-
-        match native_type {
-            Some(pt) => match pt {
-                CockroachType::Decimal(_) => crate::utils::parse_decimal(str),
-                _ => unreachable!(),
-            },
-            None => self.parse_json_decimal(
-                str,
-                Some(self.default_native_type_for_scalar_type(&ScalarType::Decimal)),
             ),
         }
     }

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -310,7 +310,7 @@ impl Connector for CockroachDatamodelConnector {
         Flavour::Cockroach
     }
 
-    fn coerce_json_datetime(
+    fn parse_json_datetime(
         &self,
         str: &str,
         nt: Option<NativeTypeInstance>,
@@ -326,11 +326,14 @@ impl Connector for CockroachDatamodelConnector {
                 CockroachType::Timetz(_) => crate::utils::parse_timetz(str),
                 _ => unreachable!(),
             },
-            None => crate::utils::parse_timestamptz(str),
+            None => self.parse_json_datetime(
+                str,
+                Some(self.default_native_type_for_scalar_type(&ScalarType::DateTime)),
+            ),
         }
     }
 
-    fn coerce_json_decimal(
+    fn parse_json_decimal(
         &self,
         str: &str,
         nt: Option<NativeTypeInstance>,
@@ -342,7 +345,10 @@ impl Connector for CockroachDatamodelConnector {
                 CockroachType::Decimal(_) => crate::utils::parse_decimal(str),
                 _ => unreachable!(),
             },
-            None => crate::utils::parse_decimal(str),
+            None => self.parse_json_decimal(
+                str,
+                Some(self.default_native_type_for_scalar_type(&ScalarType::Decimal)),
+            ),
         }
     }
 }

--- a/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/cockroach_datamodel_connector.rs
@@ -323,14 +323,7 @@ impl Connector for CockroachDatamodelConnector {
                 CockroachType::Timestamp(_) => crate::utils::parse_timestamp(str),
                 CockroachType::Date => crate::utils::parse_date(str),
                 CockroachType::Time(_) => crate::utils::parse_time(str),
-                CockroachType::Timetz(_) => {
-                    // We currently don't support time with timezone.
-                    // We strip the timezone information and parse it as a time.
-                    // This is inline with what Quaint does already.
-                    let time_without_tz = str.split("+").next().unwrap();
-
-                    crate::utils::parse_time(time_without_tz)
-                }
+                CockroachType::Timetz(_) => crate::utils::parse_timetz(str),
                 _ => unreachable!(),
             },
             None => crate::utils::parse_timestamptz(str),

--- a/psl/builtin-connectors/src/lib.rs
+++ b/psl/builtin-connectors/src/lib.rs
@@ -16,6 +16,7 @@ mod mysql_datamodel_connector;
 mod native_type_definition;
 mod postgres_datamodel_connector;
 mod sqlite_datamodel_connector;
+mod utils;
 
 use psl_core::{datamodel_connector::Connector, ConnectorRegistry};
 

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -583,11 +583,7 @@ impl Connector for PostgresDatamodelConnector {
                 Timestamp(_) => crate::utils::parse_timestamp(str),
                 Date => crate::utils::parse_date(str),
                 Time(_) => crate::utils::parse_time(str),
-                Timetz(_) => {
-                    let time_without_tz = str.split('+').next().unwrap();
-
-                    crate::utils::parse_time(time_without_tz)
-                }
+                Timetz(_) => crate::utils::parse_timetz(str),
                 _ => unreachable!(),
             },
             None => crate::utils::parse_timestamptz(str),

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -570,7 +570,7 @@ impl Connector for PostgresDatamodelConnector {
         Flavour::Postgres
     }
 
-    fn coerce_json_datetime(
+    fn parse_json_datetime(
         &self,
         str: &str,
         nt: Option<NativeTypeInstance>,
@@ -586,11 +586,14 @@ impl Connector for PostgresDatamodelConnector {
                 Timetz(_) => crate::utils::parse_timetz(str),
                 _ => unreachable!(),
             },
-            None => crate::utils::parse_timestamptz(str),
+            None => self.parse_json_datetime(
+                str,
+                Some(self.default_native_type_for_scalar_type(&ScalarType::DateTime)),
+            ),
         }
     }
 
-    fn coerce_json_decimal(
+    fn parse_json_decimal(
         &self,
         str: &str,
         nt: Option<NativeTypeInstance>,
@@ -603,7 +606,10 @@ impl Connector for PostgresDatamodelConnector {
                 Money => crate::utils::parse_money(str),
                 _ => unreachable!(),
             },
-            None => crate::utils::parse_decimal(str),
+            None => self.parse_json_decimal(
+                str,
+                Some(self.default_native_type_for_scalar_type(&ScalarType::Decimal)),
+            ),
         }
     }
 }

--- a/psl/builtin-connectors/src/postgres_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/postgres_datamodel_connector.rs
@@ -4,7 +4,6 @@ mod validations;
 
 pub use native_types::PostgresType;
 
-use bigdecimal::{BigDecimal, ParseBigDecimalError};
 use chrono::*;
 use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList, InsertTextFormat};
@@ -589,26 +588,6 @@ impl Connector for PostgresDatamodelConnector {
             None => self.parse_json_datetime(
                 str,
                 Some(self.default_native_type_for_scalar_type(&ScalarType::DateTime)),
-            ),
-        }
-    }
-
-    fn parse_json_decimal(
-        &self,
-        str: &str,
-        nt: Option<NativeTypeInstance>,
-    ) -> Result<BigDecimal, ParseBigDecimalError> {
-        let native_type: Option<&PostgresType> = nt.as_ref().map(|nt| nt.downcast_ref());
-
-        match native_type {
-            Some(pt) => match pt {
-                Decimal(_) => crate::utils::parse_decimal(str),
-                Money => crate::utils::parse_money(str),
-                _ => unreachable!(),
-            },
-            None => self.parse_json_decimal(
-                str,
-                Some(self.default_native_type_for_scalar_type(&ScalarType::Decimal)),
             ),
         }
     }

--- a/psl/builtin-connectors/src/utils.rs
+++ b/psl/builtin-connectors/src/utils.rs
@@ -1,6 +1,4 @@
-use bigdecimal::{BigDecimal, ParseBigDecimalError};
 use chrono::*;
-use std::str::FromStr;
 
 pub(crate) fn parse_date(str: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
     chrono::NaiveDate::parse_from_str(str, "%Y-%m-%d")
@@ -36,13 +34,4 @@ pub(crate) fn parse_timetz(str: &str) -> Result<DateTime<FixedOffset>, chrono::P
     let time_without_tz = str.split('+').next().unwrap();
 
     parse_time(time_without_tz)
-}
-
-pub(crate) fn parse_money(str: &str) -> Result<BigDecimal, ParseBigDecimalError> {
-    // We strip out the currency sign from the string.
-    BigDecimal::from_str(&str[1..]).map(|bd| bd.normalized())
-}
-
-pub(crate) fn parse_decimal(str: &str) -> Result<BigDecimal, ParseBigDecimalError> {
-    BigDecimal::from_str(str).map(|bd| bd.normalized())
 }

--- a/psl/builtin-connectors/src/utils.rs
+++ b/psl/builtin-connectors/src/utils.rs
@@ -29,6 +29,15 @@ pub(crate) fn parse_time(str: &str) -> Result<DateTime<FixedOffset>, chrono::Par
         .map(DateTime::<FixedOffset>::from)
 }
 
+pub(crate) fn parse_timetz(str: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
+    // We currently don't support time with timezone.
+    // We strip the timezone information and parse it as a time.
+    // This is inline with what Quaint does already.
+    let time_without_tz = str.split('+').next().unwrap();
+
+    parse_time(time_without_tz)
+}
+
 pub(crate) fn parse_money(str: &str) -> Result<BigDecimal, ParseBigDecimalError> {
     // We strip out the currency sign from the string.
     BigDecimal::from_str(&str[1..]).map(|bd| bd.normalized())

--- a/psl/builtin-connectors/src/utils.rs
+++ b/psl/builtin-connectors/src/utils.rs
@@ -1,0 +1,39 @@
+use bigdecimal::{BigDecimal, ParseBigDecimalError};
+use chrono::*;
+use std::str::FromStr;
+
+pub(crate) fn parse_date(str: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
+    chrono::NaiveDate::parse_from_str(str, "%Y-%m-%d")
+        .map(|date| DateTime::<Utc>::from_utc(date.and_hms_opt(0, 0, 0).unwrap(), Utc))
+        .map(DateTime::<FixedOffset>::from)
+}
+
+pub(crate) fn parse_timestamptz(str: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
+    DateTime::parse_from_rfc3339(str)
+}
+
+pub(crate) fn parse_timestamp(str: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
+    NaiveDateTime::parse_from_str(str, "%Y-%m-%dT%H:%M:%S%.f")
+        .map(|dt| DateTime::from_utc(dt, Utc))
+        .or_else(|_| DateTime::parse_from_rfc3339(str).map(DateTime::<Utc>::from))
+        .map(DateTime::<FixedOffset>::from)
+}
+
+pub(crate) fn parse_time(str: &str) -> Result<DateTime<FixedOffset>, chrono::ParseError> {
+    chrono::NaiveTime::parse_from_str(str, "%H:%M:%S%.f")
+        .map(|time| {
+            let base_date = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap();
+
+            DateTime::<Utc>::from_utc(base_date.and_time(time), Utc)
+        })
+        .map(DateTime::<FixedOffset>::from)
+}
+
+pub(crate) fn parse_money(str: &str) -> Result<BigDecimal, ParseBigDecimalError> {
+    // We strip out the currency sign from the string.
+    BigDecimal::from_str(&str[1..]).map(|bd| bd.normalized())
+}
+
+pub(crate) fn parse_decimal(str: &str) -> Result<BigDecimal, ParseBigDecimalError> {
+    BigDecimal::from_str(str).map(|bd| bd.normalized())
+}

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -25,7 +25,6 @@ pub use self::{
 };
 
 use crate::{configuration::DatasourceConnectorData, Configuration, Datasource, PreviewFeature};
-use bigdecimal::{BigDecimal, ParseBigDecimalError};
 use chrono::{DateTime, FixedOffset};
 use diagnostics::{DatamodelError, Diagnostics, NativeTypeErrorFactory, Span};
 use enumflags2::BitFlags;
@@ -367,14 +366,6 @@ pub trait Connector: Send + Sync {
         _str: &str,
         _nt: Option<NativeTypeInstance>,
     ) -> chrono::ParseResult<DateTime<FixedOffset>> {
-        unreachable!("This method is only implemented on connectors with lateral join support.")
-    }
-
-    fn parse_json_decimal(
-        &self,
-        _str: &str,
-        _nt: Option<NativeTypeInstance>,
-    ) -> Result<BigDecimal, ParseBigDecimalError> {
         unreachable!("This method is only implemented on connectors with lateral join support.")
     }
 }

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -362,7 +362,7 @@ pub trait Connector: Send + Sync {
         Default::default()
     }
 
-    fn coerce_json_datetime(
+    fn parse_json_datetime(
         &self,
         _str: &str,
         _nt: Option<NativeTypeInstance>,
@@ -370,7 +370,7 @@ pub trait Connector: Send + Sync {
         unreachable!("This method is only implemented on connectors with lateral join support.")
     }
 
-    fn coerce_json_decimal(
+    fn parse_json_decimal(
         &self,
         _str: &str,
         _nt: Option<NativeTypeInstance>,

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -25,6 +25,8 @@ pub use self::{
 };
 
 use crate::{configuration::DatasourceConnectorData, Configuration, Datasource, PreviewFeature};
+use bigdecimal::{BigDecimal, ParseBigDecimalError};
+use chrono::{DateTime, FixedOffset};
 use diagnostics::{DatamodelError, Diagnostics, NativeTypeErrorFactory, Span};
 use enumflags2::BitFlags;
 use lsp_types::CompletionList;
@@ -358,6 +360,22 @@ pub trait Connector: Send + Sync {
         _diagnostics: &mut Diagnostics,
     ) -> DatasourceConnectorData {
         Default::default()
+    }
+
+    fn coerce_json_datetime(
+        &self,
+        _str: &str,
+        _nt: Option<NativeTypeInstance>,
+    ) -> chrono::ParseResult<DateTime<FixedOffset>> {
+        unreachable!("This method is only implemented on connectors with lateral join support.")
+    }
+
+    fn coerce_json_decimal(
+        &self,
+        _str: &str,
+        _nt: Option<NativeTypeInstance>,
+    ) -> Result<BigDecimal, ParseBigDecimalError> {
+        unreachable!("This method is only implemented on connectors with lateral join support.")
     }
 }
 

--- a/quaint/src/ast/column.rs
+++ b/quaint/src/ast/column.rs
@@ -1,4 +1,4 @@
-use super::Aliasable;
+use super::{values::NativeColumnType, Aliasable};
 use crate::{
     ast::{Expression, ExpressionKind, Table},
     Value,
@@ -32,6 +32,8 @@ pub struct Column<'a> {
     pub(crate) alias: Option<Cow<'a, str>>,
     pub(crate) default: Option<DefaultValue<'a>>,
     pub(crate) type_family: Option<TypeFamily>,
+    /// The underlying native type of the column.
+    pub(crate) native_type: Option<NativeColumnType<'a>>,
     /// Whether the column is an enum.
     pub(crate) is_enum: bool,
     /// Whether the column is a (scalar) list.
@@ -129,6 +131,11 @@ impl<'a> Column<'a> {
             .as_ref()
             .map(|d| d == &DefaultValue::Generated)
             .unwrap_or(false)
+    }
+
+    pub fn native_column_type<T: Into<NativeColumnType<'a>>>(mut self, native_type: Option<T>) -> Column<'a> {
+        self.native_type = native_type.map(|nt| nt.into());
+        self
     }
 }
 

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -19,7 +19,6 @@ pub struct Postgres<'a> {
 
 impl<'a> Postgres<'a> {
     fn visit_json_build_obj_expr(&mut self, expr: Expression<'a>) -> crate::Result<()> {
-        dbg!(&expr);
         match expr.kind() {
             ExpressionKind::Column(col) => match (col.type_family.as_ref(), col.native_type.as_deref()) {
                 (Some(TypeFamily::Decimal(_)), Some("MONEY")) => {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/mod.rs
@@ -7,5 +7,6 @@ mod enum_type;
 mod float;
 mod int;
 mod json;
+mod native;
 mod string;
 mod through_relation;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mod.rs
@@ -1,0 +1,1 @@
+mod postgres;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
@@ -1,0 +1,321 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(only(Postgres, CockroachDb))]
+mod datetime {
+    fn schema_date() -> String {
+        let schema = indoc! {
+            r#"model Parent {
+              #id(id, Int, @id)
+
+              childId Int? @unique
+              child Child? @relation(fields: [childId], references: [id])
+            }
+            
+            model Child {
+                #id(id, Int, @id)
+                date       DateTime @test.Date
+                date_2     DateTime @test.Date
+                time       DateTime @test.Time(3)
+                time_2     DateTime @test.Time(3)
+                time_tz    DateTime @test.Timetz(3)
+                time_tz_2  DateTime @test.Timetz(3)
+                ts         DateTime @test.Timestamp(3)
+                ts_2       DateTime @test.Timestamp(3)
+                ts_tz      DateTime @test.Timestamptz(3)
+                ts_tz_2    DateTime @test.Timestamptz(3)
+
+                parent Parent?
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(schema_date))]
+    async fn dt_native(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+            id: 1,
+            child: { create: {
+                id: 1,
+                date: "2016-09-24T00:00:00.000Z"
+                date_2: "2016-09-24T00:00:00.000+03:00"
+                time: "1111-11-11T13:02:20.321Z"
+                time_2: "1111-11-11T13:02:20.321+03:00"
+                time_tz: "1111-11-11T13:02:20.321Z"
+                time_tz_2: "1111-11-11T13:02:20.321+03:00"
+                ts: "2016-09-24T14:01:30.213Z"
+                ts_2: "2016-09-24T14:01:30.213+03:00"
+                ts_tz: "2016-09-24T14:01:30.213Z"
+                ts_tz_2: "2016-09-24T14:01:30.213+03:00"
+            }}
+        }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(runner, r#"{ findManyParent { id child { date date_2 time time_2 time_tz time_tz_2 ts ts_2 ts_tz ts_tz_2 } } }"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"child":{"date":"2016-09-24T00:00:00.000Z","date_2":"2016-09-23T00:00:00.000Z","time":"1970-01-01T13:02:20.321Z","time_2":"1970-01-01T10:02:20.321Z","time_tz":"1970-01-01T13:02:20.321Z","time_tz_2":"1970-01-01T10:02:20.321Z","ts":"2016-09-24T14:01:30.213Z","ts_2":"2016-09-24T11:01:30.213Z","ts_tz":"2016-09-24T14:01:30.213Z","ts_tz_2":"2016-09-24T11:01:30.213Z"}}]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}
+
+#[test_suite(only(Postgres, CockroachDb))]
+mod decimal {
+    fn schema_decimal() -> String {
+        let schema = indoc! {
+            r#"
+            model Parent {
+                #id(id, Int, @id)
+
+                childId Int? @unique
+                child Child? @relation(fields: [childId], references: [id])
+            }
+
+            model Child {
+              #id(id, Int, @id)
+
+              float    Float   @test.Real
+              dfloat   Float   @test.DoublePrecision
+              decFloat Decimal @test.Decimal(2, 1)
+              money    Decimal @test.Money
+
+              parent Parent?
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // "Postgres native decimal types" should "work"
+    #[connector_test(schema(schema_decimal))]
+    async fn native_decimal_types(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+            id: 1,
+            child: { create: {
+                id: 1,
+                float: 1.1,
+                dfloat: 2.2,
+                decFloat: 3.1234,
+                money: 3.51,
+            }}
+        }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent { id child { float dfloat decFloat money } } }"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"child":{"float":1.1,"dfloat":2.2,"decFloat":"3.1","money":"3.51"}}]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}
+
+#[test_suite(only(Postgres, CockroachDb))]
+mod string {
+    fn schema_string() -> String {
+        let schema = indoc! {
+            r#"
+            model Parent {
+                #id(id, Int, @id)
+
+                childId Int? @unique
+                child Child? @relation(fields: [childId], references: [id])
+            }
+
+            model Child {
+              #id(id, Int, @id)
+              char  String @test.Char(10)
+              vChar String @test.VarChar(11)
+              text  String @test.Text
+              bit   String @test.Bit(4)
+              vBit  String @test.VarBit(5)
+              uuid  String @test.Uuid
+              ip    String @test.Inet
+
+              parent Parent?
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // "Postgres native string types" should "work"
+    #[connector_test(schema(schema_string))]
+    async fn native_string(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+            id: 1,
+            child: { create: {
+                id: 1,
+                char: "1234567890"
+                vChar: "12345678910"
+                text: "text"
+                bit: "1010"
+                vBit: "00110"
+                uuid: "123e4567-e89b-12d3-a456-426614174000"
+                ip: "127.0.0.1"
+            }}
+          }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent {
+            id
+            child {
+              char
+              vChar
+              text
+              bit
+              vBit
+              uuid
+              ip
+            }
+        }}"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"child":{"char":"1234567890","vChar":"12345678910","text":"text","bit":"1010","vBit":"00110","uuid":"123e4567-e89b-12d3-a456-426614174000","ip":"127.0.0.1"}}]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}
+
+#[test_suite(schema(schema), only(Postgres, CockroachDb))]
+mod others {
+    fn schema_other_types() -> String {
+        let schema = indoc! {
+            r#"
+            model Parent {
+              #id(id, Int, @id)
+
+              childId Int? @unique
+              child Child? @relation(fields: [childId], references: [id])
+            }
+
+            model Child {
+              #id(id, Int, @id)
+              bool  Boolean @test.Boolean
+              byteA Bytes   @test.ByteA
+              json  Json    @test.Json
+              jsonb Json    @test.JsonB
+
+              parent Parent?
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // "Other Postgres native types" should "work"
+    #[connector_test(schema(schema_other_types))]
+    async fn native_other_types(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+            id: 1,
+            child: {
+                create: {
+                    id: 1,
+                    bool: true
+                    byteA: "dGVzdA=="
+                    json: "{}"
+                    jsonb: "{\"a\": \"b\"}"
+                }
+            }
+          }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent { id child { id bool byteA json jsonb } } }"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"child":{"id":1,"bool":true,"byteA":"dGVzdA==","json":"{}","jsonb":"{\"a\":\"b\"}"}}]}}"###
+        );
+
+        Ok(())
+    }
+
+    fn schema_xml() -> String {
+        let schema = indoc! {
+            r#"
+            model Parent {
+              #id(id, Int, @id)
+
+              childId Int? @unique
+              child Child? @relation(fields: [childId], references: [id])
+            }
+
+            model Child {
+              #id(id, Int, @id)
+              xml String @test.Xml
+
+              parent Parent?
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(schema_xml), only(Postgres))]
+    async fn native_xml(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+            id: 1,
+            child: {
+                create: {
+                    id: 1,
+                    xml: "<salad>wurst</salad>"
+                }
+            }
+        }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent { id child { xml } } }"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"child":{"xml":"<salad>wurst</salad>"}}]}}"###
+        );
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
@@ -72,7 +72,7 @@ mod datetime {
     }
 }
 
-#[test_suite(only(Postgres, CockroachDb))]
+#[test_suite(only(Postgres))]
 mod decimal {
     fn schema_decimal() -> String {
         let schema = indoc! {
@@ -134,7 +134,7 @@ mod decimal {
     }
 }
 
-#[test_suite(only(Postgres, CockroachDb))]
+#[test_suite(only(Postgres))]
 mod string {
     fn schema_string() -> String {
         let schema = indoc! {
@@ -212,7 +212,7 @@ mod string {
     }
 }
 
-#[test_suite(schema(schema), only(Postgres, CockroachDb))]
+#[test_suite(schema(schema), only(Postgres))]
 mod others {
     fn schema_other_types() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
@@ -212,7 +212,11 @@ mod string {
     }
 }
 
-#[test_suite(schema(schema), only(Postgres))]
+// Napi & Wasm DAs excluded because of a bytes bug
+#[test_suite(
+    schema(schema),
+    only(Postgres("9", "10", "11", "12", "13", "14", "15", "pg.js", "neon.js"))
+)]
 mod others {
     fn schema_other_types() -> String {
         let schema = indoc! {

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -106,10 +106,10 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
         serde_json::Value::Bool(b) => Ok(PrismaValue::Boolean(b)),
         serde_json::Value::Number(n) => match sf.type_identifier() {
             TypeIdentifier::Int => Ok(PrismaValue::Int(n.as_i64().ok_or_else(|| {
-                build_conversion_error(&format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
+                build_conversion_error(&sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
             })?)),
             TypeIdentifier::BigInt => Ok(PrismaValue::BigInt(n.as_i64().ok_or_else(|| {
-                build_conversion_error(&format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
+                build_conversion_error(&sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
             })?)),
             TypeIdentifier::Float | TypeIdentifier::Decimal => {
                 let bd = n
@@ -117,12 +117,13 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                     .and_then(BigDecimal::from_f64)
                     .map(|bd| bd.normalized())
                     .ok_or_else(|| {
-                        build_conversion_error(&format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
+                        build_conversion_error(&sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
                     })?;
 
                 Ok(PrismaValue::Float(bd))
             }
             _ => Err(build_conversion_error(
+                &sf,
                 &format!("Number({n})"),
                 &format!("{:?}", sf.type_identifier()),
             )),
@@ -130,26 +131,43 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
         serde_json::Value::String(s) => match sf.type_identifier() {
             TypeIdentifier::String => Ok(PrismaValue::String(s)),
             TypeIdentifier::Enum(_) => Ok(PrismaValue::Enum(s)),
-            TypeIdentifier::DateTime => Ok(PrismaValue::DateTime(parse_datetime(&format!("{s}Z")).map_err(
-                |err| {
+            TypeIdentifier::DateTime => {
+                let res = sf.coerce_json_datetime(&s).map_err(|err| {
                     build_conversion_error_with_reason(
+                        &sf,
                         &format!("String({s})"),
                         &format!("{:?}", sf.type_identifier()),
                         &err.to_string(),
                     )
-                },
-            )?)),
+                })?;
+
+                Ok(PrismaValue::DateTime(res))
+            }
+            TypeIdentifier::Decimal => {
+                let res = sf.coerce_json_decimal(&s).map_err(|err| {
+                    build_conversion_error_with_reason(
+                        &sf,
+                        &format!("String({s})"),
+                        &format!("{:?}", sf.type_identifier()),
+                        &err.to_string(),
+                    )
+                })?;
+
+                Ok(PrismaValue::Float(res))
+            }
             TypeIdentifier::UUID => Ok(PrismaValue::Uuid(uuid::Uuid::parse_str(&s).map_err(|err| {
                 build_conversion_error_with_reason(
+                    &sf,
                     &format!("String({s})"),
                     &format!("{:?}", sf.type_identifier()),
                     &err.to_string(),
                 )
             })?)),
             TypeIdentifier::Bytes => {
-                // We skip the first two characters because they are the \x prefix.
+                // We skip the first two characters because there's the \x prefix.
                 let bytes = hex::decode(&s[2..]).map_err(|err| {
                     build_conversion_error_with_reason(
+                        &sf,
                         &format!("String({s})"),
                         &format!("{:?}", sf.type_identifier()),
                         &err.to_string(),
@@ -159,6 +177,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                 Ok(PrismaValue::Bytes(bytes))
             }
             _ => Err(build_conversion_error(
+                &sf,
                 &format!("String({s})"),
                 &format!("{:?}", sf.type_identifier()),
             )),
@@ -173,19 +192,25 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
     }
 }
 
-fn build_conversion_error(from: &str, to: &str) -> SqlError {
+fn build_conversion_error(sf: &ScalarField, from: &str, to: &str) -> SqlError {
+    let container_name = sf.container().name();
+    let field_name = sf.name();
+
     let error = io::Error::new(
         io::ErrorKind::InvalidData,
-        format!("Unexpected conversion failure from {from} to {to}."),
+        format!("Unexpected conversion failure for field {container_name}.{field_name} from {from} to {to}."),
     );
 
     SqlError::ConversionError(error.into())
 }
 
-fn build_conversion_error_with_reason(from: &str, to: &str, reason: &str) -> SqlError {
+fn build_conversion_error_with_reason(sf: &ScalarField, from: &str, to: &str, reason: &str) -> SqlError {
+    let container_name = sf.container().name();
+    let field_name = sf.name();
+
     let error = io::Error::new(
         io::ErrorKind::InvalidData,
-        format!("Unexpected conversion failure from {from} to {to}. Reason: ${reason}"),
+        format!("Unexpected conversion failure for field {container_name}.{field_name} from {from} to {to}. Reason: ${reason}"),
     );
 
     SqlError::ConversionError(error.into())

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -1,8 +1,7 @@
-use std::io;
-
-use bigdecimal::{BigDecimal, FromPrimitive};
+use bigdecimal::{BigDecimal, FromPrimitive, ParseBigDecimalError};
 use itertools::{Either, Itertools};
 use query_structure::*;
+use std::{io, str::FromStr};
 
 use crate::{query_arguments_ext::QueryArgumentsExt, SqlError};
 
@@ -144,7 +143,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                 Ok(PrismaValue::DateTime(res))
             }
             TypeIdentifier::Decimal => {
-                let res = sf.parse_json_decimal(&s).map_err(|err| {
+                let res = parse_decimal(&s).map_err(|err| {
                     build_conversion_error_with_reason(
                         sf,
                         &format!("String({s})"),
@@ -214,4 +213,8 @@ fn build_conversion_error_with_reason(sf: &ScalarField, from: &str, to: &str, re
     );
 
     SqlError::ConversionError(error.into())
+}
+
+fn parse_decimal(str: &str) -> std::result::Result<BigDecimal, ParseBigDecimalError> {
+    BigDecimal::from_str(str).map(|bd| bd.normalized())
 }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -132,7 +132,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
             TypeIdentifier::String => Ok(PrismaValue::String(s)),
             TypeIdentifier::Enum(_) => Ok(PrismaValue::Enum(s)),
             TypeIdentifier::DateTime => {
-                let res = sf.coerce_json_datetime(&s).map_err(|err| {
+                let res = sf.parse_json_datetime(&s).map_err(|err| {
                     build_conversion_error_with_reason(
                         sf,
                         &format!("String({s})"),
@@ -144,7 +144,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                 Ok(PrismaValue::DateTime(res))
             }
             TypeIdentifier::Decimal => {
-                let res = sf.coerce_json_decimal(&s).map_err(|err| {
+                let res = sf.parse_json_decimal(&s).map_err(|err| {
                     build_conversion_error_with_reason(
                         sf,
                         &format!("String({s})"),

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -106,10 +106,10 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
         serde_json::Value::Bool(b) => Ok(PrismaValue::Boolean(b)),
         serde_json::Value::Number(n) => match sf.type_identifier() {
             TypeIdentifier::Int => Ok(PrismaValue::Int(n.as_i64().ok_or_else(|| {
-                build_conversion_error(&sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
+                build_conversion_error(sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
             })?)),
             TypeIdentifier::BigInt => Ok(PrismaValue::BigInt(n.as_i64().ok_or_else(|| {
-                build_conversion_error(&sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
+                build_conversion_error(sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
             })?)),
             TypeIdentifier::Float | TypeIdentifier::Decimal => {
                 let bd = n
@@ -117,13 +117,13 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                     .and_then(BigDecimal::from_f64)
                     .map(|bd| bd.normalized())
                     .ok_or_else(|| {
-                        build_conversion_error(&sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
+                        build_conversion_error(sf, &format!("Number({n})"), &format!("{:?}", sf.type_identifier()))
                     })?;
 
                 Ok(PrismaValue::Float(bd))
             }
             _ => Err(build_conversion_error(
-                &sf,
+                sf,
                 &format!("Number({n})"),
                 &format!("{:?}", sf.type_identifier()),
             )),
@@ -134,7 +134,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
             TypeIdentifier::DateTime => {
                 let res = sf.coerce_json_datetime(&s).map_err(|err| {
                     build_conversion_error_with_reason(
-                        &sf,
+                        sf,
                         &format!("String({s})"),
                         &format!("{:?}", sf.type_identifier()),
                         &err.to_string(),
@@ -146,7 +146,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
             TypeIdentifier::Decimal => {
                 let res = sf.coerce_json_decimal(&s).map_err(|err| {
                     build_conversion_error_with_reason(
-                        &sf,
+                        sf,
                         &format!("String({s})"),
                         &format!("{:?}", sf.type_identifier()),
                         &err.to_string(),
@@ -157,7 +157,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
             }
             TypeIdentifier::UUID => Ok(PrismaValue::Uuid(uuid::Uuid::parse_str(&s).map_err(|err| {
                 build_conversion_error_with_reason(
-                    &sf,
+                    sf,
                     &format!("String({s})"),
                     &format!("{:?}", sf.type_identifier()),
                     &err.to_string(),
@@ -167,7 +167,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                 // We skip the first two characters because there's the \x prefix.
                 let bytes = hex::decode(&s[2..]).map_err(|err| {
                     build_conversion_error_with_reason(
-                        &sf,
+                        sf,
                         &format!("String({s})"),
                         &format!("{:?}", sf.type_identifier()),
                         &err.to_string(),
@@ -177,7 +177,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
                 Ok(PrismaValue::Bytes(bytes))
             }
             _ => Err(build_conversion_error(
-                &sf,
+                sf,
                 &format!("String({s})"),
                 &format!("{:?}", sf.type_identifier()),
             )),

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/column.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/column.rs
@@ -107,6 +107,7 @@ impl AsColumn for ScalarField {
 
         Column::from((full_table_name, col))
             .type_family(self.type_family())
+            .native_column_type(self.native_type().map(|nt| nt.name()))
             .set_is_enum(self.type_identifier().is_enum())
             .set_is_list(self.is_list())
             .default(quaint::ast::DefaultValue::Generated)

--- a/query-engine/query-structure/src/field/scalar.rs
+++ b/query-engine/query-structure/src/field/scalar.rs
@@ -1,5 +1,4 @@
 use crate::{ast, parent_container::ParentContainer, prelude::*, DefaultKind, NativeTypeInstance, ValueGenerator};
-use bigdecimal::{BigDecimal, ParseBigDecimalError};
 use chrono::{DateTime, FixedOffset};
 use psl::{
     parser_database::{walkers, ScalarFieldType, ScalarType},
@@ -177,13 +176,6 @@ impl ScalarField {
         let connector = self.dm.schema.connector;
 
         connector.parse_json_datetime(value, nt)
-    }
-
-    pub fn parse_json_decimal(&self, value: &str) -> Result<BigDecimal, ParseBigDecimalError> {
-        let nt = self.native_type().map(|nt| nt.native_type);
-        let connector = self.dm.schema.connector;
-
-        connector.parse_json_decimal(value, nt)
     }
 
     pub fn is_autoincrement(&self) -> bool {

--- a/query-engine/query-structure/src/field/scalar.rs
+++ b/query-engine/query-structure/src/field/scalar.rs
@@ -1,4 +1,6 @@
 use crate::{ast, parent_container::ParentContainer, prelude::*, DefaultKind, NativeTypeInstance, ValueGenerator};
+use bigdecimal::{BigDecimal, ParseBigDecimalError};
+use chrono::{DateTime, FixedOffset};
 use psl::{
     parser_database::{walkers, ScalarFieldType, ScalarType},
     schema_ast::ast::FieldArity,
@@ -168,6 +170,20 @@ impl ScalarField {
             native_type: nt,
             connector,
         })
+    }
+
+    pub fn coerce_json_datetime(&self, value: &str) -> chrono::ParseResult<DateTime<FixedOffset>> {
+        let nt = self.native_type().map(|nt| nt.native_type);
+        let connector = self.dm.schema.connector;
+
+        connector.coerce_json_datetime(value, nt)
+    }
+
+    pub fn coerce_json_decimal(&self, value: &str) -> Result<BigDecimal, ParseBigDecimalError> {
+        let nt = self.native_type().map(|nt| nt.native_type);
+        let connector = self.dm.schema.connector;
+
+        connector.coerce_json_decimal(value, nt)
     }
 
     pub fn is_autoincrement(&self) -> bool {

--- a/query-engine/query-structure/src/field/scalar.rs
+++ b/query-engine/query-structure/src/field/scalar.rs
@@ -172,18 +172,18 @@ impl ScalarField {
         })
     }
 
-    pub fn coerce_json_datetime(&self, value: &str) -> chrono::ParseResult<DateTime<FixedOffset>> {
+    pub fn parse_json_datetime(&self, value: &str) -> chrono::ParseResult<DateTime<FixedOffset>> {
         let nt = self.native_type().map(|nt| nt.native_type);
         let connector = self.dm.schema.connector;
 
-        connector.coerce_json_datetime(value, nt)
+        connector.parse_json_datetime(value, nt)
     }
 
-    pub fn coerce_json_decimal(&self, value: &str) -> Result<BigDecimal, ParseBigDecimalError> {
+    pub fn parse_json_decimal(&self, value: &str) -> Result<BigDecimal, ParseBigDecimalError> {
         let nt = self.native_type().map(|nt| nt.native_type);
         let connector = self.dm.schema.connector;
 
-        connector.coerce_json_decimal(value, nt)
+        connector.parse_json_decimal(value, nt)
     }
 
     pub fn is_autoincrement(&self) -> bool {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/22293

Note: `Money` type is always casted as numeric to avoid having to parse string currencies which depend on locales and can take highly variable shapes. context: have a look at this table 🤒 https://stackoverflow.com/q/71908140