### PR TITLE
fix(qe): coerce nulls to empty lists in nested relations with joins

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -14,6 +14,7 @@ in
       nodejs.pkgs.typescript-language-server
       nodejs.pkgs.pnpm
 
+      cargo-insta
       jq
       graphviz
       wasm-bindgen-cli

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -228,6 +228,8 @@ mod scalar_relations {
             bytes   Bytes[]
             bool    Boolean[]
             dt      DateTime[]
+            empty   Int[]
+            unset   Int[]
           }
           "#
         };
@@ -254,19 +256,20 @@ mod scalar_relations {
               bytes: ["AQID", "Qk9OSk9VUg=="],
               bool: [false, true],
               dt: ["1900-10-10T01:10:10.001Z", "1999-12-12T21:12:12.121Z"],
+              empty: []
           }"#,
         )
         .await?;
         create_parent(&runner, r#"{ id: 1, children: { connect: [{ childId: 1 }] } }"#).await?;
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"{ findManyParent { id children { childId string int bInt float bytes bool dt } } }"#),
-          @r###"{"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"]}]}]}}"###
+          run_query!(&runner, r#"{ findManyParent { id children { childId string int bInt float bytes bool dt empty unset } } }"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"],"empty":[],"unset":[]}]}]}}"###
         );
 
         insta::assert_snapshot!(
-          run_query!(&runner, r#"{ findUniqueParent(where: { id: 1 }) { id children { childId string int bInt float bytes bool dt } } }"#),
-          @r###"{"data":{"findUniqueParent":{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"]}]}}}"###
+          run_query!(&runner, r#"{ findUniqueParent(where: { id: 1 }) { id children { childId string int bInt float bytes bool dt empty unset } } }"#),
+          @r###"{"data":{"findUniqueParent":{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"],"empty":[],"unset":[]}]}}}"###
         );
 
         Ok(())

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -96,7 +96,13 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
     }
 
     match value {
-        serde_json::Value::Null => Ok(PrismaValue::Null),
+        serde_json::Value::Null => {
+            if sf.is_list() {
+                Ok(PrismaValue::List(vec![]))
+            } else {
+                Ok(PrismaValue::Null)
+            }
+        }
         serde_json::Value::Bool(b) => Ok(PrismaValue::Boolean(b)),
         serde_json::Value::Number(n) => match sf.type_identifier() {
             TypeIdentifier::Int => Ok(PrismaValue::Int(n.as_i64().ok_or_else(|| {


### PR DESCRIPTION
Currently we coerce database NULL values to empty scalar lists in the
regular code path that converts quaint values to `PrismaValue`s, but
this was missing in the new code path that converts the results of JSON
aggregation to `PrismaValue`s when using `relationJoins` preview feature.

Fixes: https://github.com/prisma/prisma/issues/22303
