### PR TITLE
driver-adapters: Don't read URL from schema

### DIFF
--- a/quaint/src/connector.rs
+++ b/quaint/src/connector.rs
@@ -11,6 +11,7 @@
 
 mod connection_info;
 
+pub mod external;
 pub mod metrics;
 mod queryable;
 mod result_set;
@@ -21,6 +22,7 @@ mod type_identifier;
 
 pub use self::result_set::*;
 pub use connection_info::*;
+pub use external::*;
 pub use queryable::*;
 pub use transaction::*;
 #[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]

--- a/quaint/src/connector/connection_info.rs
+++ b/quaint/src/connector/connection_info.rs
@@ -13,6 +13,8 @@ use crate::connector::SqliteParams;
 #[cfg(feature = "sqlite")]
 use std::convert::TryFrom;
 
+use super::ExternalConnectionInfo;
+
 /// General information about a SQL connection.
 #[derive(Debug, Clone)]
 pub enum ConnectionInfo {
@@ -34,7 +36,10 @@ pub enum ConnectionInfo {
         db_name: String,
     },
     #[cfg(feature = "sqlite")]
-    InMemorySqlite { db_name: String },
+    InMemorySqlite {
+        db_name: String,
+    },
+    External(ExternalConnectionInfo),
 }
 
 impl ConnectionInfo {
@@ -104,6 +109,7 @@ impl ConnectionInfo {
             ConnectionInfo::Mssql(url) => Some(url.dbname()),
             #[cfg(feature = "sqlite")]
             ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
+            ConnectionInfo::External(_) => None,
         }
     }
 
@@ -124,6 +130,7 @@ impl ConnectionInfo {
             ConnectionInfo::Sqlite { db_name, .. } => db_name,
             #[cfg(feature = "sqlite")]
             ConnectionInfo::InMemorySqlite { db_name } => db_name,
+            ConnectionInfo::External(info) => &info.schema_name,
         }
     }
 
@@ -138,6 +145,8 @@ impl ConnectionInfo {
             ConnectionInfo::Mssql(url) => url.host(),
             #[cfg(feature = "sqlite")]
             ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => "localhost",
+
+            ConnectionInfo::External(_) => "external",
         }
     }
 
@@ -152,6 +161,7 @@ impl ConnectionInfo {
             ConnectionInfo::Mssql(url) => url.username().map(Cow::from),
             #[cfg(feature = "sqlite")]
             ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
+            ConnectionInfo::External(_) => None,
         }
     }
 
@@ -168,6 +178,7 @@ impl ConnectionInfo {
             ConnectionInfo::Sqlite { file_path, .. } => Some(file_path),
             #[cfg(feature = "sqlite")]
             ConnectionInfo::InMemorySqlite { .. } => None,
+            ConnectionInfo::External(_) => None,
         }
     }
 
@@ -182,6 +193,7 @@ impl ConnectionInfo {
             ConnectionInfo::Mssql(_) => SqlFamily::Mssql,
             #[cfg(feature = "sqlite")]
             ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => SqlFamily::Sqlite,
+            ConnectionInfo::External(info) => info.sql_family.to_owned(),
         }
     }
 
@@ -196,6 +208,7 @@ impl ConnectionInfo {
             ConnectionInfo::Mssql(url) => Some(url.port()),
             #[cfg(feature = "sqlite")]
             ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
+            ConnectionInfo::External(_) => None,
         }
     }
 
@@ -223,6 +236,7 @@ impl ConnectionInfo {
             ConnectionInfo::Sqlite { file_path, .. } => file_path.clone(),
             #[cfg(feature = "sqlite")]
             ConnectionInfo::InMemorySqlite { .. } => "in-memory".into(),
+            ConnectionInfo::External(_) => "external".into(),
         }
     }
 }

--- a/quaint/src/connector/external.rs
+++ b/quaint/src/connector/external.rs
@@ -1,0 +1,23 @@
+use async_trait::async_trait;
+
+use super::{SqlFamily, TransactionCapable};
+
+#[derive(Debug, Clone)]
+pub struct ExternalConnectionInfo {
+    pub sql_family: SqlFamily,
+    pub schema_name: String,
+}
+
+impl ExternalConnectionInfo {
+    pub fn new(sql_family: SqlFamily, schema_name: String) -> Self {
+        ExternalConnectionInfo {
+            sql_family,
+            schema_name,
+        }
+    }
+}
+
+#[async_trait]
+pub trait ExternalConnector: TransactionCapable {
+    async fn get_connection_info(&self) -> crate::Result<ExternalConnectionInfo>;
+}

--- a/quaint/src/connector/mysql.rs
+++ b/quaint/src/connector/mysql.rs
@@ -1,10 +1,12 @@
 //! Wasm-compatible definitions for the MySQL connector.
 //! This module is only available with the `mysql` feature.
+mod defaults;
 pub(crate) mod error;
 pub(crate) mod url;
 
 pub use self::url::*;
 pub use error::MysqlError;
 
+pub use defaults::*;
 #[cfg(feature = "mysql-native")]
 pub(crate) mod native;

--- a/quaint/src/connector/mysql/defaults.rs
+++ b/quaint/src/connector/mysql/defaults.rs
@@ -1,0 +1,1 @@
+pub const DEFAULT_MYSQL_DB: &str = "mysql";

--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -57,8 +57,8 @@ impl MysqlUrl {
     /// Name of the database connected. Defaults to `mysql`.
     pub fn dbname(&self) -> &str {
         match self.url.path_segments() {
-            Some(mut segments) => segments.next().unwrap_or("mysql"),
-            None => "mysql",
+            Some(mut segments) => segments.next().unwrap_or(super::defaults::DEFAULT_MYSQL_DB),
+            None => super::defaults::DEFAULT_MYSQL_DB,
         }
     }
 

--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -1,9 +1,11 @@
 //! Wasm-compatible definitions for the PostgreSQL connector.
 //! This module is only available with the `postgresql` feature.
+mod defaults;
 pub(crate) mod error;
 pub(crate) mod url;
 
 pub use self::url::*;
+pub use defaults::*;
 pub use error::PostgresError;
 
 #[cfg(feature = "postgresql-native")]

--- a/quaint/src/connector/postgres/defaults.rs
+++ b/quaint/src/connector/postgres/defaults.rs
@@ -1,0 +1,1 @@
+pub const DEFAULT_POSTGRES_SCHEMA: &str = "main";

--- a/quaint/src/connector/postgres/defaults.rs
+++ b/quaint/src/connector/postgres/defaults.rs
@@ -1,1 +1,1 @@
-pub const DEFAULT_POSTGRES_SCHEMA: &str = "main";
+pub const DEFAULT_POSTGRES_SCHEMA: &str = "public";

--- a/quaint/src/connector/postgres/url.rs
+++ b/quaint/src/connector/postgres/url.rs
@@ -76,8 +76,6 @@ pub struct PostgresUrl {
     pub(crate) flavour: PostgresFlavour,
 }
 
-pub(crate) const DEFAULT_SCHEMA: &str = "public";
-
 impl PostgresUrl {
     /// Parse `Url` to `PostgresUrl`. Returns error for mistyped connection
     /// parameters.
@@ -157,7 +155,10 @@ impl PostgresUrl {
 
     /// The database schema, defaults to `public`.
     pub fn schema(&self) -> &str {
-        self.query_params.schema.as_deref().unwrap_or(DEFAULT_SCHEMA)
+        self.query_params
+            .schema
+            .as_deref()
+            .unwrap_or(super::defaults::DEFAULT_POSTGRES_SCHEMA)
     }
 
     /// Whether the pgbouncer mode is enabled.

--- a/quaint/src/connector/sqlite.rs
+++ b/quaint/src/connector/sqlite.rs
@@ -1,9 +1,11 @@
 //! Wasm-compatible definitions for the SQLite connector.
 //! This module is only available with the `sqlite` feature.
+mod defaults;
 pub(crate) mod error;
 mod ffi;
 pub(crate) mod params;
 
+pub use defaults::*;
 pub use error::SqliteError;
 pub use params::*;
 

--- a/quaint/src/connector/sqlite/defaults.rs
+++ b/quaint/src/connector/sqlite/defaults.rs
@@ -1,0 +1,1 @@
+pub const DEFAULT_SQLITE_SCHEMA: &str = "main";

--- a/quaint/src/connector/sqlite/defaults.rs
+++ b/quaint/src/connector/sqlite/defaults.rs
@@ -1,1 +1,1 @@
-pub const DEFAULT_SQLITE_SCHEMA: &str = "main";
+pub const DEFAULT_SQLITE_DATABASE: &str = "main";

--- a/quaint/src/connector/sqlite/params.rs
+++ b/quaint/src/connector/sqlite/params.rs
@@ -3,8 +3,6 @@
 use crate::error::{Error, ErrorKind};
 use std::{convert::TryFrom, path::Path, time::Duration};
 
-pub(crate) const DEFAULT_SQLITE_SCHEMA_NAME: &str = "main";
-
 /// Wraps a connection url and exposes the parsing logic used by Quaint,
 /// including default values.
 #[derive(Debug)]
@@ -95,7 +93,7 @@ impl TryFrom<&str> for SqliteParams {
             Ok(Self {
                 connection_limit,
                 file_path: path_str.to_owned(),
-                db_name: DEFAULT_SQLITE_SCHEMA_NAME.to_owned(),
+                db_name: super::DEFAULT_SQLITE_SCHEMA.to_owned(),
                 socket_timeout,
                 max_connection_lifetime,
                 max_idle_connection_lifetime,

--- a/quaint/src/connector/sqlite/params.rs
+++ b/quaint/src/connector/sqlite/params.rs
@@ -93,7 +93,7 @@ impl TryFrom<&str> for SqliteParams {
             Ok(Self {
                 connection_limit,
                 file_path: path_str.to_owned(),
-                db_name: super::DEFAULT_SQLITE_SCHEMA.to_owned(),
+                db_name: super::DEFAULT_SQLITE_DATABASE.to_owned(),
                 socket_timeout,
                 max_connection_lifetime,
                 max_idle_connection_lifetime,

--- a/quaint/src/prelude.rs
+++ b/quaint/src/prelude.rs
@@ -1,6 +1,7 @@
 //! A "prelude" for users of the `quaint` crate.
 pub use crate::ast::*;
 pub use crate::connector::{
-    ConnectionInfo, DefaultTransaction, Queryable, ResultRow, ResultSet, SqlFamily, TransactionCapable,
+    ConnectionInfo, DefaultTransaction, ExternalConnectionInfo, Queryable, ResultRow, ResultSet, SqlFamily,
+    TransactionCapable,
 };
 pub use crate::{col, val, values};

--- a/quaint/src/single.rs
+++ b/quaint/src/single.rs
@@ -168,12 +168,12 @@ impl Quaint {
     #[cfg(feature = "sqlite-native")]
     /// Open a new SQLite database in memory.
     pub fn new_in_memory() -> crate::Result<Quaint> {
-        use crate::connector::DEFAULT_SQLITE_SCHEMA_NAME;
+        use crate::connector::sqlite::DEFAULT_SQLITE_SCHEMA;
 
         Ok(Quaint {
             inner: Arc::new(connector::Sqlite::new_in_memory()?),
             connection_info: Arc::new(ConnectionInfo::InMemorySqlite {
-                db_name: DEFAULT_SQLITE_SCHEMA_NAME.to_owned(),
+                db_name: DEFAULT_SQLITE_SCHEMA.to_owned(),
             }),
         })
     }

--- a/quaint/src/single.rs
+++ b/quaint/src/single.rs
@@ -168,12 +168,12 @@ impl Quaint {
     #[cfg(feature = "sqlite-native")]
     /// Open a new SQLite database in memory.
     pub fn new_in_memory() -> crate::Result<Quaint> {
-        use crate::connector::sqlite::DEFAULT_SQLITE_SCHEMA;
+        use crate::connector::sqlite::DEFAULT_SQLITE_DATABASE;
 
         Ok(Quaint {
             inner: Arc::new(connector::Sqlite::new_in_memory()?),
             connection_info: Arc::new(ConnectionInfo::InMemorySqlite {
-                db_name: DEFAULT_SQLITE_SCHEMA.to_owned(),
+                db_name: DEFAULT_SQLITE_DATABASE.to_owned(),
             }),
         })
     }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -15,7 +15,7 @@ use query_core::{
 };
 use query_engine_metrics::MetricRegistry;
 use request_handlers::{
-    BatchTransactionOption, ConnectorMode, GraphqlBody, JsonBatchQuery, JsonBody, JsonSingleQuery, MultiQuery,
+    BatchTransactionOption, ConnectorKind, GraphqlBody, JsonBatchQuery, JsonBody, JsonSingleQuery, MultiQuery,
     RequestBody, RequestHandler,
 };
 use serde_json::json;
@@ -126,10 +126,9 @@ impl Runner {
             Some(_) => RunnerExecutor::new_external(&url, &datamodel).await?,
             None => RunnerExecutor::Builtin(
                 request_handlers::load_executor(
-                    ConnectorMode::Rust,
+                    ConnectorKind::Rust { url: url.to_owned() },
                     data_source,
                     schema.configuration.preview_features(),
-                    &url,
                 )
                 .await?,
             ),

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -272,6 +272,9 @@ pub enum ErrorKind {
 
     #[error("External connector error")]
     ExternalError(i32),
+
+    #[error("Invalid driver adapter: {0}")]
+    InvalidDriverAdapter(String),
 }
 
 impl From<DomainError> for ConnectorError {

--- a/query-engine/connectors/sql-query-connector/src/context.rs
+++ b/query-engine/connectors/sql-query-connector/src/context.rs
@@ -1,4 +1,4 @@
-use quaint::prelude::ConnectionInfo;
+use quaint::{connector::SqlFamily, prelude::ConnectionInfo};
 
 pub(super) struct Context<'a> {
     connection_info: &'a ConnectionInfo,
@@ -13,12 +13,12 @@ pub(super) struct Context<'a> {
 
 impl<'a> Context<'a> {
     pub(crate) fn new(connection_info: &'a ConnectionInfo, trace_id: Option<&'a str>) -> Self {
-        let (max_rows, default_batch_size) = match connection_info {
-            ConnectionInfo::Postgres(_) => (None, 32766),
+        let (max_rows, default_batch_size) = match connection_info.sql_family() {
+            SqlFamily::Postgres => (None, 32766),
             // See https://stackoverflow.com/a/11131824/788562
-            ConnectionInfo::Mysql(_) => (None, 65535),
-            ConnectionInfo::Mssql(_) => (Some(1000), 2099),
-            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => (Some(999), 999),
+            SqlFamily::Mysql => (None, 65535),
+            SqlFamily::Mssql => (Some(1000), 2099),
+            SqlFamily::Sqlite => (Some(999), 999),
         };
         Context {
             connection_info,

--- a/query-engine/driver-adapters/connector-test-kit-executor/src/index.ts
+++ b/query-engine/driver-adapters/connector-test-kit-executor/src/index.ts
@@ -255,7 +255,7 @@ async function pgAdapter(url: string): Promise<DriverAdapter> {
     const schemaName = postgresSchemaName(url)
     const pool = new pgDriver.Pool(postgres_options(url))
     return new prismaPg.PrismaPg(pool, {
-        schemaName
+        schema: schemaName
     })
 
 }
@@ -274,7 +274,7 @@ async function neonWsAdapter(url: string): Promise<DriverAdapter> {
     const schemaName = postgresSchemaName(url)
 
     const pool = new NeonPool(postgres_options(url))
-    return new prismaNeon.PrismaNeon(pool, { schemaName })
+    return new prismaNeon.PrismaNeon(pool, { schema: schemaName })
 }
 
 async function libsqlAdapter(url: string): Promise<DriverAdapter> {

--- a/query-engine/driver-adapters/src/lib.rs
+++ b/query-engine/driver-adapters/src/lib.rs
@@ -76,6 +76,20 @@ mod arch {
         Ok(object.get(name.into())?.into())
     }
 
+    pub(crate) fn get_optional_named_property<T>(
+        object: &super::wasm::JsObjectExtern,
+        name: &str,
+    ) -> JsResult<Option<T>>
+    where
+        T: From<wasm_bindgen::JsValue>,
+    {
+        if has_named_property(object, name)? {
+            Ok(Some(get_named_property(object, name)?))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub(crate) fn has_named_property(object: &super::wasm::JsObjectExtern, name: &str) -> JsResult<bool> {
         js_sys::Reflect::has(object, &JsString::from_str(name).unwrap().into())
     }
@@ -103,6 +117,17 @@ mod arch {
         T: ::napi::bindgen_prelude::FromNapiValue,
     {
         object.get_named_property(name)
+    }
+
+    pub(crate) fn get_optional_named_property<T>(object: &::napi::JsObject, name: &str) -> JsResult<Option<T>>
+    where
+        T: ::napi::bindgen_prelude::FromNapiValue,
+    {
+        if has_named_property(object, name)? {
+            Ok(Some(get_named_property(object, name)?))
+        } else {
+            Ok(None)
+        }
     }
 
     pub(crate) fn has_named_property(object: &::napi::JsObject, name: &str) -> JsResult<bool> {

--- a/query-engine/driver-adapters/src/napi/mod.rs
+++ b/query-engine/driver-adapters/src/napi/mod.rs
@@ -1,8 +1,8 @@
 //! Query Engine Driver Adapters: `napi`-specific implementation.
 
-mod async_js_function;
+mod adapter_method;
 mod conversion;
 mod error;
 pub(crate) mod result;
 
-pub(crate) use async_js_function::AsyncJsFunction;
+pub(crate) use adapter_method::AdapterMethod;

--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -2,7 +2,7 @@ use crate::send_future::UnsafeFuture;
 use crate::types::JsConnectionInfo;
 pub use crate::types::{ColumnType, JSResultSet, Query, TransactionOptions};
 use crate::{
-    from_js_value, get_named_property, get_optional_named_property, has_named_property, to_rust_str, AsyncJsFunction,
+    from_js_value, get_named_property, get_optional_named_property, has_named_property, to_rust_str, AdapterMethod,
     JsObject, JsResult, JsString, JsTransaction,
 };
 
@@ -19,11 +19,11 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
 pub(crate) struct CommonProxy {
     /// Execute a query given as SQL, interpolating the given parameters.
-    query_raw: AsyncJsFunction<Query, JSResultSet>,
+    query_raw: AdapterMethod<Query, JSResultSet>,
 
     /// Execute a query given as SQL, interpolating the given parameters and
     /// returning the number of affected rows.
-    execute_raw: AsyncJsFunction<Query, u32>,
+    execute_raw: AdapterMethod<Query, u32>,
 
     /// Return the provider for this driver.
     pub(crate) provider: String,
@@ -33,8 +33,8 @@ pub(crate) struct CommonProxy {
 /// JS driver objects
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
 pub(crate) struct DriverProxy {
-    start_transaction: AsyncJsFunction<(), JsTransaction>,
-    get_connection_info: Option<AsyncJsFunction<(), JsConnectionInfo>>,
+    start_transaction: AdapterMethod<(), JsTransaction>,
+    get_connection_info: Option<AdapterMethod<(), JsConnectionInfo>>,
 }
 
 /// This a JS proxy for accessing the methods, specific
@@ -45,10 +45,10 @@ pub(crate) struct TransactionProxy {
     options: TransactionOptions,
 
     /// commit transaction
-    commit: AsyncJsFunction<(), ()>,
+    commit: AdapterMethod<(), ()>,
 
     /// rollback transaction
-    rollback: AsyncJsFunction<(), ()>,
+    rollback: AdapterMethod<(), ()>,
 
     /// whether the transaction has already been committed or rolled back
     closed: AtomicBool,
@@ -74,11 +74,11 @@ impl CommonProxy {
     }
 
     pub async fn query_raw(&self, params: Query) -> quaint::Result<JSResultSet> {
-        self.query_raw.call(params).await
+        self.query_raw.call_as_async(params).await
     }
 
     pub async fn execute_raw(&self, params: Query) -> quaint::Result<u32> {
-        self.execute_raw.call(params).await
+        self.execute_raw.call_as_async(params).await
     }
 }
 
@@ -93,7 +93,7 @@ impl DriverProxy {
     pub async fn get_connection_info(&self) -> quaint::Result<JsConnectionInfo> {
         UnsafeFuture(async move {
             if let Some(fn_) = &self.get_connection_info {
-                fn_.call(()).await
+                fn_.call_as_sync(()).await
             } else {
                 Ok(JsConnectionInfo::default())
             }
@@ -102,7 +102,7 @@ impl DriverProxy {
     }
 
     async fn start_transaction_inner(&self) -> quaint::Result<Box<JsTransaction>> {
-        let tx = self.start_transaction.call(()).await?;
+        let tx = self.start_transaction.call_as_async(()).await?;
 
         // Decrement for this gauge is done in JsTransaction::commit/JsTransaction::rollback
         // Previously, it was done in JsTransaction::new, similar to the native Transaction.
@@ -153,7 +153,7 @@ impl TransactionProxy {
     ///   waiting on the JavaScript call to complete and deliver response.
     pub fn commit(&self) -> UnsafeFuture<impl Future<Output = quaint::Result<()>> + '_> {
         self.closed.store(true, Ordering::Relaxed);
-        UnsafeFuture(self.commit.call(()))
+        UnsafeFuture(self.commit.call_as_async(()))
     }
 
     /// Rolls back the transaction via the driver adapter.
@@ -173,7 +173,7 @@ impl TransactionProxy {
     ///   on the JavaScript call to complete and deliver response.
     pub fn rollback(&self) -> UnsafeFuture<impl Future<Output = quaint::Result<()>> + '_> {
         self.closed.store(true, Ordering::Relaxed);
-        UnsafeFuture(self.rollback.call(()))
+        UnsafeFuture(self.rollback.call_as_async(()))
     }
 }
 

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -6,6 +6,7 @@ use super::conversion;
 use crate::send_future::UnsafeFuture;
 use async_trait::async_trait;
 use futures::Future;
+use quaint::connector::{ExternalConnectionInfo, ExternalConnector};
 use quaint::{
     connector::{metrics, IsolationLevel, Transaction},
     error::{Error, ErrorKind},
@@ -221,6 +222,14 @@ impl std::fmt::Display for JsQueryable {
 impl std::fmt::Debug for JsQueryable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "JSQueryable(driver)")
+    }
+}
+
+#[async_trait]
+impl ExternalConnector for JsQueryable {
+    async fn get_connection_info(&self) -> quaint::Result<ExternalConnectionInfo> {
+        let conn_info = self.driver_proxy.get_connection_info().await?;
+        Ok(conn_info.into_external_connection_info(&self.inner.provider))
     }
 }
 

--- a/query-engine/driver-adapters/src/types.rs
+++ b/query-engine/driver-adapters/src/types.rs
@@ -71,7 +71,7 @@ impl JsConnectionInfo {
         match provider {
             AdapterFlavour::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
             AdapterFlavour::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
-            AdapterFlavour::Sqlite => quaint::connector::DEFAULT_SQLITE_SCHEMA,
+            AdapterFlavour::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
         }
     }
 }

--- a/query-engine/driver-adapters/src/types.rs
+++ b/query-engine/driver-adapters/src/types.rs
@@ -49,6 +49,7 @@ impl From<AdapterFlavour> for SqlFamily {
 #[cfg_attr(target_arch = "wasm32", derive(Serialize, Deserialize, Tsify))]
 #[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi, from_wasm_abi))]
 #[cfg_attr(target_arch = "wasm32", serde(rename_all = "camelCase"))]
+#[derive(Default)]
 pub(crate) struct JsConnectionInfo {
     pub schema_name: Option<String>,
 }
@@ -62,7 +63,7 @@ impl JsConnectionInfo {
     fn get_schema_name(&self, provider: &AdapterFlavour) -> &str {
         match self.schema_name.as_ref() {
             Some(name) => name,
-            None => self.default_schema_name(&provider),
+            None => self.default_schema_name(provider),
         }
     }
 
@@ -72,12 +73,6 @@ impl JsConnectionInfo {
             AdapterFlavour::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
             AdapterFlavour::Sqlite => quaint::connector::DEFAULT_SQLITE_SCHEMA,
         }
-    }
-}
-
-impl Default for JsConnectionInfo {
-    fn default() -> Self {
-        Self { schema_name: None }
     }
 }
 

--- a/query-engine/driver-adapters/src/wasm/adapter_method.rs
+++ b/query-engine/driver-adapters/src/wasm/adapter_method.rs
@@ -17,7 +17,7 @@ use crate::AdapterResult;
 pub(crate) static SERIALIZER: Serializer = Serializer::new().serialize_missing_as_null(true);
 
 #[derive(Clone)]
-pub(crate) struct AsyncJsFunction<ArgType, ReturnType>
+pub(crate) struct AdapterMethod<ArgType, ReturnType>
 where
     ArgType: Serialize,
     ReturnType: FromJsValue,
@@ -28,7 +28,7 @@ where
     _phantom_return: PhantomData<ReturnType>,
 }
 
-impl<T, R> From<JsValue> for AsyncJsFunction<T, R>
+impl<T, R> From<JsValue> for AdapterMethod<T, R>
 where
     T: Serialize,
     R: FromJsValue,
@@ -38,7 +38,7 @@ where
     }
 }
 
-impl<T, R> From<JsFunction> for AsyncJsFunction<T, R>
+impl<T, R> From<JsFunction> for AdapterMethod<T, R>
 where
     T: Serialize,
     R: FromJsValue,
@@ -52,35 +52,40 @@ where
     }
 }
 
-impl<T, R> AsyncJsFunction<T, R>
+impl<T, R> AdapterMethod<T, R>
 where
     T: Serialize,
     R: FromJsValue,
 {
-    pub(crate) async fn call(&self, arg1: T) -> quaint::Result<R> {
-        let result = self.call_internal(arg1).await;
+    pub(crate) async fn call_as_async(&self, arg1: T) -> quaint::Result<R> {
+        let future = self
+            .call_internal(arg1)
+            .await
+            .and_then(|v| v.dyn_into::<JsPromise>())
+            .map(JsFuture::from)
+            .map_err(into_quaint_error)?;
 
-        match result {
-            Ok(js_result) => js_result.into(),
-            Err(err) => Err(into_quaint_error(err)),
-        }
+        let return_value = future.await.map_err(into_quaint_error)?;
+        Self::js_result_into_quaint_result(return_value)
     }
 
-    async fn call_internal(&self, arg1: T) -> Result<AdapterResult<R>, JsValue> {
+    pub(crate) async fn call_as_sync(&self, arg1: T) -> quaint::Result<R> {
+        let return_value = self.call_internal(arg1).await.map_err(into_quaint_error)?;
+
+        Self::js_result_into_quaint_result(return_value)
+    }
+
+    fn js_result_into_quaint_result(value: JsValue) -> quaint::Result<R> {
+        AdapterResult::<R>::from_js_value(value)
+            .map_err(into_quaint_error)?
+            .into()
+    }
+
+    async fn call_internal(&self, arg1: T) -> Result<JsValue, JsValue> {
         let arg1 = arg1
             .serialize(&SERIALIZER)
             .map_err(|err| JsValue::from(JsError::from(&err)))?;
-        let return_value = self.fn_.call1(&JsValue::null(), &arg1)?;
-
-        let value = if let Some(promise) = return_value.dyn_ref::<JsPromise>() {
-            JsFuture::from(promise.to_owned()).await?
-        } else {
-            return_value
-        };
-
-        let js_result = AdapterResult::<R>::from_js_value(value)?;
-
-        Ok(js_result)
+        self.fn_.call1(&JsValue::null(), &arg1)
     }
 
     pub(crate) fn call_non_blocking(&self, arg: T) {
@@ -90,7 +95,7 @@ where
     }
 }
 
-impl<ArgType, ReturnType> WasmDescribe for AsyncJsFunction<ArgType, ReturnType>
+impl<ArgType, ReturnType> WasmDescribe for AdapterMethod<ArgType, ReturnType>
 where
     ArgType: Serialize,
     ReturnType: FromJsValue,
@@ -100,7 +105,7 @@ where
     }
 }
 
-impl<ArgType, ReturnType> FromWasmAbi for AsyncJsFunction<ArgType, ReturnType>
+impl<ArgType, ReturnType> FromWasmAbi for AdapterMethod<ArgType, ReturnType>
 where
     ArgType: Serialize,
     ReturnType: FromJsValue,

--- a/query-engine/driver-adapters/src/wasm/async_js_function.rs
+++ b/query-engine/driver-adapters/src/wasm/async_js_function.rs
@@ -14,7 +14,7 @@ use crate::AdapterResult;
 // `serialize_missing_as_null` is required to make sure that "empty" values (e.g., `None` and `()`)
 //  are serialized as `null` and not `undefined`.
 // This is due to certain drivers (e.g., LibSQL) not supporting `undefined` values.
-static SERIALIZER: Serializer = Serializer::new().serialize_missing_as_null(true);
+pub(crate) static SERIALIZER: Serializer = Serializer::new().serialize_missing_as_null(true);
 
 #[derive(Clone)]
 pub(crate) struct AsyncJsFunction<ArgType, ReturnType>

--- a/query-engine/driver-adapters/src/wasm/mod.rs
+++ b/query-engine/driver-adapters/src/wasm/mod.rs
@@ -1,11 +1,11 @@
 //! Query Engine Driver Adapters: `wasm`-specific implementation.
 
-mod async_js_function;
+mod adapter_method;
 mod error;
 mod from_js;
 mod js_object_extern;
 pub(crate) mod result;
 
-pub(crate) use async_js_function::AsyncJsFunction;
+pub(crate) use adapter_method::AdapterMethod;
 pub(crate) use from_js::FromJsValue;
 pub use js_object_extern::JsObjectExtern;

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -9,7 +9,7 @@ use query_core::{
     telemetry, QueryExecutor, TransactionOptions, TxId,
 };
 use query_engine_metrics::{MetricFormat, MetricRegistry};
-use request_handlers::{dmmf, load_executor, render_graphql_schema, ConnectorMode, RequestBody, RequestHandler};
+use request_handlers::{dmmf, load_executor, render_graphql_schema, ConnectorKind, RequestBody, RequestHandler};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -23,6 +23,11 @@ use tokio::sync::RwLock;
 use tracing::{field, instrument::WithSubscriber, Instrument, Span};
 use tracing_subscriber::filter::LevelFilter;
 use user_facing_errors::Error;
+
+enum ConnectorMode {
+    Rust,
+    Js,
+}
 
 /// The main query engine used by JS
 #[napi]
@@ -271,18 +276,6 @@ impl QueryEngine {
             let arced_schema = Arc::clone(&builder.schema);
             let arced_schema_2 = Arc::clone(&builder.schema);
 
-            let url = {
-                let data_source = builder
-                    .schema
-                    .configuration
-                    .datasources
-                    .first()
-                    .ok_or_else(|| ApiError::configuration("No valid data source found"))?;
-                data_source
-                    .load_url_with_config_dir(&builder.config_dir, |key| builder.env.get(key).map(ToString::to_string))
-                    .map_err(|err| crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned()))?
-            };
-
             let engine = async move {
                 // We only support one data source & generator at the moment, so take the first one (default not exposed yet).
                 let data_source = arced_schema
@@ -294,7 +287,20 @@ impl QueryEngine {
                 let preview_features = arced_schema.configuration.preview_features();
 
                 let executor_fut = async {
-                    let executor = load_executor(self.connector_mode, data_source, preview_features, &url).await?;
+                    let connector_kind = match self.connector_mode {
+                        ConnectorMode::Rust => {
+                            let url = data_source
+                                .load_url_with_config_dir(&builder.config_dir, |key| {
+                                    builder.env.get(key).map(ToString::to_string)
+                                })
+                                .map_err(|err| {
+                                    crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned())
+                                })?;
+                            ConnectorKind::Rust { url }
+                        }
+                        ConnectorMode::Js => ConnectorKind::Js,
+                    };
+                    let executor = load_executor(connector_kind, data_source, preview_features).await?;
                     let connector = executor.primary_connector();
 
                     let conn_span = tracing::info_span!(

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -12,7 +12,7 @@ use query_core::{
     schema::{self, QuerySchema},
     telemetry, QueryExecutor, TransactionOptions, TxId,
 };
-use request_handlers::ConnectorMode;
+use request_handlers::ConnectorKind;
 use request_handlers::{load_executor, RequestBody, RequestHandler};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -29,7 +29,6 @@ use wasm_bindgen::prelude::wasm_bindgen;
 /// The main query engine used by JS
 #[wasm_bindgen]
 pub struct QueryEngine {
-    connector_mode: ConnectorMode,
     inner: RwLock<Inner>,
     logger: Logger,
 }
@@ -131,7 +130,7 @@ impl QueryEngine {
     pub fn new(
         options: ConstructorOptions,
         callback: JsFunction,
-        maybe_adapter: Option<JsObject>,
+        adapter: JsObject,
     ) -> Result<QueryEngine, wasm_bindgen::JsError> {
         let log_callback = LogCallback(callback);
 
@@ -153,27 +152,25 @@ impl QueryEngine {
         let config = &mut schema.configuration;
         let preview_features = config.preview_features();
 
-        if let Some(adapter) = maybe_adapter {
-            let js_queryable = driver_adapters::from_js(adapter);
+        let js_queryable = driver_adapters::from_js(adapter);
 
-            sql_connector::activate_driver_adapter(Arc::new(js_queryable));
+        sql_connector::activate_driver_adapter(Arc::new(js_queryable));
 
-            let provider_name = schema.connector.provider_name();
-            tracing::info!("Received driver adapter for {provider_name}.");
-        }
+        let provider_name = schema.connector.provider_name();
+        tracing::info!("Received driver adapter for {provider_name}.");
 
         schema
             .diagnostics
             .to_result()
             .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
 
-        config
-            .resolve_datasource_urls_query_engine(
-                &overrides,
-                |key| env.get(key).map(ToString::to_string),
-                ignore_env_var_errors,
-            )
-            .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
+        // config
+        //     .resolve_datasource_urls_query_engine(
+        //         &overrides,
+        //         |key| env.get(key).map(ToString::to_string),
+        //         ignore_env_var_errors,
+        //     )
+        //     .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
 
         config
             .validate_that_one_datasource_is_provided()
@@ -193,12 +190,9 @@ impl QueryEngine {
         let log_level = log_level.parse::<LevelFilter>().unwrap();
         let logger = Logger::new(log_queries, log_level, log_callback, enable_tracing);
 
-        let connector_mode = ConnectorMode::Js;
-
         Ok(Self {
             inner: RwLock::new(Inner::Builder(builder)),
             logger,
-            connector_mode,
         })
     }
 
@@ -216,17 +210,17 @@ impl QueryEngine {
             let arced_schema = Arc::clone(&builder.schema);
             let arced_schema_2 = Arc::clone(&builder.schema);
 
-            let url = {
-                let data_source = builder
-                    .schema
-                    .configuration
-                    .datasources
-                    .first()
-                    .ok_or_else(|| ApiError::configuration("No valid data source found"))?;
-                data_source
-                    .load_url_with_config_dir(&builder.config_dir, |key| builder.env.get(key).map(ToString::to_string))
-                    .map_err(|err| crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned()))?
-            };
+            // let url = {
+            //     let data_source = builder
+            //         .schema
+            //         .configuration
+            //         .datasources
+            //         .first()
+            //         .ok_or_else(|| ApiError::configuration("No valid data source found"))?;
+            //     data_source
+            //         .load_url_with_config_dir(&builder.config_dir, |key| builder.env.get(key).map(ToString::to_string))
+            //         .map_err(|err| crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned()))?
+            // };
 
             let engine = async move {
                 // We only support one data source & generator at the moment, so take the first one (default not exposed yet).
@@ -238,7 +232,7 @@ impl QueryEngine {
 
                 let preview_features = arced_schema.configuration.preview_features();
 
-                let executor = load_executor(self.connector_mode, data_source, preview_features, &url).await?;
+                let executor = load_executor(ConnectorKind::Js {}, data_source, preview_features).await?;
                 let connector = executor.primary_connector();
 
                 let conn_span = tracing::info_span!(

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -164,14 +164,6 @@ impl QueryEngine {
             .to_result()
             .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
 
-        // config
-        //     .resolve_datasource_urls_query_engine(
-        //         &overrides,
-        //         |key| env.get(key).map(ToString::to_string),
-        //         ignore_env_var_errors,
-        //     )
-        //     .map_err(|err| ApiError::conversion(err, schema.db.source()))?;
-
         config
             .validate_that_one_datasource_is_provided()
             .map_err(|errors| ApiError::conversion(errors, schema.db.source()))?;
@@ -209,18 +201,6 @@ impl QueryEngine {
             let builder = inner.as_builder()?;
             let arced_schema = Arc::clone(&builder.schema);
             let arced_schema_2 = Arc::clone(&builder.schema);
-
-            // let url = {
-            //     let data_source = builder
-            //         .schema
-            //         .configuration
-            //         .datasources
-            //         .first()
-            //         .ok_or_else(|| ApiError::configuration("No valid data source found"))?;
-            //     data_source
-            //         .load_url_with_config_dir(&builder.config_dir, |key| builder.env.get(key).map(ToString::to_string))
-            //         .map_err(|err| crate::error::ApiError::Conversion(err, builder.schema.db.source().to_owned()))?
-            // };
 
             let engine = async move {
                 // We only support one data source & generator at the moment, so take the first one (default not exposed yet).

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -9,7 +9,7 @@ use query_core::{
 };
 use query_engine_metrics::setup as metric_setup;
 use query_engine_metrics::MetricRegistry;
-use request_handlers::{load_executor, ConnectorMode};
+use request_handlers::{load_executor, ConnectorKind};
 use std::{env, fmt, sync::Arc};
 use tracing::Instrument;
 
@@ -63,8 +63,7 @@ impl PrismaContext {
 
             let url = data_source.load_url(|key| env::var(key).ok())?;
             // Load executor
-            let connector_mode = ConnectorMode::Rust;
-            let executor = load_executor(connector_mode, data_source, preview_features, &url).await?;
+            let executor = load_executor(ConnectorKind::Rust { url }, data_source, preview_features).await?;
             executor.primary_connector().get_connection().await?;
             PrismaResult::<_>::Ok(executor)
         });

--- a/query-engine/request-handlers/src/connector_mode.rs
+++ b/query-engine/request-handlers/src/connector_mode.rs
@@ -1,9 +1,0 @@
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub enum ConnectorMode {
-    /// Indicates that Rust drivers are used in Query Engine.
-    #[cfg(feature = "native")]
-    Rust,
-
-    /// Indicates that JS drivers are used in Query Engine.
-    Js,
-}

--- a/query-engine/request-handlers/src/lib.rs
+++ b/query-engine/request-handlers/src/lib.rs
@@ -2,7 +2,6 @@
 
 pub mod dmmf;
 
-mod connector_mode;
 mod error;
 mod handler;
 mod load_executor;
@@ -10,8 +9,8 @@ mod protocols;
 mod response;
 
 pub use self::{error::HandlerError, load_executor::load as load_executor};
-pub use connector_mode::ConnectorMode;
 pub use handler::*;
+pub use load_executor::ConnectorKind;
 #[cfg(feature = "graphql-protocol")]
 pub use protocols::graphql::*;
 pub use protocols::{json::*, RequestBody};

--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -7,26 +7,31 @@ use std::collections::HashMap;
 use std::env;
 use url::Url;
 
-use super::ConnectorMode;
+pub enum ConnectorKind {
+    #[cfg(feature = "native")]
+    Rust {
+        url: String,
+    },
+    Js,
+}
 
 /// Loads a query executor based on the parsed Prisma schema (datasource).
 pub async fn load(
-    connector_mode: ConnectorMode,
+    connector_kind: ConnectorKind,
     source: &Datasource,
     features: PreviewFeatures,
-    url: &str,
 ) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync + 'static>> {
-    match connector_mode {
-        ConnectorMode::Js => {
+    match connector_kind {
+        ConnectorKind::Js { .. } => {
             #[cfg(not(feature = "driver-adapters"))]
             panic!("Driver adapters are not enabled, but connector mode is set to JS");
 
             #[cfg(feature = "driver-adapters")]
-            driver_adapter(source, url, features).await
+            driver_adapter(source, features).await
         }
 
         #[cfg(feature = "native")]
-        ConnectorMode::Rust => {
+        ConnectorKind::Rust { url } => {
             if let Ok(value) = env::var("PRISMA_DISABLE_QUAINT_EXECUTORS") {
                 let disable = value.to_uppercase();
                 if disable == "TRUE" || disable == "1" {
@@ -35,14 +40,14 @@ pub async fn load(
             }
 
             match source.active_provider {
-                p if SQLITE.is_provider(p) => native::sqlite(source, url, features).await,
-                p if MYSQL.is_provider(p) => native::mysql(source, url, features).await,
-                p if POSTGRES.is_provider(p) => native::postgres(source, url, features).await,
-                p if MSSQL.is_provider(p) => native::mssql(source, url, features).await,
-                p if COCKROACH.is_provider(p) => native::postgres(source, url, features).await,
+                p if SQLITE.is_provider(p) => native::sqlite(source, &url, features).await,
+                p if MYSQL.is_provider(p) => native::mysql(source, &url, features).await,
+                p if POSTGRES.is_provider(p) => native::postgres(source, &url, features).await,
+                p if MSSQL.is_provider(p) => native::mssql(source, &url, features).await,
+                p if COCKROACH.is_provider(p) => native::postgres(source, &url, features).await,
 
                 #[cfg(feature = "mongodb")]
-                p if MONGODB.is_provider(p) => native::mongodb(source, url, features).await,
+                p if MONGODB.is_provider(p) => native::mongodb(source, &url, features).await,
 
                 x => Err(query_core::CoreError::ConfigurationError(format!(
                     "Unsupported connector type: {x}"
@@ -55,10 +60,9 @@ pub async fn load(
 #[cfg(feature = "driver-adapters")]
 async fn driver_adapter(
     source: &Datasource,
-    url: &str,
     features: PreviewFeatures,
 ) -> Result<Box<dyn QueryExecutor + Send + Sync>, query_core::CoreError> {
-    let js = Js::from_source(source, url, features).await?;
+    let js = Js::new(&source, features).await?;
     Ok(executor_for(js, false))
 }
 

--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -62,7 +62,7 @@ async fn driver_adapter(
     source: &Datasource,
     features: PreviewFeatures,
 ) -> Result<Box<dyn QueryExecutor + Send + Sync>, query_core::CoreError> {
-    let js = Js::new(&source, features).await?;
+    let js = Js::new(source, features).await?;
     Ok(executor_for(js, false))
 }
 

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -201,7 +201,7 @@ impl TestApi {
             ConnectionInfo::Mysql(_) => SqlSchemaConnector::new_mysql(),
             ConnectionInfo::Mssql(_) => SqlSchemaConnector::new_mssql(),
             ConnectionInfo::Sqlite { .. } => SqlSchemaConnector::new_sqlite(),
-            ConnectionInfo::InMemorySqlite { .. } => unreachable!(),
+            ConnectionInfo::InMemorySqlite { .. } | ConnectionInfo::External(_) => unreachable!(),
         };
         connector.set_params(params).unwrap();
 


### PR DESCRIPTION
By design, adapter itself is responsible for establishing connection and
users are expected to provide url to JS driver manually. Yet, we
continued to validate and read URL from schema file upon initialization.

Information, derived from connection URL used in a bunch of places in
quaint and other crates. Most of them are optional, such as error
messages.

However, one important thing - default schema name - is used for
building SQL queries. We need an alternative way to provide that
information, that does not include URL parsing.

This PR expands adapter API by adding optional method,
`getConnectionInfo`. Right now, it can only return an object wiht `schemaName`
property. If it does, this name will be used as a prefix for SQL
queries. If it does not, or `getConnectionInfo` is ommited, defaults
will be used:
- `main` for postgres and sqlite
- `mysql` for mysql

Generally, it is up for adapter to decide on where to get this info
from: if URL on JS side contains it, it might get it from there or it
can have an optional constructor option with a schema name.

This PR will require a follow up on JS side too: at the minimum,
expanding public interface of a driver.

Fix prisma/team-orm#662
