### PR TITLE
fix: m2m filtering on joined queries

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/m2m.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/m2m.rs
@@ -1,8 +1,39 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schemas::posts_categories))]
+#[test_suite(schema(schema))]
 mod m2m {
     use query_engine_tests::assert_query;
+
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model Post {
+                #id(id, Int, @id)
+                title   String
+                content String @default("Wip")
+                #m2m(categories, Category[], id, Int)
+            }
+    
+            model Category {
+                #id(id, Int, @id)
+                name String
+
+                #m2m(posts, Post[], id, Int)
+
+                tags Tag[]
+            }
+            
+            model Tag {
+                #id(id, Int, @id)
+                name String
+
+                categoryId Int
+                category   Category @relation(fields: [categoryId], references: [id])
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
 
     #[connector_test]
     async fn fetch_only_associated(runner: Runner) -> TestResult<()> {
@@ -20,6 +51,100 @@ mod m2m {
             runner,
             "query { findUniqueCategory(where: { id: 1 }) { posts { id }}}",
             r#"{"data":{"findUniqueCategory":{"posts":[{"id":1},{"id":2}]}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn filtering_ordering(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+                findUniquePost(where: { id: 1 }) {
+                    categories(
+                        where: {
+                            OR: [
+                                { id: { in: [1] } },
+                                { tags: { some: { name: "Cinema" } } }
+                            ]
+                        },
+                        orderBy: { name: asc }
+                    ) {
+                        id
+                        name
+                    }
+                }
+            }"#),
+          @r###"{"data":{"findUniquePost":{"categories":[{"id":2,"name":"Fiction"},{"id":1,"name":"Marketing"}]}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn basic_pagination(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+                findUniquePost(where: { id: 1 }) {
+                    categories(
+                        take: 1,
+                        orderBy: { name: desc }
+                    ) {
+                        id
+                        name
+                    }
+                }
+            }"#),
+          @r###"{"data":{"findUniquePost":{"categories":[{"id":1,"name":"Marketing"}]}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+                  findUniquePost(where: { id: 1 }) {
+                      categories(
+                          take: 1,
+                          orderBy: { name: asc }
+                      ) {
+                          id
+                          name
+                      }
+                  }
+              }"#),
+          @r###"{"data":{"findUniquePost":{"categories":[{"id":2,"name":"Fiction"}]}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+                  findUniquePost(where: { id: 1 }) {
+                      categories(
+                          skip: 1,
+                          orderBy: { name: desc }
+                      ) {
+                          id
+                          name
+                      }
+                  }
+              }"#),
+          @r###"{"data":{"findUniquePost":{"categories":[{"id":2,"name":"Fiction"}]}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{
+                  findUniquePost(where: { id: 1 }) {
+                      categories(
+                          skip: 1,
+                          orderBy: { name: asc }
+                      ) {
+                          id
+                          name
+                      }
+                  }
+              }"#),
+          @r###"{"data":{"findUniquePost":{"categories":[{"id":1,"name":"Marketing"}]}}}"###
         );
 
         Ok(())
@@ -69,7 +194,7 @@ mod m2m {
         Ok(())
     }
 
-    fn schema() -> String {
+    fn schema_16390() -> String {
         let schema = indoc! {
             r#"model Item {
                 id         Int        @id @default(autoincrement())
@@ -90,7 +215,7 @@ mod m2m {
     }
 
     // https://github.com/prisma/prisma/issues/16390
-    #[connector_test(schema(schema), relation_mode = "prisma", only(Postgres))]
+    #[connector_test(schema(schema_16390), relation_mode = "prisma", only(Postgres))]
     async fn repro_16390(runner: Runner) -> TestResult<()> {
         run_query!(&runner, r#"mutation { createOneCategory(data: {}) { id } }"#);
         run_query!(
@@ -124,11 +249,13 @@ mod m2m {
                     create: [
                         {
                             id: 1,
-                            name: "Marketing"
+                            name: "Marketing",
+                            tags: { create: { id: 1, name: "Business" } }
                         },
                         {
                             id: 2,
-                            name: "Fiction"
+                            name: "Fiction",
+                            tags: { create: { id: 2, name: "Cinema" } }
                         }
                     ]
                 }


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/22311
fixes https://github.com/prisma/prisma/issues/22299

- No parent alias was passed to m2m filters, resulting in an unknown table. eg: `WHERE Table.id = 1` instead of `WHERE t4.id = 1`
- Relational filters weren't selected in the parent select of the select where filters are rendered, resulting in columns not existing on the filtered table.