### PR TITLE
fix: use row_to_json with postgres

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,4 +1,5 @@
 mod max_integer;
+mod prisma_22298;
 mod prisma_10098;
 mod prisma_10935;
 mod prisma_12572;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -1,5 +1,4 @@
 mod max_integer;
-mod prisma_22298;
 mod prisma_10098;
 mod prisma_10935;
 mod prisma_12572;
@@ -23,6 +22,7 @@ mod prisma_20799;
 mod prisma_21182;
 mod prisma_21369;
 mod prisma_21901;
+mod prisma_22298;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_22298.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_22298.rs
@@ -1,0 +1,215 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod many_fields_in_related_table {
+    use indoc::indoc;
+
+    fn schema() -> String {
+        indoc! {r#"
+            model A {
+                #id(id, Int, @id)
+                field1  Int
+                field2  Int
+                field3  Int
+                field4  Int
+                field5  Int
+                field6  Int
+                field7  Int
+                field8  Int
+                field9  Int
+                field10 Int
+                field11 Int
+                field12 Int
+                field13 Int
+                field14 Int
+                field15 Int
+                field16 Int
+                field17 Int
+                field18 Int
+                field19 Int
+                field20 Int
+                field21 Int
+                field22 Int
+                field23 Int
+                field24 Int
+                field25 Int
+                field26 Int
+                field27 Int
+                field28 Int
+                field29 Int
+                field30 Int
+                field31 Int
+                field32 Int
+                field33 Int
+                field34 Int
+                field35 Int
+                field36 Int
+                field37 Int
+                field38 Int
+                field39 Int
+                field40 Int
+                field41 Int
+                field42 Int
+                field43 Int
+                field44 Int
+                field45 Int
+                field46 Int
+                field47 Int
+                field48 Int
+                field49 Int
+                field50 Int
+                b_id    Int
+                b       B      @relation(fields: [b_id], references: [id])
+                c       C[]
+            }
+
+            model B {
+                #id(id, Int, @id)
+                a A[]
+            }
+
+            model C {
+                #id(id, Int, @id)
+                a_id Int
+                a    A   @relation(fields: [a_id], references: [id])
+            }
+        "#}
+        .to_owned()
+    }
+
+    #[connector_test]
+    async fn query_51_fields_through_relation(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+            run_query!(runner, r#"
+                mutation {
+                    createOneB(
+                        data: {
+                            id: 1,
+                            a: {
+                                create: {
+                                    id: 1,
+                                    field1: 0,
+                                    field2: 0,
+                                    field3: 0,
+                                    field4: 0,
+                                    field5: 0,
+                                    field6: 0,
+                                    field7: 0,
+                                    field8: 0,
+                                    field9: 0,
+                                    field10: 0,
+                                    field11: 0,
+                                    field12: 0,
+                                    field13: 0,
+                                    field14: 0,
+                                    field15: 0,
+                                    field16: 0,
+                                    field17: 0,
+                                    field18: 0,
+                                    field19: 0,
+                                    field20: 0,
+                                    field21: 0,
+                                    field22: 0,
+                                    field23: 0,
+                                    field24: 0,
+                                    field25: 0,
+                                    field26: 0,
+                                    field27: 0,
+                                    field28: 0,
+                                    field29: 0,
+                                    field30: 0,
+                                    field31: 0,
+                                    field32: 0,
+                                    field33: 0,
+                                    field34: 0,
+                                    field35: 0,
+                                    field36: 0,
+                                    field37: 0,
+                                    field38: 0,
+                                    field39: 0,
+                                    field40: 0,
+                                    field41: 0,
+                                    field42: 0,
+                                    field43: 0,
+                                    field44: 0,
+                                    field45: 0,
+                                    field46: 0,
+                                    field47: 0,
+                                    field48: 0,
+                                    field49: 0,
+                                    field50: 0,
+                                    c: {
+                                        create: {
+                                            id: 1
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        id
+                        a {
+                            id
+                            field1
+                            field2
+                            field3
+                            field4
+                            field5
+                            field6
+                            field7
+                            field8
+                            field9
+                            field10
+                            field11
+                            field12
+                            field13
+                            field14
+                            field15
+                            field16
+                            field17
+                            field18
+                            field19
+                            field20
+                            field21
+                            field22
+                            field23
+                            field24
+                            field25
+                            field26
+                            field27
+                            field28
+                            field29
+                            field30
+                            field31
+                            field32
+                            field33
+                            field34
+                            field35
+                            field36
+                            field37
+                            field38
+                            field39
+                            field40
+                            field41
+                            field42
+                            field43
+                            field44
+                            field45
+                            field46
+                            field47
+                            field48
+                            field49
+                            field50
+                            c {
+                                id
+                            }
+                        }
+                    }
+                }
+            "#),
+            @r###"{"data":{"createOneB":{"id":1,"a":[{"id":1,"field1":0,"field2":0,"field3":0,"field4":0,"field5":0,"field6":0,"field7":0,"field8":0,"field9":0,"field10":0,"field11":0,"field12":0,"field13":0,"field14":0,"field15":0,"field16":0,"field17":0,"field18":0,"field19":0,"field20":0,"field21":0,"field22":0,"field23":0,"field24":0,"field25":0,"field26":0,"field27":0,"field28":0,"field29":0,"field30":0,"field31":0,"field32":0,"field33":0,"field34":0,"field35":0,"field36":0,"field37":0,"field38":0,"field39":0,"field40":0,"field41":0,"field42":0,"field43":0,"field44":0,"field45":0,"field46":0,"field47":0,"field48":0,"field49":0,"field50":0}]}}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_22298.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_22298.rs
@@ -207,7 +207,7 @@ mod many_fields_in_related_table {
                     }
                 }
             "#),
-            @r###"{"data":{"createOneB":{"id":1,"a":[{"id":1,"field1":0,"field2":0,"field3":0,"field4":0,"field5":0,"field6":0,"field7":0,"field8":0,"field9":0,"field10":0,"field11":0,"field12":0,"field13":0,"field14":0,"field15":0,"field16":0,"field17":0,"field18":0,"field19":0,"field20":0,"field21":0,"field22":0,"field23":0,"field24":0,"field25":0,"field26":0,"field27":0,"field28":0,"field29":0,"field30":0,"field31":0,"field32":0,"field33":0,"field34":0,"field35":0,"field36":0,"field37":0,"field38":0,"field39":0,"field40":0,"field41":0,"field42":0,"field43":0,"field44":0,"field45":0,"field46":0,"field47":0,"field48":0,"field49":0,"field50":0}]}}}"###
+            @r###"{"data":{"createOneB":{"id":1,"a":[{"id":1,"field1":0,"field2":0,"field3":0,"field4":0,"field5":0,"field6":0,"field7":0,"field8":0,"field9":0,"field10":0,"field11":0,"field12":0,"field13":0,"field14":0,"field15":0,"field16":0,"field17":0,"field18":0,"field19":0,"field20":0,"field21":0,"field22":0,"field23":0,"field24":0,"field25":0,"field26":0,"field27":0,"field28":0,"field29":0,"field30":0,"field31":0,"field32":0,"field33":0,"field34":0,"field35":0,"field36":0,"field37":0,"field38":0,"field39":0,"field40":0,"field41":0,"field42":0,"field43":0,"field44":0,"field45":0,"field46":0,"field47":0,"field48":0,"field49":0,"field50":0,"c":[{"id":1}]}]}}}"###
         );
 
         Ok(())

--- a/query-engine/connectors/sql-query-connector/src/context.rs
+++ b/query-engine/connectors/sql-query-connector/src/context.rs
@@ -9,6 +9,8 @@ pub(super) struct Context<'a> {
     /// Maximum number of bind parameters allowed for a single query.
     /// None is unlimited.
     pub(crate) max_bind_values: Option<usize>,
+    /// Whether the current connector supports a function that converts a record to a JSON object.
+    pub(crate) supports_row_to_json_fn: bool,
 }
 
 impl<'a> Context<'a> {
@@ -20,11 +22,15 @@ impl<'a> Context<'a> {
             ConnectionInfo::Mssql(_) => (Some(1000), 2099),
             ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => (Some(999), 999),
         };
+
+        let supports_row_to_json_fn = matches!(connection_info, ConnectionInfo::Postgres(_));
+
         Context {
             connection_info,
             trace_id,
             max_rows,
             max_bind_values: get_batch_size(default_batch_size),
+            supports_row_to_json_fn,
         }
     }
 

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
@@ -332,6 +332,7 @@ impl<'a> SelectBuilderExt<'a> for Select<'a> {
             })
     }
 
+    // TODO: ask Flavian about ColumnIterator
     fn with_columns(self, columns: impl IntoIterator<Item = Column<'static>>) -> Select<'a> {
         columns.into_iter().fold(self, |select, col| select.column(col))
     }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
@@ -4,7 +4,7 @@ use tracing::Span;
 use crate::{
     context::Context,
     filter::alias::{Alias, AliasMode},
-    model_extensions::{AsColumn, AsColumns, AsTable, ColumnIterator, RelationFieldExt},
+    model_extensions::{AsColumn, AsColumns, AsTable, RelationFieldExt},
     ordering::OrderByBuilder,
     sql_trace::SqlTraceComment,
 };

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
@@ -114,6 +114,9 @@ impl SelectBuilder {
             }));
         }
 
+        // LEFT JOIN LATERAL () AS <root_alias> ON TRUE
+        let root = self.with_related_queries(root, rs.relations(), inner_root_table_alias, ctx);
+
         let root_as_json = match ctx.supports_row_to_json_fn {
             true => row_to_json(root_alias.to_table_string(), false),
             false => build_json_obj_fn(rs, ctx, root_alias),
@@ -122,9 +125,6 @@ impl SelectBuilder {
         // SELECT ROW_TO_JSON()/JSON_BUILD_OBJECT() FROM ( <root> )
         let inner = Select::from_table(Table::from(root).alias(root_alias.to_table_string()))
             .value(root_as_json.alias(JSON_AGG_IDENT));
-
-        // LEFT JOIN LATERAL () AS <inner_alias> ON TRUE
-        let inner = self.with_related_queries(inner, rs.relations(), root_alias, ctx);
 
         let linking_fields = rs.field.related_field().linking_fields();
 

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
@@ -137,7 +137,7 @@ impl SelectBuilder {
                     .collect();
 
             // SELECT <foreign_keys>, <orderby columns>
-            inner.with_columns(ColumnIterator::from(selection))
+            inner.with_columns(selection)
         } else {
             // select ordering, filtering & join fields from child selections to order, filter & join them on the outer query
             let inner_selection: Vec<Column<'_>> = FieldSelection::union(vec![
@@ -150,9 +150,7 @@ impl SelectBuilder {
             .map(|c| c.table(root_alias.to_table_string()))
             .collect();
 
-            let inner = inner
-                .with_columns(ColumnIterator::from(inner_selection))
-                .comment("inner select");
+            let inner = inner.with_columns(inner_selection).comment("inner select");
 
             let middle = Select::from_table(Table::from(inner).alias(inner_alias.to_table_string()))
                 // SELECT <inner_alias>.<JSON_ADD_IDENT>
@@ -235,7 +233,7 @@ trait SelectBuilderExt<'a> {
         ctx: &Context<'_>,
     ) -> Select<'a>;
     fn with_selection(self, selected_fields: &FieldSelection, table_alias: Alias, ctx: &Context<'_>) -> Select<'a>;
-    fn with_columns(self, columns: impl Iterator<Item = Column<'static>>) -> Select<'a>;
+    fn with_columns(self, columns: impl IntoIterator<Item = Column<'static>>) -> Select<'a>;
 }
 
 impl<'a> SelectBuilderExt<'a> for Select<'a> {
@@ -334,7 +332,7 @@ impl<'a> SelectBuilderExt<'a> for Select<'a> {
             })
     }
 
-    fn with_columns(self, columns: impl Iterator<Item = Column<'static>>) -> Select<'a> {
+    fn with_columns(self, columns: impl IntoIterator<Item = Column<'static>>) -> Select<'a> {
         columns.into_iter().fold(self, |select, col| select.column(col))
     }
 }


### PR DESCRIPTION
Use `ROW_TO_JSON` to build the JSON object in PostgreSQL/CockroachDB to avoid passing too many parameters to `JSON_BUILD_OBJECT`.

MySQL doesn't have an equivalent of `ROW_TO_JSON` but it also has no limit of the number of arguments we can pass to `JSON_OBJECT` (see https://github.com/aqrln/mysql-json-object-limit-testing), so we will keep building the query the old way on MySQL.

Fixes: https://github.com/prisma/prisma/issues/22298