### PR TITLE
feat(query-engine-wasm): shrink gzipped Wasm size down to 1.3MB

### DIFF
--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -69,6 +69,25 @@ pub fn validate(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSch
     }
 }
 
+/// Retrieves a Prisma schema without validating it.
+/// You should only use this method when actually validating the schema is too expensive
+/// computationally or in terms of bundle size (e.g., for `query-engine-wasm`).
+pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSchema {
+    let mut diagnostics = Diagnostics::new();
+    let db = ParserDatabase::new(file, &mut diagnostics);
+    let configuration = validate_configuration(db.ast(), &mut diagnostics, connectors);
+    let datasources = &configuration.datasources;
+    let out = validate::parse_without_validation(db, datasources);
+
+    ValidatedSchema {
+        diagnostics,
+        configuration,
+        connector: out.connector,
+        db: out.db,
+        relation_mode: out.relation_mode,
+    }
+}
+
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
 pub fn parse_configuration(
     schema: &str,

--- a/psl/psl-core/src/validate.rs
+++ b/psl/psl-core/src/validate.rs
@@ -2,4 +2,5 @@ pub(crate) mod datasource_loader;
 pub(crate) mod generator_loader;
 mod validation_pipeline;
 
+pub(crate) use validation_pipeline::parse_without_validation;
 pub(crate) use validation_pipeline::validate;

--- a/psl/psl-core/src/validate/validation_pipeline.rs
+++ b/psl/psl-core/src/validate/validation_pipeline.rs
@@ -10,6 +10,25 @@ use crate::{
 use enumflags2::BitFlags;
 use parser_database::ParserDatabase;
 
+pub struct ParseOutput {
+    pub(crate) db: ParserDatabase,
+    pub(crate) relation_mode: RelationMode,
+    pub(crate) connector: &'static dyn Connector,
+}
+
+/// Parse a Prisma schema, but skip validations.
+pub(crate) fn parse_without_validation(db: ParserDatabase, sources: &[configuration::Datasource]) -> ParseOutput {
+    let source = sources.first();
+    let connector = source.map(|s| s.active_connector).unwrap_or(&EmptyDatamodelConnector);
+    let relation_mode = source.map(|s| s.relation_mode()).unwrap_or_default();
+
+    ParseOutput {
+        db,
+        relation_mode,
+        connector,
+    }
+}
+
 pub struct ValidateOutput {
     pub(crate) db: ParserDatabase,
     pub(crate) diagnostics: Diagnostics,
@@ -24,21 +43,25 @@ pub(crate) fn validate(
     preview_features: BitFlags<PreviewFeature>,
     diagnostics: Diagnostics,
 ) -> ValidateOutput {
-    let source = sources.first();
-    let connector = source.map(|s| s.active_connector).unwrap_or(&EmptyDatamodelConnector);
-    let relation_mode = source.map(|s| s.relation_mode()).unwrap_or_default();
+    let ParseOutput {
+        connector,
+        relation_mode,
+        db,
+    } = parse_without_validation(db, sources);
 
     let mut output = ValidateOutput {
+        connector,
+        relation_mode,
         db,
         diagnostics,
-        relation_mode,
-        connector,
     };
 
     // Early return so that the validator does not have to deal with invalid schemas
     if !output.diagnostics.errors().is_empty() {
         return output;
     }
+
+    let source = sources.first();
 
     let mut context = context::Context {
         db: &output.db,

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -49,3 +49,8 @@ pub fn parse_schema(file: impl Into<SourceFile>) -> Result<ValidatedSchema, Stri
 pub fn validate(file: SourceFile) -> ValidatedSchema {
     psl_core::validate(file, builtin_connectors::BUILTIN_CONNECTORS)
 }
+
+/// Parse a Prisma schema, but skip validations.
+pub fn parse_without_validation(file: SourceFile) -> ValidatedSchema {
+    psl_core::parse_without_validation(file, builtin_connectors::BUILTIN_CONNECTORS)
+}

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -49,12 +49,7 @@ opentelemetry = { version = "0.17"}
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [
-    "-Os",                                # focus on code size
     "--vacuum",                           # removes obviously unneeded code
     "--duplicate-function-elimination",   # removes duplicate functions 
     "--duplicate-import-elimination",     # removes duplicate imports
-    "--optimize-for-js",                  # early optimize of the instruction combinations for js
-    "--gsi",                              # globally optimize struct values
-    "--directize",                        # turns indirect calls into direct ones
-    "--cfp",                              # propagate constant struct field values
 ]

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -46,3 +46,15 @@ tracing-subscriber = { version = "0.3" }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.3"
 opentelemetry = { version = "0.17"}
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = [
+    "-Oz",                                # super focus on code size
+    "--vacuum",                           # removes obviously unneeded code
+    "--duplicate-function-elimination",   # removes duplicate functions 
+    "--duplicate-import-elimination",     # removes duplicate imports
+    "--optimize-for-js",                  # early optimize of the instruction combinations for js
+    "--gsi",                              # globally optimize struct values
+    "--directize",                        # turns indirect calls into direct ones
+    "--cfp",                              # propagate constant struct field values
+]

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -49,7 +49,14 @@ opentelemetry = { version = "0.17"}
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [
+    "-O",                                 # execute default optimization passes
     "--vacuum",                           # removes obviously unneeded code
     "--duplicate-function-elimination",   # removes duplicate functions 
     "--duplicate-import-elimination",     # removes duplicate imports
+    "--remove-unused-module-elements",    # removes unused module elements
+    "--dae-optimizing",                   # removes arguments to calls in an lto-like manner
+    "--remove-unused-names",              # removes names from location that are never branched to
+    "--rse",                              # removes redundant local.sets
+    "--gsi",                              # global struct inference, to optimize constant values
+    "--gufa-optimizing",                  # optimize the entire program using type monomorphization
 ]

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -49,7 +49,7 @@ opentelemetry = { version = "0.17"}
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = [
-    "-Oz",                                # super focus on code size
+    "-Os",                                # focus on code size
     "--vacuum",                           # removes obviously unneeded code
     "--duplicate-function-elimination",   # removes duplicate functions 
     "--duplicate-import-elimination",     # removes duplicate imports

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -149,7 +149,8 @@ impl QueryEngine {
         let env = stringify_env_values(env)?; // we cannot trust anything JS sends us from process.env
         let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();
 
-        let mut schema = psl::validate(datamodel.into());
+        // Note: if we used `psl::validate`, we'd
+        let mut schema = psl::parse_without_validation(datamodel.into());
         let config = &mut schema.configuration;
         let preview_features = config.preview_features();
 

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -149,7 +149,7 @@ impl QueryEngine {
         let env = stringify_env_values(env)?; // we cannot trust anything JS sends us from process.env
         let overrides: Vec<(_, _)> = datasource_overrides.into_iter().collect();
 
-        // Note: if we used `psl::validate`, we'd
+        // Note: if we used `psl::validate`, we'd add ~1MB to the Wasm artifact (before gzip).
         let mut schema = psl::parse_without_validation(datamodel.into());
         let config = &mut schema.configuration;
         let preview_features = config.preview_features();

--- a/query-engine/query-engine-wasm/wasm-opt.md
+++ b/query-engine/query-engine-wasm/wasm-opt.md
@@ -1,0 +1,63 @@
+# `wasm-opt`
+
+## Things to keep in mind
+
+The following `wasm-opt` flags will cause disruption, as they will yield failures at runtime when running the optimized Wasm binary:
+
+- `--remove-memory`: this removes every `data` section, which contains error messages and other static data of the binary.
+  ```
+  > node --experimental-wasm-modules ./example.js
+
+  wasm://wasm/00b13efa:1
+
+
+  RuntimeError: null function or function signature mismatch
+      at wasm://wasm/00b13efa:wasm-function[915]:0x20132b
+      at wasm://wasm/00b13efa:wasm-function[887]:0x1fbe12
+      at wasm://wasm/00b13efa:wasm-function[2534]:0x29385f
+      at wasm://wasm/00b13efa:wasm-function[88]:0x2b28f
+      at new QueryEngine (file:///Users/jkomyno/work/prisma/prisma-engines/query-engine/query-engine-wasm/pkg/query_engine_bg.js:378:18)
+      at main (file:///Users/jkomyno/work/prisma/prisma-engines/query-engine/query-engine-wasm/example/example.js:35:23)
+  ```
+  This option alone reduces the gzipped binary size by 0.2 MB, but sadly we can't use it as things currently stand.
+
+
+- `--enable-reference-types`: this enables reference types, which are not compatible with how we use `serde` at the moment.
+  ```
+  > node --experimental-wasm-modules ./example.js
+
+  log-callback
+  log-callback
+  log-callback
+  log-callback
+  {
+    created: '{"errors":[{"error":"Error in connector: Database error. error code: WASM_ERROR, error message: Error: invalid type: JsValue(undefined), expected unit\\n    at __wbindgen_error_new (file:///Users/jkomyno/work/prisma/prisma-engines/query-engine/query-engine-wasm/pkg/query_engine_bg.js:520:17)\\n    at wasm://wasm/00cd3c02:wasm-function[4473]:0x2c3664\\n    at wasm://wasm/00cd3c02:wasm-function[2468]:0x279d75\\n    at wasm://wasm/00cd3c02:wasm-function[2886]:0x28a509\\n    at wasm://wasm/00cd3c02:wasm-function[1056]:0x1ff3e8\\n    at wasm://wasm/00cd3c02:wasm-function[581]:0x1a278f\\n    at wasm://wasm/00cd3c02:wasm-function[619]:0x1abbb5\\n    at wasm://wasm/00cd3c02:wasm-function[816]:0x1d8cc4\\n    at wasm://wasm/00cd3c02:wasm-function[374]:0x1518b8\\n    at wasm://wasm/00cd3c02:wasm-function[175]:0xbe722","user_facing_error":{"is_panic":false,"message":"Raw query failed. Code: `WASM_ERROR`. Message: `Error: invalid type: JsValue(undefined), expected unit\\n    at __wbindgen_error_new (file:///Users/jkomyno/work/prisma/prisma-engines/query-engine/query-engine-wasm/pkg/query_engine_bg.js:520:17)\\n    at wasm://wasm/00cd3c02:wasm-function[4473]:0x2c3664\\n    at wasm://wasm/00cd3c02:wasm-function[2468]:0x279d75\\n    at wasm://wasm/00cd3c02:wasm-function[2886]:0x28a509\\n    at wasm://wasm/00cd3c02:wasm-function[1056]:0x1ff3e8\\n    at wasm://wasm/00cd3c02:wasm-function[581]:0x1a278f\\n    at wasm://wasm/00cd3c02:wasm-function[619]:0x1abbb5\\n    at wasm://wasm/00cd3c02:wasm-function[816]:0x1d8cc4\\n    at wasm://wasm/00cd3c02:wasm-function[374]:0x1518b8\\n    at wasm://wasm/00cd3c02:wasm-function[175]:0xbe722`","meta":{"code":"WASM_ERROR","message":"Error: invalid type: JsValue(undefined), expected unit\\n    at __wbindgen_error_new (file:///Users/jkomyno/work/prisma/prisma-engines/query-engine/query-engine-wasm/pkg/query_engine_bg.js:520:17)\\n    at wasm://wasm/00cd3c02:wasm-function[4473]:0x2c3664\\n    at wasm://wasm/00cd3c02:wasm-function[2468]:0x279d75\\n    at wasm://wasm/00cd3c02:wasm-function[2886]:0x28a509\\n    at wasm://wasm/00cd3c02:wasm-function[1056]:0x1ff3e8\\n    at wasm://wasm/00cd3c02:wasm-function[581]:0x1a278f\\n    at wasm://wasm/00cd3c02:wasm-function[619]:0x1abbb5\\n    at wasm://wasm/00cd3c02:wasm-function[816]:0x1d8cc4\\n    at wasm://wasm/00cd3c02:wasm-function[374]:0x1518b8\\n    at wasm://wasm/00cd3c02:wasm-function[175]:0xbe722"},"error_code":"P2010"}}]}'
+  }
+  log-callback
+  query result = 
+  {
+    data: { findManyUser: [ { id: 1235 } ] }
+  }
+  ```
+
+- `--remove-non-js-ops`: this removes all operations that are not supported by JavaScript, but also results in code packages not found.
+  ```
+  > node --experimental-wasm-modules ./example.js
+
+  node:internal/errors:497
+      ErrorCaptureStackTrace(err);
+      ^
+
+  Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'env' imported from /Users/jkomyno/work/prisma/prisma-engines/query-engine/query-engine-wasm/pkg/query_engine_bg.wasm
+      at new NodeError (node:internal/errors:406:5)
+      at packageResolve (node:internal/modules/esm/resolve:789:9)
+      at moduleResolve (node:internal/modules/esm/resolve:838:20)
+      at defaultResolve (node:internal/modules/esm/resolve:1043:11)
+      at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
+      at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
+      at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:228:38)
+      at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
+      at link (node:internal/modules/esm/module_job:84:36) {
+    code: 'ERR_MODULE_NOT_FOUND'
+  }
+  ```

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -11,7 +11,7 @@ quaint = { path = "../../quaint" }
 psl.workspace = true
 dmmf_crate = { path = "../dmmf", package = "dmmf" }
 itertools = "0.10"
-graphql-parser = { git = "https://github.com/prisma/graphql-parser" }
+graphql-parser = { git = "https://github.com/prisma/graphql-parser", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 futures = "0.3"
@@ -42,7 +42,7 @@ native = [
     "quaint/native",
     "query-core/metrics",
 ]
-graphql-protocol = ["query-core/graphql-protocol"]
+graphql-protocol = ["query-core/graphql-protocol", "dep:graphql-parser"]
 
 [[bench]]
 name = "query_planning_bench"

--- a/query-engine/request-handlers/src/error.rs
+++ b/query-engine/request-handlers/src/error.rs
@@ -56,6 +56,7 @@ impl From<connection_string::Error> for HandlerError {
     }
 }
 
+#[cfg(feature = "graphql-protocol")]
 impl From<graphql_parser::query::ParseError> for HandlerError {
     fn from(e: graphql_parser::query::ParseError) -> Self {
         Self::configuration(format!("Error parsing GraphQL query: {e}"))


### PR DESCRIPTION
This PR contributes to https://github.com/prisma/team-orm/issues/584.

Before this PR, the gzipped `@prisma/query-engine-wasm` was 1.7MB.

- https://github.com/prisma/prisma-engines/pull/4530/commits/b5b8e2162f4b3286951220d1797e64cd25b5836c reduced the bundle size to 1.6MB:
  ```
  === Tarball Contents === 
  946B   README.md           
  355B   package.json        
  28.5kB query_engine_bg.js  
  4.3MB  query_engine_bg.wasm
  4.7kB  query_engine.d.ts   
  538B   query_engine.js     
  === Tarball Details === 
  name:          @prisma/query-engine-wasm 
  package size:  1.6 MB                                  
  unpacked size: 4.3 MB
  ```
- https://github.com/prisma/prisma-engines/pull/4530/commits/8e8c5202538aaffc1a4cd170125db106ab1141ca reduced the bundle size to 1.3MB:
  ```
  === Tarball Contents === 
  946B   README.md           
  355B   package.json        
  28.5kB query_engine_bg.js  
  3.3MB  query_engine_bg.wasm
  4.7kB  query_engine.d.ts   
  538B   query_engine.js     
  === Tarball Details (gzip) === 
  name:          @prisma/query-engine-wasm   
  package size:  1.3 MB                                  
  unpacked size: 3.3 MB
  ```

- https://github.com/prisma/prisma-engines/pull/4552/commits/398dd4a7c4336c0fd223ae64289879b5d8e2e9f3 kept the bundle size at 1.3MB, but it reveals that the unpacked size is ~0.2MB larger:
  ```
  === Tarball Contents === 
  946B   README.md           
  355B   package.json        
  28.5kB query_engine_bg.js  
  3.5MB  query_engine_bg.wasm
  4.7kB  query_engine.d.ts   
  538B   query_engine.js     
  === Tarball Details === 
  name:          @prisma/query-engine-wasm 
  package size:  1.3 MB                                  
  unpacked size: 3.5 MB
  ```
/integration

---

## Miscellaneous

Passing the `--reference-types` option to `wasm-pack build`, or the `--remove-non-js-ops` option to `wasm-opt` results in runtime errors when running the example. Reference types in particular would be good to have, as they would likely improve the CPU performance of `@prisma/query-engine-wasm`.
