### PR TITLE
ci: Show 3 digits in size reports, strip gzip timestamps

### DIFF
--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -68,13 +68,13 @@ jobs:
       - name: Compute difference
         id: compute
         run: |
-          base=$(echo "${{ needs.base-wasm-size.outputs.size }}" | numfmt --to=iec-i --suffix=B)
-          base_gz=$(echo "${{ needs.base-wasm-size.outputs.size_gz }}" | numfmt --to=iec-i --suffix=B)
-          pr=$(echo "${{ needs.pr-wasm-size.outputs.size }}" | numfmt --to=iec-i --suffix=B)
-          pr_gz=$(echo "${{ needs.pr-wasm-size.outputs.size_gz }}" | numfmt --to=iec-i --suffix=B)
+          base=$(echo "${{ needs.base-wasm-size.outputs.size }}" | numfmt --format '%.3f' --to=iec-i --suffix=B)
+          base_gz=$(echo "${{ needs.base-wasm-size.outputs.size_gz }}" | numfmt --format '%.3f' --to=iec-i --suffix=B)
+          pr=$(echo "${{ needs.pr-wasm-size.outputs.size }}" | numfmt --format '%.3f' --to=iec-i  --suffix=B)
+          pr_gz=$(echo "${{ needs.pr-wasm-size.outputs.size_gz }}" | numfmt --format '%.3f' --to=iec-i --suffix=B)
           
-          diff=$(echo "$((${{ needs.pr-wasm-size.outputs.size }} - ${{ needs.base-wasm-size.outputs.size }}))" | numfmt --to=iec-i --suffix=B)
-          diff_gz=$(echo "$((${{ needs.pr-wasm-size.outputs.size_gz }} - ${{ needs.base-wasm-size.outputs.size_gz }}))" | numfmt --to=iec-i --suffix=B)
+          diff=$(echo "$((${{ needs.pr-wasm-size.outputs.size }} - ${{ needs.base-wasm-size.outputs.size }}))" | numfmt --format '%.3f' --to=iec-i --suffix=B)
+          diff_gz=$(echo "$((${{ needs.pr-wasm-size.outputs.size_gz }} - ${{ needs.base-wasm-size.outputs.size_gz }}))" | numfmt --format '%.3f' --to=iec-i --suffix=B)
 
           echo "base=$base" >> $GITHUB_OUTPUT
           echo "base_gz=$base_gz" >> $GITHUB_OUTPUT

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           make build-qe-wasm
           echo "size=$(wc --bytes < query-engine/query-engine-wasm/pkg/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
-          echo "size_gz=$(gzip -c query-engine/query-engine-wasm/pkg/query_engine_bg.wasm | wc --bytes)" >> $GITHUB_OUTPUT
+          echo "size_gz=$(gzip -cn query-engine/query-engine-wasm/pkg/query_engine_bg.wasm | wc --bytes)" >> $GITHUB_OUTPUT
 
   base-wasm-size:
     name: Get base branch size
@@ -55,7 +55,7 @@ jobs:
         run: |
           make build-qe-wasm
           echo "size=$(wc --bytes < query-engine/query-engine-wasm/pkg/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
-          echo "size_gz=$(gzip -c query-engine/query-engine-wasm/pkg/query_engine_bg.wasm | wc --bytes)" >> $GITHUB_OUTPUT
+          echo "size_gz=$(gzip -cn query-engine/query-engine-wasm/pkg/query_engine_bg.wasm | wc --bytes)" >> $GITHUB_OUTPUT
   
   report-diff:
     name: Report module size difference


### PR DESCRIPTION
- More digits in the table make it easier to see smaller changes
- Stripping timestamp and file name from gzip should avoid random 1-3 bytes differences for gzip
