### PR TITLE
ci: Track wasm size over time

### DIFF
--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -115,7 +115,7 @@ in
     })
     { profile = "release"; };
 
-    packages.query-engine-wasm = lib.makeOverridable
+  packages.query-engine-wasm = lib.makeOverridable
     ({ profile }: stdenv.mkDerivation {
       name = "query-engine-wasm";
       inherit src;
@@ -124,8 +124,8 @@ in
       nativeBuildInputs = self'.packages.prisma-engines.nativeBuildInputs ++ (with pkgs; [wasm-pack wasm-bindgen-cli jq binaryen]);
 
       buildPhase = ''
-      cd query-engine/query-engine-wasm
-      HOME=$(mktemp -dt wasm-pack-home-XXXX) WASM_BUILD_PROFILE=${profile} ./build.sh
+        cd query-engine/query-engine-wasm
+        HOME=$(mktemp -dt wasm-pack-home-XXXX) WASM_BUILD_PROFILE=${profile} ./build.sh
       '';
 
       installPhase = ''
@@ -134,7 +134,7 @@ in
     })
     { profile = "release"; };
 
-     packages.query-engine-wasm-gz = lib.makeOverridable
+  packages.query-engine-wasm-gz = lib.makeOverridable
     ({ profile }: stdenv.mkDerivation {
       name = "query-engine-wasm-gz";
       inherit src;

--- a/nix/publish-engine-size.nix
+++ b/nix/publish-engine-size.nix
@@ -45,7 +45,9 @@
 
       ${self'.packages.update-engine-size}/bin/update-engine-size             \
           ${self'.packages.query-engine-bin-and-lib}/bin/query-engine         \
-          ${self'.packages.query-engine-bin-and-lib}/lib/libquery_engine.node
+          ${self'.packages.query-engine-bin-and-lib}/lib/libquery_engine.node \
+          ${self'.packages.query-engine-wasm-gz}/query_engine_bg.wasm.gz      \
+          ${self'.packages.query-engine-wasm}/query_engine_bg.wasm  
 
       git add "$CSV_PATH"
       git commit --quiet -m "update engines size for $CURRENT_COMMIT_SHORT"

--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -17,7 +17,6 @@ if [[ -z "${WASM_BUILD_PROFILE:-}" ]]; then
     else
         WASM_BUILD_PROFILE="release"
     fi
-    WASM_BUILD_PROFILE="dev"
 fi
 
 # Check if wasm-pack is installed

--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -10,11 +10,14 @@ OUT_JSON="${OUT_FOLDER}/package.json"
 OUT_TARGET="bundler"
 OUT_NPM_NAME="@prisma/query-engine-wasm"
 
-# use `wasm-pack build --release` on CI only
-if [[ -z "${BUILDKITE:-}" ]] && [[ -z "${GITHUB_ACTIONS:-}" ]]; then
-    BUILD_PROFILE="--dev"
-else
-    BUILD_PROFILE="--release"
+if [[ -z "${WASM_BUILD_PROFILE:-}" ]]; then
+    # use `wasm-pack build --release` by default on CI only
+    if [[ -z "${BUILDKITE:-}" ]] && [[ -z "${GITHUB_ACTIONS:-}" ]]; then
+        WASM_BUILD_PROFILE="dev"
+    else
+        WASM_BUILD_PROFILE="release"
+    fi
+    WASM_BUILD_PROFILE="dev"
 fi
 
 # Check if wasm-pack is installed
@@ -25,7 +28,7 @@ then
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 fi
 
-wasm-pack build $BUILD_PROFILE --target $OUT_TARGET --out-name query_engine
+wasm-pack build "--$WASM_BUILD_PROFILE" --target $OUT_TARGET --out-name query_engine
 
 sleep 1
 


### PR DESCRIPTION
Adds wasm and gzipped wasm engine size to the dashboard.

Fix prisma/team-orm#666
