### PR TITLE
ci: Build wasm query engine within nix environement

### DIFF
--- a/.github/workflows/publish-query-engine-wasm.yml
+++ b/.github/workflows/publish-query-engine-wasm.yml
@@ -30,29 +30,22 @@ jobs:
         with:
           ref: ${{ github.event.inputs.enginesHash }}
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+      - uses: cachix/install-nix-action@v24
+
+      - name: Build @prisma/query-engine-wasm
+        run: nix run .#export-query-engine-wasm package ${{ github.event.inputs.packageVersion }}
 
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack
-
-      - name: Build @prisma/query-engine-wasm
-        run: ./build.sh ${{ github.event.inputs.packageVersion }}
-        working-directory: ./query-engine/query-engine-wasm
-
       - name: Set up NPM token for publishing
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
 
       - name: Publish @prisma/query-engine-wasm
         run: npm publish --access public --tag ${{ github.event.inputs.npmDistTag }}
-        working-directory: ./query-engine/query-engine-wasm/pkg
+        working-directory: package
 
       #
       # Failure handlers

--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -35,16 +35,12 @@ jobs:
             setup_task: 'dev-libsql-js'
           - name: 'planetscale (wasm)'
             setup_task: 'dev-planetscale-wasm'
-            needs_wasm_pack: true
           - name: 'pg (wasm)'
             setup_task: 'dev-pg-wasm'
-            needs_wasm_pack: true
           - name: 'neon (ws) (wasm)'
             setup_task: 'dev-neon-wasm'
-            needs_wasm_pack: true
           - name: 'libsql (Turso) (wasm)'
             setup_task: 'dev-libsql-wasm'
-            needs_wasm_pack: true
         node_version: ['18']
     env:
       LOG_LEVEL: 'info' # Set to "debug" to trace the query engine and node process running the driver adapter
@@ -99,11 +95,7 @@ jobs:
             echo "DRIVER_ADAPTERS_BRANCH=$branch" >> "$GITHUB_ENV"
           fi
 
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: 'Install wasm-pack'
-        if: ${{ matrix.adapter.needs_wasm_pack }}
-        run: cargo install wasm-pack
+      - uses: cachix/install-nix-action@v24
 
       - run: make ${{ matrix.adapter.setup_task }}
 

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -21,17 +21,15 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
       
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: 'Install wasm-pack'
-        run: cargo install wasm-pack
+      - uses: cachix/install-nix-action@v24
       
       - name: Build and measure PR branch
         id: measure
         run: |
-          make build-qe-wasm
-          echo "size=$(wc --bytes < query-engine/query-engine-wasm/pkg/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
-          echo "size_gz=$(gzip -cn query-engine/query-engine-wasm/pkg/query_engine_bg.wasm | wc --bytes)" >> $GITHUB_OUTPUT
+          nix build -L .#query-engine-wasm .#query-engine-wasm-gz
+
+          echo "size=$(wc --bytes < ./result/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
+          echo "size_gz=$(wc --bytes < ./result-1/query_engine_bg.wasm.gz)" >> $GITHUB_OUTPUT
 
   base-wasm-size:
     name: Get base branch size
@@ -45,17 +43,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
       
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: 'Install wasm-pack'
-        run: cargo install wasm-pack
+      - uses: cachix/install-nix-action@v24
       
       - name: Build and measure base branch
         id: measure
         run: |
-          make build-qe-wasm
-          echo "size=$(wc --bytes < query-engine/query-engine-wasm/pkg/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
-          echo "size_gz=$(gzip -cn query-engine/query-engine-wasm/pkg/query_engine_bg.wasm | wc --bytes)" >> $GITHUB_OUTPUT
+          nix build -L .#query-engine-wasm .#query-engine-wasm-gz
+
+          echo "size=$(wc --bytes < ./result/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
+          echo "size_gz=$(wc --bytes < ./result-1/query_engine_bg.wasm.gz)" >> $GITHUB_OUTPUT
+
   
   report-diff:
     name: Report module size difference

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CONFIG_FILE = .test_config
 SCHEMA_EXAMPLES_PATH = ./query-engine/example_schemas
 DEV_SCHEMA_FILE = dev_datamodel.prisma
 DRIVER_ADAPTERS_BRANCH ?= main
+NIX := $(shell command -v nix 2> /dev/null)
 
 LIBRARY_EXT := $(shell                            \
     case "$$(uname -s)" in                        \
@@ -313,7 +314,13 @@ build-qe-napi:
 	cargo build --package query-engine-node-api
 
 build-qe-wasm:
+ifndef $(NIX)
+	@echo "Building wasm engine on nix"
+	rm -rf query-engine/query-engine-wasm/pkg
+	nix run .#export-query-engine-wasm query-engine/query-engine-wasm/pkg 0.0.0
+else
 	cd query-engine/query-engine-wasm && ./build.sh
+endif
 
 build-connector-kit-js: build-driver-adapters
 	cd query-engine/driver-adapters && pnpm i && pnpm build

--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -115,8 +115,6 @@ in
     })
     { profile = "release"; };
 
-
-
   packages.query-engine-wasm = lib.makeOverridable
     ({ profile }: stdenv.mkDerivation {
       name = "query-engine-wasm";

--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -115,6 +115,8 @@ in
     })
     { profile = "release"; };
 
+
+
   packages.query-engine-wasm = lib.makeOverridable
     ({ profile }: stdenv.mkDerivation {
       name = "query-engine-wasm";
@@ -149,4 +151,20 @@ in
       '';
     })
     { profile = "release"; };
+
+  packages.export-query-engine-wasm =
+    pkgs.writeShellApplication {
+      name = "export-query-engine-wasm";
+      runtimeInputs = with pkgs; [ jq ];
+      text = ''
+        set -euxo pipefail
+
+        OUTDIR="$1"
+        OUTVERSION="$2"
+        mkdir -p "$OUTDIR"
+        cp -r --no-target-directory ${self'.packages.query-engine-wasm} "$OUTDIR"
+        chmod -R +rw "$OUTDIR"
+        jq --arg new_version "$OUTVERSION" '.version = $new_version' "${self'.packages.query-engine-wasm}/package.json"  > "$OUTDIR/package.json"
+      '';
+    };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -19,6 +19,7 @@ in
       graphviz
       wasm-bindgen-cli
       wasm-pack
+      binaryen
     ];
 
     inputsFrom = [ self'.packages.prisma-engines ];

--- a/psl/builtin-connectors/src/lib.rs
+++ b/psl/builtin-connectors/src/lib.rs
@@ -27,4 +27,4 @@ pub const SQLITE: &'static dyn Connector = &sqlite_datamodel_connector::SqliteDa
 pub const MSSQL: &'static dyn Connector = &mssql_datamodel_connector::MsSqlDatamodelConnector;
 pub const MONGODB: &'static dyn Connector = &mongodb::MongoDbDatamodelConnector;
 
-pub static BUILTIN_CONNECTORS: ConnectorRegistry = &[POSTGRES, MYSQL, SQLITE, MSSQL, COCKROACH, MONGODB];
+pub static BUILTIN_CONNECTORS: ConnectorRegistry<'static> = &[POSTGRES, MYSQL, SQLITE, MSSQL, COCKROACH, MONGODB];

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -29,7 +29,7 @@ use diagnostics::Diagnostics;
 use parser_database::{ast, ParserDatabase, SourceFile};
 
 /// The collection of all available connectors.
-pub type ConnectorRegistry = &'static [&'static dyn datamodel_connector::Connector];
+pub type ConnectorRegistry<'a> = &'a [&'static dyn datamodel_connector::Connector];
 
 pub struct ValidatedSchema {
     pub configuration: Configuration,
@@ -53,7 +53,7 @@ impl ValidatedSchema {
 
 /// The most general API for dealing with Prisma schemas. It accumulates what analysis and
 /// validation information it can, and returns it along with any error and warning diagnostics.
-pub fn validate(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSchema {
+pub fn validate(file: SourceFile, connectors: ConnectorRegistry<'_>) -> ValidatedSchema {
     let mut diagnostics = Diagnostics::new();
     let db = ParserDatabase::new(file, &mut diagnostics);
     let configuration = validate_configuration(db.ast(), &mut diagnostics, connectors);
@@ -72,7 +72,7 @@ pub fn validate(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSch
 /// Retrieves a Prisma schema without validating it.
 /// You should only use this method when actually validating the schema is too expensive
 /// computationally or in terms of bundle size (e.g., for `query-engine-wasm`).
-pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSchema {
+pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry<'_>) -> ValidatedSchema {
     let mut diagnostics = Diagnostics::new();
     let db = ParserDatabase::new(file, &mut diagnostics);
     let configuration = validate_configuration(db.ast(), &mut diagnostics, connectors);
@@ -91,7 +91,7 @@ pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry)
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
 pub fn parse_configuration(
     schema: &str,
-    connectors: ConnectorRegistry,
+    connectors: ConnectorRegistry<'_>,
 ) -> Result<Configuration, diagnostics::Diagnostics> {
     let mut diagnostics = Diagnostics::default();
     let ast = schema_ast::parse_schema(schema, &mut diagnostics);
@@ -102,7 +102,7 @@ pub fn parse_configuration(
 fn validate_configuration(
     schema_ast: &ast::SchemaAst,
     diagnostics: &mut Diagnostics,
-    connectors: ConnectorRegistry,
+    connectors: ConnectorRegistry<'_>,
 ) -> Configuration {
     let generators = generator_loader::load_generators_from_ast(schema_ast, diagnostics);
 

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -25,7 +25,7 @@ const PROVIDER_KEY: &str = "provider";
 pub(crate) fn load_datasources_from_ast(
     ast_schema: &ast::SchemaAst,
     diagnostics: &mut Diagnostics,
-    connectors: crate::ConnectorRegistry,
+    connectors: crate::ConnectorRegistry<'_>,
 ) -> Vec<Datasource> {
     let mut sources = Vec::new();
 
@@ -51,7 +51,7 @@ pub(crate) fn load_datasources_from_ast(
 fn lift_datasource(
     ast_source: &ast::SourceConfig,
     diagnostics: &mut Diagnostics,
-    connectors: crate::ConnectorRegistry,
+    connectors: crate::ConnectorRegistry<'_>,
 ) -> Option<Datasource> {
     let source_name = ast_source.name.name.as_str();
     let mut args: HashMap<_, (_, &Expression)> = ast_source

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -12,6 +12,7 @@ pub use psl_core::{
     reformat,
     schema_ast,
     Configuration,
+    ConnectorRegistry,
     Datasource,
     DatasourceConnectorData,
     Generator,
@@ -51,6 +52,6 @@ pub fn validate(file: SourceFile) -> ValidatedSchema {
 }
 
 /// Parse a Prisma schema, but skip validations.
-pub fn parse_without_validation(file: SourceFile) -> ValidatedSchema {
-    psl_core::parse_without_validation(file, builtin_connectors::BUILTIN_CONNECTORS)
+pub fn parse_without_validation(file: SourceFile, connector_registry: ConnectorRegistry<'_>) -> ValidatedSchema {
+    psl_core::parse_without_validation(file, connector_registry)
 }

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use driver_adapters::JsObject;
 use js_sys::Function as JsFunction;
+use psl::builtin_connectors::{MYSQL, POSTGRES, SQLITE};
+use psl::ConnectorRegistry;
 use query_core::{
     protocol::EngineProtocol,
     schema::{self},
@@ -48,7 +50,8 @@ impl QueryEngine {
         } = options;
 
         // Note: if we used `psl::validate`, we'd add ~1MB to the Wasm artifact (before gzip).
-        let mut schema = psl::parse_without_validation(datamodel.into());
+        let connector_registry: ConnectorRegistry<'_> = &[POSTGRES, MYSQL, SQLITE];
+        let mut schema = psl::parse_without_validation(datamodel.into(), connector_registry);
         let config = &mut schema.configuration;
         let preview_features = config.preview_features();
 


### PR DESCRIPTION
Ensures that all necessary tooling (in particular, wasm-opt)  is always available for when it is
built. Affected jobs:

- Adapter tests
- Size comparison job
- WASM engine release

Fix https://github.com/prisma/team-orm/issues/752