### PR TITLE
ci: Call build.sh via bash explicitly

### DIFF
--- a/nix/all-engines.nix
+++ b/nix/all-engines.nix
@@ -125,7 +125,7 @@ in
 
       buildPhase = ''
         cd query-engine/query-engine-wasm
-        HOME=$(mktemp -dt wasm-pack-home-XXXX) WASM_BUILD_PROFILE=${profile} ./build.sh
+        HOME=$(mktemp -dt wasm-pack-home-XXXX) WASM_BUILD_PROFILE=${profile} bash ./build.sh
       '';
 
       installPhase = ''


### PR DESCRIPTION
/bin/bash, referenced in shebang does not exist on nix on ci.
