### PR TITLE
chore: move itertools to workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -748,7 +748,7 @@ dependencies = [
  "ciborium",
  "clap 3.2.25",
  "criterion-plot",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -769,7 +769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1085,7 +1085,7 @@ dependencies = [
  "flate2",
  "indexmap 1.9.3",
  "indoc 2.0.3",
- "itertools",
+ "itertools 0.12.0",
  "pretty_assertions",
  "psl",
  "query-structure",
@@ -1985,6 +1985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,7 +2502,7 @@ dependencies = [
  "derive_more",
  "futures",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.12.0",
  "mongodb",
  "mongodb-client",
  "pretty_assertions",
@@ -3446,7 +3455,7 @@ checksum = "62941722fb675d463659e49c4f3fe1fe792ff24fe5bbaa9c08cd3b98a1c354f5"
 dependencies = [
  "bytes",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -3465,7 +3474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cc1a3263e07e0bf68e96268f37665207b49560d98739662cdfaae215c720fe"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3503,7 +3512,7 @@ dependencies = [
  "diagnostics",
  "enumflags2",
  "indoc 2.0.3",
- "itertools",
+ "itertools 0.12.0",
  "lsp-types",
  "once_cell",
  "parser-database",
@@ -3570,7 +3579,7 @@ dependencies = [
  "getrandom 0.2.11",
  "hex",
  "indoc 0.3.6",
- "itertools",
+ "itertools 0.12.0",
  "lru-cache",
  "metrics 0.18.1",
  "mobc",
@@ -3649,7 +3658,7 @@ dependencies = [
  "chrono",
  "futures",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.12.0",
  "prisma-value",
  "query-structure",
  "serde",
@@ -3673,7 +3682,7 @@ dependencies = [
  "enumflags2",
  "futures",
  "indexmap 1.9.3",
- "itertools",
+ "itertools 0.12.0",
  "lru 0.7.8",
  "once_cell",
  "opentelemetry",
@@ -3850,7 +3859,7 @@ dependencies = [
  "chrono",
  "cuid",
  "getrandom 0.2.11",
- "itertools",
+ "itertools 0.12.0",
  "nanoid",
  "prisma-value",
  "psl",
@@ -3879,7 +3888,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indoc 2.0.3",
  "insta",
- "itertools",
+ "itertools 0.12.0",
  "jsonrpc-core",
  "nom",
  "once_cell",
@@ -4169,7 +4178,7 @@ dependencies = [
  "graphql-parser",
  "indexmap 1.9.3",
  "insta",
- "itertools",
+ "itertools 0.12.0",
  "mongodb-query-connector",
  "once_cell",
  "psl",
@@ -4984,7 +4993,7 @@ dependencies = [
  "cuid",
  "futures",
  "hex",
- "itertools",
+ "itertools 0.12.0",
  "once_cell",
  "opentelemetry",
  "prisma-value",
@@ -5062,11 +5071,11 @@ dependencies = [
 
 [[package]]
 name = "sqlformat"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c12bc9199d1db8234678b7051747c07f517cdcf019262d1847b94ec8b1aee3e"
+checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools",
+ "itertools 0.12.0",
  "nom",
  "unicode_categories",
 ]
@@ -5948,7 +5957,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "indoc 2.0.3",
- "itertools",
+ "itertools 0.12.0",
  "quaint",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio = { version = "1.25", features = [
 user-facing-errors = { path = "./libs/user-facing-errors" }
 uuid = { version = "1", features = ["serde"] }
 indoc = "2.0.1"
+itertools = "0.10"
 connection-string = "0.2"
 napi = { version = "2.12.4", default-features = false, features = [
   "napi8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tokio = { version = "1.25", features = [
 user-facing-errors = { path = "./libs/user-facing-errors" }
 uuid = { version = "1", features = ["serde"] }
 indoc = "2.0.1"
-itertools = "0.10"
+itertools = "0.12"
 connection-string = "0.2"
 napi = { version = "2.12.4", default-features = false, features = [
   "napi8",

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -10,7 +10,7 @@ serde.workspace = true
 backtrace = "0.3.40"
 tracing = "0.1"
 indoc.workspace = true
-itertools = "0.10"
+itertools.workspace = true
 quaint = { path = "../../quaint", optional = true }
 
 [features]

--- a/psl/psl-core/Cargo.toml
+++ b/psl/psl-core/Cargo.toml
@@ -11,7 +11,7 @@ schema-ast = { path = "../schema-ast" }
 
 bigdecimal = "0.3"
 chrono = { version = "0.4.6", default_features = false }
-itertools = "0.10"
+itertools.workspace = true
 once_cell = "1.3.1"
 regex = "1.3.7"
 serde.workspace = true

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -88,7 +88,7 @@ bit-vec = { version = "0.6.1", optional = true }
 bytes = { version = "1.0", optional = true }
 mobc = { version = "0.8", optional = true }
 serde = { version = "1.0", optional = true }
-sqlformat = { version = "0.2.0", optional = true }
+sqlformat = { version = "0.2.3", optional = true }
 uuid = { version = "1", features = ["v4"] }
 crosstarget-utils = { path = "../libs/crosstarget-utils" }
 

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -76,7 +76,7 @@ metrics = "0.18"
 futures = "0.3"
 url = "2.1"
 hex = "0.4"
-itertools = "0.10"
+itertools.workspace = true
 
 either = { version = "1.6" }
 base64 = { version = "0.12.3" }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -18,7 +18,7 @@ user-facing-errors = { path = "../../../libs/user-facing-errors" }
 thiserror = "1.0"
 async-trait = "0.1"
 nom = "7.1"
-itertools = "0.10"
+itertools.workspace = true
 regex = "1"
 serde.workspace = true
 tracing = "0.1"

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1"
 bigdecimal = "0.3"
 # bson = {version = "1.1.0", features = ["decimal128"]}
 futures = "0.3"
-itertools = "0.10"
+itertools.workspace = true
 mongodb = "2.8.0"
 bson = { version = "2.4.0", features = ["chrono-0_4", "uuid-1"] }
 rand = "0.7"

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -8,7 +8,7 @@ anyhow = "1.0"
 async-trait = "0.1.31"
 chrono = {version = "0.4", features = ["serde"]}
 futures = "0.3"
-itertools = "0.10"
+itertools.workspace = true
 query-structure = {path = "../../query-structure"}
 prisma-value = {path = "../../../libs/prisma-value"}
 serde.workspace = true

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 async-trait = "0.1"
 bigdecimal = "0.3"
 futures = "0.3"
-itertools = "0.10"
+itertools.workspace = true
 once_cell = "1.3"
 rand = "0.7"
 serde_json = {version = "1.0", features = ["float_roundtrip"]}

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -17,7 +17,7 @@ crossbeam-channel = "0.5.6"
 psl.workspace = true
 futures = "0.3"
 indexmap = { version = "1.7", features = ["serde-1"] }
-itertools = "0.10"
+itertools.workspace = true
 once_cell = "1"
 petgraph = "0.4"
 query-structure = { path = "../query-structure", features = [

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -19,4 +19,4 @@ pretty_assertions = "1"
 flate2 = "1.0"
 similar = { version = "2.2.1", features=["text", "inline", "bytes"] }
 colored = "2.0.0"
-itertools = "0.10.5"
+itertools.workspace = true

--- a/query-engine/query-structure/Cargo.toml
+++ b/query-engine/query-structure/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 
 [dependencies]
 psl.workspace = true
-itertools = "0.10"
+itertools.workspace = true
 prisma-value = { path = "../../libs/prisma-value" }
 bigdecimal = "0.3"
 thiserror = "1.0"

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -10,7 +10,7 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 quaint = { path = "../../quaint" }
 psl.workspace = true
 dmmf_crate = { path = "../dmmf", package = "dmmf" }
-itertools = "0.10"
+itertools.workspace = true
 graphql-parser = { git = "https://github.com/prisma/graphql-parser", optional = true }
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Move `itertools` to workspace dependencies to make it easier to manage its version and avoid multiple major versions.

In principle we could also update it to `0.12` without introducing multiple major versions of the dependency in our binaries: even though some of our dependencies transitively depend on `itertools = "0.10"`, as far as I can tell, only one is used at run time (`sqlformat`), and it is updatable to a newer version that requires `itertools = "0.12"`. `criterion`, `prost-derive` and `prost-build` all depend on older itertools even in their latest versions but they don't matter for the size of distributable binaries. ~I didn't do that in this PR, it can be done either here or separately.~ UPD: done in this PR as per request below.

Closes: https://github.com/prisma/team-orm/issues/750
