### PR TITLE
test(qe): Run Query Engine tests in ubuntu-latest rather than buildjet

### DIFF
--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -75,7 +75,7 @@ jobs:
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
 
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.trigger_build
+++ b/.trigger_build
@@ -1,0 +1,1 @@
+This file is here to trigger the build, and will be removed before merging


### PR DESCRIPTION
Our Buildjet costs have skyrocketed once again this month. In October, we eliminated BuildJet running in the Driver Adapter tests and that contributed to a nice reduction in the costs of BuildJet Runners. The change was implemented in #4374.

We implemented the change in October because these costs were approximately 5.2K per month. After the change, it decreased to ~2.7K and now it's back to ~4.1K.

I noticed that we are still running our QE tests on BuildJet. Unfortunately, BuildJet is pretty bad at providing control and visibility, making it difficult to track, measure, and even implement any kind of improvement (on the BuildJet side).

I propose to completely remove BuildJet and:

1. Find another possible/cheaper alternative.
2. Set up our runners (this could be just as expensive or almost the same amount, at least in AWS). For BuildKite we pay 0.34$ per minute for a c5.2xlarge machine.
3. Define a better strategy and control when we run these tests using more powerful runners (not on each push to main) and probably better organized/prioritized. (This would mean keeping BuildJet under certain conditions)

Besides the raw amount (pay-as-you-go per minute), we also pay for Concurrency Fleet Extension (3 x 250 = 750$) which I will cancel as well.