### PR TITLE
feat(query-engine-wasm) [size]: manually specify connector registry

### DIFF
--- a/psl/builtin-connectors/src/lib.rs
+++ b/psl/builtin-connectors/src/lib.rs
@@ -27,4 +27,4 @@ pub const SQLITE: &'static dyn Connector = &sqlite_datamodel_connector::SqliteDa
 pub const MSSQL: &'static dyn Connector = &mssql_datamodel_connector::MsSqlDatamodelConnector;
 pub const MONGODB: &'static dyn Connector = &mongodb::MongoDbDatamodelConnector;
 
-pub static BUILTIN_CONNECTORS: ConnectorRegistry = &[POSTGRES, MYSQL, SQLITE, MSSQL, COCKROACH, MONGODB];
+pub static BUILTIN_CONNECTORS: ConnectorRegistry<'static> = &[POSTGRES, MYSQL, SQLITE, MSSQL, COCKROACH, MONGODB];

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -29,7 +29,7 @@ use diagnostics::Diagnostics;
 use parser_database::{ast, ParserDatabase, SourceFile};
 
 /// The collection of all available connectors.
-pub type ConnectorRegistry = &'static [&'static dyn datamodel_connector::Connector];
+pub type ConnectorRegistry<'a> = &'a [&'static dyn datamodel_connector::Connector];
 
 pub struct ValidatedSchema {
     pub configuration: Configuration,
@@ -53,7 +53,7 @@ impl ValidatedSchema {
 
 /// The most general API for dealing with Prisma schemas. It accumulates what analysis and
 /// validation information it can, and returns it along with any error and warning diagnostics.
-pub fn validate(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSchema {
+pub fn validate(file: SourceFile, connectors: ConnectorRegistry<'_>) -> ValidatedSchema {
     let mut diagnostics = Diagnostics::new();
     let db = ParserDatabase::new(file, &mut diagnostics);
     let configuration = validate_configuration(db.ast(), &mut diagnostics, connectors);
@@ -72,7 +72,7 @@ pub fn validate(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSch
 /// Retrieves a Prisma schema without validating it.
 /// You should only use this method when actually validating the schema is too expensive
 /// computationally or in terms of bundle size (e.g., for `query-engine-wasm`).
-pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry) -> ValidatedSchema {
+pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry<'_>) -> ValidatedSchema {
     let mut diagnostics = Diagnostics::new();
     let db = ParserDatabase::new(file, &mut diagnostics);
     let configuration = validate_configuration(db.ast(), &mut diagnostics, connectors);
@@ -91,7 +91,7 @@ pub fn parse_without_validation(file: SourceFile, connectors: ConnectorRegistry)
 /// Loads all configuration blocks from a datamodel using the built-in source definitions.
 pub fn parse_configuration(
     schema: &str,
-    connectors: ConnectorRegistry,
+    connectors: ConnectorRegistry<'_>,
 ) -> Result<Configuration, diagnostics::Diagnostics> {
     let mut diagnostics = Diagnostics::default();
     let ast = schema_ast::parse_schema(schema, &mut diagnostics);
@@ -102,7 +102,7 @@ pub fn parse_configuration(
 fn validate_configuration(
     schema_ast: &ast::SchemaAst,
     diagnostics: &mut Diagnostics,
-    connectors: ConnectorRegistry,
+    connectors: ConnectorRegistry<'_>,
 ) -> Configuration {
     let generators = generator_loader::load_generators_from_ast(schema_ast, diagnostics);
 

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -25,7 +25,7 @@ const PROVIDER_KEY: &str = "provider";
 pub(crate) fn load_datasources_from_ast(
     ast_schema: &ast::SchemaAst,
     diagnostics: &mut Diagnostics,
-    connectors: crate::ConnectorRegistry,
+    connectors: crate::ConnectorRegistry<'_>,
 ) -> Vec<Datasource> {
     let mut sources = Vec::new();
 
@@ -51,7 +51,7 @@ pub(crate) fn load_datasources_from_ast(
 fn lift_datasource(
     ast_source: &ast::SourceConfig,
     diagnostics: &mut Diagnostics,
-    connectors: crate::ConnectorRegistry,
+    connectors: crate::ConnectorRegistry<'_>,
 ) -> Option<Datasource> {
     let source_name = ast_source.name.name.as_str();
     let mut args: HashMap<_, (_, &Expression)> = ast_source

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -12,6 +12,7 @@ pub use psl_core::{
     reformat,
     schema_ast,
     Configuration,
+    ConnectorRegistry,
     Datasource,
     DatasourceConnectorData,
     Generator,
@@ -51,6 +52,6 @@ pub fn validate(file: SourceFile) -> ValidatedSchema {
 }
 
 /// Parse a Prisma schema, but skip validations.
-pub fn parse_without_validation(file: SourceFile) -> ValidatedSchema {
-    psl_core::parse_without_validation(file, builtin_connectors::BUILTIN_CONNECTORS)
+pub fn parse_without_validation(file: SourceFile, connector_registry: ConnectorRegistry<'_>) -> ValidatedSchema {
+    psl_core::parse_without_validation(file, connector_registry)
 }

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use driver_adapters::JsObject;
 use js_sys::Function as JsFunction;
+use psl::builtin_connectors::{MYSQL, POSTGRES, SQLITE};
+use psl::ConnectorRegistry;
 use query_core::{
     protocol::EngineProtocol,
     schema::{self},
@@ -48,7 +50,8 @@ impl QueryEngine {
         } = options;
 
         // Note: if we used `psl::validate`, we'd add ~1MB to the Wasm artifact (before gzip).
-        let mut schema = psl::parse_without_validation(datamodel.into());
+        let connector_registry: ConnectorRegistry<'_> = &[POSTGRES, MYSQL, SQLITE];
+        let mut schema = psl::parse_without_validation(datamodel.into(), connector_registry);
         let config = &mut schema.configuration;
         let preview_features = config.preview_features();
 


### PR DESCRIPTION
This is a Wasm size-reduction attempt PR. 

The idea is: rather than using a global `BUILTIN_CONNECTORS` (which pulls in validations and strings that are specific to providers for which we have no Driver Adapters' support) in `psl`, we just specify a local one:

```rust
let connector_registry: ConnectorRegistry<'_> = &[POSTGRES, MYSQL, SQLITE];
```

The resulting gzipped Wasm engine is: `1.18 MB`.

---

Note: this PR depends on https://github.com/prisma/prisma-engines/pull/4571.