### PR TITLE
feat(query-engine-wasm): try `lol_alloc` as the global memory allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,6 +2195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "lol_alloc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36aabc32b791f1a506e0bb90e0fa03e983500549d7b1f2dad45b5fc20ef45974"
+dependencies = [
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "lru"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3853,6 +3862,7 @@ dependencies = [
  "driver-adapters",
  "futures",
  "js-sys",
+ "lol_alloc",
  "opentelemetry",
  "psl",
  "quaint",
@@ -4946,6 +4956,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "sql-ddl"

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -46,6 +46,7 @@ tracing-subscriber = { version = "0.3" }
 tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.3"
 opentelemetry = { version = "0.17"}
+lol_alloc = "0.4.0"
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false  # use wasm-opt explicitly in `./build.sh`

--- a/query-engine/query-engine-wasm/src/lib.rs
+++ b/query-engine/query-engine-wasm/src/lib.rs
@@ -16,6 +16,13 @@ mod wasm;
 mod arch {
     pub use super::wasm::*;
 
+    use lol_alloc::{AssumeSingleThreaded, FreeListAllocator};
+
+    // SAFETY: This application is single threaded, so using AssumeSingleThreaded is allowed.
+    #[global_allocator]
+    static ALLOCATOR: AssumeSingleThreaded<FreeListAllocator> =
+        unsafe { AssumeSingleThreaded::new(FreeListAllocator::new()) };
+
     pub(crate) type Result<T> = std::result::Result<T, error::ApiError>;
 }
 


### PR DESCRIPTION
This PR tries using https://github.com/Craig-Macomber/lol_alloc as the default allocator for `query-engine-wasm`.

This PR contributes to https://github.com/prisma/team-orm/issues/737.