### PR TITLE
chore(experiment): use `nightly` `panic="immediate_abort"` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,14 +30,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.11",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -149,7 +150,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -160,7 +161,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -403,7 +404,7 @@ version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88c18b51216e1f74b9d769cead6ace2f82b965b807e3d73330aabe9faec31c84"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "base64 0.13.1",
  "bitvec",
  "chrono",
@@ -869,7 +870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f34ba9a9bcb8645379e9de8cb3ecfcf4d1c85ba66d90deb3259206fa5aa193b"
 dependencies = [
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -981,7 +982,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -1084,7 +1085,7 @@ dependencies = [
  "colored",
  "expect-test",
  "flate2",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "indoc 2.0.3",
  "itertools 0.12.0",
  "pretty_assertions",
@@ -1245,7 +1246,7 @@ checksum = "5e9a1f9f7d83e59740248a6e14ecf93929ade55027844dfcea78beafccc15745"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1403,7 +1404,7 @@ checksum = "b0fa992f1656e1707946bbba340ad244f0814009ef8c0118eb7b658395f19a2e"
 dependencies = [
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1415,7 +1416,7 @@ dependencies = [
  "frunk_core",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1427,7 +1428,7 @@ dependencies = [
  "frunk_core",
  "frunk_proc_macro_helpers",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1498,7 +1499,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1655,16 +1656,16 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.6",
  "allocator-api2",
 ]
 
@@ -1674,7 +1675,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
 dependencies = [
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1888,12 +1889,13 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.0",
+ "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2502,7 +2504,7 @@ dependencies = [
  "cuid",
  "derive_more",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "mongodb",
  "mongodb-client",
@@ -2905,7 +2907,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3084,7 +3086,7 @@ dependencies = [
  "diagnostics",
  "either",
  "enumflags2",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "rustc-hash",
  "schema-ast",
 ]
@@ -3155,7 +3157,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3224,7 +3226,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3658,7 +3660,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "prisma-value",
  "query-structure",
@@ -3682,7 +3684,7 @@ dependencies = [
  "cuid",
  "enumflags2",
  "futures",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "itertools 0.12.0",
  "lru 0.7.8",
  "once_cell",
@@ -4204,7 +4206,7 @@ dependencies = [
  "dmmf",
  "futures",
  "graphql-parser",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "insta",
  "itertools 0.12.0",
  "mongodb-query-connector",
@@ -4697,7 +4699,7 @@ checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4708,7 +4710,7 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4717,7 +4719,7 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
- "indexmap 2.0.0",
+ "indexmap 2.1.0",
  "itoa",
  "ryu",
  "serde",
@@ -4731,7 +4733,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4790,7 +4792,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -5080,7 +5082,7 @@ dependencies = [
  "either",
  "enumflags2",
  "expect-test",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "indoc 2.0.3",
  "once_cell",
  "pretty_assertions",
@@ -5213,9 +5215,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.28"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5336,7 +5338,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -5481,7 +5483,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -5686,7 +5688,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -5849,7 +5851,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.28",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -6124,7 +6126,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -6158,7 +6160,7 @@ checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6459,3 +6461,23 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4061bedbb353041c12f413700357bec76df2c7e2ca8e4df8bac24c6bf68e3d"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c129550b3e6de3fd0ba67ba5c81818f9805e58b8d7fee80a3a59d2c9fc601a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ wasm-bindgen = { version = "0.2.89" }
 wasm-bindgen-futures = { version = "0.4" }
 wasm-rs-dbg = { version = "0.1.2" }
 wasm-bindgen-test = { version = "0.3.0" }
+indexmap = { version = "2.1.0", features = ["std", "serde"] }
 
 [workspace.dependencies.quaint]
 path = "quaint"

--- a/psl/parser-database/Cargo.toml
+++ b/psl/parser-database/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 diagnostics = { path = "../diagnostics" }
 schema-ast = { path = "../schema-ast" }
 
+indexmap.workspace = true
 either = "1.6.1"
 enumflags2 = "0.7"
-indexmap = "1.8.0"
 rustc-hash = "1.1.0"

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -20,7 +20,7 @@ tokio.workspace = true
 tracing = "0.1"
 tracing-futures = "0.2"
 uuid.workspace = true
-indexmap = "1.7"
+indexmap.workspace = true
 query-engine-metrics = { path = "../../metrics" }
 cuid = { git = "https://github.com/prisma/cuid-rust", branch = "wasm32-support" }
 derive_more = "0.99.17"

--- a/query-engine/connectors/query-connector/Cargo.toml
+++ b/query-engine/connectors/query-connector/Cargo.toml
@@ -16,4 +16,4 @@ serde_json.workspace = true
 thiserror = "1.0"
 user-facing-errors = {path = "../../../libs/user-facing-errors", features = ["sql"]}
 uuid = "1"
-indexmap = "1.7"
+indexmap.workspace = true

--- a/query-engine/core/Cargo.toml
+++ b/query-engine/core/Cargo.toml
@@ -16,7 +16,7 @@ connector = { path = "../connectors/query-connector", package = "query-connector
 crossbeam-channel = "0.5.6"
 psl.workspace = true
 futures = "0.3"
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap.workspace = true
 itertools.workspace = true
 once_cell = "1"
 petgraph = "0.4"

--- a/query-engine/dmmf/Cargo.toml
+++ b/query-engine/dmmf/Cargo.toml
@@ -9,7 +9,7 @@ psl.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 schema = { path = "../schema" }
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap.workspace = true
 query-structure = { path = "../query-structure", features = ["default_generators"] }
 
 [dev-dependencies]

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -52,3 +52,11 @@ wasm-opt = false  # use wasm-opt explicitly in `./build.sh`
 
 [package.metadata.wasm-pack.profile.profiling]
 wasm-opt = false  # use wasm-opt explicitly in `./build.sh`
+
+[build]
+target = "wasm32-unknown-unknown"
+rustflags = [
+    "-C", "link-arg=--no-entry",                      # inform cargo that no `main` function exists
+    "-Z", "build-std=std,panic_abort",                # ask nightly cargo to rebuild part of the standard library
+    "-Z", "build-std-features=panic_immediate_abort"  # ask nightly cargo to use the experimental `panic="immediate_abort"` strategy
+]

--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -29,7 +29,17 @@ then
     curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 fi
 
-wasm-pack build "--$WASM_BUILD_PROFILE" --target $OUT_TARGET --out-name query_engine
+# Preliminary steps:
+# - rustup component add --toolchain nightly rust-src
+# - rustup toolchain install nightly-2023-11-01 --force
+
+# Alternative steps without wasm-pack (which doesn't support `+nightly` by default):
+# - cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort -p query-engine-wasm --target=wasm32-unknown-unknown --release
+# - wasm-bindgen --target bundler --out-name query_engine --out-dir ./pkg ../../target/wasm32-unknown-unknown/release/query_engine_wasm.wasm
+
+# CARGO_BUILD_RUSTFLAGS='-Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target=wasm32-unknown-unknown' \
+rustup run nightly \
+    wasm-pack build "--$WASM_BUILD_PROFILE" --target $OUT_TARGET --out-name query_engine
 
 WASM_OPT_ARGS=(
     "-Os"                                 # execute size-focused optimization passes

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -15,7 +15,7 @@ graphql-parser = { git = "https://github.com/prisma/graphql-parser", optional = 
 serde.workspace = true
 serde_json.workspace = true
 futures = "0.3"
-indexmap = { version = "1.7", features = ["serde-1"] }
+indexmap.workspace = true
 bigdecimal = "0.3"
 thiserror = "1"
 tracing = "0.1"

--- a/schema-engine/sql-schema-describer/Cargo.toml
+++ b/schema-engine/sql-schema-describer/Cargo.toml
@@ -10,7 +10,7 @@ psl.workspace = true
 async-trait = "0.1.17"
 bigdecimal = "0.3"
 enumflags2 = { version = "0.7", features = ["serde"] }
-indexmap = { version = "1.9.1", default_features = false }
+indexmap.workspace = true
 indoc.workspace = true
 once_cell = "1.3"
 regex = "1.2"


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/769 (please read it for more details).

This PR:
- Uses `cargo +nightly` to apply the `panic="immediate_abort"` feature.
- Unifies the version of `indexmap` across the codebase to a single version (`2.1.0`). This was needed as `nightly` cargo was failing to compile/to recognize a default generic type in `indexmap`'s types.

The gzipped size shrunk from `1241449` B to `1238013` B, just `3.3`KB of gzip'd size reduction.

`nix` scripts were not updated, so this PR will likely fail on the CI.