### PR TITLE
envrc: use built-in `watch_file` instead of `nix_direnv_watch_file`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -47,9 +47,7 @@ fi
 if command -v nix &> /dev/null && [ -z ${DISABLE_NIX+x} ]
 then
     if nix flake metadata > /dev/null; then
-        if type nix_direnv_watch_file &> /dev/null; then
-            nix_direnv_watch_file nix/shell.nix nix/all-engines.nix nix/args.nix
-        fi
+        watch_file nix/shell.nix nix/all-engines.nix nix/args.nix
         use flake
     fi
 fi


### PR DESCRIPTION
Fixes the following warning:

```
direnv: `nix_direnv_watch_file` is deprecated - use `watch_file`
```
