### PR TITLE
tech-debt: Apply sharding to query-engine tests, retry flakes and get rid of buildjet

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ dir = "target/nextest"
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }
 # * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
-retries = { backoff = "fixed", count = 3, delay = "1s", jitter = true }
+retries = { backoff = "exponential", count = 5, delay = "1s", jitter = true }
 
 # The number of threads to run tests with. Supported values are either an integer or
 # the string "num-cpus". Can be overridden through the `--test-threads` option.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ dir = "target/nextest"
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }
 # * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
-retries = { backoff = "exponential", count = 5, delay = "1s", jitter = true }
+retries = { backoff = "fixed", count = 5, delay = "1s", jitter = true }
 
 # The number of threads to run tests with. Supported values are either an integer or
 # the string "num-cpus". Can be overridden through the `--test-threads` option.

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -8,7 +8,7 @@ dir = "target/nextest"
 [profile.default]
 # "retries" defines the number of times a test should be retried. If set to a
 # non-zero value, tests that succeed on a subsequent attempt will be marked as
-# non-flaky. Can be overridden through the `--retries` option.
+# flaky. Can be overridden through the `--retries` option.
 # Examples
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,88 @@
+[store]
+# The directory under the workspace root at which nextest-related files are
+# written. Profile-specific storage is currently written to dir/<profile-name>.
+dir = "target/nextest"
+
+# This section defines the default nextest profile. Custom profiles are layered
+# on top of the default profile.
+[profile.default]
+# "retries" defines the number of times a test should be retried. If set to a
+# non-zero value, tests that succeed on a subsequent attempt will be marked as
+# non-flaky. Can be overridden through the `--retries` option.
+# Examples
+# * retries = 3
+# * retries = { backoff = "fixed", count = 2, delay = "1s" }
+# * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
+retries = { backoff = "fixed", count = 3, delay = "1s", jitter = true }
+
+# The number of threads to run tests with. Supported values are either an integer or
+# the string "num-cpus". Can be overridden through the `--test-threads` option.
+test-threads = "num-cpus"
+
+# The number of threads required for each test. This is generally used in overrides to
+# mark certain tests as heavier than others. However, it can also be set as a global parameter.
+threads-required = 1
+
+# Show these test statuses in the output.
+#
+# The possible values this can take are:
+# * none: no output
+# * fail: show failed (including exec-failed) tests
+# * retry: show flaky and retried tests
+# * slow: show slow tests
+# * pass: show passed tests
+# * skip: show skipped tests (most useful for CI)
+# * all: all of the above
+#
+# Each value includes all the values above it; for example, "slow" includes
+# failed and retried tests.
+#
+# Can be overridden through the `--status-level` flag.
+status-level = "all"
+
+# Similar to status-level, show these test statuses at the end of the run.
+final-status-level = "flaky"
+
+# "failure-output" defines when standard output and standard error for failing tests are produced.
+# Accepted values are
+# * "immediate": output failures as soon as they happen
+# * "final": output failures at the end of the test run
+# * "immediate-final": output failures as soon as they happen and at the end of
+#   the test run; combination of "immediate" and "final"
+# * "never": don't output failures at all
+#
+# For large test suites and CI it is generally useful to use "immediate-final".
+#
+# Can be overridden through the `--failure-output` option.
+failure-output = "immediate-final"
+
+# "success-output" controls production of standard output and standard error on success. This should
+# generally be set to "never".
+success-output = "never"
+
+# Cancel the test run on the first failure. For CI runs, consider setting this
+# to false.
+fail-fast = false
+
+# Treat a test that takes longer than the configured 'period' as slow, and print a message.
+# See <https://nexte.st/book/slow-tests> for more information.
+#
+# Optional: specify the parameter 'terminate-after' with a non-zero integer,
+# which will cause slow tests to be terminated after the specified number of
+# periods have passed.
+# Example: slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "60s" }
+
+# Treat a test as leaky if after the process is shut down, standard output and standard error
+# aren't closed within this duration.
+#
+# This usually happens in case of a test that creates a child process and lets it inherit those
+# handles, but doesn't clean the child process up (especially when it fails).
+#
+# See <https://nexte.st/book/leaky-tests> for more information.
+leak-timeout = "100ms"
+
+# This profile is activated if MIRI_SYSROOT is set.
+[profile.default-miri]
+# Miri tests take up a lot of memory, so only run 1 test at a time by default.
+test-threads = 1

--- a/.github/workflows/build-prisma-schema-wasm.yml
+++ b/.github/workflows/build-prisma-schema-wasm.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
     paths-ignore:
+      - "!.github/workflows/build-prisma-schema-wasm.yml"
       - ".github/**"
-      - "!.github/workflows/build-wasm.yml"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/build-prisma-schema-wasm.yml
+++ b/.github/workflows/build-prisma-schema-wasm.yml
@@ -1,21 +1,20 @@
-name: Build prisma-schema-wasm
+name: Prisma Schema (WASM)
 on:
   push:
     branches:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/build-wasm.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/build-wasm.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 jobs:
   build:
-    name: 'prisma-schema-wasm build ${{ github.event.ref }} for commit ${{ github.event.inputs.commit }}'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,17 +1,17 @@
-name: Codspeed Benchmark
+name: Query Engine
 on:
   push:
     branches:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/benchmark.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/benchmark.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   benchmark:
-    name: 'Run benchmarks on Linux'
+    name: "Codespeed benchmarks"
 
     runs-on: ubuntu-latest
     steps:
@@ -29,10 +29,10 @@ jobs:
       - name: Install cargo-codspeed
         run: cargo install cargo-codspeed
 
-      - name: 'Build the benchmark targets: schema'
+      - name: "Build the benchmark targets: schema"
         run: cargo codspeed build -p schema
 
-      - name: 'Build the benchmark targets: request-handlers'
+      - name: "Build the benchmark targets: request-handlers"
         run: cargo codspeed build -p request-handlers
 
       - name: Run the benchmarks

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,4 +1,4 @@
-name: Query Engine
+name: "QE: Codespeed benchmarks"
 on:
   push:
     branches:
@@ -18,9 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  benchmark:
-    name: "Codespeed benchmarks"
-
+  run:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,4 +1,4 @@
-name: Workspace
+name: "All crates: linting"
 on:
   push:
     branches:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,17 +1,17 @@
-name: Formatting
+name: Workspace
 on:
   push:
     branches:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/formatting.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/formatting.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,9 +19,10 @@ concurrency:
 
 jobs:
   clippy:
+    name: clippy linting
     runs-on: ubuntu-latest
     env:
-      RUSTFLAGS: '-Dwarnings'
+      RUSTFLAGS: "-Dwarnings"
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -32,7 +33,7 @@ jobs:
           cargo clippy --all-features
           cargo clippy --all-features -p query-engine-wasm --target wasm32-unknown-unknown
 
-  format:
+  rustfmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +42,7 @@ jobs:
           components: rustfmt
       - name: Check formatting
         run: cargo fmt -- --check
+
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -1,14 +1,14 @@
-name: Test release binary compilation
+name: Workspace
 on:
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/compilation.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/test-compilation.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test-crate-compilation:
-    name: 'Compile top level crates on Linux'
+    name: "Check release compilation"
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
@@ -24,17 +24,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: 'cargo clean && cargo build --release -p schema-engine-cli'
-        name: 'Compile Migration Engine'
+      - run: "cargo clean && cargo build --release -p schema-engine-cli"
+        name: "Compile Migration Engine"
 
-      - run: 'cargo clean && cargo build --release -p prisma-fmt'
-        name: 'Compile prisma-fmt'
+      - run: "cargo clean && cargo build --release -p prisma-fmt"
+        name: "Compile prisma-fmt"
 
-      - run: 'cargo clean && cargo build --release -p query-engine'
-        name: 'Compile Query Engine Binary'
+      - run: "cargo clean && cargo build --release -p query-engine"
+        name: "Compile Query Engine Binary"
 
-      - run: 'cargo clean && cargo build --release -p query-engine-node-api'
-        name: 'Compile Query Engine Library'
+      - run: "cargo clean && cargo build --release -p query-engine-node-api"
+        name: "Compile Query Engine Library"
 
-      - name: 'Check that Cargo.lock did not change'
-        run: 'git diff --exit-code'
+      - name: "Check that Cargo.lock did not change"
+        run: "git diff --exit-code"

--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -1,4 +1,4 @@
-name: Workspace
+name: "All crates: compilation"
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -2,8 +2,8 @@ name: Workspace
 on:
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "!.github/workflows/test-compilation.yml"
+      - ".github/**"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/test-quaint.yml
+++ b/.github/workflows/test-quaint.yml
@@ -1,4 +1,4 @@
-name: Quaint
+name: "Quaint: integration tests"
 on:
   push:
     branches:

--- a/.github/workflows/test-quaint.yml
+++ b/.github/workflows/test-quaint.yml
@@ -1,12 +1,13 @@
-name: Test Quaint
+name: Quaint
 on:
   push:
     branches:
       - main
   pull_request:
     paths:
-      - 'quaint/**'
-  
+      - "quaint/**"
+      - "!.github/workflows/test-quaint.yml"
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -16,14 +17,6 @@ jobs:
       matrix:
         features:
           - "--lib --features=all"
-          - "--lib --no-default-features --features=sqlite"
-          - "--lib --no-default-features --features=sqlite --features=pooled"
-          - "--lib --no-default-features --features=postgresql"
-          - "--lib --no-default-features --features=postgresql --features=pooled"
-          - "--lib --no-default-features --features=mysql"
-          - "--lib --no-default-features --features=mysql --features=pooled"
-          - "--lib --no-default-features --features=mssql"
-          - "--lib --no-default-features --features=mssql --features=pooled"          
     env:
       TEST_MYSQL: "mysql://root:prisma@localhost:3306/prisma"
       TEST_MYSQL8: "mysql://root:prisma@localhost:3307/prisma"

--- a/.github/workflows/test-query-engine-black-box.yml
+++ b/.github/workflows/test-query-engine-black-box.yml
@@ -1,17 +1,17 @@
-name: Test Query Engine (Black Box)
+name: Query Engine
 on:
   push:
     branches:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/query-engine-black-box.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/test-query-engine-black-box.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,29 +19,29 @@ concurrency:
 
 jobs:
   rust-tests:
-    name: 'query-engine as a black-box'
+    name: "Black-box testing"
 
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: 'postgres16'
+          - name: "postgres16"
             single_threaded: false
-            connector: 'postgres'
+            connector: "postgres"
             # Arbitrary PostgreSQL version
             # we opted for the most recent one, there is no need to have a matrix
-            version: '16'
+            version: "16"
 
     env:
-      LOG_LEVEL: 'info'
-      LOG_QUERIES: 'y'
-      RUST_LOG_FORMAT: 'devel'
-      RUST_BACKTRACE: '1'
-      CLICOLOR_FORCE: '1'
-      CLOSED_TX_CLEANUP: '2'
-      SIMPLE_TEST_MODE: '1'
-      QUERY_BATCH_SIZE: '10'
-      TEST_RUNNER: 'direct'
+      LOG_LEVEL: "info"
+      LOG_QUERIES: "y"
+      RUST_LOG_FORMAT: "devel"
+      RUST_BACKTRACE: "1"
+      CLICOLOR_FORCE: "1"
+      CLOSED_TX_CLEANUP: "2"
+      SIMPLE_TEST_MODE: "1"
+      QUERY_BATCH_SIZE: "10"
+      TEST_RUNNER: "direct"
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
 
@@ -60,7 +60,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 'Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})'
+      - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
         run: make start-${{ matrix.database.name }}
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-query-engine-black-box.yml
+++ b/.github/workflows/test-query-engine-black-box.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "!.github/workflows/test-query-engine-black-box.yml"
+      - ".github/**"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/test-query-engine-black-box.yml
+++ b/.github/workflows/test-query-engine-black-box.yml
@@ -1,4 +1,4 @@
-name: Query Engine
+name: "QE: black-box tests"
 on:
   push:
     branches:
@@ -18,9 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  rust-tests:
-    name: "Black-box testing"
-
+  test:
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rust-query-engine-tests:
-    name: "Adapter ${{ matrix.adapter.name }}"
+    name: "Adapter ${{ matrix.adapter.name }} ${{ matrix.partition }}"
 
     strategy:
       fail-fast: false
@@ -42,6 +42,7 @@ jobs:
           - name: "libsql (wasm)"
             setup_task: "dev-libsql-wasm"
         node_version: ["18"]
+        partition: ["1/4", "2/4", "3/4", "4/4"]
     env:
       LOG_LEVEL: "info" # Set to "debug" to trace the query engine and node process running the driver adapter
       LOG_QUERIES: "y"
@@ -96,8 +97,9 @@ jobs:
           fi
 
       - uses: cachix/install-nix-action@v24
+      - uses: taiki-e/install-action@nextest
 
       - run: make ${{ matrix.adapter.setup_task }}
 
       - name: "Run tests"
-        run: cargo test --package query-engine-tests -- --test-threads=1
+        run: cargo nextest run --package query-engine-tests --test-threads=1 --partition hash:${{ matrix.partition }}

--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -1,17 +1,17 @@
-name: Test Driver Adapters
+name: Query Engine
 on:
   push:
     branches:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/query-engine-driver-adapters.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/test-query-engine-driver-adapters.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,39 +19,39 @@ concurrency:
 
 jobs:
   rust-query-engine-tests:
-    name: '${{ matrix.adapter.name }} on node v${{ matrix.node_version }}'
+    name: "Adapter ${{ matrix.adapter.name }}"
 
     strategy:
       fail-fast: false
       matrix:
         adapter:
-          - name: 'planetscale (napi)'
-            setup_task: 'dev-planetscale-js'
-          - name: 'pg (napi)'
-            setup_task: 'dev-pg-js'
-          - name: 'neon (ws) (napi)'
-            setup_task: 'dev-neon-js'
-          - name: 'libsql (Turso) (napi)'
-            setup_task: 'dev-libsql-js'
-          - name: 'planetscale (wasm)'
-            setup_task: 'dev-planetscale-wasm'
-          - name: 'pg (wasm)'
-            setup_task: 'dev-pg-wasm'
-          - name: 'neon (ws) (wasm)'
-            setup_task: 'dev-neon-wasm'
-          - name: 'libsql (Turso) (wasm)'
-            setup_task: 'dev-libsql-wasm'
-        node_version: ['18']
+          - name: "planetscale (napi)"
+            setup_task: "dev-planetscale-js"
+          - name: "pg (napi)"
+            setup_task: "dev-pg-js"
+          - name: "neon (napi)"
+            setup_task: "dev-neon-js"
+          - name: "libsql (napi)"
+            setup_task: "dev-libsql-js"
+          - name: "planetscale (wasm)"
+            setup_task: "dev-planetscale-wasm"
+          - name: "pg (wasm)"
+            setup_task: "dev-pg-wasm"
+          - name: "neon (wasm)"
+            setup_task: "dev-neon-wasm"
+          - name: "libsql (wasm)"
+            setup_task: "dev-libsql-wasm"
+        node_version: ["18"]
     env:
-      LOG_LEVEL: 'info' # Set to "debug" to trace the query engine and node process running the driver adapter
-      LOG_QUERIES: 'y'
-      RUST_LOG: 'info'
-      RUST_LOG_FORMAT: 'devel'
-      RUST_BACKTRACE: '1'
-      CLICOLOR_FORCE: '1'
-      CLOSED_TX_CLEANUP: '2'
-      SIMPLE_TEST_MODE: '1'
-      QUERY_BATCH_SIZE: '10'
+      LOG_LEVEL: "info" # Set to "debug" to trace the query engine and node process running the driver adapter
+      LOG_QUERIES: "y"
+      RUST_LOG: "info"
+      RUST_LOG_FORMAT: "devel"
+      RUST_BACKTRACE: "1"
+      CLICOLOR_FORCE: "1"
+      CLOSED_TX_CLEANUP: "2"
+      SIMPLE_TEST_MODE: "1"
+      QUERY_BATCH_SIZE: "10"
       WORKSPACE_ROOT: ${{ github.workspace }}
 
     runs-on: ubuntu-latest
@@ -60,22 +60,22 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: 'Setup Node.js'
+      - name: "Setup Node.js"
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node_version }}
 
-      - name: 'Setup pnpm'
+      - name: "Setup pnpm"
         uses: pnpm/action-setup@v2
         with:
           version: 8
 
-      - name: 'Get pnpm store directory'
+      - name: "Get pnpm store directory"
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - name: 'Login to Docker Hub'
+      - name: "Login to Docker Hub"
         uses: docker/login-action@v3
         continue-on-error: true
         env:
@@ -99,5 +99,5 @@ jobs:
 
       - run: make ${{ matrix.adapter.setup_task }}
 
-      - name: 'Run tests'
+      - name: "Run tests"
         run: cargo test --package query-engine-tests -- --test-threads=1

--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rust-query-engine-tests:
-    name: "Adapter ${{ matrix.adapter.name }} ${{ matrix.partition }}"
+    name: "${{ matrix.adapter.name }} ${{ matrix.partition }}"
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -1,4 +1,4 @@
-name: Query Engine
+name: "QE: driver-adapter integration tests"
 on:
   push:
     branches:

--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "!.github/workflows/test-query-engine-driver-adapters.yml"
+      - ".github/**"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - ".github/**"
       - "!.github/workflows/test-query-engine.yml"
+      - ".github/**"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"
@@ -22,6 +22,7 @@ jobs:
     name: "${{ matrix.database.name }} - ${{ matrix.engine_protocol }} ${{ matrix.partition }}"
 
     strategy:
+      fail-fast: false
       matrix:
         database:
           - name: "vitess_8_0"

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -95,7 +95,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
-        run: make start-${{ matrix.database.name }
+        run: make start-${{ matrix.database.name }}
 
       - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
         if: ${{ matrix.database.single_threaded }}

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -1,4 +1,4 @@
-name: QE
+name: Query Engine
 on:
   push:
     branches:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -1,4 +1,4 @@
-name: Query Engine
+name: "QE: integration tests"
 on:
   push:
     branches:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -104,7 +104,7 @@ jobs:
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }}
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=8
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -5,13 +5,13 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
       - "!.github/workflows/test-query-engine.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,58 +19,58 @@ concurrency:
 
 jobs:
   rust-query-engine-tests:
-    name: '${{ matrix.database.name }} (${{ matrix.engine_protocol }}) on Linux'
+    name: "${{ matrix.database.name }} (${{ matrix.engine_protocol }}) on Linux"
 
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: 'vitess_8_0'
+          - name: "vitess_8_0"
             single_threaded: true
-            connector: 'vitess'
-            version: '8.0'
+            connector: "vitess"
+            version: "8.0"
           # Arbitrary PostgreSQL version
           # we opted for the most recent one, there is no need to have a matrix
-          - name: 'postgres16'
+          - name: "postgres16"
             single_threaded: true
-            connector: 'postgres'
-            version: '16'
-          - name: 'mssql_2022'
+            connector: "postgres"
+            version: "16"
+          - name: "mssql_2022"
             single_threaded: false
-            connector: 'sqlserver'
-            version: '2022'
-          - name: 'sqlite'
+            connector: "sqlserver"
+            version: "2022"
+          - name: "sqlite"
             single_threaded: false
-            connector: 'sqlite'
-            version: '3'
-          - name: 'mongodb_4_2'
+            connector: "sqlite"
+            version: "3"
+          - name: "mongodb_4_2"
             single_threaded: true
-            connector: 'mongodb'
-            version: '4.2'
-          - name: 'cockroach_23_1'
+            connector: "mongodb"
+            version: "4.2"
+          - name: "cockroach_23_1"
             single_threaded: false
-            connector: 'cockroachdb'
-            version: '23.1'
-          - name: 'cockroach_22_2'
+            connector: "cockroachdb"
+            version: "23.1"
+          - name: "cockroach_22_2"
             single_threaded: false
-            connector: 'cockroachdb'
-            version: '22.2'
-          - name: 'cockroach_22_1_0'
+            connector: "cockroachdb"
+            version: "22.2"
+          - name: "cockroach_22_1_0"
             single_threaded: false
-            connector: 'cockroachdb'
-            version: '22.1'
+            connector: "cockroachdb"
+            version: "22.1"
         engine_protocol: [graphql, json]
 
     env:
-      LOG_LEVEL: 'info'
-      LOG_QUERIES: 'y'
-      RUST_LOG_FORMAT: 'devel'
-      RUST_BACKTRACE: '1'
-      CLICOLOR_FORCE: '1'
-      CLOSED_TX_CLEANUP: '2'
-      SIMPLE_TEST_MODE: '1'
-      QUERY_BATCH_SIZE: '10'
-      TEST_RUNNER: 'direct'
+      LOG_LEVEL: "info"
+      LOG_QUERIES: "y"
+      RUST_LOG_FORMAT: "devel"
+      RUST_BACKTRACE: "1"
+      CLICOLOR_FORCE: "1"
+      CLOSED_TX_CLEANUP: "2"
+      SIMPLE_TEST_MODE: "1"
+      QUERY_BATCH_SIZE: "10"
+      TEST_RUNNER: "direct"
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
@@ -90,7 +90,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 'Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})'
+      - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
         run: make start-${{ matrix.database.name }}
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -22,7 +22,6 @@ jobs:
     name: "${{ matrix.database.name }} - ${{ matrix.engine_protocol }} ${{ matrix.partition }}"
 
     strategy:
-      fail-fast: false
       matrix:
         database:
           - name: "vitess_8_0"

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -95,12 +95,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=1
+      - uses: taiki-e/install-action@nextest
+
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest --package query-engine-tests -- --test-threads=1
         if: ${{ matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package query-engine-tests -- --test-threads=8
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest --package query-engine-tests -- --test-threads=8
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -1,4 +1,4 @@
-name: Test Query Engine
+name: QE
 on:
   push:
     branches:
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   rust-query-engine-tests:
-    name: "${{ matrix.database.name }} (${{ matrix.engine_protocol }}) on Linux"
+    name: "${{ matrix.database.name }} - ${{ matrix.engine_protocol }} ${{ matrix.partition }}"
 
     strategy:
       fail-fast: false
@@ -60,6 +60,7 @@ jobs:
             connector: "cockroachdb"
             version: "22.1"
         engine_protocol: [graphql, json]
+        partition: ["1/4", "2/4", "3/4", "4/4"]
 
     env:
       LOG_LEVEL: "info"
@@ -74,6 +75,7 @@ jobs:
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
+      PARTITION: ${{ matrix.partition }}
 
     runs-on: ubuntu-latest
     steps:
@@ -97,12 +99,12 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --test-threads=1
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
         if: ${{ matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }}
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -75,7 +75,6 @@ jobs:
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
-      PARTITION: ${{ matrix.partition }}
 
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -75,7 +75,7 @@ jobs:
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
 
-    runs-on: buildjet-16vcpu-ubuntu-2004
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -6,12 +6,12 @@ on:
   pull_request:
     paths-ignore:
       - '.github/**'
-      - '!.github/workflows/query-engine.yml'
       - '.buildkite/**'
       - '*.md'
       - 'LICENSE'
       - 'CODEOWNERS'
       - 'renovate.json'
+      - "!.github/workflows/test-query-engine.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -80,6 +80,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -93,11 +95,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
-        run: make start-${{ matrix.database.name }}
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: taiki-e/install-action@nextest
+        run: make start-${{ matrix.database.name }
 
       - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
         if: ${{ matrix.database.single_threaded }}

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -97,12 +97,12 @@ jobs:
 
       - uses: taiki-e/install-action@nextest
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest --package query-engine-tests -- --test-threads=1
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --test-threads=1
         if: ${{ matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest --package query-engine-tests -- --test-threads=8
+      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -5,9 +5,8 @@ on:
       - main
   pull_request:
     paths-ignore:
-      # Generic
-      - ".github/**"
       - "!.github/workflows/test-schema-engine.yml"
+      - ".github/**"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -37,6 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -48,7 +49,7 @@ jobs:
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}-single
 
-      - run: cargo test -p mongodb-schema-connector
+      - run: cargo nextest run -p mongodb-schema-connector
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
@@ -106,6 +107,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -121,26 +123,26 @@ jobs:
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}
 
-      - run: cargo test -p sql-introspection-tests
+      - run: cargo nextest run -p sql-introspection-tests
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
-      - run: cargo test -p sql-schema-describer
+      - run: cargo nextest run -p sql-schema-describer
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
-      - run: cargo test -p sql-migration-tests
+      - run: cargo nextest run -p sql-migration-tests
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
           RUST_LOG: debug
 
-      - run: cargo test -p schema-engine-cli
+      - run: cargo nextest run -p schema-engine-cli
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
@@ -149,14 +151,14 @@ jobs:
       #
       # Vitess tests
       #
-      - run: cargo test -p sql-introspection-tests -- --test-threads=1
+      - run: cargo nextest run -p sql-introspection-tests --test-threads=1
         if: ${{ matrix.database.is_vitess }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
           TEST_SHADOW_DATABASE_URL: ${{ matrix.database.shadow_database_url }}
 
-      - run: cargo test -p sql-migration-tests -- --test-threads=1
+      - run: cargo nextest run -p sql-migration-tests --test-threads=1
         if: ${{ matrix.database.is_vitess }}
         env:
           CLICOLOR_FORCE: 1
@@ -164,7 +166,7 @@ jobs:
           TEST_SHADOW_DATABASE_URL: ${{ matrix.database.shadow_database_url }}
           RUST_LOG: debug
 
-      - run: cargo test -p schema-engine-cli -- --test-threads=1
+      - run: cargo nextest run -p schema-engine-cli --test-threads=1
         if: ${{ matrix.database.is_vitess }}
         env:
           CLICOLOR_FORCE: 1
@@ -174,26 +176,26 @@ jobs:
       #
       # Single threaded tests (excluding Vitess)
       #
-      - run: cargo test -p sql-schema-describer -- --test-threads=1
+      - run: cargo nextest run -p sql-schema-describer --test-threads=1
         if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
-      - run: cargo test -p sql-introspection-tests -- --test-threads=1
+      - run: cargo nextest run -p sql-introspection-tests --test-threads=1
         if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
-      - run: cargo test -p sql-migration-tests -- --test-threads=1
+      - run: cargo nextest run -p sql-migration-tests --test-threads=1
         if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
           RUST_LOG: debug
 
-      - run: cargo test -p schema-engine-cli -- --test-threads=1
+      - run: cargo nextest run -p schema-engine-cli --test-threads=1
         if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
@@ -220,6 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
 
       - uses: actions/cache@v3
         with:
@@ -240,6 +243,6 @@ jobs:
           sudo sc start MySQL
 
       - name: Run tests
-        run: cargo test -p sql-migration-tests
+        run: cargo nextest run -p sql-migration-tests
         env:
           TEST_DATABASE_URL: ${{ matrix.db.url }}

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -1,4 +1,4 @@
-name: Test Schema Engine
+name: Schema Engine
 on:
   push:
     branches:
@@ -6,15 +6,15 @@ on:
   pull_request:
     paths-ignore:
       # Generic
-      - '.github/**'
-      - '!.github/workflows/schema-engine.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/test-schema-engine.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
       # Specific
-      - 'query-engine/**'
+      - "query-engine/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -22,17 +22,17 @@ concurrency:
 
 jobs:
   test-mongodb-schema-connector:
-    name: '${{ matrix.database.name }} on Linux'
+    name: "${{ matrix.database.name }}"
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: 'mongodb42'
-            url: 'mongodb://prisma:prisma@localhost:27016/?authSource=admin&retryWrites=true'
-          - name: 'mongodb44'
-            url: 'mongodb://prisma:prisma@localhost:27017/?authSource=admin&retryWrites=true'
-          - name: 'mongodb5'
-            url: 'mongodb://prisma:prisma@localhost:27018/?authSource=admin&retryWrites=true'
+          - name: "mongodb42"
+            url: "mongodb://prisma:prisma@localhost:27016/?authSource=admin&retryWrites=true"
+          - name: "mongodb44"
+            url: "mongodb://prisma:prisma@localhost:27017/?authSource=admin&retryWrites=true"
+          - name: "mongodb5"
+            url: "mongodb://prisma:prisma@localhost:27018/?authSource=admin&retryWrites=true"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 'Start ${{ matrix.database.name }}'
+      - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}-single
 
       - run: cargo test -p mongodb-schema-connector
@@ -54,51 +54,51 @@ jobs:
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
   test-linux:
-    name: '${{ matrix.database.name }} on Linux'
+    name: "${{ matrix.database.name }}"
 
     strategy:
       fail-fast: false
       matrix:
         database:
           - name: mssql_2017
-            url: 'sqlserver://localhost:1434;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED'
+            url: "sqlserver://localhost:1434;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
           - name: mssql_2019
-            url: 'sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED'
+            url: "sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
           - name: mysql_5_6
-            url: 'mysql://root:prisma@localhost:3309'
+            url: "mysql://root:prisma@localhost:3309"
           - name: mysql_5_7
-            url: 'mysql://root:prisma@localhost:3306'
+            url: "mysql://root:prisma@localhost:3306"
           - name: mysql_8
-            url: 'mysql://root:prisma@localhost:3307'
+            url: "mysql://root:prisma@localhost:3307"
           - name: mysql_mariadb
-            url: 'mysql://root:prisma@localhost:3308'
+            url: "mysql://root:prisma@localhost:3308"
           - name: postgres9
-            url: 'postgresql://postgres:prisma@localhost:5431'
+            url: "postgresql://postgres:prisma@localhost:5431"
           - name: postgres10
-            url: 'postgresql://postgres:prisma@localhost:5432'
+            url: "postgresql://postgres:prisma@localhost:5432"
           - name: postgres11
-            url: 'postgresql://postgres:prisma@localhost:5433'
+            url: "postgresql://postgres:prisma@localhost:5433"
           - name: postgres12
-            url: 'postgresql://postgres:prisma@localhost:5434'
+            url: "postgresql://postgres:prisma@localhost:5434"
           - name: postgres13
-            url: 'postgresql://postgres:prisma@localhost:5435'
+            url: "postgresql://postgres:prisma@localhost:5435"
           - name: postgres14
-            url: 'postgresql://postgres:prisma@localhost:5437'
+            url: "postgresql://postgres:prisma@localhost:5437"
           - name: postgres15
-            url: 'postgresql://postgres:prisma@localhost:5438'
+            url: "postgresql://postgres:prisma@localhost:5438"
           - name: postgres16
-            url: 'postgresql://postgres:prisma@localhost:5439'
+            url: "postgresql://postgres:prisma@localhost:5439"
           - name: cockroach_23_1
-            url: 'postgresql://prisma@localhost:26260'
+            url: "postgresql://prisma@localhost:26260"
           - name: cockroach_22_2
-            url: 'postgresql://prisma@localhost:26259'
+            url: "postgresql://prisma@localhost:26259"
           - name: cockroach_22_1_0
-            url: 'postgresql://prisma@localhost:26257'
+            url: "postgresql://prisma@localhost:26257"
           - name: sqlite
             url: sqlite
           - name: vitess_8_0
-            url: 'mysql://root:prisma@localhost:33807/test'
-            shadow_database_url: 'mysql://root:prisma@localhost:33808/shadow'
+            url: "mysql://root:prisma@localhost:33807/test"
+            shadow_database_url: "mysql://root:prisma@localhost:33808/shadow"
             is_vitess: true
             single_threaded: true
 
@@ -118,7 +118,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: 'Start ${{ matrix.database.name }}'
+      - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}
 
       - run: cargo test -p sql-introspection-tests
@@ -205,9 +205,9 @@ jobs:
       matrix:
         db:
           - name: mysql
-            url: 'mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60'
+            url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"
           - name: mariadb
-            url: 'mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60'
+            url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"
         rust:
           - stable
         os:
@@ -215,7 +215,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    name: '${{ matrix.db.name }} on Windows'
+    name: "${{ matrix.db.name }} on Windows"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -1,4 +1,4 @@
-name: Schema Engine
+name: "SE: integration tests"
 on:
   push:
     branches:

--- a/.github/workflows/test-unit-tests.yml
+++ b/.github/workflows/test-unit-tests.yml
@@ -1,17 +1,17 @@
-name: Test Unit tests
+name: Workspace
 on:
   push:
     branches:
       - main
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/unit-tests.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/test-unit-tests.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   test:
-    name: Workspace unit tests
+    name: Unit tests
 
     strategy:
       fail-fast: false

--- a/.github/workflows/test-unit-tests.yml
+++ b/.github/workflows/test-unit-tests.yml
@@ -1,4 +1,4 @@
-name: Workspace
+name: "All crates: unit tests"
 on:
   push:
     branches:
@@ -19,8 +19,6 @@ concurrency:
 
 jobs:
   test:
-    name: Unit tests
-
     strategy:
       fail-fast: false
 

--- a/.github/workflows/wasm-benhmarks.yml
+++ b/.github/workflows/wasm-benhmarks.yml
@@ -1,4 +1,4 @@
-name: Query Engine (WASM)
+name: "QE: WASM benchmarks"
 on:
   pull_request:
     paths-ignore:
@@ -8,7 +8,10 @@ on:
       - "*.md"
       - "LICENSE"
       - "CODEOWNERS"
-      - "renovate.json"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmarks:

--- a/.github/workflows/wasm-benhmarks.yml
+++ b/.github/workflows/wasm-benhmarks.yml
@@ -1,4 +1,4 @@
-name: Wasm perf
+name: Query Engine (WASM)
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -1,4 +1,4 @@
-name: Query Engine (WASM)
+name: "QE: WASM size"
 on:
   pull_request:
     paths-ignore:
@@ -9,6 +9,10 @@ on:
       - "LICENSE"
       - "CODEOWNERS"
       - "renovate.json"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pr-wasm-size:

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -1,28 +1,28 @@
-name: Report wasm size
+name: Query Engine (WASM)
 on:
   pull_request:
     paths-ignore:
-      - '.github/**'
-      - '!.github/workflows/wasm-size.yml'
-      - '.buildkite/**'
-      - '*.md'
-      - 'LICENSE'
-      - 'CODEOWNERS'
-      - 'renovate.json'
+      - ".github/**"
+      - "!.github/workflows/wasm-size.yml"
+      - ".buildkite/**"
+      - "*.md"
+      - "LICENSE"
+      - "CODEOWNERS"
+      - "renovate.json"
 
 jobs:
   pr-wasm-size:
-    name: Get PR module size
+    name: calculate module size (pr)
     runs-on: ubuntu-latest
     outputs:
-      size: ${{ steps.measure.outputs.size }} 
-      size_gz: ${{ steps.measure.outputs.size_gz }} 
+      size: ${{ steps.measure.outputs.size }}
+      size_gz: ${{ steps.measure.outputs.size_gz }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
-      
+
       - uses: cachix/install-nix-action@v24
-      
+
       - name: Build and measure PR branch
         id: measure
         run: |
@@ -32,19 +32,19 @@ jobs:
           echo "size_gz=$(wc --bytes < ./result-1/query_engine_bg.wasm.gz)" >> $GITHUB_OUTPUT
 
   base-wasm-size:
-    name: Get base branch size
+    name: calculate module size (main)
     runs-on: ubuntu-latest
     outputs:
-      size: ${{ steps.measure.outputs.size }} 
-      size_gz: ${{ steps.measure.outputs.size_gz }} 
+      size: ${{ steps.measure.outputs.size }}
+      size_gz: ${{ steps.measure.outputs.size_gz }}
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
-      
+
       - uses: cachix/install-nix-action@v24
-      
+
       - name: Build and measure base branch
         id: measure
         run: |
@@ -53,12 +53,11 @@ jobs:
           echo "size=$(wc --bytes < ./result/query_engine_bg.wasm)" >> $GITHUB_OUTPUT
           echo "size_gz=$(wc --bytes < ./result-1/query_engine_bg.wasm.gz)" >> $GITHUB_OUTPUT
 
-  
   report-diff:
-    name: Report module size difference
+    name: report module size
     runs-on: ubuntu-latest
-    needs: 
-      - pr-wasm-size 
+    needs:
+      - pr-wasm-size
       - base-wasm-size
 
     steps:
@@ -69,7 +68,7 @@ jobs:
           base_gz=$(echo "${{ needs.base-wasm-size.outputs.size_gz }}" | numfmt --format '%.3f' --to=iec-i --suffix=B)
           pr=$(echo "${{ needs.pr-wasm-size.outputs.size }}" | numfmt --format '%.3f' --to=iec-i  --suffix=B)
           pr_gz=$(echo "${{ needs.pr-wasm-size.outputs.size_gz }}" | numfmt --format '%.3f' --to=iec-i --suffix=B)
-          
+
           diff=$(echo "$((${{ needs.pr-wasm-size.outputs.size }} - ${{ needs.base-wasm-size.outputs.size }}))" | numfmt --format '%.3f' --to=iec-i --suffix=B)
           diff_gz=$(echo "$((${{ needs.pr-wasm-size.outputs.size_gz }} - ${{ needs.base-wasm-size.outputs.size_gz }}))" | numfmt --format '%.3f' --to=iec-i --suffix=B)
 
@@ -87,7 +86,7 @@ jobs:
         id: findReportComment
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body-includes: '<!-- wasm-size -->'
+          body-includes: "<!-- wasm-size -->"
 
       - name: Create or update report
         uses: peter-evans/create-or-update-comment@v3
@@ -103,6 +102,3 @@ jobs:
             | WASM         | ${{ steps.compute.outputs.pr}}    |  ${{ steps.compute.outputs.base}}    | ${{ steps.compute.outputs.diff}}
             | WASM (gzip)  | ${{ steps.compute.outputs.pr_gz}} |  ${{ steps.compute.outputs.base_gz}} | ${{ steps.compute.outputs.diff_gz}}
           edit-mode: replace
-
-        
-  


### PR DESCRIPTION
Close https://github.com/prisma/team-orm/issues/759
Close https://github.com/prisma/team-orm/issues/781
Supersede and close https://github.com/prisma/prisma-engines/pull/4581

This PR:
- Removes buildjet in favor of GH actions free runners
- Replaces cargo test with [`cargo-nextest`](https://nexte.st/) (🎩  to @aqrln for bringing the crate to our attention) for query-engine tests and schema-engine tests
- Applies a sharding strategy to query-engine tests ,and query-engine driver adapter tests
- Applies retryal of flakey tests (5 retries) and marks tests as flakey on query-engine, query-engine driver adapters, and schema-engine tests
- Adds some cosmetic refactoring and fixes to the workflow files

Outcomes:
- Suite latency end-to-end is similar than before removing buildjet in this PR
- We can get rid of buildjet entirely and get back $60k / year to the engineering budget
- Paves the path to applying the same sharding and flakey handling strategies to other test suites thus improving the overall CI story

Limits:
- Currently (and in the near future) the amount of jobs enqueued per commit will be 100 < n <= 200. According to [GitHub docs on usage limits](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits):

   * There is a limit on the number of concurrent jobs by plan: Enterprise plan (ours) is 1000 concurrent jobs.
   * A matrix can generate 256 jobs per workflow.
   * No more than 500 jobs can be queued in a 10s interval per repository
   
    Napking math says that each commit end-to-end latency for most jobs is about 20 minutes. So if a commit is pushed every 10 minutes, we can exhaust the amount of jobs queued. However, we cancel previous jobs if a new commit is pushed and the previous job didn't finish. So this would only be a problem if multiple people are pushing commits at a very fast pace in parallel to respective topic branches.

   This might not be a problem as of today, and my expectation is that it will only cause a bit of delay on the whole suite feedback for each committer. But if we moved to a monorepo, these jobs will add to those in prisma-prisma, and all the committers previously spread across the two repositories will be committing to a single repository. Thus increasing the probability of saturating the job queues.


