### PR TITLE
psl: Ensure `set_config_dir` can be eliminated if not used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,6 +3510,7 @@ version = "0.1.0"
 dependencies = [
  "bigdecimal",
  "chrono",
+ "connection-string",
  "diagnostics",
  "enumflags2",
  "indoc 2.0.3",

--- a/psl/builtin-connectors/src/mssql_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/mssql_datamodel_connector.rs
@@ -3,7 +3,6 @@ mod validations;
 
 pub use native_types::{MsSqlType, MsSqlTypeParameter};
 
-use connection_string::JdbcString;
 use enumflags2::BitFlags;
 use lsp_types::{CompletionItem, CompletionItemKind, CompletionList};
 use psl_core::{
@@ -15,7 +14,6 @@ use psl_core::{
     parser_database::{self, ast, ParserDatabase, ReferentialAction, ScalarType},
     PreviewFeature,
 };
-use std::borrow::Cow;
 
 use MsSqlType::*;
 use MsSqlTypeParameter::*;
@@ -161,35 +159,6 @@ impl Connector for MsSqlDatamodelConnector {
         SCALAR_TYPE_DEFAULTS
             .iter()
             .any(|(st, nt)| scalar_type == st && native_type == nt)
-    }
-
-    fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
-        let mut jdbc: JdbcString = match format!("jdbc:{url}").parse() {
-            Ok(jdbc) => jdbc,
-            _ => return Cow::from(url),
-        };
-
-        let set_root = |path: String| {
-            let path = std::path::Path::new(&path);
-
-            if path.is_relative() {
-                Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
-            } else {
-                Some(path.to_str().unwrap().to_string())
-            }
-        };
-
-        let props = jdbc.properties_mut();
-
-        let cert_path = props.remove("trustservercertificateca").and_then(set_root);
-
-        if let Some(path) = cert_path {
-            props.insert("trustServerCertificateCA".to_owned(), path);
-        }
-
-        let final_connection_string = format!("{jdbc}").replace("jdbc:sqlserver://", "sqlserver://");
-
-        Cow::Owned(final_connection_string)
     }
 
     fn validate_native_type_arguments(

--- a/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
+++ b/psl/builtin-connectors/src/sqlite_datamodel_connector.rs
@@ -7,7 +7,6 @@ use psl_core::{
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{ReferentialAction, ScalarType},
 };
-use std::borrow::Cow;
 
 const NATIVE_TYPE_CONSTRUCTORS: &[NativeTypeConstructor] = &[];
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalKeyIndex];
@@ -102,24 +101,6 @@ impl Connector for SqliteDatamodelConnector {
             span,
         ));
         None
-    }
-
-    fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
-        let set_root = |path: &str| {
-            let path = std::path::Path::new(path);
-
-            if path.is_relative() {
-                Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
-            } else {
-                None
-            }
-        };
-
-        if let Some(path) = set_root(url.trim_start_matches("file:")) {
-            return Cow::Owned(format!("file:{path}"));
-        };
-
-        Cow::Borrowed(url)
     }
 
     fn validate_url(&self, url: &str) -> Result<(), String> {

--- a/psl/psl-core/Cargo.toml
+++ b/psl/psl-core/Cargo.toml
@@ -11,6 +11,7 @@ schema-ast = { path = "../schema-ast" }
 
 bigdecimal = "0.3"
 chrono = { version = "0.4.6", default_features = false }
+connection-string.workspace = true
 itertools.workspace = true
 once_cell = "1.3.1"
 regex = "1.3.7"

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -2,6 +2,7 @@ use crate::{
     configuration::StringFromEnvVar,
     datamodel_connector::{Connector, ConnectorCapabilities, RelationMode},
     diagnostics::{DatamodelError, Diagnostics, Span},
+    set_config_dir,
 };
 use std::{any::Any, borrow::Cow, path::Path};
 
@@ -208,7 +209,7 @@ impl Datasource {
     {
         //CHECKUP
         let url = self.load_url(env)?;
-        let url = self.active_connector.set_config_dir(config_dir, &url);
+        let url = set_config_dir(self.active_connector.flavour(), config_dir, &url);
 
         Ok(url.into_owned())
     }

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -33,11 +33,7 @@ use parser_database::{
     ast::{self, SchemaPosition},
     walkers, IndexAlgorithm, ParserDatabase, ReferentialAction, ScalarType,
 };
-use std::{
-    borrow::Cow,
-    collections::{BTreeMap, HashMap},
-    str::FromStr,
-};
+use std::{borrow::Cow, collections::HashMap, str::FromStr};
 
 pub const EXTENSIONS_KEY: &str = "extensions";
 

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -226,49 +226,6 @@ pub trait Connector: Send + Sync {
         diagnostics: &mut Diagnostics,
     ) -> Option<NativeTypeInstance>;
 
-    fn set_config_dir<'a>(&self, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
-        let set_root = |path: &str| {
-            let path = std::path::Path::new(path);
-
-            if path.is_relative() {
-                Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
-            } else {
-                None
-            }
-        };
-
-        let mut url = match url::Url::parse(url) {
-            Ok(url) => url,
-            Err(_) => return Cow::from(url), // bail
-        };
-
-        let mut params: BTreeMap<String, String> =
-            url.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
-
-        url.query_pairs_mut().clear();
-
-        // Only for PostgreSQL + MySQL
-        if let Some(path) = params.get("sslcert").map(|s| s.as_str()).and_then(set_root) {
-            params.insert("sslcert".into(), path);
-        }
-
-        // Only for PostgreSQL + MySQL
-        if let Some(path) = params.get("sslidentity").map(|s| s.as_str()).and_then(set_root) {
-            params.insert("sslidentity".into(), path);
-        }
-
-        // Only for MongoDB
-        if let Some(path) = params.get("tlsCAFile").map(|s| s.as_str()).and_then(set_root) {
-            params.insert("tlsCAFile".into(), path);
-        }
-
-        for (k, v) in params.into_iter() {
-            url.query_pairs_mut().append_pair(&k, &v);
-        }
-
-        url.to_string().into()
-    }
-
     fn supports_scalar_lists(&self) -> bool {
         self.has_capability(ConnectorCapability::ScalarLists)
     }

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mcf;
 mod common;
 mod configuration;
 mod reformat;
+mod set_config_dir;
 mod validate;
 
 pub use crate::{
@@ -23,6 +24,7 @@ pub use crate::{
 pub use diagnostics;
 pub use parser_database::{self, is_reserved_type_name};
 pub use schema_ast;
+pub use set_config_dir::set_config_dir;
 
 use self::validate::{datasource_loader, generator_loader};
 use diagnostics::Diagnostics;

--- a/psl/psl-core/src/set_config_dir.rs
+++ b/psl/psl-core/src/set_config_dir.rs
@@ -1,0 +1,101 @@
+use connection_string::JdbcString;
+use std::{borrow::Cow, collections::BTreeMap};
+
+use crate::datamodel_connector::Flavour;
+
+pub fn set_config_dir<'a>(flavour: Flavour, config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
+    match flavour {
+        Flavour::Sqlserver => set_config_dir_mssql(config_dir, url),
+        Flavour::Sqlite => set_config_dir_sqlite(config_dir, url),
+        _ => set_config_dir_default(config_dir, url),
+    }
+}
+
+fn set_config_dir_default<'a>(config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
+    let set_root = |path: &str| {
+        let path = std::path::Path::new(path);
+
+        if path.is_relative() {
+            Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
+        } else {
+            None
+        }
+    };
+
+    let mut url = match url::Url::parse(url) {
+        Ok(url) => url,
+        Err(_) => return Cow::from(url), // bail
+    };
+
+    let mut params: BTreeMap<String, String> = url.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+
+    url.query_pairs_mut().clear();
+
+    // Only for PostgreSQL + MySQL
+    if let Some(path) = params.get("sslcert").map(|s| s.as_str()).and_then(set_root) {
+        params.insert("sslcert".into(), path);
+    }
+
+    // Only for PostgreSQL + MySQL
+    if let Some(path) = params.get("sslidentity").map(|s| s.as_str()).and_then(set_root) {
+        params.insert("sslidentity".into(), path);
+    }
+
+    // Only for MongoDB
+    if let Some(path) = params.get("tlsCAFile").map(|s| s.as_str()).and_then(set_root) {
+        params.insert("tlsCAFile".into(), path);
+    }
+
+    for (k, v) in params.into_iter() {
+        url.query_pairs_mut().append_pair(&k, &v);
+    }
+
+    url.to_string().into()
+}
+
+pub fn set_config_dir_mssql<'a>(config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
+    let mut jdbc: JdbcString = match format!("jdbc:{url}").parse() {
+        Ok(jdbc) => jdbc,
+        _ => return Cow::from(url),
+    };
+
+    let set_root = |path: String| {
+        let path = std::path::Path::new(&path);
+
+        if path.is_relative() {
+            Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
+        } else {
+            Some(path.to_str().unwrap().to_string())
+        }
+    };
+
+    let props = jdbc.properties_mut();
+
+    let cert_path = props.remove("trustservercertificateca").and_then(set_root);
+
+    if let Some(path) = cert_path {
+        props.insert("trustServerCertificateCA".to_owned(), path);
+    }
+
+    let final_connection_string = format!("{jdbc}").replace("jdbc:sqlserver://", "sqlserver://");
+
+    Cow::Owned(final_connection_string)
+}
+
+pub fn set_config_dir_sqlite<'a>(config_dir: &std::path::Path, url: &'a str) -> Cow<'a, str> {
+    let set_root = |path: &str| {
+        let path = std::path::Path::new(path);
+
+        if path.is_relative() {
+            Some(config_dir.join(path).to_str().map(ToString::to_string).unwrap())
+        } else {
+            None
+        }
+    };
+
+    if let Some(path) = set_root(url.trim_start_matches("file:")) {
+        return Cow::Owned(format!("file:{path}"));
+    };
+
+    Cow::Borrowed(url)
+}

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -11,6 +11,7 @@ pub use psl_core::{
     parser_database::{self, SourceFile},
     reformat,
     schema_ast,
+    set_config_dir,
     Configuration,
     ConnectorRegistry,
     Datasource,

--- a/schema-engine/core/src/lib.rs
+++ b/schema-engine/core/src/lib.rs
@@ -129,7 +129,7 @@ fn schema_to_connector(
     let (source, url, preview_features, shadow_database_url) = parse_configuration(schema)?;
 
     let url = config_dir
-        .map(|config_dir| source.active_connector.set_config_dir(config_dir, &url).into_owned())
+        .map(|config_dir| psl::set_config_dir(source.active_connector.flavour(), config_dir, &url).into_owned())
         .unwrap_or(url);
 
     let params = ConnectorParams {

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -245,10 +245,7 @@ impl GenericApi for EngineState {
                 std::path::Path::new(file_path)
                     .parent()
                     .map(|config_dir| {
-                        datasource
-                            .active_connector
-                            .set_config_dir(config_dir, &url)
-                            .into_owned()
+                        psl::set_config_dir(datasource.active_connector.flavour(), config_dir, &url).into_owned()
                     })
                     .unwrap_or(url)
             }


### PR DESCRIPTION
Due to dynamic dispatch, optimizer does not remove it from WASM bundle,
even though it is not used. It brings in heavy URL parser that adds
around 270K uncompressed/130K gzip. This PR rewrites it to be a free
function outside of `Connector` trait that does not have this problem.

Fix prisma/team-orm#772
