### PR TITLE
nix: add `prisma-schema-wasm.dev` derivation

### DIFF
--- a/prisma-schema-wasm/scripts/install.sh
+++ b/prisma-schema-wasm/scripts/install.sh
@@ -2,6 +2,16 @@
 
 set -euo pipefail
 
+if [[ -z "${WASM_BUILD_PROFILE:-}" ]]; then
+    WASM_BUILD_PROFILE="release"
+fi
+
+if [[ $WASM_BUILD_PROFILE == "dev" ]]; then
+    TARGET_DIR="debug"
+else
+    TARGET_DIR=$WASM_BUILD_PROFILE
+fi
+
 printf '%s\n' "entering install.sh"
 
 printf '%s\n' " -> Creating out dir..."
@@ -18,4 +28,4 @@ printf '%s\n' " -> Generating node package"
 wasm-bindgen \
   --target nodejs \
   --out-dir "$out"/src \
-  target/wasm32-unknown-unknown/release/prisma_schema_build.wasm
+  target/wasm32-unknown-unknown/$TARGET_DIR/prisma_schema_build.wasm

--- a/prisma-schema-wasm/scripts/install.sh
+++ b/prisma-schema-wasm/scripts/install.sh
@@ -28,4 +28,4 @@ printf '%s\n' " -> Generating node package"
 wasm-bindgen \
   --target nodejs \
   --out-dir "$out"/src \
-  target/wasm32-unknown-unknown/$TARGET_DIR/prisma_schema_build.wasm
+  "target/wasm32-unknown-unknown/$TARGET_DIR/prisma_schema_build.wasm"


### PR DESCRIPTION
Make it possible to conjure a local debug build of
`@prisma/prisma-schema-wasm` npm package with `nix build
.#prisma-schema-wasm.dev` command.

Normal `nix build .#prisma-schema-wasm` still builds in release profile
by default.

This makes it easier to test local changes to DMMF end-to-end with
TypeScript client generator.
