### PR TITLE
qe: Remove global JS adapter variable

### DIFF
--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -119,15 +119,17 @@ impl Runner {
 
         let protocol = EngineProtocol::from(&ENGINE_PROTOCOL.to_string());
         let schema = psl::parse_schema(&datamodel).unwrap();
-        let data_source = schema.configuration.datasources.first().unwrap();
-        let url = data_source.load_url(|key| env::var(key).ok()).unwrap();
+        let datasource = schema.configuration.datasources.first().unwrap();
+        let url = datasource.load_url(|key| env::var(key).ok()).unwrap();
 
         let executor = match crate::CONFIG.external_test_executor() {
             Some(_) => RunnerExecutor::new_external(&url, &datamodel).await?,
             None => RunnerExecutor::Builtin(
                 request_handlers::load_executor(
-                    ConnectorKind::Rust { url: url.to_owned() },
-                    data_source,
+                    ConnectorKind::Rust {
+                        url: url.to_owned(),
+                        datasource,
+                    },
                     schema.configuration.preview_features(),
                 )
                 .await?,

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -24,7 +24,7 @@ use quaint::prelude::Queryable;
 
 pub use database::FromSource;
 #[cfg(feature = "driver-adapters")]
-pub use database::{activate_driver_adapter, Js};
+pub use database::Js;
 pub use error::SqlError;
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -9,6 +9,7 @@ use driver_adapters::JsObject;
 use js_sys::Function as JsFunction;
 use psl::builtin_connectors::{MYSQL, POSTGRES, SQLITE};
 use psl::ConnectorRegistry;
+use quaint::connector::ExternalConnector;
 use query_core::{
     protocol::EngineProtocol,
     schema::{self},
@@ -18,7 +19,7 @@ use query_engine_common::engine::{map_known_error, ConnectedEngine, ConstructorO
 use request_handlers::ConnectorKind;
 use request_handlers::{load_executor, RequestBody, RequestHandler};
 use serde_json::json;
-use std::sync::Arc;
+use std::{marker::PhantomData, sync::Arc};
 use tokio::sync::RwLock;
 use tracing::{field, instrument::WithSubscriber, Instrument, Span};
 use tracing_subscriber::filter::LevelFilter;
@@ -28,6 +29,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[wasm_bindgen]
 pub struct QueryEngine {
     inner: RwLock<Inner>,
+    adapter: Arc<dyn ExternalConnector>,
     logger: Logger,
 }
 
@@ -55,9 +57,7 @@ impl QueryEngine {
         let config = &mut schema.configuration;
         let preview_features = config.preview_features();
 
-        let js_queryable = driver_adapters::from_js(adapter);
-
-        sql_connector::activate_driver_adapter(Arc::new(js_queryable));
+        let js_queryable = Arc::new(driver_adapters::from_js(adapter));
 
         let provider_name = schema.connector.provider_name();
         tracing::info!("Registered driver adapter for {provider_name}.");
@@ -85,6 +85,7 @@ impl QueryEngine {
 
         Ok(Self {
             inner: RwLock::new(Inner::Builder(builder)),
+            adapter: js_queryable,
             logger,
         })
     }
@@ -104,16 +105,16 @@ impl QueryEngine {
             let arced_schema_2 = Arc::clone(&builder.schema);
 
             let engine = async move {
-                // We only support one data source & generator at the moment, so take the first one (default not exposed yet).
-                let data_source = arced_schema
-                    .configuration
-                    .datasources
-                    .first()
-                    .ok_or_else(|| ApiError::configuration("No valid data source found"))?;
-
                 let preview_features = arced_schema.configuration.preview_features();
 
-                let executor = load_executor(ConnectorKind::Js {}, data_source, preview_features).await?;
+                let executor = load_executor(
+                    ConnectorKind::Js {
+                        adapter: Arc::clone(&self.adapter),
+                        _phantom: PhantomData,
+                    },
+                    preview_features,
+                )
+                .await?;
                 let connector = executor.primary_connector();
 
                 let conn_span = tracing::info_span!(

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -56,14 +56,14 @@ impl PrismaContext {
             let preview_features = config.preview_features();
 
             // We only support one data source at the moment, so take the first one (default not exposed yet).
-            let data_source = config
+            let datasource = config
                 .datasources
                 .first()
                 .ok_or_else(|| PrismaError::ConfigurationError("No valid data source found".into()))?;
 
-            let url = data_source.load_url(|key| env::var(key).ok())?;
+            let url = datasource.load_url(|key| env::var(key).ok())?;
             // Load executor
-            let executor = load_executor(ConnectorKind::Rust { url }, data_source, preview_features).await?;
+            let executor = load_executor(ConnectorKind::Rust { url, datasource }, preview_features).await?;
             executor.primary_connector().get_connection().await?;
             PrismaResult::<_>::Ok(executor)
         });

--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -1,37 +1,40 @@
 #![allow(unused_imports)]
 
 use psl::{builtin_connectors::*, Datasource, PreviewFeatures};
+use quaint::connector::ExternalConnector;
 use query_core::{executor::InterpretingExecutor, Connector, QueryExecutor};
 use sql_query_connector::*;
 use std::collections::HashMap;
 use std::env;
+use std::marker::PhantomData;
+use std::sync::Arc;
 use url::Url;
 
-pub enum ConnectorKind {
+pub enum ConnectorKind<'a> {
     #[cfg(feature = "native")]
-    Rust {
-        url: String,
+    Rust { url: String, datasource: &'a Datasource },
+    Js {
+        adapter: Arc<dyn ExternalConnector>,
+        _phantom: PhantomData<&'a ()>, // required for WASM target, where JS is the only variant and lifetime gets unused
     },
-    Js,
 }
 
 /// Loads a query executor based on the parsed Prisma schema (datasource).
 pub async fn load(
-    connector_kind: ConnectorKind,
-    source: &Datasource,
+    connector_kind: ConnectorKind<'_>,
     features: PreviewFeatures,
 ) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync + 'static>> {
     match connector_kind {
-        ConnectorKind::Js { .. } => {
+        ConnectorKind::Js { adapter, _phantom } => {
             #[cfg(not(feature = "driver-adapters"))]
             panic!("Driver adapters are not enabled, but connector mode is set to JS");
 
             #[cfg(feature = "driver-adapters")]
-            driver_adapter(source, features).await
+            driver_adapter(adapter, features).await
         }
 
         #[cfg(feature = "native")]
-        ConnectorKind::Rust { url } => {
+        ConnectorKind::Rust { url, datasource } => {
             if let Ok(value) = env::var("PRISMA_DISABLE_QUAINT_EXECUTORS") {
                 let disable = value.to_uppercase();
                 if disable == "TRUE" || disable == "1" {
@@ -39,15 +42,15 @@ pub async fn load(
                 }
             }
 
-            match source.active_provider {
-                p if SQLITE.is_provider(p) => native::sqlite(source, &url, features).await,
-                p if MYSQL.is_provider(p) => native::mysql(source, &url, features).await,
-                p if POSTGRES.is_provider(p) => native::postgres(source, &url, features).await,
-                p if MSSQL.is_provider(p) => native::mssql(source, &url, features).await,
-                p if COCKROACH.is_provider(p) => native::postgres(source, &url, features).await,
+            match datasource.active_provider {
+                p if SQLITE.is_provider(p) => native::sqlite(datasource, &url, features).await,
+                p if MYSQL.is_provider(p) => native::mysql(datasource, &url, features).await,
+                p if POSTGRES.is_provider(p) => native::postgres(datasource, &url, features).await,
+                p if MSSQL.is_provider(p) => native::mssql(datasource, &url, features).await,
+                p if COCKROACH.is_provider(p) => native::postgres(datasource, &url, features).await,
 
                 #[cfg(feature = "mongodb")]
-                p if MONGODB.is_provider(p) => native::mongodb(source, &url, features).await,
+                p if MONGODB.is_provider(p) => native::mongodb(datasource, &url, features).await,
 
                 x => Err(query_core::CoreError::ConfigurationError(format!(
                     "Unsupported connector type: {x}"
@@ -59,10 +62,12 @@ pub async fn load(
 
 #[cfg(feature = "driver-adapters")]
 async fn driver_adapter(
-    source: &Datasource,
+    driver_adapter: Arc<dyn ExternalConnector>,
     features: PreviewFeatures,
 ) -> Result<Box<dyn QueryExecutor + Send + Sync>, query_core::CoreError> {
-    let js = Js::new(source, features).await?;
+    use quaint::connector::ExternalConnector;
+
+    let js = Js::new(driver_adapter, features).await?;
     Ok(executor_for(js, false))
 }
 


### PR DESCRIPTION
It is now passed as parameter for `ConnectorKind::Js`.
Was initial done as size exploration work that have not quite worked
out. I still find the refactor on itself valuable though.
