### PR TITLE
wasm: Cleanup unused attributes from driver-adapters crate

### DIFF
--- a/query-engine/driver-adapters/src/proxy.rs
+++ b/query-engine/driver-adapters/src/proxy.rs
@@ -10,13 +10,9 @@ use futures::Future;
 use metrics::increment_gauge;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::wasm_bindgen;
-
 /// Proxy is a struct wrapping a javascript object that exhibits basic primitives for
 /// querying and executing SQL (i.e. a client connector). The Proxy uses Napi/Wasm's JsFunction
 /// to invoke the code within the node runtime that implements the client connector.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
 pub(crate) struct CommonProxy {
     /// Execute a query given as SQL, interpolating the given parameters.
     query_raw: AdapterMethod<Query, JSResultSet>,
@@ -31,7 +27,6 @@ pub(crate) struct CommonProxy {
 
 /// This is a JS proxy for accessing the methods specific to top level
 /// JS driver objects
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
 pub(crate) struct DriverProxy {
     start_transaction: AdapterMethod<(), JsTransaction>,
     get_connection_info: Option<AdapterMethod<(), JsConnectionInfo>>,
@@ -39,7 +34,6 @@ pub(crate) struct DriverProxy {
 
 /// This a JS proxy for accessing the methods, specific
 /// to JS transaction objects
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
 pub(crate) struct TransactionProxy {
     /// transaction options
     options: TransactionOptions,

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -15,9 +15,6 @@ use quaint::{
 };
 use tracing::{info_span, Instrument};
 
-#[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::wasm_bindgen;
-
 /// A JsQueryable adapts a Proxy to implement quaint's Queryable interface. It has the
 /// responsibility of transforming inputs and outputs of `query` and `execute` methods from quaint
 /// types to types that can be translated into javascript and viceversa. This is to let the rest of
@@ -30,7 +27,6 @@ use wasm_bindgen::prelude::wasm_bindgen;
 /// Transforming a `JSResultSet` (what client connectors implemented in javascript provide)
 /// into a `quaint::connector::result_set::ResultSet`. A quaint `ResultSet` is basically a vector
 /// of `quaint::Value` but said type is a tagged enum, with non-unit variants that cannot be converted to javascript as is.
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen(getter_with_clone))]
 pub(crate) struct JsBaseQueryable {
     pub(crate) proxy: CommonProxy,
     pub provider: AdapterFlavour,

--- a/query-engine/driver-adapters/src/types.rs
+++ b/query-engine/driver-adapters/src/types.rs
@@ -13,8 +13,7 @@ use crate::conversion::JSArg;
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 
-#[cfg_attr(target_arch = "wasm32", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", derive(Deserialize))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum AdapterFlavour {
     Mysql,
@@ -46,8 +45,7 @@ impl From<AdapterFlavour> for SqlFamily {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), napi_derive::napi(object))]
-#[cfg_attr(target_arch = "wasm32", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", derive(Deserialize))]
 #[cfg_attr(target_arch = "wasm32", serde(rename_all = "camelCase"))]
 #[derive(Default)]
 pub(crate) struct JsConnectionInfo {
@@ -91,8 +89,7 @@ impl JsConnectionInfo {
 /// representing the Value in javascript.
 ///
 #[cfg_attr(not(target_arch = "wasm32"), napi_derive::napi(object))]
-#[cfg_attr(target_arch = "wasm32", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", derive(Deserialize))]
 #[cfg_attr(target_arch = "wasm32", serde(rename_all = "camelCase"))]
 #[derive(Debug)]
 pub struct JSResultSet {
@@ -110,8 +107,7 @@ impl JSResultSet {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), napi_derive::napi(object))]
-#[cfg_attr(target_arch = "wasm32", derive(Clone, Copy, Serialize_repr, Deserialize_repr, Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", derive(Clone, Copy, Deserialize_repr))]
 #[repr(u8)]
 #[derive(Debug)]
 pub enum ColumnType {
@@ -247,8 +243,7 @@ pub enum ColumnType {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), napi_derive::napi(object))]
-#[cfg_attr(target_arch = "wasm32", derive(Serialize, Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", derive(Serialize))]
 #[derive(Debug, Default)]
 pub struct Query {
     pub sql: String,
@@ -256,8 +251,7 @@ pub struct Query {
 }
 
 #[cfg_attr(not(target_arch = "wasm32"), napi_derive::napi(object))]
-#[cfg_attr(target_arch = "wasm32", derive(Serialize, Deserialize, Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi, from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", derive(Deserialize, Tsify))]
 #[cfg_attr(target_arch = "wasm32", serde(rename_all = "camelCase"))]
 #[derive(Debug, Default)]
 pub struct TransactionOptions {


### PR DESCRIPTION
Not so much savings in terms of raw size, mostly just cleaning up visual
noise.
