### PR TITLE
tech(engines): Add rust-toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "stable"
+components = []
+targets = []
+profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,3 @@
 [toolchain]
-channel = "stable"
-components = []
-targets = []
-profile = "minimal"
+channel = "1.75.0"
+targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "stable"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
We could also specify it as the following if we want to pin a specific version like we do in nix.
```toml
channel = "1.75.0"
```

But we currently also use `channel = "stable"` for the toolchain in `prisma-schema-wasm`

[Rustup Book Info](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file)