### PR TITLE
feat(query-engine-wasm): quick and dirty exclude native-drivers only errors from `wasm32` target

### DIFF
--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -162,11 +162,11 @@ pub struct DatabaseAccessDenied {
     pub database_name: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P1011", message = "Error opening a TLS connection: {message}")]
-pub struct TlsConnectionError {
-    pub message: String,
-}
+// #[derive(Debug, UserFacingError, Serialize)]
+// #[user_facing(code = "P1011", message = "Error opening a TLS connection: {message}")]
+// pub struct TlsConnectionError {
+//     pub message: String,
+// }
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(code = "P1012", message = "{full_error}")]

--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -1,5 +1,5 @@
 use crate::{common, query_engine, KnownError};
-use common::ModelKind;
+// use common::ModelKind;
 use indoc::formatdoc;
 use quaint::{error::ErrorKind, prelude::ConnectionInfo};
 
@@ -38,166 +38,164 @@ pub fn invalid_connection_string_description(error_details: &str) -> String {
 
 pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -> Option<KnownError> {
     match (kind, connection_info) {
-        (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Sqlite { .. }) => {
-            unreachable!(); // quaint implicitly creates sqlite databases
-        }
+        // (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Sqlite { .. }) => {
+        //     unreachable!(); // quaint implicitly creates sqlite databases
+        // }
 
-        (ErrorKind::DatabaseDoesNotExist { db_name }, ConnectionInfo::Postgres(url)) => {
-            Some(KnownError::new(common::DatabaseDoesNotExist::Postgres {
-                database_name: db_name.to_string(),
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::DatabaseDoesNotExist { db_name }, ConnectionInfo::Postgres(url)) => {
+        //     Some(KnownError::new(common::DatabaseDoesNotExist::Postgres {
+        //         database_name: db_name.to_string(),
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Mysql(url)) => {
-            Some(KnownError::new(common::DatabaseDoesNotExist::Mysql {
-                database_name: url.dbname().to_owned(),
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
-        (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Mssql(url)) => {
-            Some(KnownError::new(common::DatabaseDoesNotExist::Mssql {
-                database_name: url.dbname().to_owned(),
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Mysql(url)) => {
+        //     Some(KnownError::new(common::DatabaseDoesNotExist::Mysql {
+        //         database_name: url.dbname().to_owned(),
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::DatabaseAccessDenied { .. }, ConnectionInfo::Postgres(url)) => {
-            Some(KnownError::new(common::DatabaseAccessDenied {
-                database_user: url.username().into_owned(),
-                database_name: format!("{}.{}", url.dbname(), url.schema()),
-            }))
-        }
+        // (ErrorKind::DatabaseDoesNotExist { .. }, ConnectionInfo::Mssql(url)) => {
+        //     Some(KnownError::new(common::DatabaseDoesNotExist::Mssql {
+        //         database_name: url.dbname().to_owned(),
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::DatabaseAccessDenied { .. }, ConnectionInfo::Mysql(url)) => {
-            Some(KnownError::new(common::DatabaseAccessDenied {
-                database_user: url.username().into_owned(),
-                database_name: url.dbname().to_owned(),
-            }))
-        }
+        // (ErrorKind::DatabaseAccessDenied { .. }, ConnectionInfo::Postgres(url)) => {
+        //     Some(KnownError::new(common::DatabaseAccessDenied {
+        //         database_user: url.username().into_owned(),
+        //         database_name: format!("{}.{}", url.dbname(), url.schema()),
+        //     }))
+        // }
 
-        (ErrorKind::DatabaseAlreadyExists { db_name }, ConnectionInfo::Postgres(url)) => {
-            Some(KnownError::new(common::DatabaseAlreadyExists {
-                database_name: format!("{db_name}"),
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::DatabaseAccessDenied { .. }, ConnectionInfo::Mysql(url)) => {
+        //     Some(KnownError::new(common::DatabaseAccessDenied {
+        //         database_user: url.username().into_owned(),
+        //         database_name: url.dbname().to_owned(),
+        //     }))
+        // }
 
-        (ErrorKind::DatabaseAlreadyExists { db_name }, ConnectionInfo::Mysql(url)) => {
-            Some(KnownError::new(common::DatabaseAlreadyExists {
-                database_name: format!("{db_name}"),
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::DatabaseAlreadyExists { db_name }, ConnectionInfo::Postgres(url)) => {
+        //     Some(KnownError::new(common::DatabaseAlreadyExists {
+        //         database_name: format!("{db_name}"),
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::AuthenticationFailed { user }, ConnectionInfo::Postgres(url)) => {
-            Some(KnownError::new(common::IncorrectDatabaseCredentials {
-                database_user: format!("{user}"),
-                database_host: url.host().to_owned(),
-            }))
-        }
+        // (ErrorKind::DatabaseAlreadyExists { db_name }, ConnectionInfo::Mysql(url)) => {
+        //     Some(KnownError::new(common::DatabaseAlreadyExists {
+        //         database_name: format!("{db_name}"),
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::AuthenticationFailed { user }, ConnectionInfo::Mysql(url)) => {
-            Some(KnownError::new(common::IncorrectDatabaseCredentials {
-                database_user: format!("{user}"),
-                database_host: url.host().to_owned(),
-            }))
-        }
+        // (ErrorKind::AuthenticationFailed { user }, ConnectionInfo::Postgres(url)) => {
+        //     Some(KnownError::new(common::IncorrectDatabaseCredentials {
+        //         database_user: format!("{user}"),
+        //         database_host: url.host().to_owned(),
+        //     }))
+        // }
 
-        (ErrorKind::ConnectionError(_), ConnectionInfo::Postgres(url)) => {
-            Some(KnownError::new(common::DatabaseNotReachable {
-                database_port: url.port(),
-                database_host: url.host().to_owned(),
-            }))
-        }
+        // (ErrorKind::AuthenticationFailed { user }, ConnectionInfo::Mysql(url)) => {
+        //     Some(KnownError::new(common::IncorrectDatabaseCredentials {
+        //         database_user: format!("{user}"),
+        //         database_host: url.host().to_owned(),
+        //     }))
+        // }
 
-        (ErrorKind::ConnectionError(_), ConnectionInfo::Mysql(url)) => {
-            Some(KnownError::new(common::DatabaseNotReachable {
-                database_port: url.port(),
-                database_host: url.host().to_owned(),
-            }))
-        }
+        // (ErrorKind::ConnectionError(_), ConnectionInfo::Postgres(url)) => {
+        //     Some(KnownError::new(common::DatabaseNotReachable {
+        //         database_port: url.port(),
+        //         database_host: url.host().to_owned(),
+        //     }))
+        // }
 
+        // (ErrorKind::ConnectionError(_), ConnectionInfo::Mysql(url)) => {
+        //     Some(KnownError::new(common::DatabaseNotReachable {
+        //         database_port: url.port(),
+        //         database_host: url.host().to_owned(),
+        //     }))
+        // }
         (ErrorKind::UniqueConstraintViolation { constraint }, _) => {
             Some(KnownError::new(query_engine::UniqueKeyViolation {
                 constraint: constraint.into(),
             }))
         }
 
-        (ErrorKind::TlsError { message }, _) => Some(KnownError::new(common::TlsConnectionError {
-            message: message.into(),
-        })),
+        // (ErrorKind::TlsError { message }, _) => Some(KnownError::new(common::TlsConnectionError {
+        //     message: message.into(),
+        // })),
 
-        (ErrorKind::ConnectTimeout, ConnectionInfo::Mysql(url)) => {
-            Some(KnownError::new(common::DatabaseNotReachable {
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::ConnectTimeout, ConnectionInfo::Mysql(url)) => {
+        //     Some(KnownError::new(common::DatabaseNotReachable {
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::ConnectTimeout, ConnectionInfo::Postgres(url)) => {
-            Some(KnownError::new(common::DatabaseNotReachable {
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::ConnectTimeout, ConnectionInfo::Postgres(url)) => {
+        //     Some(KnownError::new(common::DatabaseNotReachable {
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::ConnectTimeout, ConnectionInfo::Mssql(url)) => {
-            Some(KnownError::new(common::DatabaseNotReachable {
-                database_host: url.host().to_owned(),
-                database_port: url.port(),
-            }))
-        }
+        // (ErrorKind::ConnectTimeout, ConnectionInfo::Mssql(url)) => {
+        //     Some(KnownError::new(common::DatabaseNotReachable {
+        //         database_host: url.host().to_owned(),
+        //         database_port: url.port(),
+        //     }))
+        // }
 
-        (ErrorKind::SocketTimeout, ConnectionInfo::Mysql(url)) => {
-            let time = match url.socket_timeout() {
-                Some(dur) => format!("{}s", dur.as_secs()),
-                None => String::from("N/A"),
-            };
+        // (ErrorKind::SocketTimeout, ConnectionInfo::Mysql(url)) => {
+        //     let time = match url.socket_timeout() {
+        //         Some(dur) => format!("{}s", dur.as_secs()),
+        //         None => String::from("N/A"),
+        //     };
 
-            Some(KnownError::new(common::DatabaseOperationTimeout {
-                time,
-                context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/mysql-connector for more details.)."
-                    .into(),
-            }))
-        }
+        //     Some(KnownError::new(common::DatabaseOperationTimeout {
+        //         time,
+        //         context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/mysql-connector for more details.)."
+        //             .into(),
+        //     }))
+        // }
 
-        (ErrorKind::SocketTimeout, ConnectionInfo::Postgres(url)) => {
-            let time = match url.socket_timeout() {
-                Some(dur) => format!("{}s", dur.as_secs()),
-                None => String::from("N/A"),
-            };
+        // (ErrorKind::SocketTimeout, ConnectionInfo::Postgres(url)) => {
+        //     let time = match url.socket_timeout() {
+        //         Some(dur) => format!("{}s", dur.as_secs()),
+        //         None => String::from("N/A"),
+        //     };
 
-            Some(KnownError::new(common::DatabaseOperationTimeout {
-                time,
-                context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/mssql-connector for more details.)."
-                    .into(),
-            }))
-        }
+        //     Some(KnownError::new(common::DatabaseOperationTimeout {
+        //         time,
+        //         context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/mssql-connector for more details.)."
+        //             .into(),
+        //     }))
+        // }
 
-        (ErrorKind::SocketTimeout, ConnectionInfo::Mssql(url)) => {
-            let time = match url.socket_timeout() {
-                Some(dur) => format!("{}s", dur.as_secs()),
-                None => String::from("N/A"),
-            };
+        // (ErrorKind::SocketTimeout, ConnectionInfo::Mssql(url)) => {
+        //     let time = match url.socket_timeout() {
+        //         Some(dur) => format!("{}s", dur.as_secs()),
+        //         None => String::from("N/A"),
+        //     };
 
-            Some(KnownError::new(common::DatabaseOperationTimeout {
-                time,
-                context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/postgres-connector for more details.)."
-                    .into(),
-            }))
-        }
-
-        (ErrorKind::PoolTimeout { max_open, timeout, .. }, _) => Some(KnownError::new(query_engine::PoolTimeout {
-            connection_limit: *max_open,
-            timeout: *timeout,
-        })),
-
+        //     Some(KnownError::new(common::DatabaseOperationTimeout {
+        //         time,
+        //         context: "Socket timeout (the database failed to respond to a query within the configured timeout — see https://pris.ly/d/postgres-connector for more details.)."
+        //             .into(),
+        //     }))
+        // }
+        // (ErrorKind::PoolTimeout { max_open, timeout, .. }, _) => Some(KnownError::new(query_engine::PoolTimeout {
+        //     connection_limit: *max_open,
+        //     timeout: *timeout,
+        // })),
         (ErrorKind::DatabaseUrlIsInvalid(details), _connection_info) => {
             Some(KnownError::new(common::InvalidConnectionString {
                 details: details.to_owned(),
@@ -216,41 +214,40 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
             }))
         }
 
-        (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Mysql(_)) => {
-            Some(KnownError::new(common::InvalidModel {
-                model: format!("{model}"),
-                kind: ModelKind::Table,
-            }))
-        }
+        // (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Mysql(_)) => {
+        //     Some(KnownError::new(common::InvalidModel {
+        //         model: format!("{model}"),
+        //         kind: ModelKind::Table,
+        //     }))
+        // }
 
-        (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Postgres(_)) => {
-            Some(KnownError::new(common::InvalidModel {
-                model: format!("{model}"),
-                kind: ModelKind::Table,
-            }))
-        }
+        // (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Postgres(_)) => {
+        //     Some(KnownError::new(common::InvalidModel {
+        //         model: format!("{model}"),
+        //         kind: ModelKind::Table,
+        //     }))
+        // }
 
-        (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Sqlite { .. }) => {
-            Some(KnownError::new(common::InvalidModel {
-                model: format!("{model}"),
-                kind: ModelKind::Table,
-            }))
-        }
+        // (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Sqlite { .. }) => {
+        //     Some(KnownError::new(common::InvalidModel {
+        //         model: format!("{model}"),
+        //         kind: ModelKind::Table,
+        //     }))
+        // }
 
-        (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Mssql(_)) => {
-            Some(KnownError::new(common::InvalidModel {
-                model: format!("{model}"),
-                kind: ModelKind::Table,
-            }))
-        }
+        // (ErrorKind::TableDoesNotExist { table: model }, ConnectionInfo::Mssql(_)) => {
+        //     Some(KnownError::new(common::InvalidModel {
+        //         model: format!("{model}"),
+        //         kind: ModelKind::Table,
+        //     }))
+        // }
 
-        (ErrorKind::IncorrectNumberOfParameters { expected, actual }, ConnectionInfo::Mssql(_)) => {
-            Some(KnownError::new(common::IncorrectNumberOfParameters {
-                expected: *expected,
-                actual: *actual,
-            }))
-        }
-
+        // (ErrorKind::IncorrectNumberOfParameters { expected, actual }, ConnectionInfo::Mssql(_)) => {
+        //     Some(KnownError::new(common::IncorrectNumberOfParameters {
+        //         expected: *expected,
+        //         actual: *actual,
+        //     }))
+        // }
         (ErrorKind::ConnectionClosed, _) => Some(KnownError::new(common::ConnectionClosed)),
 
         _ => None,

--- a/libs/user-facing-errors/src/query_engine/mod.rs
+++ b/libs/user-facing-errors/src/query_engine/mod.rs
@@ -113,12 +113,13 @@ pub struct TypeMismatch {
     pub field_name: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2007", message = "Data validation error `{database_error}`")]
-pub struct TypeMismatchInvalidCustomType {
-    /// Database error returned by the underlying data source
-    pub database_error: String,
-}
+// Note: this error isn't used anywhere in the codebase.
+// #[derive(Debug, UserFacingError, Serialize)]
+// #[user_facing(code = "P2007", message = "Data validation error `{database_error}`")]
+// pub struct TypeMismatchInvalidCustomType {
+//     /// Database error returned by the underlying data source
+//     pub database_error: String,
+// }
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
@@ -233,15 +234,15 @@ pub struct InconsistentColumnData {
     pub message: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(
-    code = "P2024",
-    message = "Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: {timeout}, connection limit: {connection_limit})"
-)]
-pub struct PoolTimeout {
-    pub connection_limit: u64,
-    pub timeout: u64,
-}
+// #[derive(Debug, UserFacingError, Serialize)]
+// #[user_facing(
+//     code = "P2024",
+//     message = "Timed out fetching a new connection from the connection pool. More info: http://pris.ly/d/connection-pool (Current connection pool timeout: {timeout}, connection limit: {connection_limit})"
+// )]
+// pub struct PoolTimeout {
+//     pub connection_limit: u64,
+//     pub timeout: u64,
+// }
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
@@ -289,12 +290,12 @@ pub struct QueryParameterLimitExceeded {
 )]
 pub struct MissingFullTextSearchIndex {}
 
-#[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(
-    code = "P2031",
-    message = "Prisma needs to perform transactions, which requires your MongoDB server to be run as a replica set. https://pris.ly/d/mongodb-replica-set"
-)]
-pub struct MongoReplicaSetRequired {}
+// #[derive(Debug, UserFacingError, Serialize)]
+// #[user_facing(
+//     code = "P2031",
+//     message = "Prisma needs to perform transactions, which requires your MongoDB server to be run as a replica set. https://pris.ly/d/mongodb-replica-set"
+// )]
+// pub struct MongoReplicaSetRequired {}
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
@@ -315,19 +316,19 @@ pub struct ValueFitError {
     pub details: String,
 }
 
-#[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(
-    code = "P2034",
-    message = "Transaction failed due to a write conflict or a deadlock. Please retry your transaction"
-)]
-pub struct TransactionWriteConflict {}
+// #[derive(Debug, UserFacingError, Serialize)]
+// #[user_facing(
+//     code = "P2034",
+//     message = "Transaction failed due to a write conflict or a deadlock. Please retry your transaction"
+// )]
+// pub struct TransactionWriteConflict {}
 
-#[derive(Debug, UserFacingError, Serialize)]
-#[user_facing(code = "P2035", message = "Assertion violation on the database: `{database_error}`")]
-pub struct DatabaseAssertionViolation {
-    /// Database error returned by the underlying connector driver.
-    pub database_error: String,
-}
+// #[derive(Debug, UserFacingError, Serialize)]
+// #[user_facing(code = "P2035", message = "Assertion violation on the database: `{database_error}`")]
+// pub struct DatabaseAssertionViolation {
+//     /// Database error returned by the underlying connector driver.
+//     pub database_error: String,
+// }
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(code = "P2036", message = "Error in external connector (id {id})")]

--- a/quaint/src/connector/connection_info.rs
+++ b/quaint/src/connector/connection_info.rs
@@ -19,26 +19,26 @@ use super::ExternalConnectionInfo;
 #[derive(Debug, Clone)]
 pub enum ConnectionInfo {
     /// A PostgreSQL connection URL.
-    #[cfg(feature = "postgresql")]
-    Postgres(PostgresUrl),
-    /// A MySQL connection URL.
-    #[cfg(feature = "mysql")]
-    Mysql(MysqlUrl),
-    /// A SQL Server connection URL.
-    #[cfg(feature = "mssql")]
-    Mssql(MssqlUrl),
-    /// A SQLite connection URL.
-    #[cfg(feature = "sqlite")]
-    Sqlite {
-        /// The filesystem path of the SQLite database.
-        file_path: String,
-        /// The name the database is bound to - Always "main"
-        db_name: String,
-    },
-    #[cfg(feature = "sqlite")]
-    InMemorySqlite {
-        db_name: String,
-    },
+    // #[cfg(feature = "postgresql")]
+    // Postgres(PostgresUrl),
+    // /// A MySQL connection URL.
+    // #[cfg(feature = "mysql")]
+    // Mysql(MysqlUrl),
+    // /// A SQL Server connection URL.
+    // #[cfg(feature = "mssql")]
+    // Mssql(MssqlUrl),
+    // /// A SQLite connection URL.
+    // #[cfg(feature = "sqlite")]
+    // Sqlite {
+    //     /// The filesystem path of the SQLite database.
+    //     file_path: String,
+    //     /// The name the database is bound to - Always "main"
+    //     db_name: String,
+    // },
+    // #[cfg(feature = "sqlite")]
+    // InMemorySqlite {
+    //     db_name: String,
+    // },
     External(ExternalConnectionInfo),
 }
 
@@ -47,68 +47,68 @@ impl ConnectionInfo {
     ///
     /// Will fail if URI is invalid or the scheme points to an unsupported
     /// database.
-    pub fn from_url(url_str: &str) -> crate::Result<Self> {
-        let url_result: Result<Url, _> = url_str.parse();
+    // pub fn from_url(url_str: &str) -> crate::Result<Self> {
+    //     let url_result: Result<Url, _> = url_str.parse();
 
-        // Non-URL database strings are interpreted as SQLite file paths.
-        match url_str {
-            #[cfg(feature = "sqlite")]
-            s if s.starts_with("file") => {
-                if url_result.is_err() {
-                    let params = SqliteParams::try_from(s)?;
+    //     // Non-URL database strings are interpreted as SQLite file paths.
+    //     match url_str {
+    //         #[cfg(feature = "sqlite")]
+    //         s if s.starts_with("file") => {
+    //             if url_result.is_err() {
+    //                 let params = SqliteParams::try_from(s)?;
 
-                    return Ok(ConnectionInfo::Sqlite {
-                        file_path: params.file_path,
-                        db_name: params.db_name,
-                    });
-                }
-            }
-            #[cfg(feature = "mssql")]
-            s if s.starts_with("jdbc:sqlserver") || s.starts_with("sqlserver") => {
-                return Ok(ConnectionInfo::Mssql(MssqlUrl::new(url_str)?));
-            }
-            _ => (),
-        }
+    //                 return Ok(ConnectionInfo::Sqlite {
+    //                     file_path: params.file_path,
+    //                     db_name: params.db_name,
+    //                 });
+    //             }
+    //         }
+    //         #[cfg(feature = "mssql")]
+    //         s if s.starts_with("jdbc:sqlserver") || s.starts_with("sqlserver") => {
+    //             return Ok(ConnectionInfo::Mssql(MssqlUrl::new(url_str)?));
+    //         }
+    //         _ => (),
+    //     }
 
-        let url = url_result?;
+    //     let url = url_result?;
 
-        let sql_family = SqlFamily::from_scheme(url.scheme()).ok_or_else(|| {
-            let kind =
-                ErrorKind::DatabaseUrlIsInvalid(format!("{} is not a supported database URL scheme.", url.scheme()));
+    //     let sql_family = SqlFamily::from_scheme(url.scheme()).ok_or_else(|| {
+    //         let kind =
+    //             ErrorKind::DatabaseUrlIsInvalid(format!("{} is not a supported database URL scheme.", url.scheme()));
 
-            Error::builder(kind).build()
-        })?;
+    //         Error::builder(kind).build()
+    //     })?;
 
-        match sql_family {
-            #[cfg(feature = "mysql")]
-            SqlFamily::Mysql => Ok(ConnectionInfo::Mysql(MysqlUrl::new(url)?)),
-            #[cfg(feature = "sqlite")]
-            SqlFamily::Sqlite => {
-                let params = SqliteParams::try_from(url_str)?;
+    //     match sql_family {
+    //         #[cfg(feature = "mysql")]
+    //         SqlFamily::Mysql => Ok(ConnectionInfo::Mysql(MysqlUrl::new(url)?)),
+    //         #[cfg(feature = "sqlite")]
+    //         SqlFamily::Sqlite => {
+    //             let params = SqliteParams::try_from(url_str)?;
 
-                Ok(ConnectionInfo::Sqlite {
-                    file_path: params.file_path,
-                    db_name: params.db_name,
-                })
-            }
-            #[cfg(feature = "postgresql")]
-            SqlFamily::Postgres => Ok(ConnectionInfo::Postgres(PostgresUrl::new(url)?)),
-            #[allow(unreachable_patterns)]
-            _ => unreachable!(),
-        }
-    }
+    //             Ok(ConnectionInfo::Sqlite {
+    //                 file_path: params.file_path,
+    //                 db_name: params.db_name,
+    //             })
+    //         }
+    //         #[cfg(feature = "postgresql")]
+    //         SqlFamily::Postgres => Ok(ConnectionInfo::Postgres(PostgresUrl::new(url)?)),
+    //         #[allow(unreachable_patterns)]
+    //         _ => unreachable!(),
+    //     }
+    // }
 
     /// The provided database name. This will be `None` on SQLite.
     pub fn dbname(&self) -> Option<&str> {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => Some(url.dbname()),
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(url) => Some(url.dbname()),
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(url) => Some(url.dbname()),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => Some(url.dbname()),
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(url) => Some(url.dbname()),
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(url) => Some(url.dbname()),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
             ConnectionInfo::External(_) => None,
         }
     }
@@ -120,16 +120,16 @@ impl ConnectionInfo {
     /// - In MySQL, it is the database name.
     pub fn schema_name(&self) -> &str {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => url.schema(),
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(url) => url.dbname(),
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(url) => url.schema(),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { db_name, .. } => db_name,
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::InMemorySqlite { db_name } => db_name,
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => url.schema(),
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(url) => url.dbname(),
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(url) => url.schema(),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { db_name, .. } => db_name,
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::InMemorySqlite { db_name } => db_name,
             ConnectionInfo::External(info) => &info.schema_name,
         }
     }
@@ -137,15 +137,14 @@ impl ConnectionInfo {
     /// The provided database host. This will be `"localhost"` on SQLite.
     pub fn host(&self) -> &str {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => url.host(),
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(url) => url.host(),
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(url) => url.host(),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => "localhost",
-
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => url.host(),
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(url) => url.host(),
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(url) => url.host(),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => "localhost",
             ConnectionInfo::External(_) => "external",
         }
     }
@@ -153,14 +152,14 @@ impl ConnectionInfo {
     /// The provided database user name. This will be `None` on SQLite.
     pub fn username(&self) -> Option<Cow<str>> {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => Some(url.username()),
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(url) => Some(url.username()),
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(url) => url.username().map(Cow::from),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => Some(url.username()),
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(url) => Some(url.username()),
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(url) => url.username().map(Cow::from),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
             ConnectionInfo::External(_) => None,
         }
     }
@@ -168,16 +167,16 @@ impl ConnectionInfo {
     /// The database file for SQLite, otherwise `None`.
     pub fn file_path(&self) -> Option<&str> {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(_) => None,
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(_) => None,
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(_) => None,
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { file_path, .. } => Some(file_path),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::InMemorySqlite { .. } => None,
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(_) => None,
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(_) => None,
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(_) => None,
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { file_path, .. } => Some(file_path),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::InMemorySqlite { .. } => None,
             ConnectionInfo::External(_) => None,
         }
     }
@@ -185,14 +184,14 @@ impl ConnectionInfo {
     /// The family of databases connected.
     pub fn sql_family(&self) -> SqlFamily {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(_) => SqlFamily::Postgres,
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(_) => SqlFamily::Mysql,
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(_) => SqlFamily::Mssql,
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => SqlFamily::Sqlite,
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(_) => SqlFamily::Postgres,
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(_) => SqlFamily::Mysql,
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(_) => SqlFamily::Mssql,
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => SqlFamily::Sqlite,
             ConnectionInfo::External(info) => info.sql_family.to_owned(),
         }
     }
@@ -200,14 +199,14 @@ impl ConnectionInfo {
     /// The provided database port, if applicable.
     pub fn port(&self) -> Option<u16> {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => Some(url.port()),
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(url) => Some(url.port()),
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(url) => Some(url.port()),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => Some(url.port()),
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(url) => Some(url.port()),
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(url) => Some(url.port()),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { .. } | ConnectionInfo::InMemorySqlite { .. } => None,
             ConnectionInfo::External(_) => None,
         }
     }
@@ -216,8 +215,8 @@ impl ConnectionInfo {
     pub fn pg_bouncer(&self) -> bool {
         #[allow(unreachable_patterns)]
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => url.pg_bouncer(),
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => url.pg_bouncer(),
             _ => false,
         }
     }
@@ -226,16 +225,16 @@ impl ConnectionInfo {
     /// and port on MySQL/Postgres, and the file path on SQLite.
     pub fn database_location(&self) -> String {
         match self {
-            #[cfg(feature = "postgresql")]
-            ConnectionInfo::Postgres(url) => format!("{}:{}", url.host(), url.port()),
-            #[cfg(feature = "mysql")]
-            ConnectionInfo::Mysql(url) => format!("{}:{}", url.host(), url.port()),
-            #[cfg(feature = "mssql")]
-            ConnectionInfo::Mssql(url) => format!("{}:{}", url.host(), url.port()),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::Sqlite { file_path, .. } => file_path.clone(),
-            #[cfg(feature = "sqlite")]
-            ConnectionInfo::InMemorySqlite { .. } => "in-memory".into(),
+            // #[cfg(feature = "postgresql")]
+            // ConnectionInfo::Postgres(url) => format!("{}:{}", url.host(), url.port()),
+            // #[cfg(feature = "mysql")]
+            // ConnectionInfo::Mysql(url) => format!("{}:{}", url.host(), url.port()),
+            // #[cfg(feature = "mssql")]
+            // ConnectionInfo::Mssql(url) => format!("{}:{}", url.host(), url.port()),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::Sqlite { file_path, .. } => file_path.clone(),
+            // #[cfg(feature = "sqlite")]
+            // ConnectionInfo::InMemorySqlite { .. } => "in-memory".into(),
             ConnectionInfo::External(_) => "external".into(),
         }
     }

--- a/quaint/src/connector/timeout.rs
+++ b/quaint/src/connector/timeout.rs
@@ -2,13 +2,13 @@ use crate::error::{Error, ErrorKind};
 use futures::Future;
 use std::time::Duration;
 
-pub async fn connect<T, F, E>(duration: Option<Duration>, f: F) -> crate::Result<T>
-where
-    F: Future<Output = std::result::Result<T, E>>,
-    E: Into<Error>,
-{
-    timeout(duration, f, || Error::builder(ErrorKind::ConnectTimeout).build()).await
-}
+// pub async fn connect<T, F, E>(duration: Option<Duration>, f: F) -> crate::Result<T>
+// where
+//     F: Future<Output = std::result::Result<T, E>>,
+//     E: Into<Error>,
+// {
+//     timeout(duration, f, || Error::builder(ErrorKind::ConnectTimeout).build()).await
+// }
 
 pub async fn socket<T, F, E>(duration: Option<Duration>, f: F) -> crate::Result<T>
 where

--- a/quaint/src/error.rs
+++ b/quaint/src/error.rs
@@ -163,9 +163,8 @@ pub enum ErrorKind {
     #[error("Error querying the database: {}", _0)]
     QueryError(Box<dyn std::error::Error + Send + Sync + 'static>),
 
-    #[error("Invalid input provided to query: {}", _0)]
-    QueryInvalidInput(String),
-
+    // #[error("Invalid input provided to query: {}", _0)]
+    // QueryInvalidInput(String),
     #[error("Database does not exist: {}", db_name)]
     DatabaseDoesNotExist { db_name: Name },
 
@@ -193,9 +192,8 @@ pub enum ErrorKind {
     #[error("Foreign key constraint failed: {}", constraint)]
     ForeignKeyConstraintViolation { constraint: DatabaseConstraint },
 
-    #[error("Error creating a database connection.")]
-    ConnectionError(Box<dyn std::error::Error + Send + Sync + 'static>),
-
+    // #[error("Error creating a database connection.")]
+    // ConnectionError(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Error reading the column value: {}", _0)]
     ColumnReadFailure(Box<dyn std::error::Error + Send + Sync + 'static>),
 
@@ -220,12 +218,11 @@ pub enum ErrorKind {
     #[error("The provided arguments are not supported")]
     InvalidConnectionArguments,
 
-    #[error("Error in an I/O operation: {0}")]
-    IoError(io::Error),
+    // #[error("Error in an I/O operation: {0}")]
+    // IoError(io::Error),
 
-    #[error("Timed out when connecting to the database.")]
-    ConnectTimeout,
-
+    // #[error("Timed out when connecting to the database.")]
+    // ConnectTimeout,
     #[error("The server terminated the connection.")]
     ConnectionClosed,
 
@@ -243,9 +240,8 @@ pub enum ErrorKind {
     #[error("Timed out during query execution.")]
     SocketTimeout,
 
-    #[error("Error opening a TLS connection. {}", message)]
-    TlsError { message: String },
-
+    // #[error("Error opening a TLS connection. {}", message)]
+    // TlsError { message: String },
     #[error("Value out of range error. {}", message)]
     ValueOutOfRange { message: String },
 
@@ -357,11 +353,11 @@ impl From<url::ParseError> for Error {
     }
 }
 
-impl From<io::Error> for Error {
-    fn from(e: io::Error) -> Error {
-        Error::builder(ErrorKind::IoError(e)).build()
-    }
-}
+// impl From<io::Error> for Error {
+//     fn from(e: io::Error) -> Error {
+//         Error::builder(ErrorKind::IoError(e)).build()
+//     }
+// }
 
 impl From<std::num::ParseIntError> for Error {
     fn from(_e: std::num::ParseIntError) -> Error {

--- a/quaint/src/single.rs
+++ b/quaint/src/single.rs
@@ -125,45 +125,45 @@ impl Quaint {
     /// - `isolationLevel` the transaction isolation level. Possible values:
     ///   `READ UNCOMMITTED`, `READ COMMITTED`, `REPEATABLE READ`, `SNAPSHOT`,
     ///   `SERIALIZABLE`.
-    #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
-    #[allow(unreachable_code)]
-    pub async fn new(url_str: &str) -> crate::Result<Self> {
-        let inner = match url_str {
-            #[cfg(feature = "sqlite-native")]
-            s if s.starts_with("file") => {
-                let params = connector::SqliteParams::try_from(s)?;
-                let sqlite = connector::Sqlite::new(&params.file_path)?;
+    // #[cfg_attr(target_arch = "wasm32", allow(unused_variables))]
+    // #[allow(unreachable_code)]
+    // pub async fn new(url_str: &str) -> crate::Result<Self> {
+    //     let inner = match url_str {
+    //         #[cfg(feature = "sqlite-native")]
+    //         s if s.starts_with("file") => {
+    //             let params = connector::SqliteParams::try_from(s)?;
+    //             let sqlite = connector::Sqlite::new(&params.file_path)?;
 
-                Arc::new(sqlite) as Arc<dyn Queryable>
-            }
-            #[cfg(feature = "mysql-native")]
-            s if s.starts_with("mysql") => {
-                let url = connector::MysqlUrl::new(url::Url::parse(s)?)?;
-                let mysql = connector::Mysql::new(url).await?;
+    //             Arc::new(sqlite) as Arc<dyn Queryable>
+    //         }
+    //         #[cfg(feature = "mysql-native")]
+    //         s if s.starts_with("mysql") => {
+    //             let url = connector::MysqlUrl::new(url::Url::parse(s)?)?;
+    //             let mysql = connector::Mysql::new(url).await?;
 
-                Arc::new(mysql) as Arc<dyn Queryable>
-            }
-            #[cfg(feature = "postgresql-native")]
-            s if s.starts_with("postgres") || s.starts_with("postgresql") => {
-                let url = connector::PostgresUrl::new(url::Url::parse(s)?)?;
-                let psql = connector::PostgreSql::new(url).await?;
-                Arc::new(psql) as Arc<dyn Queryable>
-            }
-            #[cfg(feature = "mssql-native")]
-            s if s.starts_with("jdbc:sqlserver") | s.starts_with("sqlserver") => {
-                let url = connector::MssqlUrl::new(s)?;
-                let psql = connector::Mssql::new(url).await?;
+    //             Arc::new(mysql) as Arc<dyn Queryable>
+    //         }
+    //         #[cfg(feature = "postgresql-native")]
+    //         s if s.starts_with("postgres") || s.starts_with("postgresql") => {
+    //             let url = connector::PostgresUrl::new(url::Url::parse(s)?)?;
+    //             let psql = connector::PostgreSql::new(url).await?;
+    //             Arc::new(psql) as Arc<dyn Queryable>
+    //         }
+    //         #[cfg(feature = "mssql-native")]
+    //         s if s.starts_with("jdbc:sqlserver") | s.starts_with("sqlserver") => {
+    //             let url = connector::MssqlUrl::new(s)?;
+    //             let psql = connector::Mssql::new(url).await?;
 
-                Arc::new(psql) as Arc<dyn Queryable>
-            }
-            _ => unimplemented!("Supported url schemes: file or sqlite, mysql, postgresql or jdbc:sqlserver."),
-        };
+    //             Arc::new(psql) as Arc<dyn Queryable>
+    //         }
+    //         _ => unimplemented!("Supported url schemes: file or sqlite, mysql, postgresql or jdbc:sqlserver."),
+    //     };
 
-        let connection_info = Arc::new(ConnectionInfo::from_url(url_str)?);
-        Self::log_start(&connection_info);
+    //     let connection_info = Arc::new(ConnectionInfo::from_url(url_str)?);
+    //     Self::log_start(&connection_info);
 
-        Ok(Self { inner, connection_info })
-    }
+    //     Ok(Self { inner, connection_info })
+    // }
 
     #[cfg(feature = "sqlite-native")]
     /// Open a new SQLite database in memory.

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -58,11 +58,11 @@ impl ConnectorError {
                     message: format!("{message}"),
                 },
             )),
-            ErrorKind::QueryInvalidInput(message) => Some(KnownError::new(
-                user_facing_errors::query_engine::DatabaseAssertionViolation {
-                    database_error: message.to_owned(),
-                },
-            )),
+            // ErrorKind::QueryInvalidInput(message) => Some(KnownError::new(
+            //     user_facing_errors::query_engine::DatabaseAssertionViolation {
+            //         database_error: message.to_owned(),
+            //     },
+            // )),
             ErrorKind::UnsupportedFeature(feature) => {
                 Some(KnownError::new(user_facing_errors::query_engine::UnsupportedFeature {
                     feature: feature.clone(),
@@ -95,18 +95,18 @@ impl ConnectorError {
             ErrorKind::TransactionAborted { message } => Some(KnownError::new(
                 user_facing_errors::query_engine::InteractiveTransactionError { error: message.clone() },
             )),
-            ErrorKind::TransactionWriteConflict => Some(KnownError::new(
-                user_facing_errors::query_engine::TransactionWriteConflict {},
-            )),
+            // ErrorKind::TransactionWriteConflict => Some(KnownError::new(
+            //     user_facing_errors::query_engine::TransactionWriteConflict {},
+            // )),
             ErrorKind::TransactionAlreadyClosed { message } => {
                 Some(KnownError::new(user_facing_errors::common::TransactionAlreadyClosed {
                     message: message.clone(),
                 }))
             }
             ErrorKind::ConnectionClosed => Some(KnownError::new(user_facing_errors::common::ConnectionClosed)),
-            ErrorKind::MongoReplicaSetRequired => Some(KnownError::new(
-                user_facing_errors::query_engine::MongoReplicaSetRequired {},
-            )),
+            // ErrorKind::MongoReplicaSetRequired => Some(KnownError::new(
+            //     user_facing_errors::query_engine::MongoReplicaSetRequired {},
+            // )),
             ErrorKind::RawDatabaseError { code, message } => Some(user_facing_errors::KnownError::new(
                 user_facing_errors::query_engine::RawQueryFailed {
                     code: code.clone(),
@@ -203,9 +203,8 @@ pub enum ErrorKind {
     #[error("Conversion error: {}", _0)]
     ConversionError(anyhow::Error),
 
-    #[error("Invalid input provided to query: {}", _0)]
-    QueryInvalidInput(String),
-
+    // #[error("Invalid input provided to query: {}", _0)]
+    // QueryInvalidInput(String),
     #[error("Conversion error: {}", _0)]
     InternalConversionError(String),
 

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -10,7 +10,7 @@ pub(crate) enum RawError {
         expected: usize,
         actual: usize,
     },
-    QueryInvalidInput(String),
+    // QueryInvalidInput(String),
     ConnectionClosed,
     Database {
         code: Option<String>,
@@ -30,7 +30,7 @@ impl From<RawError> for SqlError {
             RawError::IncorrectNumberOfParameters { expected, actual } => {
                 Self::IncorrectNumberOfParameters { expected, actual }
             }
-            RawError::QueryInvalidInput(message) => Self::QueryInvalidInput(message),
+            // RawError::QueryInvalidInput(message) => Self::QueryInvalidInput(message),
             RawError::UnsupportedColumnType { column_type } => Self::RawError {
                 code: String::from("N/A"),
                 message: format!(
@@ -60,7 +60,7 @@ impl From<quaint::error::Error> for RawError {
             quaint::error::ErrorKind::UnsupportedColumnType { column_type } => Self::UnsupportedColumnType {
                 column_type: column_type.to_owned(),
             },
-            quaint::error::ErrorKind::QueryInvalidInput(message) => Self::QueryInvalidInput(message.to_owned()),
+            // quaint::error::ErrorKind::QueryInvalidInput(message) => Self::QueryInvalidInput(message.to_owned()),
             quaint::error::ErrorKind::ExternalError(id) => Self::External { id: *id },
             _ => Self::Database {
                 code: e.original_code().map(ToString::to_string),
@@ -106,9 +106,8 @@ pub enum SqlError {
     #[error("Error querying the database: {}", _0)]
     QueryError(Box<dyn std::error::Error + Send + Sync>),
 
-    #[error("Invalid input provided to query: {}", _0)]
-    QueryInvalidInput(String),
-
+    // #[error("Invalid input provided to query: {}", _0)]
+    // QueryInvalidInput(String),
     #[error("The column value was different from the model")]
     ColumnReadFailure(Box<dyn std::error::Error + Send + Sync>),
 
@@ -230,7 +229,7 @@ impl SqlError {
                 child_name,
             }),
             SqlError::ConversionError(e) => ConnectorError::from_kind(ErrorKind::ConversionError(e)),
-            SqlError::QueryInvalidInput(e) => ConnectorError::from_kind(ErrorKind::QueryInvalidInput(e)),
+            // SqlError::QueryInvalidInput(e) => ConnectorError::from_kind(ErrorKind::QueryInvalidInput(e)),
             SqlError::IncorrectNumberOfParameters { expected, actual } => {
                 ConnectorError::from_kind(ErrorKind::IncorrectNumberOfParameters { expected, actual })
             }
@@ -281,8 +280,8 @@ impl From<quaint::error::Error> for SqlError {
                 message: reason,
             },
             QuaintKind::QueryError(qe) => Self::QueryError(qe),
-            QuaintKind::QueryInvalidInput(qe) => Self::QueryInvalidInput(qe),
-            e @ QuaintKind::IoError(_) => Self::ConnectionError(e),
+            // QuaintKind::QueryInvalidInput(qe) => Self::QueryInvalidInput(qe),
+            // e @ QuaintKind::IoError(_) => Self::ConnectionError(e),
             QuaintKind::NotFound => Self::RecordDoesNotExist,
             QuaintKind::UniqueConstraintViolation { constraint } => Self::UniqueConstraintViolation {
                 constraint: constraint.into(),
@@ -296,7 +295,7 @@ impl From<quaint::error::Error> for SqlError {
                 constraint: constraint.into(),
             },
             QuaintKind::MissingFullTextSearchIndex => Self::MissingFullTextSearchIndex,
-            e @ QuaintKind::ConnectionError(_) => Self::ConnectionError(e),
+            // e @ QuaintKind::ConnectionError(_) => Self::ConnectionError(e),
             QuaintKind::ColumnReadFailure(e) => Self::ColumnReadFailure(e),
             QuaintKind::ColumnNotFound { column } => SqlError::ColumnDoesNotExist(format!("{column}")),
             QuaintKind::TableDoesNotExist { table } => SqlError::TableDoesNotExist(format!("{table}")),
@@ -315,16 +314,18 @@ impl From<quaint::error::Error> for SqlError {
             e @ QuaintKind::ValueOutOfRange { .. } => SqlError::QueryError(e.into()),
             e @ QuaintKind::UUIDError(_) => SqlError::ConversionError(e.into()),
             e @ QuaintKind::DatabaseUrlIsInvalid { .. } => SqlError::ConnectionError(e),
+
+            // Note: not sure whether `DatabaseDoesNotExist` is reachable when targeting `wasm32`
             e @ QuaintKind::DatabaseDoesNotExist { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::AuthenticationFailed { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::DatabaseAccessDenied { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::DatabaseAlreadyExists { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::InvalidConnectionArguments => SqlError::ConnectionError(e),
-            e @ QuaintKind::ConnectTimeout => SqlError::ConnectionError(e),
+            // e @ QuaintKind::ConnectTimeout => SqlError::ConnectionError(e),
             e @ QuaintKind::SocketTimeout => SqlError::ConnectionError(e),
             e @ QuaintKind::PoolTimeout { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::PoolClosed { .. } => SqlError::ConnectionError(e),
-            e @ QuaintKind::TlsError { .. } => Self::ConnectionError(e),
+            // e @ QuaintKind::TlsError { .. } => Self::ConnectionError(e),
         }
     }
 }


### PR DESCRIPTION
**DO NOT MERGE**

Idea: comment out every error message that cannot arise in `wasm32`, pruning and simplifying error-handling functions as a result.

In a follow-up PR, we should implement this conditionally, via compile-time feature flags.
Errors and enum variants that can only appear in a `native` Rust driver context, should probably be scoped into a new `Native-` variant.

There are also possibility for improvement of the important `ConnectionInfo` struct (we only need the `External` variant when compiling for `wasm32`).

Other possible room for improvement: getting rid of `connection_info.clone()` when possible.

---

[Gzip] Baseline: 1099109 B, 1.048 MB
[Gzip] This PR: 1090555 B, 1.040 MB

This PR gets rid of ~8KB in the gzip bundle.