### PR TITLE
wasm-qe-size: Turn off loop vectorization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ strip = "symbols"
 [profile.release]
 lto = "fat"
 codegen-units = 1
-opt-level = 's'   # Optimize for size.
+opt-level = 'z'   # Optimize for size.
 
 [profile.profiling]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ strip = "symbols"
 [profile.release]
 lto = "fat"
 codegen-units = 1
-opt-level = 'z'   # Optimize for size.
+opt-level = 's'   # Optimize for size.
 
 [profile.profiling]
 inherits = "release"

--- a/Makefile
+++ b/Makefile
@@ -335,6 +335,18 @@ else
 	cd query-engine/query-engine-wasm && ./build.sh
 endif
 
+.PHONY: measure-qe-wasm
+measure-qe-wasm: build-qe-wasm	
+	@cd query-engine/query-engine-wasm/pkg; \
+	gzip -c query_engine_bg.wasm | wc -c | awk '{$$1/=(1024*1024); printf "%.3fMB\n", $$1}' > temp_size.txt; \
+	if [ ! -f size.txt ]; then \
+		echo "0MB" > size.txt; \
+	fi; \
+	echo "Previous size: `cat size.txt`"; \
+	echo "Current size: `cat temp_size.txt`"; \
+	awk '{print $$1}' size.txt temp_size.txt | paste -d" " - - | awk '{printf "Increment: %.3fMB\n", $$2 - $$1}'; \
+	mv temp_size.txt size.txt; \
+
 build-driver-adapters-kit: build-driver-adapters
 	cd query-engine/driver-adapters && pnpm i && pnpm build
 

--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -29,7 +29,7 @@ then
 fi
 
 echo "Building query-engine-wasm using $WASM_BUILD_PROFILE profile"
-wasm-pack build "--$WASM_BUILD_PROFILE" --target $OUT_TARGET --out-name query_engine
+CARGO_PROFILE_RELEASE_OPT_LEVEL="z" wasm-pack build "--$WASM_BUILD_PROFILE" --target $OUT_TARGET --out-name query_engine
 
 WASM_OPT_ARGS=(
     "-Os"                                 # execute size-focused optimization passes


### PR DESCRIPTION
This makes the engine slower, still the absolute ms margin is not *that bad* if we consider that benchmarks are measuring net CPU time. 

Read https://github.com/prisma/prisma-engines/pull/4618#issuecomment-1870197130 report carefully.