### PR TITLE
Makefile: fix building wasm-engine when nix is not installed and add task for local size measuring and comparision

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ CONFIG_FILE = .test_config
 SCHEMA_EXAMPLES_PATH = ./query-engine/example_schemas
 DEV_SCHEMA_FILE = dev_datamodel.prisma
 DRIVER_ADAPTERS_BRANCH ?= main
-NIX := $(shell command -v nix 2> /dev/null)
+NIX := $(shell type nix 2> /dev/null)
 
 LIBRARY_EXT := $(shell                            \
     case "$$(uname -s)" in                        \

--- a/Makefile
+++ b/Makefile
@@ -335,17 +335,9 @@ else
 	cd query-engine/query-engine-wasm && ./build.sh
 endif
 
-.PHONY: measure-qe-wasm
 measure-qe-wasm: build-qe-wasm	
 	@cd query-engine/query-engine-wasm/pkg; \
-	gzip -c query_engine_bg.wasm | wc -c | awk '{$$1/=(1024*1024); printf "%.3fMB\n", $$1}' > temp_size.txt; \
-	if [ ! -f size.txt ]; then \
-		echo "0MB" > size.txt; \
-	fi; \
-	echo "Previous size: `cat size.txt`"; \
-	echo "Current size: `cat temp_size.txt`"; \
-	awk '{print $$1}' size.txt temp_size.txt | paste -d" " - - | awk '{printf "Increment: %.3fMB\n", $$2 - $$1}'; \
-	mv temp_size.txt size.txt; \
+	gzip -k -c query_engine_bg.wasm | wc -c | awk '{$$1/=(1024*1024); printf "Current wasm query-engine size compressed: %.3fMB\n", $$1}'
 
 build-driver-adapters-kit: build-driver-adapters
 	cd query-engine/driver-adapters && pnpm i && pnpm build


### PR DESCRIPTION
This PR:
* Fixes build-qe-wasm when nix is not installed on mac https://github.com/prisma/prisma-engines/pull/4622/commits/684dffca76a697bdc64a917aa83665b865087e45
* Adds a new make task `measure-qe-wasm` to continuously measure size locally. https://github.com/prisma/prisma-engines/pull/4622/commits/fab903f1083e050b4cf1eb075cb87c4024ada51a