### PR TITLE
Fix benchmark reporting when benchmark script fails, and provide more reliable and informative results

### DIFF
--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -54,13 +54,9 @@ jobs:
         run: |
           make run-bench | tee results.txt          
 
-          regressed_values=$(grep "slower than Web Assembly: Latest" results.txt | cut -f1 -d'x')
-          echo "Regressed values:"
-          echo $regressed_values
-
+          # Extract the values from the benchmark output
+          regressed_values=$(grep "slower than Web Assembly: Latest" results.txt | cut -f1 -d'x')          
           improved_values=$(grep "faster than Web Assembly: Latest" results.txt | cut -f1 -d'x')          
-          echo "Improved values:"
-          echo $improved_values
 
           # Initialize sum variable and count
           total_sum=0
@@ -71,14 +67,14 @@ jobs:
               inverted=$(echo "scale=4; 1/$value" | bc)
               echo "Regressed value: $inverted"
               total_sum=$(echo "$total_sum + $inverted" | bc)
-              ((total_count++))
+              total_count=$((total_count + 1))
           done
 
           # Add the improved values to the sum
           for value in $improved_values; do
               echo "Improved value: $value"
               total_sum=$(echo "$total_sum + $value" | bc)
-              ((total_count++))
+              total_count=$((total_count + 1))
           done
 
           if [ $total_count -eq 0 ]; then
@@ -88,24 +84,23 @@ jobs:
 
           mean=$(echo "scale=4; $total_sum / $total_count" | bc)
 
-
           echo "Extracted $total_count values from the benchmark output"
           echo "Total sum: $total_sum"
           echo "Total count: $total_count"
           echo "Mean: $mean"
 
-          # Calculate the percentage of improvement or worsening
-          if (( $(echo "$mean > 1.01" | bc -l) )); then
-              change_percentage=$(echo "scale=4; $mean - 1" | bc)
-              summary="🚀 WASM query-engine performance will improve by $(echo "$change_percentage * 100" | bc) percent"
-              status=passed
-          elif (( $(echo "$mean < 0.99" | bc -l) )); then
-              change_percentage=$(echo "scale=4; (1 / $mean) - 1" | bc)
-              summary="❌ WASM query-engine performance will worsen by $(echo "$change_percentage * 100" | bc) percent"
+          # Report improvement or worsening. Fails if >= 1.5% worsening.          
+          if (( $(echo "$mean < 0.985" | bc -l) )); then
+              percent=$(echo "scale=4; ((1 / $mean) - 1) * 100" | bc)
+              summary="❌ WASM query-engine performance will worsen by $(printf %.2f "$percent")%"
               status=failed
+          elif (( $(echo "$mean > 1.015" | bc -l) )); then
+              percent=$(echo "scale=4; ($mean - 1) * 100" | bc)
+              summary="🚀 WASM query-engine performance will improve by $(printf %.2f "$percent")%"
+              status=passed
           else
-              change_percentage=$(echo "scale=4; (1 / $mean)" | bc)
-              summary="✅ WASM query-engine performance won't change substantially. AVG(latency) = $(echo "$change_percentage")x"
+              delta=$(echo "scale=4; (1 / $mean)" | bc)
+              summary="✅ WASM query-engine performance won't change substantially. AVG(latency) = $(printf %.2f "$delta")x"
               status=passed
           fi
 

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: "Setup Node.js"
         uses: actions/setup-node@v4
-        with:
-          node-version: 18
 
       - name: "Setup pnpm"
         uses: pnpm/action-setup@v2
@@ -51,17 +49,15 @@ jobs:
       - name: Run benchmarks
         id: bench
         run: |
-          make run-bench | tee results.txt
-
-          # Save the output to a file so we can use it in the comment
-          {
-            echo 'bench_output<<EOF'
-            cat results.txt
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
+          make run-bench | tee results.txt          
 
           regressed_values=$(grep "slower than Web Assembly: Latest" results.txt | cut -f1 -d'x')
-          improved_values=$(grep "faster than Web Assembly: Latest" results.txt | cut -f1 -d'x')
+          echo "Regressed values:"
+          echo $regressed_values
+
+          improved_values=$(grep "faster than Web Assembly: Latest" results.txt | cut -f1 -d'x')          
+          echo "Improved values:"
+          echo $improved_values
 
           # Initialize sum variable and count
           total_sum=0
@@ -83,8 +79,7 @@ jobs:
           done
 
           if [ $total_count -eq 0 ]; then
-              echo "summary=💥 something was wrong running the benchmarks" >> "$GITHUB_OUTPUT"
-              echo "status=failed" >> "$GITHUB_OUTPUT"
+              echo "💥 something was wrong running the benchmarks"              
               exit 1
           fi
 
@@ -113,6 +108,13 @@ jobs:
 
           echo "summary=$summary" >> "$GITHUB_OUTPUT"
           echo "status=$status" >> "$GITHUB_OUTPUT"
+
+          # Save the output to a file so we can use it in the comment
+          {
+            echo 'bench_output<<EOF'
+            cat results.txt
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
       - name: Find past report comment
         uses: peter-evans/find-comment@v2
         id: findReportComment

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -25,7 +25,7 @@ jobs:
       - name: "Setup Node.js"
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: 18
 
       - name: "Setup pnpm"
         uses: pnpm/action-setup@v2
@@ -83,9 +83,9 @@ jobs:
           done
 
           if [ $total_count -eq 0 ]; then
-              echo "summary=✅ WASM query-engine: no benchmarks have changed substantially" >> "$GITHUB_OUTPUT"
-              echo "status=passed" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "summary=💥 something was wrong running the benchmarks" >> "$GITHUB_OUTPUT"
+              echo "status=failed" >> "$GITHUB_OUTPUT"
+              exit 1
           fi
 
           mean=$(echo "scale=4; $total_sum / $total_count" | bc)

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -53,23 +53,66 @@ jobs:
         run: |
           make run-bench | tee results.txt
 
-          regressed=$(grep "slower than Web Assembly: Latest" results.txt | cut -f1 -d'x' | awk '$1 > 1.02' | wc -l )
-          if [ "$regressed" -gt 0 ]; then
-              summary="🚨 WASM query-engine: $regressed benchmark(s) have regressed at least 2%"
-              status=failed
-          else
-              summary="✅ WASM query-engine: no benchmarks have regressed"
-              status=passed
-          fi
-
-          echo "summary=$summary" >> "$GITHUB_OUTPUT"
-          echo "status=$status" >> "$GITHUB_OUTPUT"
+          # Save the output to a file so we can use it in the comment
           {
             echo 'bench_output<<EOF'
             cat results.txt
             echo EOF
           } >> "$GITHUB_OUTPUT"
 
+          regressed_values=$(grep "slower than Web Assembly: Latest" results.txt | cut -f1 -d'x')
+          improved_values=$(grep "faster than Web Assembly: Latest" results.txt | cut -f1 -d'x')
+
+          # Initialize sum variable and count
+          total_sum=0
+          total_count=0
+
+          # Add the inverted regressed values to the sum
+          for value in $regressed_values; do
+              inverted=$(echo "scale=4; 1/$value" | bc)
+              echo "Regressed value: $inverted"
+              total_sum=$(echo "$total_sum + $inverted" | bc)
+              ((total_count++))
+          done
+
+          # Add the improved values to the sum
+          for value in $improved_values; do
+              echo "Improved value: $value"
+              total_sum=$(echo "$total_sum + $value" | bc)
+              ((total_count++))
+          done
+
+          if [ $total_count -eq 0 ]; then
+              echo "summary=✅ WASM query-engine: no benchmarks have changed substantially" >> "$GITHUB_OUTPUT"
+              echo "status=passed" >> "$GITHUB_OUTPUT"
+              exit 0
+          fi
+
+          mean=$(echo "scale=4; $total_sum / $total_count" | bc)
+
+
+          echo "Extracted $total_count values from the benchmark output"
+          echo "Total sum: $total_sum"
+          echo "Total count: $total_count"
+          echo "Mean: $mean"
+
+          # Calculate the percentage of improvement or worsening
+          if (( $(echo "$mean > 1.01" | bc -l) )); then
+              change_percentage=$(echo "scale=4; $mean - 1" | bc)
+              summary="🚀 WASM query-engine performance will improve by $(echo "$change_percentage * 100" | bc) percent"
+              status=passed
+          elif (( $(echo "$mean < 0.99" | bc -l) )); then
+              change_percentage=$(echo "scale=4; (1 / $mean) - 1" | bc)
+              summary="❌ WASM query-engine performance will worsen by $(echo "$change_percentage * 100" | bc) percent"
+              status=failed
+          else
+              change_percentage=$(echo "scale=4; (1 / $mean)" | bc)
+              summary="✅ WASM query-engine performance won't change substantially. AVG(latency) = $(echo "$change_percentage")x"
+              status=passed
+          fi
+
+          echo "summary=$summary" >> "$GITHUB_OUTPUT"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
       - name: Find past report comment
         uses: peter-evans/find-comment@v2
         id: findReportComment

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -99,8 +99,8 @@ jobs:
               summary="🚀 WASM query-engine performance will improve by $(printf %.2f "$percent")%"
               status=passed
           else
-              delta=$(echo "scale=4; (1 / $mean)" | bc)
-              summary="✅ WASM query-engine performance won't change substantially. AVG(latency) = $(printf %.2f "$delta")x"
+              delta=$(echo "scale=3; (1 / $mean)" | bc)
+              summary="✅ WASM query-engine performance won't change substantially ($(printf %.3f "$delta")x)"
               status=passed
           fi
 

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           version: 8
 
+      - name: Install bc
+        run: sudo apt update && sudo apt-get install -y bc
+
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
         continue-on-error: true

--- a/query-engine/driver-adapters/executor/src/bench.ts
+++ b/query-engine/driver-adapters/executor/src/bench.ts
@@ -213,6 +213,7 @@ function initQeWasmBaseLine(
   return new WasmBaseline(qe.queryEngineOptions(datamodel), debug, adapter);
 }
 
-const err = (...args: any[]) => console.error("[nodejs] ERROR:", ...args);
-
-main().catch(err);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/query-engine/driver-adapters/executor/src/recording.ts
+++ b/query-engine/driver-adapters/executor/src/recording.ts
@@ -61,7 +61,13 @@ function createInMemoryRecordings() {
   const queryResults = {};
   const commandResults = {};
 
-  const queryToKey = (query) => JSON.stringify(query);
+  // Recording is currently only used in benchmarks. Before we used to serialize the whole query
+  // (sql + args) but since bigints are not serialized by JSON.stringify, and we didn't really need
+  // args for benchmarks, we just serialize the sql part.
+  //
+  // If this ever changes (we reuse query recording in tests) we need to make sure to serialize the
+  // args as well.
+  const queryToKey = (query) => JSON.stringify(query.sql);
 
   return {
     addQueryResults: (params, result) => {


### PR DESCRIPTION
Close https://github.com/prisma/team-orm/issues/851

We found a bug reporting the benchmarks when the benchmarks errored. This PR fixes that and also improves overall benchmark reporting.

The script has been tested with an artificial benchmark results file to:
- Report benchmark improvements
- Report benchmark regressions
- Report no substantial changes

And to take into consideration a failed benchmarking script.