### PR TITLE
feat(query-engine-wasm): add "analyse" script with "pnpm crates" crate-size analysis command

### DIFF
--- a/query-engine/query-engine-wasm/README.md
+++ b/query-engine/query-engine-wasm/README.md
@@ -49,3 +49,7 @@ To try importing the , you can run:
 - Build the Wasm binary with `WASM_BUILD_PROFILE="profiling" ./build.sh "0.0.1"`
 - Run `twiggy top -n 20 ./pkg/query_engine_bg.wasm`
 - Take a look at this [Notion document](https://www.notion.so/prismaio/Edge-Functions-how-to-use-twiggy-and-other-size-tracking-tools-c1cb481cbd0c4a0488f6876674988382) for more details, and for instructions on how to refine `twiggy`'s output via [`./wasm-inspect.sh`](./wasm-inspect.sh).
+
+## How to analyse the size impact of Rust crates on the Wasm binary
+
+Please refer to the `pnpm crates` command in the [`./analyse`](./analyse/README.md) README.

--- a/query-engine/query-engine-wasm/analyse/.gitignore
+++ b/query-engine/query-engine-wasm/analyse/.gitignore
@@ -1,0 +1,2 @@
+*.db
+out/twiggy.profiling.json

--- a/query-engine/query-engine-wasm/analyse/README.md
+++ b/query-engine/query-engine-wasm/analyse/README.md
@@ -7,4 +7,4 @@
 - `pnpm i`: Install dependencies.
 - `pnpm build`: Build the Wasm binary in `"profiling"` mode.
 - `pnpm prepare:crates`: Invoke `twiggy top` on the Wasm binary, saving the results in `./twiggy.profiling.json`.
-- `pnpm crates`: Filter and analyse the `twiggy top` results, printing a summary Markdown table of the size impact of each Rust crate involved.
+- `pnpm crates`: Filter and analyse the `twiggy top` results, printing a summary Markdown table of the size impact of each Rust crate involved. Wasm sections, like `data` (bunch of static strings) also appear in the table, and are marked with a `🧩`.

--- a/query-engine/query-engine-wasm/analyse/README.md
+++ b/query-engine/query-engine-wasm/analyse/README.md
@@ -1,0 +1,10 @@
+# @prisma/analyse-query-engine-wasm
+
+> Internal utility tool to analyse the size impact of Rust crates on the Wasm binary.
+
+## Scripts
+
+- `pnpm i`: Install dependencies.
+- `pnpm build`: Build the Wasm binary in `"profiling"` mode.
+- `pnpm prepare:crates`: Invoke `twiggy top` on the Wasm binary, saving the results in `./twiggy.profiling.json`.
+- `pnpm crates`: Filter and analyse the `twiggy top` results, printing a summary Markdown table of the size impact of each Rust crate involved.

--- a/query-engine/query-engine-wasm/analyse/package.json
+++ b/query-engine/query-engine-wasm/analyse/package.json
@@ -1,0 +1,15 @@
+{
+  "type": "module",
+  "name": "@prisma/analyse-query-engine-wasm",
+  "private": true,
+  "scripts": {
+    "build": "(cd .. && WASM_BUILD_PROFILE=profiling ./build.sh 0.0.1 && wasm-pack pack)",
+    "prepare:crates": "twiggy top -f json ../pkg/query_engine_bg.wasm | jq > ./out/twiggy.profiling.json",
+    "crates": "node --import tsx --no-warnings ./src/crates.ts"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/query-engine/query-engine-wasm/analyse/pnpm-lock.yaml
+++ b/query-engine/query-engine-wasm/analyse/pnpm-lock.yaml
@@ -1,0 +1,408 @@
+lockfileVersion: '6.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+devDependencies:
+  ts-node:
+    specifier: ^10.9.2
+    version: 10.9.2(@types/node@20.10.8)(typescript@5.3.3)
+  tsx:
+    specifier: ^4.7.0
+    version: 4.7.0
+  typescript:
+    specifier: ^5.3.3
+    version: 5.3.3
+
+packages:
+
+  /@cspotcode/source-map-support@0.8.1:
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@esbuild/aix-ppc64@0.19.11:
+    resolution: {integrity: sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm64@0.19.11:
+    resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-arm@0.19.11:
+    resolution: {integrity: sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/android-x64@0.19.11:
+    resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-arm64@0.19.11:
+    resolution: {integrity: sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/darwin-x64@0.19.11:
+    resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.19.11:
+    resolution: {integrity: sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/freebsd-x64@0.19.11:
+    resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm64@0.19.11:
+    resolution: {integrity: sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-arm@0.19.11:
+    resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ia32@0.19.11:
+    resolution: {integrity: sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-loong64@0.19.11:
+    resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-mips64el@0.19.11:
+    resolution: {integrity: sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-ppc64@0.19.11:
+    resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-riscv64@0.19.11:
+    resolution: {integrity: sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-s390x@0.19.11:
+    resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/linux-x64@0.19.11:
+    resolution: {integrity: sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/netbsd-x64@0.19.11:
+    resolution: {integrity: sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/openbsd-x64@0.19.11:
+    resolution: {integrity: sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/sunos-x64@0.19.11:
+    resolution: {integrity: sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-arm64@0.19.11:
+    resolution: {integrity: sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-ia32@0.19.11:
+    resolution: {integrity: sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@esbuild/win32-x64@0.19.11:
+    resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
+    engines: {node: '>=6.0.0'}
+    dev: true
+
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+    dev: true
+
+  /@jridgewell/trace-mapping@0.3.9:
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
+    dev: true
+
+  /@tsconfig/node10@1.0.9:
+    resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
+    dev: true
+
+  /@tsconfig/node12@1.0.11:
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+    dev: true
+
+  /@tsconfig/node14@1.0.3:
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+    dev: true
+
+  /@tsconfig/node16@1.0.4:
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+    dev: true
+
+  /@types/node@20.10.8:
+    resolution: {integrity: sha512-f8nQs3cLxbAFc00vEU59yf9UyGUftkPaLGfvbVOIDdx2i1b8epBqj2aNGyP19fiyXWvlmZ7qC1XLjAzw/OKIeA==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
+  /acorn-walk@8.3.1:
+    resolution: {integrity: sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn@8.11.3:
+    resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+    dev: true
+
+  /arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+    dev: true
+
+  /create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+    dev: true
+
+  /diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+    dev: true
+
+  /esbuild@0.19.11:
+    resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
+    engines: {node: '>=12'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.11
+      '@esbuild/android-arm': 0.19.11
+      '@esbuild/android-arm64': 0.19.11
+      '@esbuild/android-x64': 0.19.11
+      '@esbuild/darwin-arm64': 0.19.11
+      '@esbuild/darwin-x64': 0.19.11
+      '@esbuild/freebsd-arm64': 0.19.11
+      '@esbuild/freebsd-x64': 0.19.11
+      '@esbuild/linux-arm': 0.19.11
+      '@esbuild/linux-arm64': 0.19.11
+      '@esbuild/linux-ia32': 0.19.11
+      '@esbuild/linux-loong64': 0.19.11
+      '@esbuild/linux-mips64el': 0.19.11
+      '@esbuild/linux-ppc64': 0.19.11
+      '@esbuild/linux-riscv64': 0.19.11
+      '@esbuild/linux-s390x': 0.19.11
+      '@esbuild/linux-x64': 0.19.11
+      '@esbuild/netbsd-x64': 0.19.11
+      '@esbuild/openbsd-x64': 0.19.11
+      '@esbuild/sunos-x64': 0.19.11
+      '@esbuild/win32-arm64': 0.19.11
+      '@esbuild/win32-ia32': 0.19.11
+      '@esbuild/win32-x64': 0.19.11
+    dev: true
+
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /get-tsconfig@4.7.2:
+    resolution: {integrity: sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==}
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+    dev: true
+
+  /make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+    dev: true
+
+  /resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+    dev: true
+
+  /ts-node@10.9.2(@types/node@20.10.8)(typescript@5.3.3):
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.9
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 20.10.8
+      acorn: 8.11.3
+      acorn-walk: 8.3.1
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.3.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    dev: true
+
+  /tsx@4.7.0:
+    resolution: {integrity: sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+    dependencies:
+      esbuild: 0.19.11
+      get-tsconfig: 4.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /typescript@5.3.3:
+    resolution: {integrity: sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: true
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
+  /v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+    dev: true
+
+  /yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+    dev: true

--- a/query-engine/query-engine-wasm/analyse/src/crates.ts
+++ b/query-engine/query-engine-wasm/analyse/src/crates.ts
@@ -12,6 +12,30 @@ type ParsedTwiggyEntry = {
 }
 
 function parseEntry({ name, ...rest }: TwiggyEntry): ParsedTwiggyEntry | undefined {
+  const sections = [
+    'data',
+    'type',
+    'global',
+    'table',
+    'elem',
+    'memory',
+  ]
+  
+  if (
+    sections.some(section => name.startsWith(`${section}[`))
+  ) {
+    let sectionName = name.split('[')[0]
+    sectionName = `${sectionName}[..] 🧩`
+
+    return {
+      crate: sectionName,
+      original: {
+        name,
+        ...rest,
+      },
+    }
+  }
+  
   const prefixesToAvoid = [        
     // exported functions
     'queryengine_',
@@ -22,12 +46,6 @@ function parseEntry({ name, ...rest }: TwiggyEntry): ParsedTwiggyEntry | undefin
 
     // misc. noise
     '"function names"',
-    'data[',
-    'type[',
-    'global[',
-    'table[',
-    'elem[',
-    'memory[',
     'export ',
     'import ',
   ]
@@ -59,17 +77,15 @@ function parseEntry({ name, ...rest }: TwiggyEntry): ParsedTwiggyEntry | undefin
   name = match ? match[1] : name
 
   // extract the crate name, e.g., `psl_core`
-  let crateName = name.split('::')[0]
+  const crateName = name.split('::')[0]
 
-  const parsedTwiggyEntry: ParsedTwiggyEntry = {
+  return {
     crate: crateName,
     original: {
       name,
       ...rest,
     },
   }
-
-  return parsedTwiggyEntry
 }
 
 // print the twiggy data as a markdown table with columns:

--- a/query-engine/query-engine-wasm/analyse/src/crates.ts
+++ b/query-engine/query-engine-wasm/analyse/src/crates.ts
@@ -55,10 +55,19 @@ function parseEntry({ name, ...rest }: TwiggyEntry): ParsedTwiggyEntry | undefin
     'custom section',
     'wasm magic'
   ]
+
+  const stringsToAvoid = [
+    // memory utilities
+    'memmove',
+    'memset',
+    'memcpy',
+    'memcmp',
+  ]
   
   if (
     prefixesToAvoid.some(prefix => name.startsWith(prefix))
     || substringsToAvoid.some(substring => name.includes(substring))
+    || stringsToAvoid.includes(name)
   ) {
     return undefined
   }

--- a/query-engine/query-engine-wasm/analyse/src/crates.ts
+++ b/query-engine/query-engine-wasm/analyse/src/crates.ts
@@ -1,0 +1,146 @@
+import twiggyData from '../out/twiggy.profiling.json' with { type: 'json' }
+
+type TwiggyEntry = {
+  name: string // name of a symbol in a Wasm binary
+  shallow_size: number // size as bytes
+  shallow_size_percent: number // percentage as float
+}
+
+type ParsedTwiggyEntry = {
+  crate: string
+  original: TwiggyEntry
+}
+
+function parseEntry({ name, ...rest }: TwiggyEntry): ParsedTwiggyEntry | undefined {
+  const prefixesToAvoid = [        
+    // exported functions
+    'queryengine_',
+    'getBuildTimeInfo',
+
+    // compiler utilities (e.g., `__rust_alloc`, arithmetic routines, etc.)
+    '__',
+
+    // misc. noise
+    '"function names"',
+    'data[',
+    'type[',
+    'global[',
+    'table[',
+    'elem[',
+    'memory[',
+    'export ',
+    'import ',
+  ]
+
+  const substringsToAvoid = [
+    'section headers',
+    'custom section',
+    'wasm magic'
+  ]
+  
+  if (
+    prefixesToAvoid.some(prefix => name.startsWith(prefix))
+    || substringsToAvoid.some(substring => name.includes(substring))
+  ) {
+    return undefined
+  }
+
+  // Symbols like:
+  // ```
+  // <builtin_psl_connectors::mysql_datamodel_connector::MySqlDatamodelConnector
+  //   as psl_core::datamodel_connector::Connector>::provider_name::h9720aa1dba9e87e9
+  // >
+  // ```
+  // should be parsed as:
+  // ```
+  // psl_core::datamodel_connector::Connector
+  // ```
+  const match = name.match(/<.*? as (.*?)>::/)
+  name = match ? match[1] : name
+
+  // extract the crate name, e.g., `psl_core`
+  let crateName = name.split('::')[0]
+
+  const parsedTwiggyEntry: ParsedTwiggyEntry = {
+    crate: crateName,
+    original: {
+      name,
+      ...rest,
+    },
+  }
+
+  return parsedTwiggyEntry
+}
+
+// print the twiggy data as a markdown table with columns:
+// - crate: the name of the crate
+// - bytes: the number of bytes the crate occupies
+// - frequency: the number of times the crate is referenced
+function printAsMarkdown(twiggyMap: TwiggyMap, { CRATE_NAME_PADDING }: { CRATE_NAME_PADDING: number }) {
+  const BYTE_SIZE_PADDING = 8
+  const FREQUENCY_PADDING = 10
+
+  console.log(`| ${'crate'.padStart(CRATE_NAME_PADDING)} | ${'bytes'.padEnd(BYTE_SIZE_PADDING)} | ${'frequency'.padEnd(FREQUENCY_PADDING)} |`)
+  console.log(`| ${'-'.repeat(CRATE_NAME_PADDING - 1)}: | :${'-'.repeat(BYTE_SIZE_PADDING - 1)} | :${'-'.repeat(FREQUENCY_PADDING - 1)} |`)
+
+  for (const [crate, { size, entries }] of twiggyMap.entries()) {
+    console.log(`| ${crate.padStart(CRATE_NAME_PADDING)} | ${size.toString().padEnd(BYTE_SIZE_PADDING)} | ${entries.length.toString().padEnd(FREQUENCY_PADDING)} |`)
+  }
+}
+
+type TwiggyMapValue = {
+  size: number
+  entries: ParsedTwiggyEntry[]
+}
+
+type TwiggyMap = Map<
+  ParsedTwiggyEntry['crate'],
+  TwiggyMapValue
+>
+
+function analyseDeps(twiggyData: TwiggyEntry[]): TwiggyMap {
+  // parse the twiggy data, filter out noise entries, and for each crate,
+  // keep track of how much space it takes up and the twiggy entries that belong to it
+  const twiggyMap = twiggyData
+    .map(parseEntry)
+    .filter((entry): entry is ParsedTwiggyEntry => entry !== undefined)
+    .reduce((acc, item) => {
+      const { crate, original } = item
+
+      // get a reference to the current map entry for the crate, if it already exists
+      const currEntry = acc.get(crate)
+
+      if (currEntry) {
+        currEntry.size += original.shallow_size
+        currEntry.entries.push(item)
+      } else {
+        acc.set(crate, {
+          size: original.shallow_size,
+          entries: [item],
+        })
+      }
+
+      return acc
+    }, new Map() as TwiggyMap)
+
+  // sort the map values by space occupied, descending
+  // (maps maintain insertion order)
+  const sortedTwiggyMap = new Map(
+    [...twiggyMap.entries()].sort((a, b) => b[1].size - a[1].size)
+  )
+
+  return sortedTwiggyMap
+}
+
+function main() {
+  const sortedTwiggyMap = analyseDeps(twiggyData as TwiggyEntry[])
+  
+  // visual adjustment for the "crate" column in the markdown table
+  const CRATE_NAME_PADDING = 24
+
+  printAsMarkdown(sortedTwiggyMap, {
+    CRATE_NAME_PADDING,
+  })
+}
+
+main()


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/808.

This PR creates an `analyse` TypeScript project within `./query-engine/query-engine-wasm` with the following commands available:

- `pnpm i`: Install dependencies.
- `pnpm build`: Build the Wasm binary in `"profiling"` mode.
- `pnpm prepare:crates`: Invoke `twiggy top` on the Wasm binary, saving the results in `./twiggy.profiling.json`.
- `pnpm crates`: Filter and analyse the `twiggy top` results, printing a summary Markdown table of the size impact of each Rust crate involved. Wasm sections, like `data` (bunch of static strings) also appear in the table, and are marked with a `🧩`.

---

Example output:

|                    crate | bytes    | frequency  |
| -----------------------: | :------- | :--------- |
|                     core | 750329   | 2103       |
|               query_core | 430965   | 213        |
|      sql_query_connector | 250481   | 110        |
|              data[..] 🧩 | 232776   | 206        |
|                   quaint | 197547   | 279        |
|          driver_adapters | 87213    | 16         |
|                     pest | 73842    | 53         |
|                    alloc | 64729    | 268        |
|                    serde | 56884    | 144        |
|          query_connector | 52427    | 121        |
|          query_structure | 51516    | 110        |
|     wasm_bindgen_futures | 49314    | 22         |
|                   schema | 48242    | 75         |
|                hashbrown | 46607    | 71         |
|                 psl_core | 44159    | 107        |
|                   chrono | 38747    | 68         |
|               serde_json | 38626    | 53         |
|          parser_database | 35792    | 82         |
|               num_bigint | 35736    | 31         |
|       user_facing_errors | 31659    | 27         |
|                 indexmap | 20880    | 35         |
|         request_handlers | 16995    | 12         |
|               schema_ast | 14364    | 16         |
|               bigdecimal | 11407    | 6          |
|             tracing_core | 10689    | 50         |
|        crosstarget_utils | 10025    | 5          |
|                    tokio | 7927     | 27         |
|   builtin_psl_connectors | 7102     | 7          |
|                 dlmalloc | 6826     | 6          |
|                   base64 | 6599     | 2          |
|                itertools | 6573     | 8          |
|                rand_core | 4987     | 3          |
|             prisma_value | 4588     | 4          |
|            opentelemetry | 3631     | 10         |
|             sharded_slab | 3414     | 10         |
|              elem[..] 🧩 | 3349     | 2          |
|       serde_wasm_bindgen | 3116     | 7          |
|                     uuid | 2703     | 4          |
|                      ryu | 2579     | 4          |
|                     cuid | 2446     | 4          |
|              diagnostics | 1840     | 12         |
|                      std | 1751     | 14         |
|               num_traits | 1678     | 4          |
|                getrandom | 1609     | 2          |
|                  tracing | 1320     | 4          |
|                   keccak | 1094     | 1          |
|                      url | 1094     | 4          |
|             thread_local | 1088     | 3          |
|                once_cell | 1063     | 4          |
|                   anyhow | 1015     | 18         |
|             futures_util | 971      | 7          |
|             futures_task | 945      | 10         |
|                 petgraph | 868      | 3          |
|              num_integer | 857      | 2          |
|         percent_encoding | 835      | 2          |
|             wasm_bindgen | 798      | 19         |
|       tracing_subscriber | 725      | 12         |
|      query_engine_common | 672      | 1          |
|              type[..] 🧩 | 629      | 78         |
|                     itoa | 596      | 2          |
|                   js_sys | 572      | 4          |
|                      hex | 471      | 1          |
|                     rand | 455      | 1          |
|              debug_panic | 451      | 1          |
|    tracing_opentelemetry | 358      | 3          |
|             futures_core | 352      | 1          |
|                    ahash | 30       | 2          |
|            global[..] 🧩 | 8        | 1          |
|             table[..] 🧩 | 6        | 1          |
|            memory[..] 🧩 | 2        | 1          |

---

Please note that `core` refers to a subset of Rust's standard library.