### PR TITLE
qe: Fix timeout errors

### DIFF
--- a/libs/crosstarget-utils/src/native/spawn.rs
+++ b/libs/crosstarget-utils/src/native/spawn.rs
@@ -1,11 +1,15 @@
+use futures::FutureExt;
 use std::future::Future;
 
 use crate::common::SpawnError;
 
-pub async fn spawn_if_possible<F>(future: F) -> Result<F::Output, SpawnError>
+pub fn spawn_if_possible<F>(future: F) -> impl Future<Output = Result<F::Output, SpawnError>>
 where
     F: Future + 'static + Send,
     F::Output: Send + 'static,
 {
-    tokio::spawn(future).await.map_err(|_| SpawnError)
+    tokio::spawn(future).map(|result| match result {
+        Ok(result) => Ok(result),
+        Err(_) => Err(SpawnError),
+    })
 }

--- a/libs/crosstarget-utils/src/native/spawn.rs
+++ b/libs/crosstarget-utils/src/native/spawn.rs
@@ -1,4 +1,4 @@
-use futures::FutureExt;
+use futures::TryFutureExt;
 use std::future::Future;
 
 use crate::common::SpawnError;
@@ -8,8 +8,5 @@ where
     F: Future + 'static + Send,
     F::Output: Send + 'static,
 {
-    tokio::spawn(future).map(|result| match result {
-        Ok(result) => Ok(result),
-        Err(_) => Err(SpawnError),
-    })
+    tokio::spawn(future).map_err(|_| SpawnError)
 }

--- a/libs/crosstarget-utils/src/wasm/spawn.rs
+++ b/libs/crosstarget-utils/src/wasm/spawn.rs
@@ -1,10 +1,12 @@
 use std::future::Future;
 
+use futures::FutureExt;
+
 use crate::common::SpawnError;
 
-pub async fn spawn_if_possible<F>(future: F) -> Result<F::Output, SpawnError>
+pub fn spawn_if_possible<F>(future: F) -> impl Future<F::Output, SpawnError>
 where
     F: Future + 'static,
 {
-    Ok(future.await)
+    future.map(Ok)
 }

--- a/libs/crosstarget-utils/src/wasm/spawn.rs
+++ b/libs/crosstarget-utils/src/wasm/spawn.rs
@@ -4,7 +4,7 @@ use futures::FutureExt;
 
 use crate::common::SpawnError;
 
-pub fn spawn_if_possible<F>(future: F) -> impl Future<F::Output, SpawnError>
+pub fn spawn_if_possible<F>(future: F) -> impl Future<Output = Result<F::Output, SpawnError>>
 where
     F: Future + 'static,
 {


### PR DESCRIPTION
Problem: we awaited spawned future immediately, which kind of makes
spawn useless, effecctively serializing batch requests instead of
executing them in parallel. Affects only the batches that could not be
compated into a single query.

I struggled to reproduce the error in engine's test suite. I suggest we
test it in client instead.

Fix prisma/prisma#22610
