### PR TITLE
qe: Fix test runner under Node 20

### DIFF
--- a/query-engine/driver-adapters/executor/src/testd.ts
+++ b/query-engine/driver-adapters/executor/src/testd.ts
@@ -21,10 +21,13 @@ import { Client as PlanetscaleClient } from '@planetscale/database'
 import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 
 
+
 import {bindAdapter, DriverAdapter, ErrorCapturingDriverAdapter} from "@prisma/driver-adapter-utils";
 import { webcrypto } from 'node:crypto';
 
-(global as any).crypto = webcrypto
+if (!global.crypto) {
+  global.crypto = webcrypto as Crypto
+}
 
 
 const SUPPORTED_ADAPTERS: Record<string, (_ : string) => Promise<DriverAdapter>>


### PR DESCRIPTION
`crypto` global is already defined on Node 20+ and can not be overriden.

Close prisma/team-orm#798
