### PR TITLE
qe: remove unneccessary `clone()` in `ReadQuery::satisfy_dependency`

### DIFF
--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -4,7 +4,7 @@ use crate::ToGraphviz;
 use connector::{AggregationSelection, RelAggregationSelection};
 use enumflags2::BitFlags;
 use query_structure::{prelude::*, Filter, QueryArguments, RelationLoadStrategy};
-use std::fmt::Display;
+use std::{fmt::Display, mem};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
@@ -35,13 +35,13 @@ impl ReadQuery {
     pub fn satisfy_dependency(&mut self, field_selection: FieldSelection) {
         match self {
             ReadQuery::RecordQuery(x) => {
-                x.selected_fields = x.selected_fields.clone().merge(field_selection);
+                x.selected_fields = mem::take(&mut x.selected_fields).merge(field_selection);
             }
             ReadQuery::ManyRecordsQuery(x) => {
-                x.selected_fields = x.selected_fields.clone().merge(field_selection);
+                x.selected_fields = mem::take(&mut x.selected_fields).merge(field_selection);
             }
             ReadQuery::RelatedRecordsQuery(x) => {
-                x.selected_fields = x.selected_fields.clone().merge(field_selection);
+                x.selected_fields = mem::take(&mut x.selected_fields).merge(field_selection);
             }
             ReadQuery::AggregateRecordsQuery(_) => (),
         }


### PR DESCRIPTION
`clone()` was there to work around not being able to directly move
values out of a mutable reference. However, moving out of a mutable
reference is possible as long as you leave something behind instead.

`std::mem::take` leaves `Default::default()` behind, which, unlike
reallocating and copying a vector, can be easily optimized out, and even
if it isn't, constructing a default `FieldSelection` is just a few `mov`
instructions anyway.

Before: https://rust.godbolt.org/z/dzPjPEqeP
After: https://rust.godbolt.org/z/o5PhYqhTW
