### PR TITLE
qe: Default `make-qe` task to JSON protocol and improve error message

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,7 +7,6 @@ export RUST_LOG=info
 export PRISMA_DML_PATH=$(pwd)/dev_datamodel.prisma
 export PRISMA2_BINARY_PATH="/usr/local/lib/node_modules/prisma2/"
 export PRISMA_BINARY_PATH=$(pwd)/target/release/query-engine
-export PRISMA_ENGINE_PROTOCOL="graphql"
 
 ### QE config vars, set to testing values ###
 export SQLITE_MAX_VARIABLE_NUMBER=250000 # This must be in sync with the setting in the engineer build CLI

--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,10 @@ validate:
 	cargo run --bin test-cli -- validate-datamodel dev_datamodel.prisma
 
 qe:
-	cargo run --bin query-engine -- --enable-playground --enable-raw-queries --enable-metrics --enable-open-telemetry --enable-telemetry-in-response
+	cargo run --bin query-engine -- --engine-protocol json --enable-raw-queries --enable-metrics --enable-open-telemetry --enable-telemetry-in-response
+
+qe-graphql:
+	cargo run --bin query-engine -- --engine-protocol graphql --enable-playground --enable-raw-queries --enable-metrics --enable-open-telemetry --enable-telemetry-in-response
 
 qe-dmmf:
 	cargo run --bin query-engine -- cli dmmf > dmmf.json

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -189,7 +189,7 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
             }
             Err(e) => {
                 let ufe: user_facing_errors::Error = request_handlers::HandlerError::query_conversion(format!(
-                    "Error parsing {:?} query. {}",
+                    "Error parsing {:?} query. Ensure that engine protocol of the client and the engine matches. {}",
                     cx.engine_protocol(),
                     e
                 ))


### PR DESCRIPTION
I beleive prisma/team-orm#710 was caused by engine defaulting to GraphQL
via `.envrc` file. Error handling in BinaryEngine
being broken in this case (prisma/prisma#22636) made finding this out
really hard.
So, while main fix is done on the client side, I beleive we can adjust
few things on the engine side too:

- `make-qe` task will now always use JSON protocol.
- `make-qe-graphql` task added for cases where it is necessary. For
  example, using the playground.
- Default `PRISMA_ENGINE_PROTOCOL` is removed from `.envrc`. If needed,
  it can be restored via `.envrc.local`.
- Error message adjusted to mention incorrect protocol possiblity.


For reviewers: I would appreciate if you'd checked out the branch and tested
if [instructions here](https://www.notion.so/prismaio/Connect-client-to-running-engine-ad28858cdbba432eb6b6d5c1aa2f3743) work for you now.

Contributes to prisma/team-orm#710
