### PR TITLE
qe: Fix neon tests after 0.7.0 update

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -15,6 +15,7 @@ in
       nodejs_20.pkgs.pnpm
 
       cargo-insta
+      cargo-nextest
       jq
       graphviz
       wasm-bindgen-cli

--- a/query-engine/driver-adapters/executor/package.json
+++ b/query-engine/driver-adapters/executor/package.json
@@ -21,7 +21,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@libsql/client": "0.3.6",
-    "@neondatabase/serverless": "0.6.0",
+    "@neondatabase/serverless": "0.7.2",
     "@planetscale/database": "1.13.0",
     "query-engine-wasm-latest": "npm:@prisma/query-engine-wasm@latest",
     "query-engine-wasm-baseline": "npm:@prisma/query-engine-wasm@0.0.19",


### PR DESCRIPTION
Due to the way our dependencies are structured, we end up with 2 copies
of neon if client have incompatible versions:
- dev dependency in client
- dependency in executor

So, global changes made to one of them do not affect another. That broke
engine's test when client updated to 0.7.0. PR updates executor
dependecy as well, which fixes the problem.

This problem is a quirk of our test setup and won't affect end users.
