### PR TITLE
qe-wasm: Fix consistent `now()` value

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
@@ -26,11 +26,7 @@ mod prisma_12572 {
         .to_owned()
     }
 
-    #[connector_test(exclude(
-        Postgres("pg.js.wasm", "neon.js.wasm"),
-        Sqlite("libsql.js.wasm"),
-        Vitess("planetscale.js.wasm")
-    ))]
+    #[connector_test]
     async fn all_generated_timestamps_are_the_same(runner: Runner) -> TestResult<()> {
         runner
             .query(r#"mutation { createOneTest1(data: {id:"one", test2s: { create: {id: "two"}}}) { id }}"#)

--- a/query-engine/core/src/executor/request_context.rs
+++ b/query-engine/core/src/executor/request_context.rs
@@ -18,14 +18,17 @@ tokio::task_local! {
 ///
 /// If we had a query context we carry for the entire lifetime of the query, it would belong there.
 pub(crate) fn get_request_now() -> PrismaValue {
-    // FIXME: we want to bypass task locals if this code is executed outside of a tokio context. As
-    // of this writing, it happens only in the query validation test suite.
-    //
-    // Eventually, this will go away when we have a plain query context reference we pass around.
-    if tokio::runtime::Handle::try_current().is_err() {
-        return PrismaValue::DateTime(chrono::Utc::now().into());
-    }
-    REQUEST_CONTEXT.with(|rc| rc.request_now.clone())
+
+    REQUEST_CONTEXT
+        .try_with(|rc| rc.request_now.clone())
+        .unwrap_or_else(|_| 
+            // FIXME: we want to bypass task locals if this code is executed outside of a tokio context. As
+            // of this writing, it happens only in the query validation test suite.
+            //
+            // Eventually, this will go away when we have a plain query context reference we pass around.
+            // Skipping the branch for WASM since there we never have a running tokio runtime
+            PrismaValue::DateTime(chrono::Utc::now().into())
+        )
 }
 
 /// The engine protocol used for the whole duration of a request.

--- a/query-engine/core/src/executor/request_context.rs
+++ b/query-engine/core/src/executor/request_context.rs
@@ -18,17 +18,13 @@ tokio::task_local! {
 ///
 /// If we had a query context we carry for the entire lifetime of the query, it would belong there.
 pub(crate) fn get_request_now() -> PrismaValue {
-
-    REQUEST_CONTEXT
-        .try_with(|rc| rc.request_now.clone())
-        .unwrap_or_else(|_| 
+    REQUEST_CONTEXT.try_with(|rc| rc.request_now.clone()).unwrap_or_else(|_|
             // FIXME: we want to bypass task locals if this code is executed outside of a tokio context. As
             // of this writing, it happens only in the query validation test suite.
             //
             // Eventually, this will go away when we have a plain query context reference we pass around.
             // Skipping the branch for WASM since there we never have a running tokio runtime
-            PrismaValue::DateTime(chrono::Utc::now().into())
-        )
+            PrismaValue::DateTime(chrono::Utc::now().into()))
 }
 
 /// The engine protocol used for the whole duration of a request.


### PR DESCRIPTION
We introduced consitent `request_now` value in #3200,
however, we've opted out of thread local value if there is no active
tokio handle. This is problem for WASM build, since it does not have
use an actual tokio runtime.

Replacing handle check with `LocalKey::try_with` allows us to use task
local variable without the runtime, while still preserving fallback for
immediate value if task local is not set.

Fix prisma/team-orm#645
