### PR TITLE
fix(user-facing-errors): fix Prisma pipeline, add sqlserver test to sql-migration-tests

### DIFF
--- a/libs/user-facing-errors/src/quaint.rs
+++ b/libs/user-facing-errors/src/quaint.rs
@@ -229,6 +229,12 @@ pub fn render_quaint_error(kind: &ErrorKind, connection_info: &ConnectionInfo) -
                     database_host: url.host().to_owned(),
                 }))
             }
+            (NativeErrorKind::ConnectionError(_), ConnectionInfo::Native(NativeConnectionInfo::Mssql(url))) => {
+                Some(KnownError::new(common::DatabaseNotReachable {
+                    database_port: url.port(),
+                    database_host: url.host().to_owned(),
+                }))
+            }
             (NativeErrorKind::TlsError { message }, _) => Some(KnownError::new(common::TlsConnectionError {
                 message: message.into(),
             })),


### PR DESCRIPTION
This PR unlocks the [pipeline](https://github.com/prisma/prisma/pull/22685) in `prisma/prisma`, and it accidentally fixes https://github.com/prisma/prisma/issues/11407.

The test added in this PR prompted the creation of a new tech-debt issue, https://github.com/prisma/team-orm/issues/835.

/integration