### PR TITLE
Load .envrc.local before running nix

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -34,6 +34,12 @@ else
     export INIT_WAIT_SEC="2"
 fi
 
+# Source the gitignored .envrc.local if it exists.
+if test -f .envrc.local; then
+    watch_file .envrc.local
+    source .envrc.local
+fi
+
 # (Example env vars if you're not using the make commands, i.e. the config files, to set up query engine tests)
 # export TEST_RUNNER="direct"
 # export TEST_CONNECTOR="postgres"
@@ -49,10 +55,4 @@ then
         watch_file nix/shell.nix nix/all-engines.nix nix/args.nix
         use flake
     fi
-fi
-
-# Source the gitignored .envrc.local if it exists.
-if test -f .envrc.local; then
-    watch_file .envrc.local
-    source .envrc.local
 fi


### PR DESCRIPTION
Makes it possible to disable nix by adding the `DISABLE_NIX` env var in `.envrc.local`