### PR TITLE
qe-wasm: Unskip raw queries tests

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/input_coercion.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/input_coercion.rs
@@ -5,7 +5,7 @@ mod input_coercion {
     use query_engine_tests::fmt_execute_raw;
 
     // Checks that query raw inputs are coerced to the correct types
-    #[connector_test(only(Postgres), exclude(Postgres("pg.js.wasm", "neon.js.wasm"),))]
+    #[connector_test(only(Postgres))]
     async fn scalar_input_correctly_coerced(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/null_list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/null_list.rs
@@ -5,11 +5,7 @@ use query_engine_tests::*;
 mod null_list {
     use query_engine_tests::{fmt_query_raw, run_query, run_query_pretty};
 
-    #[connector_test(
-        schema(common_list_types),
-        only(Postgres),
-        exclude(Postgres("pg.js.wasm", "neon.js.wasm"),)
-    )]
+    #[connector_test(schema(common_list_types), only(Postgres))]
     async fn null_scalar_lists(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/typed_output.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/typed_output.rs
@@ -26,7 +26,7 @@ mod typed_output {
         schema.to_owned()
     }
 
-    #[connector_test(schema(schema_pg), only(Postgres), exclude(Postgres("pg.js.wasm", "neon.js.wasm")))]
+    #[connector_test(schema(schema_pg), only(Postgres))]
     async fn all_scalars_pg(runner: Runner) -> TestResult<()> {
         create_row(
             &runner,


### PR DESCRIPTION
Needs #4648 to be merged into main before, but all raw queries isses
are already fixed either by me or Alberto, so we have to just unskip the
tests.

Close prisma/team-orm#659
