### PR TITLE
test(driver-adapters): ensure JSON nulls are NOT stripped out on Wasm

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(capabilities(JsonFiltering), exclude(MySql(5.6)))]
+#[test_suite(capabilities(JsonFiltering), exclude(Mysql56))]
 mod json_filter {
     use query_engine_tests::run_query;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/field_reference/json_filter.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(capabilities(JsonFiltering), exclude(Mysql56))]
+#[test_suite(capabilities(JsonFiltering), exclude(MySQL(5.6)))]
 mod json_filter {
     use query_engine_tests::run_query;
 
@@ -25,7 +25,8 @@ mod json_filter {
             Postgres("pg.js"),
             Postgres("neon.js"),
             Sqlite("libsql.js"),
-            Vitess("planetscale.js")
+            Vitess("planetscale.js"),
+            MySQL(5.6)
         )
     )]
     async fn does_not_strip_nulls_in_json(runner: Runner) -> TestResult<()> {


### PR DESCRIPTION
This PR contributes to https://github.com/prisma/team-orm/issues/683.

This PR adds a new test to verify we're not stripping JSON nulls when using `query-engine-wasm` (with Wasm `driver-adapters`) or `query-engine-node-api` (without any `driver-adapters`).

Fixing this bug for `query-engine-node-api` (with Napi.rs `driver-adapters`) requires patching `napi.rs`, as explained in detail [here](https://github.com/prisma/team-orm/issues/683#issuecomment-1898305228).