### PR TITLE
[wip] Refactor relation aggregation selection

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/error.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/error.rs
@@ -286,6 +286,7 @@ impl<T> DecorateErrorWithFieldInformationExtension for crate::Result<T> {
             SelectedField::Scalar(sf) => self.decorate_with_scalar_field_info(sf),
             SelectedField::Composite(composite_sel) => self.decorate_with_composite_field_info(&composite_sel.field),
             SelectedField::Relation(_) => unreachable!(),
+            SelectedField::Virtual(_) => todo!(),
         }
     }
 

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -6,8 +6,7 @@ use crate::{
 };
 use async_trait::async_trait;
 use connector_interface::{
-    Connection, ConnectionLike, ReadOperations, RelAggregationSelection, Transaction, UpdateType, WriteArgs,
-    WriteOperations,
+    Connection, ConnectionLike, ReadOperations, Transaction, UpdateType, WriteArgs, WriteOperations,
 };
 use mongodb::{ClientSession, Database};
 use query_structure::{prelude::*, RelationLoadStrategy, SelectionResult};
@@ -234,7 +233,6 @@ impl ReadOperations for MongoDbConnection {
         model: &Model,
         filter: &query_structure::Filter,
         selected_fields: &FieldSelection,
-        aggr_selections: &[RelAggregationSelection],
         _relation_load_strategy: RelationLoadStrategy,
         _trace_id: Option<String>,
     ) -> connector_interface::Result<Option<SingleRecord>> {
@@ -244,7 +242,6 @@ impl ReadOperations for MongoDbConnection {
             model,
             filter,
             selected_fields,
-            aggr_selections,
         ))
         .await
     }
@@ -254,7 +251,6 @@ impl ReadOperations for MongoDbConnection {
         model: &Model,
         query_arguments: query_structure::QueryArguments,
         selected_fields: &FieldSelection,
-        aggregation_selections: &[RelAggregationSelection],
         _relation_load_strategy: RelationLoadStrategy,
         _trace_id: Option<String>,
     ) -> connector_interface::Result<ManyRecords> {
@@ -264,7 +260,6 @@ impl ReadOperations for MongoDbConnection {
             model,
             query_arguments,
             selected_fields,
-            aggregation_selections,
         ))
         .await
     }

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -3,9 +3,7 @@ use crate::{
     error::MongoError,
     root_queries::{aggregate, read, write},
 };
-use connector_interface::{
-    ConnectionLike, ReadOperations, RelAggregationSelection, Transaction, UpdateType, WriteOperations,
-};
+use connector_interface::{ConnectionLike, ReadOperations, Transaction, UpdateType, WriteOperations};
 use mongodb::options::{Acknowledgment, ReadConcern, TransactionOptions, WriteConcern};
 use query_engine_metrics::{decrement_gauge, increment_gauge, metrics, PRISMA_CLIENT_QUERIES_ACTIVE};
 use query_structure::{RelationLoadStrategy, SelectionResult};
@@ -264,7 +262,6 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
         model: &Model,
         filter: &query_structure::Filter,
         selected_fields: &FieldSelection,
-        aggr_selections: &[RelAggregationSelection],
         _relation_load_strategy: RelationLoadStrategy,
         _trace_id: Option<String>,
     ) -> connector_interface::Result<Option<SingleRecord>> {
@@ -274,7 +271,6 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
             model,
             filter,
             selected_fields,
-            aggr_selections,
         ))
         .await
     }
@@ -284,7 +280,6 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
         model: &Model,
         query_arguments: query_structure::QueryArguments,
         selected_fields: &FieldSelection,
-        aggregation_selections: &[RelAggregationSelection],
         _relation_load_strategy: RelationLoadStrategy,
         _trace_id: Option<String>,
     ) -> connector_interface::Result<ManyRecords> {
@@ -294,7 +289,6 @@ impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
             model,
             query_arguments,
             selected_fields,
-            aggregation_selections,
         ))
         .await
     }

--- a/query-engine/connectors/mongodb-query-connector/src/output_meta.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/output_meta.rs
@@ -1,4 +1,4 @@
-use connector_interface::{AggregationSelection, RelAggregationSelection};
+use connector_interface::AggregationSelection;
 use indexmap::IndexMap;
 use query_structure::{
     ast::FieldArity, DefaultKind, FieldSelection, PrismaValue, ScalarFieldRef, SelectedField, TypeIdentifier,
@@ -48,18 +48,12 @@ impl CompositeOutputMeta {
     }
 }
 
-pub fn from_selected_fields(
-    selected_fields: &FieldSelection,
-    aggregation_selections: &[RelAggregationSelection],
-) -> OutputMetaMapping {
-    let selections: Vec<&SelectedField> = selected_fields.selections().collect();
-    from_selections(&selections, aggregation_selections)
+pub fn from_selected_fields(selected_fields: &FieldSelection) -> OutputMetaMapping {
+    let selections: Vec<_> = selected_fields.selections().collect();
+    from_selections(&selections)
 }
 
-pub fn from_selections(
-    selected_fields: &[&SelectedField],
-    aggregation_selections: &[RelAggregationSelection],
-) -> OutputMetaMapping {
+pub fn from_selections(selected_fields: &[&SelectedField]) -> OutputMetaMapping {
     let mut map = OutputMetaMapping::new();
 
     for selection in selected_fields {
@@ -70,7 +64,7 @@ pub fn from_selections(
 
             SelectedField::Composite(cs) => {
                 let selections: Vec<&SelectedField> = cs.selections.iter().collect();
-                let inner = from_selections(&selections, &[]);
+                let inner = from_selections(&selections);
 
                 map.insert(
                     cs.field.db_name().to_owned(),
@@ -80,12 +74,22 @@ pub fn from_selections(
                     }),
                 );
             }
-            SelectedField::Relation(_) => unreachable!(),
-        }
-    }
 
-    for selection in aggregation_selections {
-        map.insert(selection.db_alias(), from_rel_aggregation_selection(selection));
+            SelectedField::Relation(_) => unreachable!(),
+
+            SelectedField::Virtual(vs) => {
+                let (ident, arity) = vs.type_identifier_with_arity();
+
+                map.insert(
+                    vs.db_alias(),
+                    OutputMeta::Scalar(ScalarOutputMeta {
+                        ident,
+                        default: None,
+                        list: matches!(arity, FieldArity::List),
+                    }),
+                );
+            }
+        }
     }
 
     map
@@ -124,18 +128,6 @@ pub fn from_aggregation_selection(selection: &AggregationSelection) -> OutputMet
     }
 
     map
-}
-
-/// Mapping for one specific relation aggregation selection.
-/// DB alias -> OutputMeta
-pub fn from_rel_aggregation_selection(aggr_selection: &RelAggregationSelection) -> OutputMeta {
-    let (ident, arity) = aggr_selection.type_identifier_with_arity();
-
-    OutputMeta::Scalar(ScalarOutputMeta {
-        ident,
-        default: None,
-        list: matches!(arity, FieldArity::List),
-    })
 }
 
 impl From<ScalarOutputMeta> for OutputMeta {

--- a/query-engine/connectors/mongodb-query-connector/src/projection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/projection.rs
@@ -26,7 +26,10 @@ fn path_prefixed_selection(doc: &mut Document, parent_paths: Vec<String>, select
                 parent_paths.push(cs.field.db_name().to_owned());
                 path_prefixed_selection(doc, parent_paths, cs.selections);
             }
+
             query_structure::SelectedField::Relation(_) => unreachable!(),
+
+            query_structure::SelectedField::Virtual(_) => {}
         }
     }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -10,14 +10,14 @@ use crate::{
     root_queries::observing,
     vacuum_cursor, BsonTransform, IntoBson,
 };
-use connector_interface::{AggregationSelection, RelAggregationSelection};
+use connector_interface::AggregationSelection;
 use itertools::Itertools;
 use mongodb::{
     bson::{doc, Document},
     options::AggregateOptions,
     ClientSession, Collection,
 };
-use query_structure::{FieldSelection, Filter, Model, QueryArguments, ScalarFieldRef};
+use query_structure::{FieldSelection, Filter, Model, QueryArguments, ScalarFieldRef, VirtualSelection};
 use std::convert::TryFrom;
 
 // Mongo Driver broke usage of the simple API, can't be used by us anymore.
@@ -355,13 +355,13 @@ impl MongoReadQueryBuilder {
     }
 
     /// Adds the necessary joins and the associated selections to the projection
-    pub fn with_aggregation_selections(
+    pub fn with_virtual_fields<'a>(
         mut self,
-        aggregation_selections: &[RelAggregationSelection],
+        virtual_selections: impl Iterator<Item = &'a VirtualSelection>,
     ) -> crate::Result<Self> {
-        for aggr in aggregation_selections {
+        for aggr in virtual_selections {
             let join = match aggr {
-                RelAggregationSelection::Count(rf, filter) => {
+                VirtualSelection::RelationCount(rf, filter) => {
                     let filter = filter
                         .as_ref()
                         .map(|f| MongoFilterVisitor::new(FilterPrefix::default(), false).visit(f.clone()))

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -312,7 +312,7 @@ pub async fn delete_record<'conn>(
         cause: "Record to delete does not exist.".to_owned(),
     })?;
 
-    let meta_mapping = output_meta::from_selected_fields(&selected_fields, &[]);
+    let meta_mapping = output_meta::from_selected_fields(&selected_fields);
     let field_names: Vec<_> = selected_fields.db_names().collect();
     let record = document_to_record(document, &field_names, &meta_mapping)?;
     Ok(SingleRecord { record, field_names })

--- a/query-engine/connectors/mongodb-query-connector/src/value.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/value.rs
@@ -24,6 +24,7 @@ impl IntoBson for (&SelectedField, PrismaValue) {
             SelectedField::Scalar(sf) => (sf, value).into_bson(),
             SelectedField::Composite(_) => todo!(), // [Composites] todo
             SelectedField::Relation(_) => unreachable!(),
+            SelectedField::Virtual(_) => unreachable!(),
         }
     }
 }

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -176,6 +176,8 @@ pub enum AggregationResult {
     Max(ScalarFieldRef, PrismaValue),
 }
 
+////// Remove all of this:
+
 #[derive(Debug, Clone)]
 pub enum RelAggregationSelection {
     // Always a count(*) for now
@@ -217,6 +219,8 @@ impl RelAggregationSelection {
     }
 }
 
+//////////
+
 #[async_trait]
 pub trait ReadOperations {
     /// Gets a single record or `None` back from the database.
@@ -230,7 +234,6 @@ pub trait ReadOperations {
         model: &Model,
         filter: &Filter,
         selected_fields: &FieldSelection,
-        aggregation_selections: &[RelAggregationSelection],
         relation_load_strategy: RelationLoadStrategy,
         trace_id: Option<String>,
     ) -> crate::Result<Option<SingleRecord>>;
@@ -246,7 +249,6 @@ pub trait ReadOperations {
         model: &Model,
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
-        aggregation_selections: &[RelAggregationSelection],
         relation_load_strategy: RelationLoadStrategy,
         trace_id: Option<String>,
     ) -> crate::Result<ManyRecords>;

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -328,6 +328,7 @@ impl From<(&SelectedField, PrismaValue)> for WriteOperation {
             SelectedField::Scalar(sf) => (sf, pv).into(),
             SelectedField::Composite(cs) => (&cs.field, pv).into(),
             SelectedField::Relation(_) => todo!(),
+            SelectedField::Virtual(_) => todo!(),
         }
     }
 }
@@ -462,7 +463,7 @@ pub fn merge_write_args(loaded_ids: Vec<SelectionResult>, incoming_args: WriteAr
         .pairs
         .iter()
         .enumerate()
-        .filter_map(|(i, (selection, _))| incoming_args.get_field_value(selection.db_name()).map(|val| (i, val)))
+        .filter_map(|(i, (selection, _))| incoming_args.get_field_value(&selection.db_name()).map(|val| (i, val)))
         .collect();
 
     loaded_ids

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -3,7 +3,7 @@
 use super::{catch, transaction::SqlConnectorTransaction};
 use crate::{database::operations::*, Context, SqlError};
 use async_trait::async_trait;
-use connector::{ConnectionLike, RelAggregationSelection};
+use connector::ConnectionLike;
 use connector_interface::{
     self as connector, AggregationRow, AggregationSelection, Connection, ReadOperations, RecordFilter, Transaction,
     WriteArgs, WriteOperations,
@@ -86,7 +86,6 @@ where
         model: &Model,
         filter: &Filter,
         selected_fields: &FieldSelection,
-        aggr_selections: &[RelAggregationSelection],
         relation_load_strategy: RelationLoadStrategy,
         trace_id: Option<String>,
     ) -> connector::Result<Option<SingleRecord>> {
@@ -99,7 +98,6 @@ where
                 model,
                 filter,
                 selected_fields,
-                aggr_selections,
                 relation_load_strategy,
                 &ctx,
             ),
@@ -112,7 +110,6 @@ where
         model: &Model,
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
-        aggr_selections: &[RelAggregationSelection],
         relation_load_strategy: RelationLoadStrategy,
         trace_id: Option<String>,
     ) -> connector::Result<ManyRecords> {
@@ -124,7 +121,6 @@ where
                 model,
                 query_arguments,
                 selected_fields,
-                aggr_selections,
                 relation_load_strategy,
                 &ctx,
             ),

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -17,23 +17,12 @@ pub(crate) async fn get_single_record(
     model: &Model,
     filter: &Filter,
     selected_fields: &FieldSelection,
-    aggr_selections: &[RelAggregationSelection],
     relation_load_strategy: RelationLoadStrategy,
     ctx: &Context<'_>,
 ) -> crate::Result<Option<SingleRecord>> {
     match relation_load_strategy {
         RelationLoadStrategy::Join => get_single_record_joins(conn, model, filter, selected_fields, ctx).await,
-        RelationLoadStrategy::Query => {
-            get_single_record_wo_joins(
-                conn,
-                model,
-                filter,
-                &ModelProjection::from(selected_fields),
-                aggr_selections,
-                ctx,
-            )
-            .await
-        }
+        RelationLoadStrategy::Query => get_single_record_wo_joins(conn, model, filter, selected_fields, ctx).await,
     }
 }
 
@@ -67,30 +56,22 @@ pub(crate) async fn get_single_record_wo_joins(
     conn: &dyn Queryable,
     model: &Model,
     filter: &Filter,
-    selected_fields: &ModelProjection,
-    aggr_selections: &[RelAggregationSelection],
+    selected_fields: &FieldSelection,
     ctx: &Context<'_>,
 ) -> crate::Result<Option<SingleRecord>> {
     let query = read::get_records(
         model,
-        selected_fields.as_columns(ctx).mark_all_selected(),
-        aggr_selections,
+        ModelProjection::from(selected_fields)
+            .as_columns(ctx)
+            .mark_all_selected(),
+        &selected_fields.virtuals().collect::<Vec<_>>(), // TODO: pass the iterator all the way down
         filter,
         ctx,
     );
 
-    let mut field_names: Vec<_> = selected_fields.db_names().collect();
-    let mut aggr_field_names: Vec<_> = aggr_selections.iter().map(|aggr_sel| aggr_sel.db_alias()).collect();
+    let field_names: Vec<_> = selected_fields.db_names().collect();
 
-    field_names.append(&mut aggr_field_names);
-
-    let mut idents = selected_fields.type_identifiers_with_arities();
-    let mut aggr_idents = aggr_selections
-        .iter()
-        .map(|aggr_sel| aggr_sel.type_identifier_with_arity())
-        .collect();
-
-    idents.append(&mut aggr_idents);
+    let idents = selected_fields.type_identifiers_with_arities();
 
     let record = execute_find_one(conn, query, &idents, &field_names, ctx)
         .await?
@@ -124,24 +105,13 @@ pub(crate) async fn get_many_records(
     model: &Model,
     query_arguments: QueryArguments,
     selected_fields: &FieldSelection,
-    aggr_selections: &[RelAggregationSelection],
     relation_load_strategy: RelationLoadStrategy,
     ctx: &Context<'_>,
 ) -> crate::Result<ManyRecords> {
     match relation_load_strategy {
-        RelationLoadStrategy::Join => {
-            get_many_records_joins(conn, model, query_arguments, selected_fields, aggr_selections, ctx).await
-        }
+        RelationLoadStrategy::Join => get_many_records_joins(conn, model, query_arguments, selected_fields, ctx).await,
         RelationLoadStrategy::Query => {
-            get_many_records_wo_joins(
-                conn,
-                model,
-                query_arguments,
-                &ModelProjection::from(selected_fields),
-                aggr_selections,
-                ctx,
-            )
-            .await
+            get_many_records_wo_joins(conn, model, query_arguments, selected_fields, ctx).await
         }
     }
 }
@@ -151,7 +121,6 @@ pub(crate) async fn get_many_records_joins(
     _model: &Model,
     query_arguments: QueryArguments,
     selected_fields: &FieldSelection,
-    _aggr_selections: &[RelAggregationSelection],
     ctx: &Context<'_>,
 ) -> crate::Result<ManyRecords> {
     let field_names: Vec<_> = selected_fields.db_names().collect();
@@ -197,25 +166,13 @@ pub(crate) async fn get_many_records_wo_joins(
     conn: &dyn Queryable,
     model: &Model,
     mut query_arguments: QueryArguments,
-    selected_fields: &ModelProjection,
-    aggr_selections: &[RelAggregationSelection],
+    selected_fields: &FieldSelection,
     ctx: &Context<'_>,
 ) -> crate::Result<ManyRecords> {
     let reversed = query_arguments.needs_reversed_order();
 
-    let mut field_names: Vec<_> = selected_fields.db_names().collect();
-    let mut aggr_field_names: Vec<_> = aggr_selections.iter().map(|aggr_sel| aggr_sel.db_alias()).collect();
-
-    field_names.append(&mut aggr_field_names);
-
-    let mut aggr_idents = aggr_selections
-        .iter()
-        .map(|aggr_sel| aggr_sel.type_identifier_with_arity())
-        .collect();
-
-    let mut idents = selected_fields.type_identifiers_with_arities();
-
-    idents.append(&mut aggr_idents);
+    let field_names: Vec<_> = selected_fields.db_names().collect();
+    let idents = selected_fields.type_identifiers_with_arities();
 
     let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
     let mut records = ManyRecords::new(field_names.clone());
@@ -252,8 +209,10 @@ pub(crate) async fn get_many_records_wo_joins(
             for args in batches.into_iter() {
                 let query = read::get_records(
                     model,
-                    selected_fields.as_columns(ctx).mark_all_selected(),
-                    aggr_selections,
+                    ModelProjection::from(selected_fields)
+                        .as_columns(ctx)
+                        .mark_all_selected(),
+                    &selected_fields.virtuals().collect::<Vec<_>>(), // TODO: pass an iterator
                     args,
                     ctx,
                 );
@@ -274,8 +233,10 @@ pub(crate) async fn get_many_records_wo_joins(
         _ => {
             let query = read::get_records(
                 model,
-                selected_fields.as_columns(ctx).mark_all_selected(),
-                aggr_selections,
+                ModelProjection::from(selected_fields)
+                    .as_columns(ctx)
+                    .mark_all_selected(),
+                &selected_fields.virtuals().collect::<Vec<_>>(), // TODO: pass an iterator
                 query_arguments,
                 ctx,
             );

--- a/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
@@ -25,17 +25,7 @@ pub(crate) async fn update_one_with_selection(
     // TODO(perf): Technically, if the selectors are fulfilling the field selection, there's no need to perform an additional read.
     if args.args.is_empty() {
         let filter = build_update_one_filter(record_filter);
-
-        return get_single_record(
-            conn,
-            model,
-            &filter,
-            &selected_fields,
-            &[],
-            RelationLoadStrategy::Query,
-            ctx,
-        )
-        .await;
+        return get_single_record(conn, model, &filter, &selected_fields, RelationLoadStrategy::Query, ctx).await;
     }
 
     let selected_fields = ModelProjection::from(selected_fields);

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -13,6 +13,7 @@ use quaint::{
     prelude::{native_uuid, uuid_to_bin, uuid_to_bin_swapped, Aliasable, Select, SqlFamily},
 };
 use query_structure::*;
+use std::borrow::Cow;
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
@@ -173,7 +174,7 @@ pub(crate) async fn create_record(
 
         // All values provided in the write args
         (Some(identifier), _, _) if !identifier.misses_autogen_value() => {
-            let field_names = identifier.db_names().map(ToOwned::to_owned).collect();
+            let field_names = identifier.db_names().map(Cow::into_owned).collect();
             let record = Record::from(identifier);
 
             Ok(SingleRecord { record, field_names })
@@ -183,7 +184,7 @@ pub(crate) async fn create_record(
         (Some(mut identifier), _, Some(num)) if identifier.misses_autogen_value() => {
             identifier.add_autogen_value(num as i64);
 
-            let field_names = identifier.db_names().map(ToOwned::to_owned).collect();
+            let field_names = identifier.db_names().map(Cow::into_owned).collect();
             let record = Record::from(identifier);
 
             Ok(SingleRecord { record, field_names })

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -1,7 +1,7 @@
 use super::catch;
 use crate::{database::operations::*, Context, SqlError};
 use async_trait::async_trait;
-use connector::{ConnectionLike, RelAggregationSelection};
+use connector::ConnectionLike;
 use connector_interface::{
     self as connector, AggregationRow, AggregationSelection, ReadOperations, RecordFilter, Transaction, WriteArgs,
     WriteOperations,
@@ -68,7 +68,6 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         model: &Model,
         filter: &Filter,
         selected_fields: &FieldSelection,
-        aggr_selections: &[RelAggregationSelection],
         relation_load_strategy: RelationLoadStrategy,
         trace_id: Option<String>,
     ) -> connector::Result<Option<SingleRecord>> {
@@ -80,7 +79,6 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 model,
                 filter,
                 selected_fields,
-                aggr_selections,
                 relation_load_strategy,
                 &ctx,
             ),
@@ -93,7 +91,6 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
         model: &Model,
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
-        aggr_selections: &[RelAggregationSelection],
         relation_load_strategy: RelationLoadStrategy,
         trace_id: Option<String>,
     ) -> connector::Result<ManyRecords> {
@@ -105,7 +102,6 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
                 model,
                 query_arguments,
                 selected_fields,
-                aggr_selections,
                 relation_load_strategy,
                 &ctx,
             ),

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/selection_result.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/selection_result.rs
@@ -38,6 +38,7 @@ impl SelectionResultExt for SelectionResult {
                 SelectedField::Scalar(sf) => Some(sf.value(v.clone(), ctx)),
                 SelectedField::Composite(_) => None,
                 SelectedField::Relation(_) => None,
+                SelectedField::Virtual(_) => None,
             })
             .collect()
     }

--- a/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
+++ b/query-engine/connectors/sql-query-connector/src/nested_aggregations.rs
@@ -2,8 +2,8 @@ use crate::{
     join_utils::{compute_aggr_join, AggregationType, AliasedJoin},
     Context,
 };
-use connector_interface::RelAggregationSelection;
 use quaint::prelude::*;
+use query_structure::VirtualSelection;
 
 #[derive(Debug)]
 pub(crate) struct RelAggregationJoins {
@@ -13,13 +13,14 @@ pub(crate) struct RelAggregationJoins {
     pub(crate) columns: Vec<Expression<'static>>,
 }
 
-pub(crate) fn build(aggr_selections: &[RelAggregationSelection], ctx: &Context<'_>) -> RelAggregationJoins {
+// TODO: forward an iterator all the way from `FieldSelection::virtuals` to here without collecting
+pub(crate) fn build(virtual_selections: &[&VirtualSelection], ctx: &Context<'_>) -> RelAggregationJoins {
     let mut joins = vec![];
     let mut columns: Vec<Expression<'static>> = vec![];
 
-    for (index, selection) in aggr_selections.iter().enumerate() {
+    for (index, selection) in virtual_selections.iter().enumerate() {
         match selection {
-            RelAggregationSelection::Count(rf, filter) => {
+            VirtualSelection::RelationCount(rf, filter) => {
                 let join_alias = format!("aggr_selection_{index}");
                 let aggregator_alias = selection.db_alias();
                 let join = compute_aggr_join(

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -52,7 +52,7 @@ fn read_one(
 
                 Ok(RecordSelection {
                     name: query.name,
-                    fields: query.selection_order,
+                    fields: query.user_selection.into_inner(),
                     scalars,
                     nested,
                     model,
@@ -66,7 +66,7 @@ fn read_one(
                 Ok(RecordSelectionWithRelations {
                     name: query.name,
                     model,
-                    fields: query.selection_order,
+                    fields: query.user_selection.into_inner(),
                     records,
                     nested: build_relation_record_selection(query.full_selection.relations()),
                 }
@@ -77,7 +77,7 @@ fn read_one(
 
             None => Ok(QueryResult::RecordSelection(Some(Box::new(RecordSelection {
                 name: query.name,
-                fields: query.selection_order,
+                fields: query.user_selection.into_inner(),
                 scalars: ManyRecords::default(),
                 nested: vec![],
                 model,
@@ -143,7 +143,7 @@ fn read_many_by_queries(
             let nested: Vec<QueryResult> = process_nested(tx, query.nested, Some(&scalars)).await?;
             Ok(RecordSelection {
                 name: query.name,
-                fields: query.selection_order,
+                fields: query.user_selection.into_inner(),
                 scalars,
                 nested,
                 model: query.model,
@@ -178,7 +178,7 @@ fn read_many_by_joins(
         } else {
             Ok(RecordSelectionWithRelations {
                 name: query.name,
-                fields: query.selection_order,
+                fields: query.user_selection.into_inner(),
                 records: result,
                 nested: build_relation_record_selection(query.full_selection.relations()),
                 model: query.model,
@@ -233,7 +233,7 @@ fn read_related<'conn>(
 
         Ok(RecordSelection {
             name: query.name,
-            fields: query.selection_order,
+            fields: query.user_selection.into_inner(),
             scalars,
             nested,
             model,

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -48,7 +48,7 @@ async fn create_one(
     Ok(QueryResult::RecordSelection(Some(Box::new(RecordSelection {
         name: q.name,
         fields: q.selection_order,
-        aggregation_rows: None,
+        // aggregation_rows: None,
         model: q.model,
         scalars: res.into(),
         nested: vec![],
@@ -89,7 +89,7 @@ async fn update_one(
                     scalars: res.into(),
                     nested: vec![],
                     model: q.model,
-                    aggregation_rows: None,
+                    // aggregation_rows: None,
                 })
                 .map(Box::new);
 
@@ -118,7 +118,7 @@ async fn native_upsert(
         scalars: scalars.into(),
         nested: Vec::new(),
         model: query.model().clone(),
-        aggregation_rows: None,
+        // aggregation_rows: None,
     }
     .into())
 }
@@ -147,7 +147,7 @@ async fn delete_one(
             scalars: record.into(),
             nested: vec![],
             model: q.model,
-            aggregation_rows: None,
+            // aggregation_rows: None,
         };
 
         Ok(QueryResult::RecordSelection(Some(Box::new(selection))))

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -48,7 +48,6 @@ async fn create_one(
     Ok(QueryResult::RecordSelection(Some(Box::new(RecordSelection {
         name: q.name,
         fields: q.selection_order,
-        // aggregation_rows: None,
         model: q.model,
         scalars: res.into(),
         nested: vec![],
@@ -89,7 +88,6 @@ async fn update_one(
                     scalars: res.into(),
                     nested: vec![],
                     model: q.model,
-                    // aggregation_rows: None,
                 })
                 .map(Box::new);
 
@@ -118,7 +116,6 @@ async fn native_upsert(
         scalars: scalars.into(),
         nested: Vec::new(),
         model: query.model().clone(),
-        // aggregation_rows: None,
     }
     .into())
 }

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -201,7 +201,7 @@ pub struct RecordQuery {
     pub user_selection: FieldSelection,
     pub full_selection: FieldSelection,
     pub(crate) nested: Vec<ReadQuery>,
-    pub selection_order: Vec<String>,
+    // pub selection_order: Vec<String>,
     // pub aggregation_selections: Vec<RelAggregationSelection>,
     pub options: QueryOptions,
     pub relation_load_strategy: RelationLoadStrategy,
@@ -216,7 +216,7 @@ pub struct ManyRecordsQuery {
     pub user_selection: FieldSelection,
     pub full_selection: FieldSelection,
     pub(crate) nested: Vec<ReadQuery>,
-    pub selection_order: Vec<String>, // TODO: get rid of it as well
+    // pub selection_order: Vec<String>, // TODO: get rid of it as well
     // pub aggregation_selections: Vec<RelAggregationSelection>,
     pub options: QueryOptions,
     pub relation_load_strategy: RelationLoadStrategy,
@@ -231,7 +231,7 @@ pub struct RelatedRecordsQuery {
     pub user_selection: FieldSelection,
     pub full_selection: FieldSelection,
     pub nested: Vec<ReadQuery>,
-    pub selection_order: Vec<String>,
+    // pub selection_order: Vec<String>,
     // pub aggregation_selections: Vec<RelAggregationSelection>,
     /// Fields and values of the parent to satisfy the relation query without
     /// relying on the parent result passed by the interpreter.

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -37,7 +37,7 @@ impl WriteQuery {
 
         for (selected_field, value) in result {
             args.insert(
-                DatasourceFieldName(selected_field.db_name().to_owned()),
+                DatasourceFieldName(selected_field.db_name().into_owned()),
                 (&selected_field, value),
             )
         }
@@ -143,7 +143,7 @@ impl WriteQuery {
             record_filter,
             create,
             update,
-            read.selected_fields,
+            read.full_selection,
             read.selection_order,
         )))
     }
@@ -257,7 +257,7 @@ impl CreateManyRecords {
         for (selected_field, value) in result {
             for args in self.args.iter_mut() {
                 args.insert(
-                    DatasourceFieldName(selected_field.db_name().to_owned()),
+                    DatasourceFieldName(selected_field.db_name().into_owned()),
                     (&selected_field, value.clone()),
                 )
             }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -793,10 +793,8 @@ impl QueryGraph {
                 model: model.clone(),
                 args: QueryArguments::new(model),
                 full_selection: identifiers.merge(primary_model_id.clone()),
-                user_selection: identifiers.merge(primary_model_id.clone()),
+                user_selection: vec![].into(),
                 nested: vec![],
-                selection_order: vec![],
-                // aggregation_selections: vec![],
                 options: QueryOptions::none(),
                 relation_load_strategy: query_structure::RelationLoadStrategy::Query,
             });

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -792,10 +792,11 @@ impl QueryGraph {
                 alias: None,
                 model: model.clone(),
                 args: QueryArguments::new(model),
-                selected_fields: identifiers.merge(primary_model_id.clone()),
+                full_selection: identifiers.merge(primary_model_id.clone()),
+                user_selection: identifiers.merge(primary_model_id.clone()),
                 nested: vec![],
                 selection_order: vec![],
-                aggregation_selections: vec![],
+                // aggregation_selections: vec![],
                 options: QueryOptions::none(),
                 relation_load_strategy: query_structure::RelationLoadStrategy::Query,
             });

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -30,15 +30,17 @@ fn find_many_with_options(
     let name = field.name;
     let alias = field.alias;
     let nested_fields = field.nested_fields.unwrap().fields;
-    let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
-    let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
-    let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
-    let selected_fields = utils::collect_selected_fields(&nested_fields, args.distinct.clone(), &model, query_schema)?;
+    // let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
+    // let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
+    // let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
+    let (user_selection, full_selection) =
+        utils::collect_selected_fields(&nested_fields, args.distinct.clone(), &model, query_schema)?;
+
     let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
 
-    let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
-    let selected_fields = utils::merge_cursor_fields(selected_fields, &args.cursor);
-    let selected_fields = selected_fields.clone().merge(virtual_fields);
+    let full_selection = utils::merge_relation_selections(full_selection, None, &nested);
+    let full_selection = utils::merge_cursor_fields(full_selection, &args.cursor);
+    // let selected_fields = selected_fields.clone().merge(virtual_fields);
 
     let relation_load_strategy = get_relation_load_strategy(
         args.relation_load_strategy,
@@ -46,7 +48,7 @@ fn find_many_with_options(
         args.distinct.as_ref(),
         &nested,
         // &aggregation_selections,
-        &selected_fields,
+        &user_selection,
         query_schema,
     );
 
@@ -55,10 +57,10 @@ fn find_many_with_options(
         alias,
         model,
         args,
-        user_selection: selected_fields.clone(),
-        full_selection: selected_fields,
+        user_selection,
+        full_selection,
         nested,
-        selection_order,
+        // selection_order,
         // aggregation_selections,
         options,
         relation_load_strategy,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -45,13 +45,13 @@ fn find_unique_with_options(
     let name = field.name;
     let alias = field.alias;
     let nested_fields = field.nested_fields.unwrap().fields;
-    let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
-    let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
-    let selection_order = utils::collect_selection_order(&nested_fields);
-    let selected_fields = utils::collect_selected_fields(&nested_fields, None, &model, query_schema)?;
+    // let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
+    // let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
+    // let selection_order = utils::collect_selection_order(&nested_fields);
+    let (user_selection, full_selection) = utils::collect_selected_fields(&nested_fields, None, &model, query_schema)?;
     let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
-    let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
-    let selected_fields = selected_fields.merge(virtual_fields);
+    let full_selection = utils::merge_relation_selections(full_selection, None, &nested);
+    // let selected_fields = selected_fields.merge(virtual_fields);
 
     let relation_load_strategy = get_relation_load_strategy(
         requested_rel_load_strategy,
@@ -59,7 +59,7 @@ fn find_unique_with_options(
         None,
         &nested,
         // &aggregation_selections,
-        &selected_fields,
+        &user_selection,
         query_schema,
     );
 
@@ -68,10 +68,10 @@ fn find_unique_with_options(
         alias,
         model,
         filter,
-        user_selection: selected_fields.clone(),
-        full_selection: selected_fields,
+        user_selection,
+        full_selection,
         nested,
-        selection_order,
+        // selection_order,
         // aggregation_selections,
         options,
         relation_load_strategy,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -44,21 +44,22 @@ fn find_unique_with_options(
 
     let name = field.name;
     let alias = field.alias;
-    let model = model;
     let nested_fields = field.nested_fields.unwrap().fields;
     let (aggr_fields_pairs, nested_fields) = extractors::extract_nested_rel_aggr_selections(nested_fields);
-    let aggregation_selections = utils::collect_relation_aggr_selections(aggr_fields_pairs, &model)?;
-    let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
+    let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
+    let selection_order = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, None, &model, query_schema)?;
     let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
+    let selected_fields = selected_fields.merge(virtual_fields);
 
     let relation_load_strategy = get_relation_load_strategy(
         requested_rel_load_strategy,
         None,
         None,
         &nested,
-        &aggregation_selections,
+        // &aggregation_selections,
+        &selected_fields,
         query_schema,
     );
 
@@ -67,10 +68,11 @@ fn find_unique_with_options(
         alias,
         model,
         filter,
-        selected_fields,
+        user_selection: selected_fields.clone(),
+        full_selection: selected_fields,
         nested,
         selection_order,
-        aggregation_selections,
+        // aggregation_selections,
         options,
         relation_load_strategy,
     }))

--- a/query-engine/core/src/query_graph_builder/read/related.rs
+++ b/query-engine/core/src/query_graph_builder/read/related.rs
@@ -13,26 +13,27 @@ pub(crate) fn find_related(
     let name = field.name;
     let alias = field.alias;
     let sub_selections = field.nested_fields.unwrap().fields;
-    let (aggr_fields_pairs, sub_selections) = extractors::extract_nested_rel_aggr_selections(sub_selections);
-    let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
-    let selection_order: Vec<String> = utils::collect_selection_order(&sub_selections);
-    let selected_fields = utils::collect_selected_fields(&sub_selections, args.distinct.clone(), &model, query_schema)?;
+    // let (aggr_fields_pairs, sub_selections) = extractors::extract_nested_rel_aggr_selections(sub_selections);
+    // let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
+    // let selection_order: Vec<String> = utils::collect_selection_order(&sub_selections);
+    let (user_selection, full_selection) =
+        utils::collect_selected_fields(&sub_selections, args.distinct.clone(), &model, query_schema)?;
     let nested = utils::collect_nested_queries(sub_selections, &model, query_schema)?;
     let parent_field = parent;
 
-    let selected_fields = utils::merge_relation_selections(selected_fields, Some(parent_field.clone()), &nested);
-    let selected_fields = utils::merge_cursor_fields(selected_fields, &args.cursor);
-    let selected_fields = selected_fields.merge(virtual_fields);
+    let full_selection = utils::merge_relation_selections(full_selection, Some(parent_field.clone()), &nested);
+    let full_selection = utils::merge_cursor_fields(full_selection, &args.cursor);
+    // let selected_fields = selected_fields.merge(virtual_fields);
 
     Ok(ReadQuery::RelatedRecordsQuery(RelatedRecordsQuery {
         name,
         alias,
         parent_field,
         args,
-        user_selection: selected_fields.clone(),
-        full_selection: selected_fields,
+        user_selection,
+        full_selection,
         nested,
-        selection_order,
+        // selection_order,
         // aggregation_selections,
         parent_results: None,
     }))

--- a/query-engine/core/src/query_graph_builder/read/related.rs
+++ b/query-engine/core/src/query_graph_builder/read/related.rs
@@ -14,7 +14,7 @@ pub(crate) fn find_related(
     let alias = field.alias;
     let sub_selections = field.nested_fields.unwrap().fields;
     let (aggr_fields_pairs, sub_selections) = extractors::extract_nested_rel_aggr_selections(sub_selections);
-    let aggregation_selections = utils::collect_relation_aggr_selections(aggr_fields_pairs, &model)?;
+    let virtual_fields = utils::collect_virtual_fields(aggr_fields_pairs, &model)?;
     let selection_order: Vec<String> = utils::collect_selection_order(&sub_selections);
     let selected_fields = utils::collect_selected_fields(&sub_selections, args.distinct.clone(), &model, query_schema)?;
     let nested = utils::collect_nested_queries(sub_selections, &model, query_schema)?;
@@ -22,16 +22,18 @@ pub(crate) fn find_related(
 
     let selected_fields = utils::merge_relation_selections(selected_fields, Some(parent_field.clone()), &nested);
     let selected_fields = utils::merge_cursor_fields(selected_fields, &args.cursor);
+    let selected_fields = selected_fields.merge(virtual_fields);
 
     Ok(ReadQuery::RelatedRecordsQuery(RelatedRecordsQuery {
         name,
         alias,
         parent_field,
         args,
-        selected_fields,
+        user_selection: selected_fields.clone(),
+        full_selection: selected_fields,
         nested,
         selection_order,
-        aggregation_selections,
+        // aggregation_selections,
         parent_results: None,
     }))
 }

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -39,10 +39,11 @@ where
         alias: None,
         model: model.clone(),
         args: (model, filter).into(),
-        selected_fields,
+        full_selection: selected_fields,
+        user_selection: selected_fields,
         nested: vec![],
         selection_order: vec![],
-        aggregation_selections: vec![],
+        // aggregation_selections: vec![],
         options: QueryOptions::none(),
         relation_load_strategy: query_structure::RelationLoadStrategy::Query,
     });
@@ -112,8 +113,8 @@ where
         parent_field: parent_relation_field.clone(),
         parent_results: None,
         args: (child_model, filter).into(),
-        selected_fields,
-        aggregation_selections: vec![],
+        user_selection: selected_fields.clone(),
+        full_selection: selected_fields,
         nested: vec![],
         selection_order: vec![],
     })));
@@ -839,7 +840,7 @@ pub fn emulate_on_update_restrict(
 
     let linking_fields_updated = linking_fields
         .into_iter()
-        .any(|parent_pk| parent_update_args.get_field_value(parent_pk.db_name()).is_some());
+        .any(|parent_pk| parent_update_args.get_field_value(&parent_pk.db_name()).is_some());
 
     graph.create_edge(
         &read_node,

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -40,10 +40,8 @@ where
         model: model.clone(),
         args: (model, filter).into(),
         full_selection: selected_fields,
-        user_selection: selected_fields,
+        user_selection: vec![].into(),
         nested: vec![],
-        selection_order: vec![],
-        // aggregation_selections: vec![],
         options: QueryOptions::none(),
         relation_load_strategy: query_structure::RelationLoadStrategy::Query,
     });
@@ -113,10 +111,9 @@ where
         parent_field: parent_relation_field.clone(),
         parent_results: None,
         args: (child_model, filter).into(),
-        user_selection: selected_fields.clone(),
+        user_selection: vec![].into(),
         full_selection: selected_fields,
         nested: vec![],
-        selection_order: vec![],
     })));
 
     graph.create_edge(

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use connector::{AggregationResult, RelAggregationResult, RelAggregationRow};
 use indexmap::IndexMap;
-use itertools::Itertools;
 use query_structure::{CompositeFieldRef, Field, PrismaValue, SelectionResult};
 use schema::{
     constants::{aggregations::*, output_fields::*},

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -1,5 +1,5 @@
 use connector::AggregationRow;
-use query_structure::{ManyRecords, Model, SelectionResult};
+use query_structure::{ManyRecords, Model, SelectionResult, SelectedField};
 
 #[derive(Debug, Clone)]
 pub(crate) enum QueryResult {
@@ -18,7 +18,7 @@ pub struct RecordSelectionWithRelations {
     pub(crate) name: String,
 
     /// Holds an ordered list of selected field names for each contained record.
-    pub(crate) fields: Vec<String>,
+    pub(crate) fields: Vec<SelectedField>,
 
     /// Selection results
     pub(crate) records: ManyRecords,
@@ -53,7 +53,7 @@ pub struct RecordSelection {
     pub(crate) name: String,
 
     /// Holds an ordered list of selected field names for each contained record.
-    pub(crate) fields: Vec<String>,
+    pub(crate) fields: Vec<SelectedField>,
 
     /// Scalar field results
     pub(crate) scalars: ManyRecords,

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -1,4 +1,4 @@
-use connector::{AggregationRow, RelAggregationRow};
+use connector::AggregationRow;
 use query_structure::{ManyRecords, Model, SelectionResult};
 
 #[derive(Debug, Clone)]
@@ -64,9 +64,8 @@ pub struct RecordSelection {
 
     /// The model of the contained records.
     pub(crate) model: Model,
-
-    /// Holds an ordered list of aggregation selections results for each contained record
-    pub(crate) aggregation_rows: Option<Vec<RelAggregationRow>>,
+    // Holds an ordered list of aggregation selections results for each contained record
+    // pub(crate) aggregation_rows: Option<Vec<RelAggregationRow>>,
 }
 
 impl From<RecordSelection> for QueryResult {

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -1,12 +1,12 @@
 use crate::{
     parent_container::ParentContainer, prisma_value_ext::PrismaValueExtensions, CompositeFieldRef, DomainError, Field,
-    Model, ModelProjection, QueryArguments, RelationField, ScalarField, ScalarFieldRef, SelectionResult,
-    TypeIdentifier,
+    Filter, Model, ModelProjection, QueryArguments, RelationField, RelationFieldRef, ScalarField, ScalarFieldRef,
+    SelectionResult, TypeIdentifier,
 };
 use itertools::Itertools;
 use prisma_value::PrismaValue;
 use psl::schema_ast::ast::FieldArity;
-use std::fmt::Display;
+use std::{borrow::Cow, fmt::Display};
 
 /// A selection of fields from a model.
 #[derive(Debug, Clone, PartialEq, Default, Hash, Eq)]
@@ -35,6 +35,7 @@ impl FieldSelection {
                 .unwrap_or(false),
             // TODO: Relation selections are ignored for now to prevent breaking the existing query-based strategy to resolve relations.
             SelectedField::Relation(_) => true,
+            SelectedField::Virtual(vs) => self.contains(&vs.db_alias()),
         })
     }
 
@@ -42,16 +43,23 @@ impl FieldSelection {
         self.selections.iter()
     }
 
+    pub fn virtuals(&self) -> impl Iterator<Item = &VirtualSelection> {
+        self.selections().filter_map(|field| match field {
+            SelectedField::Virtual(ref vs) => Some(vs),
+            _ => None,
+        })
+    }
+
     /// Returns all Prisma (e.g. schema model field) names of contained fields.
     /// Does _not_ recurse into composite selections and only iterates top level fields.
     pub fn prisma_names(&self) -> impl Iterator<Item = String> + '_ {
-        self.selections.iter().map(|f| f.prisma_name().to_owned())
+        self.selections.iter().map(|f| f.prisma_name().into_owned())
     }
 
     /// Returns all database (e.g. column or document field) names of contained fields.
     /// Does _not_ recurse into composite selections and only iterates level fields.
     pub fn db_names(&self) -> impl Iterator<Item = String> + '_ {
-        self.selections.iter().map(|f| f.db_name().to_owned())
+        self.selections.iter().map(|f| f.db_name().into_owned())
     }
 
     /// Checked if a field of prisma name `name` is present in this `FieldSelection`.
@@ -69,6 +77,7 @@ impl FieldSelection {
                 SelectedField::Scalar(sf) => sf.clone().into(),
                 SelectedField::Composite(cf) => cf.field.clone().into(),
                 SelectedField::Relation(rs) => rs.field.clone().into(),
+                SelectedField::Virtual(vs) => vs.field(),
             })
             .collect()
     }
@@ -82,6 +91,7 @@ impl FieldSelection {
                 SelectedField::Scalar(sf) => Some(sf.clone()),
                 SelectedField::Composite(_) => None,
                 SelectedField::Relation(_) => None,
+                SelectedField::Virtual(_) => None,
             })
             .collect::<Vec<_>>();
 
@@ -158,6 +168,7 @@ impl FieldSelection {
                 SelectedField::Relation(rf) if rf.field.is_list() => Some((TypeIdentifier::Json, FieldArity::Required)),
                 SelectedField::Relation(rf) => Some((TypeIdentifier::Json, rf.field.arity())),
                 SelectedField::Composite(_) => None,
+                SelectedField::Virtual(vs) => Some(vs.type_identifier_with_arity()),
             })
             .collect()
     }
@@ -172,15 +183,20 @@ impl FieldSelection {
     pub fn into_projection(self) -> ModelProjection {
         self.into()
     }
+
+    pub fn has_virtual_fields(&self) -> bool {
+        self.selections()
+            .any(|field| matches!(field, SelectedField::Virtual(_)))
+    }
 }
 
 /// A selected field. Can be contained on a model or composite type.
-// Todo: Think about virtual selections like aggregations.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SelectedField {
     Scalar(ScalarFieldRef),
     Composite(CompositeSelection),
     Relation(RelationSelection),
+    Virtual(VirtualSelection),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -213,20 +229,68 @@ impl RelationSelection {
     }
 }
 
-impl SelectedField {
-    pub fn prisma_name(&self) -> &str {
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum VirtualSelection {
+    RelationCount(RelationFieldRef, Option<Filter>),
+}
+
+impl VirtualSelection {
+    pub fn db_alias(&self) -> String {
         match self {
-            SelectedField::Scalar(sf) => sf.name(),
-            SelectedField::Composite(cf) => cf.field.name(),
-            SelectedField::Relation(rs) => rs.field.name(),
+            Self::RelationCount(rf, _) => format!("_aggr_count_{}", rf.name()),
         }
     }
 
-    pub fn db_name(&self) -> &str {
+    pub fn model(&self) -> Model {
         match self {
-            SelectedField::Scalar(sf) => sf.db_name(),
-            SelectedField::Composite(cs) => cs.field.db_name(),
-            SelectedField::Relation(rs) => rs.field.name(),
+            Self::RelationCount(rf, _) => rf.model(),
+        }
+    }
+
+    pub fn coerce_value(&self, value: PrismaValue) -> crate::Result<PrismaValue> {
+        match self {
+            Self::RelationCount(_, _) => match value {
+                PrismaValue::Null => Ok(PrismaValue::Int(0)),
+                _ => value.coerce(TypeIdentifier::Int),
+            },
+        }
+    }
+
+    pub fn field(&self) -> Field {
+        match self {
+            Self::RelationCount(rf, _) => rf.clone().into(),
+        }
+    }
+
+    pub fn type_identifier_with_arity(&self) -> (TypeIdentifier, FieldArity) {
+        match self {
+            Self::RelationCount(_, _) => (TypeIdentifier::Int, FieldArity::Required),
+        }
+    }
+}
+
+impl Display for VirtualSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.db_alias())
+    }
+}
+
+impl SelectedField {
+    pub fn prisma_name(&self) -> Cow<'_, str> {
+        match self {
+            SelectedField::Scalar(sf) => sf.name().into(),
+            SelectedField::Composite(cf) => cf.field.name().into(),
+            SelectedField::Relation(rs) => rs.field.name().into(),
+            SelectedField::Virtual(vs) => vs.db_alias().into(),
+        }
+    }
+
+    pub fn db_name(&self) -> Cow<'_, str> {
+        match self {
+            SelectedField::Scalar(sf) => sf.db_name().into(),
+            SelectedField::Composite(cs) => cs.field.db_name().into(),
+            SelectedField::Relation(rs) => rs.field.name().into(),
+            SelectedField::Virtual(vs) => vs.db_alias().into(),
         }
     }
 
@@ -242,15 +306,17 @@ impl SelectedField {
             SelectedField::Scalar(sf) => sf.container(),
             SelectedField::Composite(cs) => cs.field.container(),
             SelectedField::Relation(rs) => ParentContainer::from(rs.field.model()),
+            SelectedField::Virtual(vs) => ParentContainer::from(vs.model()), // TODO
         }
     }
 
     /// Coerces a value to fit the selection. If the conversion is not possible, an error will be thrown.
     pub(crate) fn coerce_value(&self, value: PrismaValue) -> crate::Result<PrismaValue> {
         match self {
-            SelectedField::Scalar(sf) => value.coerce(&sf.type_identifier()),
+            SelectedField::Scalar(sf) => value.coerce(sf.type_identifier()),
             SelectedField::Composite(cs) => cs.coerce_value(value),
             SelectedField::Relation(_) => todo!(),
+            SelectedField::Virtual(vs) => vs.coerce_value(value),
         }
     }
 
@@ -277,6 +343,7 @@ impl CompositeSelection {
                     .map(|cs| cs.is_superset_of(other_cs))
                     .unwrap_or(false),
                 SelectedField::Relation(_) => true, // A composite selection cannot hold relations.
+                SelectedField::Virtual(_) => true,  // TODO
             })
     }
 
@@ -358,6 +425,7 @@ impl Display for SelectedField {
                 rs.field,
                 rs.selections.iter().map(|selection| format!("{selection}")).join(", ")
             ),
+            SelectedField::Virtual(vs) => write!(f, "{vs}"),
         }
     }
 }

--- a/query-engine/query-structure/src/filter/into_filter.rs
+++ b/query-engine/query-structure/src/filter/into_filter.rs
@@ -16,6 +16,7 @@ impl IntoFilter for SelectionResult {
                 SelectedField::Scalar(sf) => sf.equals(value),
                 SelectedField::Composite(_) => unreachable!(), // [Composites] todo
                 SelectedField::Relation(_) => unreachable!(),
+                SelectedField::Virtual(_) => unreachable!(),
             })
             .collect();
 

--- a/query-engine/query-structure/src/prisma_value_ext.rs
+++ b/query-engine/query-structure/src/prisma_value_ext.rs
@@ -3,12 +3,12 @@ use crate::DomainError;
 use bigdecimal::ToPrimitive;
 
 pub(crate) trait PrismaValueExtensions {
-    fn coerce(self, to_type: &TypeIdentifier) -> crate::Result<PrismaValue>;
+    fn coerce(self, to_type: TypeIdentifier) -> crate::Result<PrismaValue>;
 }
 
 impl PrismaValueExtensions for PrismaValue {
     // Todo this is not exhaustive for now.
-    fn coerce(self, to_type: &TypeIdentifier) -> crate::Result<PrismaValue> {
+    fn coerce(self, to_type: TypeIdentifier) -> crate::Result<PrismaValue> {
         let coerced = match (self, to_type) {
             // Trivial cases
             (PrismaValue::Null, _) => PrismaValue::Null,

--- a/query-engine/query-structure/src/projections/model_projection.rs
+++ b/query-engine/query-structure/src/projections/model_projection.rs
@@ -31,6 +31,7 @@ impl From<&FieldSelection> for ModelProjection {
                     SelectedField::Scalar(sf) => Some(sf.clone().into()),
                     SelectedField::Composite(_cf) => None,
                     SelectedField::Relation(_) => None,
+                    SelectedField::Virtual(_) => None,
                 })
                 .collect(),
         }

--- a/query-engine/query-structure/src/record.rs
+++ b/query-engine/query-structure/src/record.rs
@@ -172,7 +172,7 @@ impl Record {
         let pairs: Vec<_> = extraction_selection
             .selections()
             .map(|selection| {
-                self.get_field_value(field_names, selection.db_name())
+                self.get_field_value(field_names, &selection.db_name())
                     .and_then(|val| Ok((selection.clone(), selection.coerce_value(val.clone())?)))
             })
             .collect::<crate::Result<Vec<_>>>()?;

--- a/query-engine/query-structure/src/selection_result.rs
+++ b/query-engine/query-structure/src/selection_result.rs
@@ -1,6 +1,6 @@
 use crate::{DomainError, FieldSelection, PrismaValue, ScalarFieldRef, SelectedField};
 use itertools::Itertools;
-use std::convert::TryFrom;
+use std::{borrow::Cow, convert::TryFrom};
 
 /// Represents a set of results.
 #[derive(Default, Clone, PartialEq, Eq, Hash)]
@@ -61,7 +61,7 @@ impl SelectionResult {
         self.len() == 0
     }
 
-    pub fn db_names(&self) -> impl Iterator<Item = &str> + '_ {
+    pub fn db_names(&self) -> impl Iterator<Item = Cow<'_, str>> + '_ {
         self.pairs.iter().map(|(field, _)| field.db_name())
     }
 
@@ -95,6 +95,7 @@ impl SelectionResult {
                 SelectedField::Scalar(sf) => Some(sf.clone()),
                 SelectedField::Composite(_) => None,
                 SelectedField::Relation(_) => None,
+                SelectedField::Virtual(_) => None,
             })
             .collect();
 


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/815

On hold for now, the scope seems to be bigger than anticipated.

Next steps:
* Fix all the write queries that return `RecordSelection`
* Rework `serialize_objects` and `serialize_objects_with_relations`
* Remove commented-out code
* Remove dead code (lots of stuff that's not commented out but not used or called anymore), overall this PR should have more removed than added lines