### PR TITLE
qe: Fix nested objects with `$type` key in JSON protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,11 @@ members = [
 
 [workspace.dependencies]
 psl = { path = "./psl/psl" }
-serde_json = { version = "1", features = ["float_roundtrip", "preserve_order"] }
+serde_json = { version = "1", features = [
+  "float_roundtrip",
+  "preserve_order",
+  "raw_value",
+] }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "1.25", features = [
   "rt-multi-thread",

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -21,6 +21,7 @@ mod prisma_18517;
 mod prisma_20799;
 mod prisma_21182;
 mod prisma_21369;
+mod prisma_21454;
 mod prisma_21901;
 mod prisma_22298;
 mod prisma_5952;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21454.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_21454.rs
@@ -1,0 +1,74 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), capabilities(Json))]
+mod prisma_21454 {
+
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"
+            model Model {
+                #id(id, String, @id)
+                json Json
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test]
+    async fn dollar_type_in_json(runner: Runner) -> TestResult<()> {
+        let res = runner
+            .query_json(
+                r#"{
+                    "modelName": "Model",
+                    "action": "createOne",
+                    "query": {
+                       "selection": { "json": true },
+                       "arguments": {
+                          "data": {
+                             "id": "123",
+                             "json": { "$type": "Json", "value": "{\"$type\": \"Something\" }" }
+                          }
+                       }
+                    }
+                }"#,
+            )
+            .await?;
+
+        res.assert_success();
+
+        insta::assert_snapshot!(res.to_string(), @r###"{"data":{"createOneModel":{"json":{"$type":"Json","value":"{\"$type\":\"Something\"}"}}}}"###);
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn nested_dollar_type_in_json(runner: Runner) -> TestResult<()> {
+        let res = runner
+            .query_json(
+                r#"{
+                    "modelName": "Model",
+                    "action": "createOne",
+                    "query": {
+                       "selection": { "json": true },
+                       "arguments": {
+                          "data": {
+                             "id": "123",
+                             "json": {
+                                "something": { "$type": "Json", "value": "{\"$type\": \"Something\" }" }
+                             }
+                          }
+                       }
+                    }
+                }"#,
+            )
+            .await?;
+
+        res.assert_success();
+
+        insta::assert_snapshot!(res.to_string(), @r###"{"data":{"createOneModel":{"json":{"$type":"Json","value":"{\"something\":{\"$type\":\"Something\"}}"}}}}"###);
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
@@ -94,7 +94,7 @@ mod json {
 
                 insta::assert_snapshot!(
                   res,
-                  @r###"{"data":{"findManyTestModel":[{"json":null},{"json":null}]}}"###
+                  @r###"{"data":{"findManyTestModel":[{"json":null},{"json":"null"}]}}"###
                 );
             }
             query_engine_tests::EngineProtocol::Json => {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
@@ -94,7 +94,7 @@ mod json {
 
                 insta::assert_snapshot!(
                   res,
-                  @r###"{"data":{"findManyTestModel":[{"json":null},{"json":"null"}]}}"###
+                  @r###"{"data":{"findManyTestModel":[{"json":null},{"json":null}]}}"###
                 );
             }
             query_engine_tests::EngineProtocol::Json => {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/json_adapter/request.rs
@@ -228,7 +228,7 @@ impl<'a, 'b> FieldTypeInferrer<'a, 'b> {
                     None => InferredType::Unknown,
                 }
             }
-            ArgumentValue::FieldRef(_) => unreachable!(),
+            ArgumentValue::FieldRef(_) | ArgumentValue::Json(_) => unreachable!(),
         }
     }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -228,13 +228,14 @@ impl Runner {
         tracing::debug!("Querying: {}", query.clone().green());
 
         println!("{}", query.bright_green());
+        let query: serde_json::Value = serde_json::from_str(&query).unwrap();
 
         let executor = match &self.executor {
             RunnerExecutor::Builtin(e) => e,
-            RunnerExecutor::External(_) => {
+            RunnerExecutor::External(schema_id) => {
                 let response_str: String = executor_process_request(
                     "query",
-                    json!({ "query": query, "txId": self.current_tx_id.as_ref().map(ToString::to_string) }),
+                    json!({ "query": query, "schemaId": schema_id, "txId": self.current_tx_id.as_ref().map(ToString::to_string) }),
                 )
                 .await?;
                 let response: QueryResult = serde_json::from_str(&response_str).unwrap();
@@ -244,7 +245,7 @@ impl Runner {
 
         let handler = RequestHandler::new(&**executor, &self.query_schema, EngineProtocol::Json);
 
-        let serialized_query: JsonSingleQuery = serde_json::from_str(&query).unwrap();
+        let serialized_query: JsonSingleQuery = serde_json::from_value(query).unwrap();
         let request_body = RequestBody::Json(JsonBody::Single(serialized_query));
 
         let result: QueryResult = handler

--- a/query-engine/core/src/query_document/argument_value.rs
+++ b/query-engine/core/src/query_document/argument_value.rs
@@ -4,6 +4,8 @@ use indexmap::IndexMap;
 use query_structure::PrismaValue;
 use serde::Serialize;
 
+use super::raw_json_value::RawJson;
+
 pub type ArgumentValueObject = IndexMap<String, ArgumentValue>;
 
 /// Represents the input values in a Document.
@@ -14,6 +16,7 @@ pub enum ArgumentValue {
     Scalar(PrismaValue),
     Object(ArgumentValueObject),
     List(Vec<ArgumentValue>),
+    Json(RawJson),
     FieldRef(ArgumentValueObject),
 }
 
@@ -43,7 +46,7 @@ impl ArgumentValue {
     }
 
     pub fn json(str: String) -> Self {
-        Self::Scalar(PrismaValue::Json(str))
+        Self::Json(RawJson::from_string(str))
     }
 
     pub fn bytes(bytes: Vec<u8>) -> Self {
@@ -76,6 +79,7 @@ impl ArgumentValue {
     pub(crate) fn should_be_parsed_as_json(&self) -> bool {
         match self {
             ArgumentValue::Object(_) => true,
+            ArgumentValue::Json(_) => true,
             ArgumentValue::List(l) => l.iter().all(|v| v.should_be_parsed_as_json()),
             ArgumentValue::Scalar(pv) => !matches!(pv, PrismaValue::Enum(_) | PrismaValue::Json(_)),
             ArgumentValue::FieldRef(_) => false,

--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -18,6 +18,7 @@ mod argument_value;
 mod operation;
 mod parse_ast;
 mod parser;
+mod raw_json_value;
 mod selection;
 mod transformers;
 

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -871,6 +871,7 @@ pub(crate) mod conversions {
                 format!("({})", itertools::join(v.iter().map(argument_value_to_type_name), ", "))
             }
             ArgumentValue::FieldRef(_) => "FieldRef".to_string(),
+            ArgumentValue::Json(_) => "Json".to_string(),
         }
     }
 

--- a/query-engine/core/src/query_document/raw_json_value.rs
+++ b/query-engine/core/src/query_document/raw_json_value.rs
@@ -1,0 +1,23 @@
+use serde::Serialize;
+use serde_json::value::RawValue;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawJson {
+    value: String,
+}
+
+impl RawJson {
+    pub fn from_string(value: String) -> Self {
+        Self { value }
+    }
+}
+
+impl Serialize for RawJson {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let raw_value = RawValue::from_string(self.value.to_owned()).map_err(serde::ser::Error::custom)?;
+        raw_value.serialize(serializer)
+    }
+}

--- a/query-engine/core/src/query_document/raw_json_value.rs
+++ b/query-engine/core/src/query_document/raw_json_value.rs
@@ -1,6 +1,19 @@
 use serde::Serialize;
 use serde_json::value::RawValue;
 
+/// We are using RawJson object to prevent stringification of 
+/// certain JSON values. Difference between this is and PrismaValue::Json
+/// is the following:
+/// 
+/// PrismaValue::Json(r"""{"foo": "bar"}""") when serialized will produce the string "{\"foo\":\"bar\"}".
+/// RawJson(r"""{"foo": "bar"}""") will produce {"foo": "bar" } JSON object.
+/// So, it essentially would treat provided string as pre-serialized JSON fragment and not a string to be serialized.
+/// 
+/// It is a wrapper of `serde_json::value::RawValue`. We don't want to use `RawValue` inside of `ArgumentValue`
+/// directly because:
+/// 1. We need `Eq` implementation
+/// 2. `serde_json::value::RawValue::from_string` may error and we'd like to delay handling of that error to
+/// serialization time
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct RawJson {
     value: String,

--- a/query-engine/core/src/query_document/raw_json_value.rs
+++ b/query-engine/core/src/query_document/raw_json_value.rs
@@ -1,14 +1,14 @@
 use serde::Serialize;
 use serde_json::value::RawValue;
 
-/// We are using RawJson object to prevent stringification of 
+/// We are using RawJson object to prevent stringification of
 /// certain JSON values. Difference between this is and PrismaValue::Json
 /// is the following:
-/// 
+///
 /// PrismaValue::Json(r"""{"foo": "bar"}""") when serialized will produce the string "{\"foo\":\"bar\"}".
 /// RawJson(r"""{"foo": "bar"}""") will produce {"foo": "bar" } JSON object.
 /// So, it essentially would treat provided string as pre-serialized JSON fragment and not a string to be serialized.
-/// 
+///
 /// It is a wrapper of `serde_json::value::RawValue`. We don't want to use `RawValue` inside of `ArgumentValue`
 /// directly because:
 /// 1. We need `Eq` implementation

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -210,11 +210,11 @@ impl<'a> JsonProtocolAdapter<'a> {
                 Some(custom_types::JSON) => {
                     // At the moment, client would send {"$type": "Json"} record only in 1 case:
                     // if anywhere in the user's input it would see `$type` key, it will encode as json
-                    // to avoid conflict with protocol-level `$type` keys. 
+                    // to avoid conflict with protocol-level `$type` keys.
                     // Such record will not necessary be top level, it can be nested. See https://github.com/prisma/prisma/issues/21454.
                     //
                     // In that case, when serializing the JSON value, we don't want to treat such objects as strings but rather, insert their
-                    // value as is into generated document. 
+                    // value as is into generated document.
                     // See also query-engine/core/src/query_document/raw_json_value.rs
                     // To future generations: I am sorry, we failed you, JSON handling in TS client is mess. If you are reading this,
                     // ask for explicit wrapper for JSON values on the client side that would solve most of this mess https://github.com/prisma/prisma/issues/19611

--- a/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-engine/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -1288,10 +1288,10 @@ mod tests {
         assert_debug_snapshot!(operation.arguments()[0].1, @r###"
         Object(
             {
-                "x": Scalar(
-                    Json(
-                        "{ \"$type\": \"foo\", \"value\": \"bar\" }",
-                    ),
+                "x": Json(
+                    RawJson {
+                        value: "{ \"$type\": \"foo\", \"value\": \"bar\" }",
+                    },
                 ),
             },
         )


### PR DESCRIPTION
In JSON protocol, we use `$type` key as a special marker for the types
that can not be represented in JSON natively. We did not want to make
`$type` identifier reserved, so we took some precautions: if during
encoding, at any point, `$type` key would be seen in user's input we
encode whole object as `{"$type": "Json", "value": [Serialized object] }`.

Engine handled those cases correctly, when `$type: Json` is encountered
at the top level, but not when it is nested. In that case,
`ArgumentValue`-to-`JSON` serialization just picked `value` key and
saved it as a string.

Fixed by moving Json value into it's own kind of `ArgumentValue`, that
are serialized to json as-is.

Fix prisma/prisma#21454
