### PR TITLE
driver-adapters analyze: Add percentages to crates output for size analysis

### DIFF
--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-
+#!/bin/bash 
 # Call this script as `./build.sh <npm_version>`
 set -euo pipefail
 


### PR DESCRIPTION
When continuously measuring size data presented this way is easier to interpret without much post-processing

Output:

```markdown
|                    crate | size(KB) | size(%)  | frequency  |
| -----------------------: | :------- | :------- | :--------- |
|                     core |    625.1 |  21.134% |       3080 |
|               query_core |    347.8 |  11.759% |        264 |
|      (section) data[..]  |    227.9 |   7.704% |        211 |
|      sql_query_connector |    187.8 |   6.349% |        125 |
|                   quaint |    177.8 |   6.012% |        334 |
|          driver_adapters |     71.0 |   2.401% |         19 |
|                    alloc |     61.4 |   2.077% |        414 |
|          query_structure |     50.1 |   1.695% |        164 |
|                    serde |     45.1 |   1.526% |        187 |
|                     pest |     44.0 |   1.489% |         49 |
|     wasm_bindgen_futures |     43.6 |   1.473% |         23 |
|                   schema |     43.4 |   1.467% |         95 |
|                hashbrown |     40.0 |   1.353% |        192 |
|                 psl_core |     39.0 |   1.320% |        118 |
|          query_connector |     33.3 |   1.127% |        114 |
|          parser_database |     28.3 |   0.957% |        131 |
|                   chrono |     28.2 |   0.955% |         87 |
|               serde_json |     27.9 |   0.942% |        101 |
|               num_bigint |     19.6 |   0.663% |         67 |
|         request_handlers |     18.4 |   0.624% |         16 |
|                 indexmap |     14.4 |   0.488% |         52 |
|       user_facing_errors |     12.8 |   0.432% |         19 |
|             tracing_core |     10.1 |   0.341% |         61 |
|               schema_ast |      8.8 |   0.299% |         24 |
|               bigdecimal |      8.3 |   0.279% |          9 |
|        crosstarget_utils |      7.6 |   0.258% |          7 |
|                rand_core |      7.2 |   0.242% |          3 |
|                    tokio |      7.0 |   0.237% |         35 |
|             prisma_value |      7.0 |   0.235% |          7 |
|                 dlmalloc |      6.4 |   0.216% |          7 |
|                      std |      5.7 |   0.193% |         30 |
|                itertools |      4.4 |   0.149% |          7 |
|              diagnostics |      3.5 |   0.119% |         21 |
|            opentelemetry |      3.4 |   0.115% |         10 |
|      (section) elem[..]  |      3.4 |   0.114% |          2 |
|                   base64 |      3.1 |   0.105% |          3 |
|       serde_wasm_bindgen |      3.0 |   0.102% |         11 |
|             sharded_slab |      2.6 |   0.088% |          9 |
|                once_cell |      2.6 |   0.086% |         13 |
|                      ryu |      2.3 |   0.077% |          7 |
|                     uuid |      2.2 |   0.074% |          3 |
|                     cuid |      2.1 |   0.072% |          4 |
|             wasm_bindgen |      1.6 |   0.055% |         38 |
|               num_traits |      1.6 |   0.052% |          6 |
|                  tracing |      1.3 |   0.044% |          6 |
|                   anyhow |      1.3 |   0.044% |         22 |
|                getrandom |      1.2 |   0.040% |          2 |
|             thread_local |      1.1 |   0.039% |          5 |
|                   keccak |      1.1 |   0.038% |          1 |
|             futures_util |      1.1 |   0.038% |          9 |
|                 petgraph |      1.1 |   0.037% |          5 |
|                   js_sys |      0.8 |   0.028% |         12 |
|             futures_task |      0.8 |   0.025% |         10 |
|       tracing_subscriber |      0.7 |   0.025% |         14 |
|                     rand |      0.7 |   0.024% |          2 |
|      (section) type[..]  |      0.7 |   0.024% |         90 |
|      query_engine_common |      0.6 |   0.021% |          1 |
|                     itoa |      0.6 |   0.020% |          2 |
|              num_integer |      0.6 |   0.019% |          5 |
|             futures_core |      0.5 |   0.016% |          4 |
|              debug_panic |      0.5 |   0.015% |          1 |
|                     time |      0.4 |   0.013% |          5 |
|                      hex |      0.3 |   0.012% |          2 |
|    tracing_opentelemetry |      0.3 |   0.010% |          4 |
|        query_engine_wasm |      0.2 |   0.006% |          1 |
|                    ahash |      0.1 |   0.004% |          3 |
|               ppv_lite86 |      0.1 |   0.002% |          1 |
|    (section) global[..]  |      0.0 |   0.000% |          1 |
|     (section) table[..]  |      0.0 |   0.000% |          1 |
|    (section) memory[..]  |      0.0 |   0.000% |          1 |
```