### PR TITLE
qe: support `_count` in joined queries

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -57,7 +57,7 @@ fn coerce_json_relation_to_pv(value: serde_json::Value, rs: &RelationSelection) 
                 .map(|value| coerce_json_relation_to_pv(value, rs));
 
             // TODO(HACK): We probably want to update the sql builder instead to not aggregate to-one relations as array
-            // If the arary is empty, it means there's no relations, so we coerce it to
+            // If the array is empty, it means there's no relations, so we coerce it to
             if let Some(val) = coerced {
                 val
             } else {

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -9,14 +9,24 @@ use crate::{query_arguments_ext::QueryArgumentsExt, SqlError};
 /// Note: Some in-memory processing is baked into this function too for performance reasons.
 pub(crate) fn coerce_record_with_json_relation(
     record: &mut Record,
-    rs_indexes: Vec<(usize, &RelationSelection)>,
+    rs_indexes: &[(usize, &RelationSelection)],
+    vs_indexes: &[(usize, &str)],
 ) -> crate::Result<()> {
-    for (val_idx, rs) in rs_indexes {
+    for &(val_idx, rs) in rs_indexes {
         let val = record.values.get_mut(val_idx).unwrap();
         // TODO(perf): Find ways to avoid serializing and deserializing multiple times.
         let json_val: serde_json::Value = serde_json::from_str(val.as_json().unwrap()).unwrap();
 
         *val = coerce_json_relation_to_pv(json_val, rs)?;
+    }
+
+    // TODO: merge rs_indexes and vs_indexes and have a single loop
+    for &(val_idx, obj_name) in vs_indexes {
+        let val = record.values.get_mut(val_idx).unwrap();
+        // TODO(perf): Find ways to avoid serializing and deserializing multiple times.
+        let json_val: serde_json::Value = serde_json::from_str(val.as_json().unwrap()).unwrap();
+
+        *val = coerce_json_virtual_field_to_pv(obj_name, json_val)?;
     }
 
     Ok(())

--- a/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/coerce.rs
@@ -234,7 +234,7 @@ fn build_conversion_error_with_reason(sf: &ScalarField, from: &str, to: &str, re
     let field_name = sf.name();
 
     build_generic_conversion_error(format!(
-        "Unexpected conversion failure for field {container_name}.{field_name} from {from} to {to}. Reason: ${reason}"
+        "Unexpected conversion failure for field {container_name}.{field_name} from {from} to {to}. Reason: {reason}"
     ))
 }
 

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -33,8 +33,8 @@ pub(crate) async fn get_single_record_joins(
     selected_fields: &FieldSelection,
     ctx: &Context<'_>,
 ) -> crate::Result<Option<SingleRecord>> {
-    let field_names: Vec<_> = selected_fields.db_names().collect();
-    let idents = selected_fields.type_identifiers_with_arities();
+    let field_names: Vec<_> = selected_fields.db_names_grouping_virtuals().collect();
+    let idents = selected_fields.type_identifiers_with_arities_grouping_virtuals();
     let rs_indexes = get_relation_selection_indexes(selected_fields.relations().collect(), &field_names);
 
     let query = query_builder::select::SelectBuilder::default().build(
@@ -125,8 +125,8 @@ pub(crate) async fn get_many_records_joins(
     selected_fields: &FieldSelection,
     ctx: &Context<'_>,
 ) -> crate::Result<ManyRecords> {
-    let field_names: Vec<_> = selected_fields.db_names().collect();
-    let idents = selected_fields.type_identifiers_with_arities();
+    let field_names: Vec<_> = selected_fields.db_names_grouping_virtuals().collect();
+    let idents = selected_fields.type_identifiers_with_arities_grouping_virtuals();
     let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
     let rs_indexes = get_relation_selection_indexes(selected_fields.relations().collect(), &field_names);
 

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -35,6 +35,7 @@ pub(crate) async fn get_single_record_joins(
 ) -> crate::Result<Option<SingleRecord>> {
     let field_names: Vec<_> = selected_fields.db_names_grouping_virtuals().collect();
     let idents = selected_fields.type_identifiers_with_arities_grouping_virtuals();
+
     let indexes = get_selection_indexes(
         selected_fields.relations().collect(),
         selected_fields.virtuals().collect(),
@@ -132,6 +133,7 @@ pub(crate) async fn get_many_records_joins(
     let field_names: Vec<_> = selected_fields.db_names_grouping_virtuals().collect();
     let idents = selected_fields.type_identifiers_with_arities_grouping_virtuals();
     let meta = column_metadata::create(field_names.as_slice(), idents.as_slice());
+
     let indexes = get_selection_indexes(
         selected_fields.relations().collect(),
         selected_fields.virtuals().collect(),

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -418,8 +418,7 @@ fn get_selection_indexes<'a>(
         .filter_map(|(idx, field_name)| {
             relations
                 .iter()
-                .find(|rs| rs.field.name() == field_name)
-                .map(|rs| IndexedSelection::Relation(rs))
+                .find_map(|rs| (rs.field.name() == field_name).then_some(IndexedSelection::Relation(rs)))
                 .or_else(|| {
                     virtuals.iter().find_map(|vs| {
                         let obj_name = vs.serialized_name().0;

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
@@ -422,13 +422,13 @@ fn json_agg() -> Function<'static> {
 fn build_virtual_selection(selected_fields: &FieldSelection) -> Vec<(&'static str, Expression<'static>)> {
     let mut selected_objects = BTreeMap::new();
 
-    for (i, vs) in selected_fields.virtuals().enumerate() {
+    for vs in selected_fields.virtuals() {
         match vs {
             VirtualSelection::RelationCount(rf, _) => {
                 let (object_name, field_name) = vs.serialized_name();
 
                 let coalesce_args: Vec<Expression<'static>> = vec![
-                    Column::from((relation_count_alias_name(i, rf), vs.db_alias())).into(),
+                    Column::from((relation_count_alias_name(rf), vs.db_alias())).into(),
                     0.raw().into(),
                 ];
 
@@ -446,6 +446,6 @@ fn build_virtual_selection(selected_fields: &FieldSelection) -> Vec<(&'static st
         .collect()
 }
 
-fn relation_count_alias_name(vs_index: usize, rf: &RelationField) -> String {
-    format!("aggr_count_{}_{}_{}", vs_index, rf.model().name(), rf.name())
+fn relation_count_alias_name(rf: &RelationField) -> String {
+    format!("aggr_count_{}_{}", rf.model().name(), rf.name())
 }

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select.rs
@@ -167,8 +167,7 @@ impl SelectBuilder {
         let left_columns = rf.related_field().m2m_columns(ctx);
         let right_columns = ModelProjection::from(rf.model().primary_identifier()).as_columns(ctx);
 
-        let join_conditions =
-            build_join_conditions(left_columns.into_iter(), right_columns, m2m_table_alias, parent_alias);
+        let join_conditions = build_join_conditions(left_columns.into(), right_columns, m2m_table_alias, parent_alias);
 
         let m2m_join_data = Table::from(self.build_related_query_select(rs, m2m_table_alias, ctx))
             .alias(m2m_join_alias.to_table_string())
@@ -283,9 +282,9 @@ impl SelectBuilder {
             .on(m2m_join_conditions);
 
         let aggregation_join_conditions = {
-            let left_columns = rf.related_field().m2m_columns(ctx).into_iter();
+            let left_columns = rf.related_field().m2m_columns(ctx);
             let right_columns = ModelProjection::from(rf.model().primary_identifier()).as_columns(ctx);
-            build_join_conditions(left_columns, right_columns, m2m_table_alias, parent_alias)
+            build_join_conditions(left_columns.into(), right_columns, m2m_table_alias, parent_alias)
         };
 
         let select = Select::from_table(related_table)
@@ -411,8 +410,8 @@ impl<'a> SelectBuilderExt<'a> for Select<'a> {
 }
 
 fn build_join_conditions(
-    left_columns: impl Iterator<Item = Column<'static>>,
-    right_columns: impl Iterator<Item = Column<'static>>,
+    left_columns: ColumnIterator,
+    right_columns: ColumnIterator,
     left_alias: Alias,
     right_alias: Alias,
 ) -> ConditionTree<'static> {

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -64,6 +64,7 @@ fn read_one(
                     name: query.name,
                     model,
                     fields: query.selection_order,
+                    virtuals: query.selected_fields.virtuals_owned(),
                     records,
                     nested: build_relation_record_selection(query.selected_fields.relations()),
                 }
@@ -172,6 +173,7 @@ fn read_many_by_joins(
             Ok(RecordSelectionWithRelations {
                 name: query.name,
                 fields: query.selection_order,
+                virtuals: query.selected_fields.virtuals_owned(),
                 records: result,
                 nested: build_relation_record_selection(query.selected_fields.relations()),
                 model: query.model,
@@ -190,6 +192,7 @@ fn build_relation_record_selection<'a>(
         .map(|rq| RelationRecordSelection {
             name: rq.field.name().to_owned(),
             fields: rq.result_fields.clone(),
+            virtuals: rq.virtuals().cloned().collect(),
             model: rq.field.related_model(),
             nested: build_relation_record_selection(rq.relations()),
         })

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -73,19 +73,6 @@ impl ReadQuery {
             ReadQuery::AggregateRecordsQuery(_) => false,
         }
     }
-
-    pub(crate) fn has_virtual_selections(&self) -> bool {
-        fn has_virtuals(selection: &FieldSelection, nested: &[ReadQuery]) -> bool {
-            selection.has_virtual_fields() || nested.iter().any(|q| q.has_virtual_selections())
-        }
-
-        match self {
-            ReadQuery::RecordQuery(q) => has_virtuals(&q.selected_fields, &q.nested),
-            ReadQuery::ManyRecordsQuery(q) => has_virtuals(&q.selected_fields, &q.nested),
-            ReadQuery::RelatedRecordsQuery(q) => has_virtuals(&q.selected_fields, &q.nested),
-            ReadQuery::AggregateRecordsQuery(_) => false,
-        }
-    }
 }
 
 impl FilteredQuery for ReadQuery {

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -243,10 +243,6 @@ impl RelatedRecordsQuery {
     pub fn has_distinct(&self) -> bool {
         self.args.distinct.is_some() || self.nested.iter().any(|q| q.has_distinct())
     }
-
-    pub fn has_virtual_selections(&self) -> bool {
-        self.selected_fields.has_virtual_fields() || self.nested.iter().any(|q| q.has_virtual_selections())
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -42,7 +42,6 @@ fn find_many_with_options(
         args.cursor.as_ref(),
         args.distinct.as_ref(),
         &nested,
-        &selected_fields,
         query_schema,
     );
 

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -50,14 +50,8 @@ fn find_unique_with_options(
     let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
-    let relation_load_strategy = get_relation_load_strategy(
-        requested_rel_load_strategy,
-        None,
-        None,
-        &nested,
-        &selected_fields,
-        query_schema,
-    );
+    let relation_load_strategy =
+        get_relation_load_strategy(requested_rel_load_strategy, None, None, &nested, query_schema);
 
     Ok(ReadQuery::RecordQuery(RecordQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -257,14 +257,12 @@ pub(crate) fn get_relation_load_strategy(
     cursor: Option<&SelectionResult>,
     distinct: Option<&FieldSelection>,
     nested_queries: &[ReadQuery],
-    selected_fields: &FieldSelection,
     query_schema: &QuerySchema,
 ) -> RelationLoadStrategy {
     if query_schema.has_feature(PreviewFeature::RelationJoins)
         && query_schema.has_capability(ConnectorCapability::LateralJoin)
         && cursor.is_none()
         && distinct.is_none()
-        && !selected_fields.has_virtual_fields()
         && !nested_queries.iter().any(|q| match q {
             ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.has_distinct() || q.has_virtual_selections(),
             _ => false,

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -264,7 +264,7 @@ pub(crate) fn get_relation_load_strategy(
         && cursor.is_none()
         && distinct.is_none()
         && !nested_queries.iter().any(|q| match q {
-            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.has_distinct() || q.has_virtual_selections(),
+            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.has_distinct(),
             _ => false,
         })
         && requested_strategy != Some(RelationLoadStrategy::Query)

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -499,7 +499,7 @@ fn serialize_virtuals_group(obj_value: PrismaValue, virtuals: &[&VirtualSelectio
     let mut db_object: HashMap<String, PrismaValue> = HashMap::from_iter(obj_value.into_object().unwrap());
     let mut out_object = Map::new();
 
-    // We have to re-collect the object according to selection even if the query
+    // We have to reorder the object fields according to selection even if the query
     // builder respects the initial order because JSONB does not preserve order.
     for vs in virtuals {
         let (group_name, nested_name) = vs.serialized_name();

--- a/query-engine/core/src/result_ast/mod.rs
+++ b/query-engine/core/src/result_ast/mod.rs
@@ -20,6 +20,11 @@ pub struct RecordSelectionWithRelations {
     /// Holds an ordered list of selected field names for each contained record.
     pub(crate) fields: Vec<String>,
 
+    /// Holds the list of virtual selections included in the query result.
+    /// TODO: in the future it should be covered by [`RecordSelection::fields`] by storing ordered
+    /// `Vec<SelectedField>` or `FieldSelection` instead of `Vec<String>`.
+    pub(crate) virtuals: Vec<VirtualSelection>,
+
     /// Selection results
     pub(crate) records: ManyRecords,
 
@@ -41,6 +46,8 @@ pub struct RelationRecordSelection {
     pub name: String,
     /// Holds an ordered list of selected field names for each contained record.
     pub fields: Vec<String>,
+    /// Holds the list of virtual selections included in the query result.
+    pub virtuals: Vec<VirtualSelection>,
     /// The model of the contained records.
     pub model: Model,
     /// Nested relation selections

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -242,6 +242,10 @@ impl RelationSelection {
         })
     }
 
+    pub fn virtuals(&self) -> impl Iterator<Item = &VirtualSelection> {
+        self.selections.iter().filter_map(SelectedField::as_virtual)
+    }
+
     pub fn related_model(&self) -> Model {
         self.field.related_model()
     }

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -44,10 +44,7 @@ impl FieldSelection {
     }
 
     pub fn virtuals(&self) -> impl Iterator<Item = &VirtualSelection> {
-        self.selections().filter_map(|field| match field {
-            SelectedField::Virtual(ref vs) => Some(vs),
-            _ => None,
-        })
+        self.selections().filter_map(SelectedField::as_virtual)
     }
 
     pub fn virtuals_owned(&self) -> Vec<VirtualSelection> {
@@ -326,6 +323,13 @@ impl SelectedField {
     pub fn as_composite(&self) -> Option<&CompositeSelection> {
         match self {
             SelectedField::Composite(ref cs) => Some(cs),
+            _ => None,
+        }
+    }
+
+    pub fn as_virtual(&self) -> Option<&VirtualSelection> {
+        match self {
+            SelectedField::Virtual(vs) => Some(vs),
             _ => None,
         }
     }

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -82,11 +82,11 @@ impl FieldSelection {
         self.selections.iter().map(|f| f.db_name().into_owned())
     }
 
-    /// Returns all database (e.g. column or document field) names of contained fields.
-    /// Does _not_ recurse into composite selections and only iterates top level fields.
-    /// Also does not recurse into the grouped containers for virtual fields, like `_count`,
-    /// representing results of queries that use JSON objects to represent joined relations
-    /// and relation aggregations.
+    /// Returns all database (e.g. column or document field) names of contained fields. Does not
+    /// recurse into composite selections and only iterates top level fields. Also does not recurse
+    /// into the grouped containers for virtual fields, like `_count`. The names returned by this
+    /// method correspond to the results of queries that use JSON objects to represent joined
+    /// relations and relation aggregations.
     pub fn db_names_grouping_virtuals(&self) -> impl Iterator<Item = String> + '_ {
         self.selections
             .iter()

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -339,6 +339,9 @@ impl SelectedField {
         }
     }
 
+    /// Returns the name of the field in the database (if applicable) or other kind of name that is
+    /// used in the queries for this field. For virtual fields, this returns the alias used in the
+    /// queries that do not group them into objects.
     pub fn db_name(&self) -> Cow<'_, str> {
         match self {
             SelectedField::Scalar(sf) => sf.db_name().into(),
@@ -348,6 +351,14 @@ impl SelectedField {
         }
     }
 
+    /// Returns the name of the field in the database (if applicable) or other kind of name that is
+    /// used in the queries for this field. For virtual fields that are wrapped inside an object in
+    /// Prisma queries, this returns the name of the surrounding object and not the field itself,
+    /// so this method can return identical values for multiple fields in the [`FieldSelection`].
+    /// This is used in queries with relation JOINs which use JSON objects to represent both
+    /// relations and relation aggregations. For those queries, the result of this method
+    /// corresponds to the top-level name of the value in the selection which is a JSON object
+    /// where this field can be found in.
     pub fn db_name_grouping_virtuals(&self) -> Cow<'_, str> {
         match self {
             SelectedField::Virtual(vs) => vs.serialized_name().0.into(),


### PR DESCRIPTION
## Description

Implement relation aggregations support for the `join` strategy:
* Build relation aggregation queries in the new query builder
* Add new methods to the abstractions that represent selections to account for differences in representation in queries that use or don't use JSON objects
* Implement coercion and serialization logic

Next step: https://github.com/prisma/team-orm/issues/903

Part of: https://github.com/prisma/team-orm/issues/700
Closes: https://github.com/prisma/team-orm/issues/902

## Examples

### Schema

```prisma
model User {
  id         Int       @id @default(autoincrement())
  login      String    @unique
  profile    Profile?
  posts      Post[]
  comments   Comment[]
  followedBy User[]    @relation("UserFollows")
  follows    User[]    @relation("UserFollows")
}

model Profile {
  id      Int     @id @default(autoincrement())
  user    User    @relation(fields: [userId], references: [id])
  userId  Int     @unique
  name    String?
  address String?
}

model Post {
  id       Int       @id @default(autoincrement())
  user     User      @relation(fields: [userId], references: [id])
  userId   Int
  title    String
  content  String
  comments Comment[]
}

model Comment {
  id     Int    @id @default(autoincrement())
  body   String
  post   Post   @relation(fields: [postId], references: [id])
  postId Int
  user   User   @relation(fields: [userId], references: [id])
  userId Int
}
```

### 1:m, top-level

```graphql
query {
  findManyUser {
    _count {
      comments(where: { postId: 1 })
    }
  }
}
```

```sql
SELECT
  "t1"."id",
  JSONB_BUILD_OBJECT(
    'comments',
    COALESCE(
      "aggr_count_User_comments"."_aggr_count_comments",
      0
    )
  ) AS "_count"
FROM
  "public"."User" AS "t1"
  LEFT JOIN LATERAL (
    SELECT
      COUNT(*) AS "_aggr_count_comments"
    FROM
      "public"."Comment" AS "t2"
    WHERE
      (
        "t1"."id" = "t2"."userId"
        AND "t2"."postId" = $1
      )
  ) AS "aggr_count_User_comments" ON true
```

### m:n, top-level

```graphql
query {
  findManyUser {
    _count {
      follows(where: { profile: { isNot: null } })
    }
  }
}
```

```sql
SELECT
  "t1"."id",
  JSONB_BUILD_OBJECT(
    'follows',
    COALESCE(
      "aggr_count_User_follows"."_aggr_count_follows",
      0
    )
  ) AS "_count"
FROM
  "public"."User" AS "t1"
  LEFT JOIN LATERAL (
    SELECT
      COUNT(*) AS "_aggr_count_follows"
    FROM
      "public"."User" AS "t2"
      LEFT JOIN "public"."_UserFollows" AS "t3" ON "t3"."A" = "t2"."id"
      LEFT JOIN "public"."Profile" AS "j1" ON ("j1"."userId") = ("t2"."id")
    WHERE
      (
        "t3"."B" = "t1"."id"
        AND (NOT ("j1"."userId" IS NULL))
      )
  ) AS "aggr_count_User_follows" ON true
```

### 1:m, nested

```graphql
query {
  findManyUser {
    posts {
      _count {
        comments
      }
    }
  }
}
```

```sql
SELECT
  "t1"."id",
  "User_posts"."__prisma_data__" AS "posts"
FROM
  "public"."User" AS "t1"
  LEFT JOIN LATERAL (
    SELECT
      COALESCE(JSONB_AGG("__prisma_data__"), '[]') AS "__prisma_data__"
    FROM
      (
        SELECT
          "t4"."__prisma_data__"
        FROM
          (
            SELECT
              JSONB_BUILD_OBJECT(
                '_count',
                JSONB_BUILD_OBJECT(
                  'comments',
                  COALESCE(
                    "aggr_count_Post_comments"."_aggr_count_comments",
                    0
                  )
                )
              ) AS "__prisma_data__"
            FROM
              (
                SELECT
                  "t2".*
                FROM
                  "public"."Post" AS "t2"
                WHERE
                  "t1"."id" = "t2"."userId"
                  /* root select */
              ) AS "t3"
              LEFT JOIN LATERAL (
                SELECT
                  COUNT(*) AS "_aggr_count_comments"
                FROM
                  "public"."Comment" AS "t6"
                WHERE
                  "t3"."id" = "t6"."postId"
              ) AS "aggr_count_Post_comments" ON true
              /* inner select */
          ) AS "t4"
          /* middle select */
      ) AS "t5"
      /* outer select */
  ) AS "User_posts" ON true
```