### PR TITLE
Experimental support for Azure managed service identities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3580,6 +3580,7 @@ dependencies = [
  "postgres-types",
  "quaint-test-macros",
  "quaint-test-setup",
+ "reqwest",
  "rusqlite",
  "serde",
  "serde_json",

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -52,7 +52,7 @@ postgresql-native = [
 ]
 postgresql = []
 
-mssql-native = ["mssql", "tiberius", "tokio-util", "tokio/time", "tokio/net"]
+mssql-native = ["mssql", "tiberius", "tokio-util", "tokio/time", "tokio/net", "reqwest/json"]
 mssql = []
 
 mysql-native = ["mysql", "mysql_async", "tokio/time", "lru-cache"]
@@ -77,6 +77,7 @@ futures = "0.3"
 url = "2.1"
 hex = "0.4"
 itertools.workspace = true
+reqwest = "0.11"
 
 either = { version = "1.6" }
 base64 = { version = "0.12.3" }

--- a/quaint/src/error/mod.rs
+++ b/quaint/src/error/mod.rs
@@ -175,6 +175,12 @@ pub enum ErrorKind {
     #[error("Foreign key constraint failed: {}", constraint)]
     ForeignKeyConstraintViolation { constraint: DatabaseConstraint },
 
+    #[error("Error fetching auth token: {}", _0)]
+    AuthTokenFetchFailure(Box<dyn std::error::Error + Send + Sync + 'static>),
+
+    #[error("Missing environment variable: {}", name)]
+    MissingEnvironmentVariable { name: String },
+
     #[error("Error reading the column value: {}", _0)]
     ColumnReadFailure(Box<dyn std::error::Error + Send + Sync + 'static>),
 

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -351,6 +351,8 @@ impl From<quaint::error::Error> for SqlError {
             e @ QuaintKind::DatabaseAccessDenied { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::DatabaseAlreadyExists { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::InvalidConnectionArguments => SqlError::ConnectionError(e),
+            e @ QuaintKind::AuthTokenFetchFailure { .. } => SqlError::ConnectionError(e),
+            e @ QuaintKind::MissingEnvironmentVariable { .. } => SqlError::ConnectionError(e),
             e @ QuaintKind::SocketTimeout => SqlError::ConnectionError(e),
         }
     }


### PR DESCRIPTION
Related to #12562, I happen to need support for Azure managed service identities.

I believe that the feature which #12562 is asking for should be *extremely* similar to this, because that also involves sending a HTTP request to a local endpoint and then creating a token from that.

Please note TODOs in quaint/src/connector/mssql/native/mod.rs:

- I'm not certain that this is the right place to fix this problem, maybe I should have put the change in `tiberius` instead?
- these tokens do expire; currently I have no mechanism to refresh them