### PR TITLE
chore: fix and prevent clippy warnings on main

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -29,9 +29,13 @@ jobs:
         with:
           components: clippy
           targets: wasm32-unknown-unknown
+      # Check the whole workspace with clippy for the native compilation
+      # target, and query-engine-wasm and dependencies for wasm32-unknown-unknown.
+      # Note that `--all-targets` is unrelated to `--target` as in target platform,
+      # it is a shortcut for `--lib --bins --tests --benches --examples`.
       - run: |
-          cargo clippy --all-features
-          cargo clippy --all-features -p query-engine-wasm --target wasm32-unknown-unknown
+          cargo clippy --workspace --all-features --all-targets
+          cargo clippy --all-features --all-targets -p query-engine-wasm --target wasm32-unknown-unknown
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/transactional_batch.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/transactional_batch.rs
@@ -70,7 +70,7 @@ mod transactional {
         ];
 
         let batch_results = runner.batch(queries, true, None).await?;
-        let batch_request_idx = batch_results.errors().get(0).unwrap().batch_request_idx();
+        let batch_request_idx = batch_results.errors().first().unwrap().batch_request_idx();
 
         assert_eq!(batch_request_idx, Some(1));
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -276,7 +276,7 @@ mod scalar_relations {
 
     async fn create_common_children(runner: &Runner) -> TestResult<()> {
         create_child(
-            &runner,
+            runner,
             r#"{
           childId: 1,
           string: "abc",
@@ -291,7 +291,7 @@ mod scalar_relations {
         .await?;
 
         create_child(
-            &runner,
+            runner,
             r#"{
           childId: 2,
           string: "def",
@@ -306,7 +306,7 @@ mod scalar_relations {
         .await?;
 
         create_parent(
-            &runner,
+            runner,
             r#"{ id: 1, children: { connect: [{ childId: 1 }, { childId: 2 }] } }"#,
         )
         .await?;

--- a/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
@@ -468,7 +468,7 @@ fn decimal_to_boolean_migrations_work(api: TestApi) {
         }
     "#;
 
-    api.create_migration("create-cats-decimal", &dm1, &dir)
+    api.create_migration("create-cats-decimal", dm1, &dir)
         .send_sync()
         .assert_migration_directories_count(1)
         .assert_migration("create-cats-decimal", move |migration| {
@@ -497,7 +497,7 @@ fn decimal_to_boolean_migrations_work(api: TestApi) {
         }
     "#;
 
-    api.create_migration("migrate-cats-boolean", &dm2, &dir)
+    api.create_migration("migrate-cats-boolean", dm2, &dir)
         .send_sync()
         .assert_migration_directories_count(2)
         .assert_migration("migrate-cats-boolean", move |migration| {

--- a/schema-engine/sql-schema-describer/tests/test_api/mod.rs
+++ b/schema-engine/sql-schema-describer/tests/test_api/mod.rs
@@ -2,7 +2,7 @@ pub use expect_test::expect;
 pub use indoc::{formatdoc, indoc};
 pub use quaint::{prelude::Queryable, single::Quaint};
 pub use test_macros::test_connector;
-pub use test_setup::{runtime::run_with_thread_local_runtime as tok, BitFlags, Capabilities, Tags};
+pub use test_setup::{runtime::run_with_thread_local_runtime as tok, BitFlags, Tags};
 
 use quaint::prelude::SqlFamily;
 use sql_schema_describer::{


### PR DESCRIPTION
- Fix all clippy warnings in tests using `cargo clippy --fix
  --all-targets` (nothing required manual action).

- Change the `clippy` command in the GitHub Actions pipeline to check
  the whole codebase.
