### PR TITLE
nix-shell: Mange rust versions with rustup and rust-toolchain files

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,13 +1,12 @@
-{ self', pkgs, rustToolchain, ... }:
+{ self', pkgs, ... }:
 
 let
-  devToolchain = rustToolchain.override { extensions = [ "rust-analyzer" "rust-src" ]; };
   nodejs = pkgs.nodejs_latest;
 in
 {
   devShells.default = pkgs.mkShell {
     packages = with pkgs; [
-      devToolchain
+      rustup
       llvmPackages_latest.bintools
 
       nodejs_20
@@ -21,7 +20,6 @@ in
       graphviz
       wabt
       wasm-bindgen-cli
-      wasm-pack
     ];
 
     inputsFrom = [ self'.packages.prisma-engines ];

--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -50,10 +50,6 @@ fi
 
 echo "Using build profile: \"${WASM_BUILD_PROFILE}\"" 
 
-echo "ℹ️  Configuring rust toolchain to use nightly and rust-src component"
-rustup default nightly-2024-01-25 
-rustup target add wasm32-unknown-unknown
-rustup component add rust-src --target wasm32-unknown-unknown
 export RUSTFLAGS="-Zlocation-detail=none"
 CARGO_TARGET_DIR=$(cargo metadata --format-version 1 | jq -r .target_directory)
 

--- a/query-engine/query-engine-wasm/rust-toolchain.toml
+++ b/query-engine/query-engine-wasm/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2024-01-25"
+components = ["rust-src"]
+targets = ["wasm32-unknown-unknown"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.75.0"
+components = ["clippy", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
-channel = "1.75.0"
-components = ["clippy", "rustfmt"]
+channel = "1.76.0"
+components = ["clippy", "rustfmt", "rust-src"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
At the moment, nix dev shell can not build WASM modules. This PR makes
it possible through following:

- Removes manual nightly toolchain installation from build scrupt in
  favor of `rust-toolchain.toml` file (gets picked up by rustup
  automatically)

- Removes `devToolchain` package from shell and replaces it with rustup.
- Adds `rust-toolchain.toml` file into the root of the repo so stable
  toolchain will be used there as well.
