### PR TITLE
fix(wasm-size): Correctly fomrat negative numbers

### DIFF
--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
 
           fmt() {
-            numfmt --format '%.3f' --to=iec-i --suffix=B "$1"
+            echo "$1" | numfmt --format '%.3f' --to=iec-i --suffix=B
           }
 
           compute_diff() {


### PR DESCRIPTION
`numfmt -100` interprets `-100` as a cli flag and complains, passing
input via stdin fixes it
