### PR TITLE
feat: exclude MySQL < 8.0.14 from joins

### DIFF
--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -243,6 +243,6 @@ jobs:
           sudo sc start MySQL
 
       - name: Run tests
-        run: cargo test -p sql-migration-tests -- --nocapture
+        run: cargo nextest run -p sql-migration-tests
         env:
           TEST_DATABASE_URL: ${{ matrix.db.url }}

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -243,6 +243,6 @@ jobs:
           sudo sc start MySQL
 
       - name: Run tests
-        run: cargo nextest run -p sql-migration-tests
+        run: cargo test -p sql-migration-tests
         env:
           TEST_DATABASE_URL: ${{ matrix.db.url }}

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -243,6 +243,6 @@ jobs:
           sudo sc start MySQL
 
       - name: Run tests
-        run: cargo test -p sql-migration-tests
+        run: cargo test -p sql-migration-tests -- --nocapture
         env:
           TEST_DATABASE_URL: ${{ matrix.db.url }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.13.2",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -1626,16 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash 0.8.7",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
@@ -2554,7 +2545,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#dad187b50dc7e8ce2b61fec126822e8e172a9c8a"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#d8ffc297874bf4b12ce8387c4a01836b52fd3216"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -5847,7 +5838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2257,9 +2257,9 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -2545,7 +2545,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=test/dbg-handshake-version#1f55045d83e471e04d39e7de86c5dad93b1c28a7"
+source = "git+https://github.com/prisma/mysql_async?branch=fix/mariadb-11-version-detection#1717a444cbaa137b14af7295a3bcb7defd324eed"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2554,6 +2554,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "lazy_static",
+ "lexical",
  "lru 0.8.1",
  "mio",
  "mysql_common",
@@ -2563,6 +2564,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "priority-queue",
+ "regex",
  "serde",
  "serde_json",
  "socket2 0.4.9",
@@ -4122,14 +4124,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick 1.0.3",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -4143,13 +4145,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick 1.0.3",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -4160,9 +4162,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
@@ -5838,7 +5840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.3.23",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1626,7 +1626,7 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
@@ -2257,9 +2257,9 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
@@ -2545,7 +2545,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#0d40d0d2c332fc97512bff81e82e62002f03c224"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#d8ffc297874bf4b12ce8387c4a01836b52fd3216"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2554,7 +2554,6 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "lazy_static",
- "lexical",
  "lru 0.8.1",
  "mio",
  "mysql_common",
@@ -2564,7 +2563,6 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "priority-queue",
- "regex",
  "serde",
  "serde_json",
  "socket2 0.4.9",
@@ -4124,14 +4122,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
 dependencies = [
  "aho-corasick 1.0.3",
  "memchr",
- "regex-automata 0.4.5",
- "regex-syntax 0.8.2",
+ "regex-automata 0.3.6",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -4145,13 +4143,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick 1.0.3",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -4162,9 +4160,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rend"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.12.3",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
@@ -2545,7 +2545,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=fix/mariadb-11-version-detection#1717a444cbaa137b14af7295a3bcb7defd324eed"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#0d40d0d2c332fc97512bff81e82e62002f03c224"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -5840,7 +5840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.3.23",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4114279215a005bc675e386011e594e1d9b800918cea18fcadadcce864a2046b"
 dependencies = [
  "borsh-derive",
- "hashbrown 0.11.2",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2257,9 +2257,9 @@ checksum = "7e6bcd6433cff03a4bfc3d9834d504467db1f1cf6d0ea765d37d330249ed629d"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memoffset"
@@ -2545,7 +2545,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#d8ffc297874bf4b12ce8387c4a01836b52fd3216"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#0d40d0d2c332fc97512bff81e82e62002f03c224"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -2554,6 +2554,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "lazy_static",
+ "lexical",
  "lru 0.8.1",
  "mio",
  "mysql_common",
@@ -2563,6 +2564,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "priority-queue",
+ "regex",
  "serde",
  "serde_json",
  "socket2 0.4.9",
@@ -4122,14 +4124,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick 1.0.3",
  "memchr",
- "regex-automata 0.3.6",
- "regex-syntax 0.7.4",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -4143,13 +4145,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick 1.0.3",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -4160,9 +4162,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
@@ -5838,7 +5840,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.3.23",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#d8ffc297874bf4b12ce8387c4a01836b52fd3216"
+source = "git+https://github.com/prisma/mysql_async?branch=test/dbg-handshake-version#1f55045d83e471e04d39e7de86c5dad93b1c28a7"
 dependencies = [
  "bytes",
  "crossbeam",

--- a/Makefile
+++ b/Makefile
@@ -287,7 +287,13 @@ dev-mysql8: start-mysql_8
 start-mysql_mariadb:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans mariadb-10-0
 
+start-mysql_mariadb_11:
+	docker compose -f docker-compose.yml up --wait -d --remove-orphans mariadb-11-0
+
 dev-mariadb: start-mysql_mariadb
+	cp $(CONFIG_PATH)/mariadb $(CONFIG_FILE)
+
+dev-mariadb11: start-mysql_mariadb_11
 	cp $(CONFIG_PATH)/mariadb $(CONFIG_FILE)
 
 start-mssql_2019:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,6 +294,19 @@ services:
       - databases
     tmpfs: /var/lib/mariadb
 
+  mariadb-11-0:
+    image: mariadb:11
+    restart: unless-stopped
+    environment:
+      MYSQL_USER: root
+      MYSQL_ROOT_PASSWORD: prisma
+      MYSQL_DATABASE: prisma
+    ports:
+      - '3308:3306'
+    networks:
+      - databases
+    tmpfs: /var/lib/mariadb
+
   vitess-test-8_0:
     image: vitess/vttestserver:mysql80@sha256:53a2d2f58ecf8e6cf984c725612f7651c4fc7ac9bc7d198dbd9964d50e28b9a2
     restart: unless-stopped

--- a/psl/psl-core/src/builtin_connectors/mysql_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/mysql_datamodel_connector.rs
@@ -8,8 +8,8 @@ use prisma_value::{decode_bytes, PrismaValueResult};
 use super::completions;
 use crate::{
     datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, NativeTypeConstructor,
-        NativeTypeInstance, RelationMode,
+        Connector, ConnectorCapabilities, ConnectorCapability, ConstraintScope, Flavour, JoinStrategySupport,
+        NativeTypeConstructor, NativeTypeInstance, RelationMode,
     },
     diagnostics::{DatamodelError, Diagnostics, Span},
     parser_database::{walkers, ReferentialAction, ScalarType},
@@ -315,5 +315,14 @@ impl Connector for MySqlDatamodelConnector {
     // On MySQL, bytes are encoded as base64 in the database directly.
     fn parse_json_bytes(&self, str: &str, _nt: Option<NativeTypeInstance>) -> PrismaValueResult<Vec<u8>> {
         decode_bytes(str)
+    }
+
+    fn runtime_join_strategy_support(&self) -> JoinStrategySupport {
+        match self.static_join_strategy_support() {
+            // Prior to MySQL 8.0.14 and for MariaDB, a derived table cannot contain outer references.
+            // Source: https://dev.mysql.com/doc/refman/8.0/en/derived-tables.html.
+            true => JoinStrategySupport::UnknownYet,
+            false => JoinStrategySupport::No,
+        }
     }
 }

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -114,7 +114,7 @@ version = ">1.4.0"
 [dependencies.mysql_async]
 git = "https://github.com/prisma/mysql_async"
 optional = true
-branch = "vendored-openssl"
+branch = "test/dbg-handshake-version"
 
 [dependencies.rusqlite]
 version = "0.29"

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -114,7 +114,7 @@ version = ">1.4.0"
 [dependencies.mysql_async]
 git = "https://github.com/prisma/mysql_async"
 optional = true
-branch = "test/dbg-handshake-version"
+branch = "fix/mariadb-11-version-detection"
 
 [dependencies.rusqlite]
 version = "0.29"

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -114,7 +114,7 @@ version = ">1.4.0"
 [dependencies.mysql_async]
 git = "https://github.com/prisma/mysql_async"
 optional = true
-branch = "fix/mariadb-11-version-detection"
+branch = "vendored-openssl"
 
 [dependencies.rusqlite]
 version = "0.29"

--- a/quaint/src/connector/connection_info.rs
+++ b/quaint/src/connector/connection_info.rs
@@ -255,6 +255,26 @@ impl ConnectionInfo {
             ConnectionInfo::External(_) => "external".into(),
         }
     }
+
+    #[allow(unused_variables)]
+    pub fn set_version(&mut self, version: Option<String>) {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            ConnectionInfo::Native(native) => native.set_version(version),
+            ConnectionInfo::External(_) => (),
+        }
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            ConnectionInfo::Native(nt) => match nt {
+                NativeConnectionInfo::Mysql(m) => m.version(),
+                _ => None,
+            },
+            ConnectionInfo::External(_) => None,
+        }
+    }
 }
 
 /// One of the supported SQL variants.

--- a/quaint/src/connector/mysql/native/mod.rs
+++ b/quaint/src/connector/mysql/native/mod.rs
@@ -266,14 +266,12 @@ impl Queryable for Mysql {
     }
 
     async fn version(&self) -> crate::Result<Option<String>> {
-        let query = r#"SELECT @@GLOBAL.version version"#;
-        let rows = timeout::socket(self.socket_timeout, self.query_raw(query, &[])).await?;
+        let guard = self.conn.lock().await;
+        let (major, minor, patch) = guard.server_version();
+        let flavour = if guard.is_mariadb() { "MariaDB" } else { "MySQL" };
+        drop(guard);
 
-        let version_string = rows
-            .first()
-            .and_then(|row| row.get("version").and_then(|version| version.typed.to_string()));
-
-        Ok(version_string)
+        Ok(Some(format!("{major}.{minor}.{patch}/{flavour}")))
     }
 
     fn is_healthy(&self) -> bool {

--- a/quaint/src/connector/mysql/native/mod.rs
+++ b/quaint/src/connector/mysql/native/mod.rs
@@ -266,25 +266,12 @@ impl Queryable for Mysql {
     }
 
     async fn version(&self) -> crate::Result<Option<String>> {
-        let query = r#"SELECT @@GLOBAL.version version"#;
-        let rows = timeout::socket(self.socket_timeout, self.query_raw(query, &[])).await?;
-
-        let selected_version = rows
-            .first()
-            .and_then(|row| row.get("version").and_then(|version| version.typed.to_string()));
-
-        dbg!(&selected_version);
-
         let guard = self.conn.lock().await;
         let (major, minor, patch) = guard.server_version();
         let flavour = if guard.is_mariadb() { "MariaDB" } else { "MySQL" };
         drop(guard);
 
-        let connection_version = format!("{major}.{minor}.{patch}-{flavour}");
-
-        dbg!(&connection_version);
-
-        Ok(Some(connection_version))
+        Ok(Some(format!("{major}.{minor}.{patch}-{flavour}")))
     }
 
     fn is_healthy(&self) -> bool {

--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -13,6 +13,7 @@ use url::{Host, Url};
 #[derive(Debug, Clone)]
 pub struct MysqlUrl {
     url: Url,
+    version: Option<String>,
     pub(crate) query_params: MysqlUrlQueryParams,
 }
 
@@ -22,7 +23,15 @@ impl MysqlUrl {
     pub fn new(url: Url) -> Result<Self, Error> {
         let query_params = Self::parse_query_params(&url)?;
 
-        Ok(Self { url, query_params })
+        Ok(Self {
+            url,
+            query_params,
+            version: None,
+        })
+    }
+
+    pub fn set_version(&mut self, version: Option<String>) {
+        self.version = version;
     }
 
     /// The bare `Url` to the database.
@@ -297,6 +306,10 @@ impl MysqlUrl {
     #[cfg(feature = "pooled")]
     pub(crate) fn connection_limit(&self) -> Option<usize> {
         self.query_params.connection_limit
+    }
+
+    pub fn version(&self) -> Option<&str> {
+        self.version.as_deref()
     }
 }
 

--- a/quaint/src/connector/native.rs
+++ b/quaint/src/connector/native.rs
@@ -29,3 +29,12 @@ pub enum NativeConnectionInfo {
     #[cfg(feature = "sqlite")]
     InMemorySqlite { db_name: String },
 }
+
+impl NativeConnectionInfo {
+    pub fn set_version(&mut self, version: Option<String>) {
+        #[cfg(feature = "mysql")]
+        if let NativeConnectionInfo::Mysql(c) = self {
+            c.set_version(version);
+        }
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/relation_load_strategy.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/relation_load_strategy.rs
@@ -123,7 +123,7 @@ mod relation_load_strategy {
         };
     }
 
-    macro_rules! relation_load_strategy_tests_pair {
+    macro_rules! relation_load_strategy_tests {
         ($name:ident, $query:expr, $result:literal) => {
             paste::paste! {
                 relation_load_strategy_test!(
@@ -159,7 +159,7 @@ mod relation_load_strategy {
         };
     }
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         find_many,
         r#"
         query {
@@ -178,7 +178,7 @@ mod relation_load_strategy {
         r#"{"data":{"findManyUser":[{"login":"author","posts":[{"title":"first post","comments":[{"author":{"login":"commenter"},"body":"a comment"}]}]},{"login":"commenter","posts":[]}]}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         find_first,
         r#"
         query {
@@ -202,7 +202,7 @@ mod relation_load_strategy {
         r#"{"data":{"findFirstUser":{"login":"author","posts":[{"title":"first post","comments":[{"author":{"login":"commenter"},"body":"a comment"}]}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         find_first_or_throw,
         r#"
         query {
@@ -226,7 +226,7 @@ mod relation_load_strategy {
         r#"{"data":{"findFirstUserOrThrow":{"login":"author","posts":[{"title":"first post","comments":[{"author":{"login":"commenter"},"body":"a comment"}]}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         find_unique,
         r#"
         query {
@@ -250,7 +250,7 @@ mod relation_load_strategy {
         r#"{"data":{"findUniqueUser":{"login":"author","posts":[{"title":"first post","comments":[{"author":{"login":"commenter"},"body":"a comment"}]}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         find_unique_or_throw,
         r#"
         query {
@@ -274,7 +274,7 @@ mod relation_load_strategy {
         r#"{"data":{"findUniqueUserOrThrow":{"login":"author","posts":[{"title":"first post","comments":[{"author":{"login":"commenter"},"body":"a comment"}]}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         create,
         r#"
         mutation {
@@ -305,7 +305,7 @@ mod relation_load_strategy {
         r#"{"data":{"createOneUser":{"login":"reader","comments":[{"post":{"title":"first post"},"body":"most insightful indeed!"}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         update,
         r#"
         mutation {
@@ -329,7 +329,7 @@ mod relation_load_strategy {
         r#"{"data":{"updateOneUser":{"login":"distinguished author","posts":[{"title":"first post","comments":[{"body":"a comment"}]}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         delete,
         r#"
         mutation {
@@ -350,7 +350,7 @@ mod relation_load_strategy {
         r#"{"data":{"deleteOneUser":{"login":"author","posts":[{"title":"first post","comments":[{"body":"a comment"}]}]}}}"#
     );
 
-    relation_load_strategy_tests_pair!(
+    relation_load_strategy_tests!(
         upsert,
         r#"
         mutation {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -326,11 +326,6 @@ impl ConnectorVersion {
                 | Self::Sqlite(Some(SqliteVersion::LibsqlJsWasm))
         )
     }
-
-    /// Returns `true` if the connector version is [`MySql`].
-    pub(crate) fn is_mysql(&self) -> bool {
-        matches!(self, Self::MySql(..))
-    }
 }
 
 impl fmt::Display for ConnectorVersion {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/mod.rs
@@ -4,13 +4,11 @@ mod sql_renderer;
 pub use mongodb_renderer::*;
 pub use sql_renderer::*;
 
-use crate::{
-    connection_string, templating, ConnectorVersion, DatamodelFragment, IdFragment, M2mFragment, MySqlVersion, CONFIG,
-};
+use crate::{connection_string, templating, DatamodelFragment, IdFragment, M2mFragment, CONFIG};
 use indoc::indoc;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
-use psl::{PreviewFeature, ALL_PREVIEW_FEATURES};
+use psl::ALL_PREVIEW_FEATURES;
 use regex::Regex;
 
 /// Test configuration, loaded once at runtime.
@@ -39,7 +37,7 @@ pub fn render_test_datamodel(
     isolation_level: Option<&'static str>,
 ) -> String {
     let (tag, version) = CONFIG.test_connector().unwrap();
-    let preview_features = render_preview_features(excluded_features, &version);
+    let preview_features = render_preview_features(excluded_features);
 
     let is_multi_schema = !db_schemas.is_empty();
 
@@ -91,13 +89,8 @@ fn process_template(template: String, renderer: Box<dyn DatamodelRenderer>) -> S
     })
 }
 
-fn render_preview_features(excluded_features: &[&str], version: &ConnectorVersion) -> String {
-    let mut excluded_features: Vec<_> = excluded_features.iter().map(|f| format!(r#""{f}""#)).collect();
-
-    // TODO: Remove this once we are able to have version speficic preview features.
-    if version.is_mysql() && !matches!(version, ConnectorVersion::MySql(Some(MySqlVersion::V8))) {
-        excluded_features.push(format!(r#""{}""#, PreviewFeature::RelationJoins));
-    }
+fn render_preview_features(excluded_features: &[&str]) -> String {
+    let excluded_features: Vec<_> = excluded_features.iter().map(|f| format!(r#""{f}""#)).collect();
 
     ALL_PREVIEW_FEATURES
         .active_features()

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -40,6 +40,10 @@ impl Connection for MongoDbConnection {
         Ok(tx as Box<dyn Transaction>)
     }
 
+    async fn version(&self) -> Option<String> {
+        None
+    }
+
     fn as_connection_like(&mut self) -> &mut dyn ConnectionLike {
         self
     }

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -60,6 +60,10 @@ impl<'conn> Transaction for MongoDbTransaction<'conn> {
         Ok(())
     }
 
+    async fn version(&self) -> Option<String> {
+        None
+    }
+
     fn as_connection_like(&mut self) -> &mut dyn ConnectionLike {
         self
     }

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -287,6 +287,9 @@ pub enum ErrorKind {
 
     #[error("Too many DB connections opened: {}", _0)]
     TooManyConnections(Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Failed to parse database version: {}. Reason: {}", version, reason)]
+    UnexpectedDatabaseVersion { version: String, reason: String },
 }
 
 impl From<DomainError> for ConnectorError {

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -24,6 +24,8 @@ pub trait Connection: ConnectionLike {
         isolation_level: Option<String>,
     ) -> crate::Result<Box<dyn Transaction + 'a>>;
 
+    async fn version(&self) -> Option<String>;
+
     /// Explicit upcast.
     fn as_connection_like(&mut self) -> &mut dyn ConnectionLike;
 }
@@ -32,6 +34,8 @@ pub trait Connection: ConnectionLike {
 pub trait Transaction: ConnectionLike {
     async fn commit(&mut self) -> crate::Result<()>;
     async fn rollback(&mut self) -> crate::Result<()>;
+
+    async fn version(&self) -> Option<String>;
 
     /// Explicit upcast of self reference. Rusts current vtable layout doesn't allow for an upcast if
     /// `trait A`, `trait B: A`, so that `Box<dyn B> as Box<dyn A>` works. This is a simple, explicit workaround.

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -26,9 +26,7 @@ impl<C> SqlConnection<C>
 where
     C: TransactionCapable + Send + Sync + 'static,
 {
-    pub fn new(inner: C, connection_info: &ConnectionInfo, features: psl::PreviewFeatures) -> Self {
-        let connection_info = connection_info.clone();
-
+    pub fn new(inner: C, connection_info: ConnectionInfo, features: psl::PreviewFeatures) -> Self {
         Self {
             inner,
             connection_info,
@@ -69,6 +67,10 @@ where
             Ok(Box::new(SqlConnectorTransaction::new(tx, connection_info, features)) as Box<dyn Transaction>)
         })
         .await
+    }
+
+    async fn version(&self) -> Option<String> {
+        self.connection_info.version().map(|v| v.to_string())
     }
 
     fn as_connection_like(&mut self) -> &mut dyn ConnectionLike {

--- a/query-engine/connectors/sql-query-connector/src/database/js.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/js.rs
@@ -41,7 +41,7 @@ impl Js {
 impl Connector for Js {
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         super::catch(&self.connection_info, async move {
-            let sql_conn = SqlConnection::new(self.connector.clone(), &self.connection_info, self.features);
+            let sql_conn = SqlConnection::new(self.connector.clone(), self.connection_info.clone(), self.features);
             Ok(Box::new(sql_conn) as Box<dyn Connection + Send + Sync + 'static>)
         })
         .await

--- a/query-engine/connectors/sql-query-connector/src/database/native/mssql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/native/mssql.rs
@@ -62,7 +62,7 @@ impl Connector for Mssql {
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
-            let conn = SqlConnection::new(conn, &self.connection_info, self.features);
+            let conn = SqlConnection::new(conn, self.connection_info.clone(), self.features);
 
             Ok(Box::new(conn) as Box<dyn Connection + Send + Sync + 'static>)
         })

--- a/query-engine/connectors/sql-query-connector/src/database/native/mysql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/native/mysql.rs
@@ -6,6 +6,7 @@ use connector_interface::{
     error::{ConnectorError, ErrorKind},
     Connection, Connector,
 };
+use quaint::connector::Queryable;
 use quaint::{pooled::Quaint, prelude::ConnectionInfo};
 use std::time::Duration;
 
@@ -69,7 +70,12 @@ impl Connector for Mysql {
             let runtime_conn = self.pool.check_out().await?;
 
             // Note: `runtime_conn` must be `Sized`, as that's required by `TransactionCapable`
-            let sql_conn = SqlConnection::new(runtime_conn, &self.connection_info, self.features);
+            let mut conn_info = self.connection_info.clone();
+            let db_version = runtime_conn.version().await.unwrap();
+            // MySQL has its version grabbed at connection time. We know it's infaillible.
+            conn_info.set_version(db_version);
+
+            let sql_conn = SqlConnection::new(runtime_conn, conn_info, self.features);
 
             Ok(Box::new(sql_conn) as Box<dyn Connection + Send + Sync + 'static>)
         })

--- a/query-engine/connectors/sql-query-connector/src/database/native/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/native/postgresql.rs
@@ -69,7 +69,7 @@ impl Connector for PostgreSql {
     async fn get_connection<'a>(&'a self) -> connector_interface::Result<Box<dyn Connection + Send + Sync + 'static>> {
         catch(&self.connection_info, async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
-            let conn = SqlConnection::new(conn, &self.connection_info, self.features);
+            let conn = SqlConnection::new(conn, self.connection_info.clone(), self.features);
             Ok(Box::new(conn) as Box<dyn Connection + Send + Sync + 'static>)
         })
         .await

--- a/query-engine/connectors/sql-query-connector/src/database/native/sqlite.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/native/sqlite.rs
@@ -82,7 +82,7 @@ impl Connector for Sqlite {
     async fn get_connection<'a>(&'a self) -> connector::Result<Box<dyn Connection + Send + Sync + 'static>> {
         catch(self.connection_info(), async move {
             let conn = self.pool.check_out().await.map_err(SqlError::from)?;
-            let conn = SqlConnection::new(conn, self.connection_info(), self.features);
+            let conn = SqlConnection::new(conn, self.connection_info().clone(), self.features);
 
             Ok(Box::new(conn) as Box<dyn Connection + Send + Sync + 'static>)
         })

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -56,6 +56,10 @@ impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
         .await
     }
 
+    async fn version(&self) -> Option<String> {
+        self.connection_info.version().map(|v| v.to_string())
+    }
+
     fn as_connection_like(&mut self) -> &mut dyn ConnectionLike {
         self
     }

--- a/query-engine/core/src/lib.rs
+++ b/query-engine/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod executor;
 pub mod protocol;
 pub mod query_document;
 pub mod query_graph_builder;
+pub mod relation_load_strategy;
 pub mod response_ir;
 pub mod telemetry;
 

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -43,7 +43,7 @@ fn find_many_with_options(
         args.distinct.as_ref(),
         &nested,
         query_schema,
-    );
+    )?;
 
     Ok(ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -51,7 +51,7 @@ fn find_unique_with_options(
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
     let relation_load_strategy =
-        get_relation_load_strategy(requested_rel_load_strategy, None, None, &nested, query_schema);
+        get_relation_load_strategy(requested_rel_load_strategy, None, None, &nested, query_schema)?;
 
     Ok(ReadQuery::RecordQuery(RecordQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -1,5 +1,6 @@
 use super::*;
 use crate::{ArgumentListLookup, FieldPair, ParsedField, ReadQuery};
+use psl::datamodel_connector::JoinStrategySupport;
 use query_structure::{prelude::*, RelationLoadStrategy};
 use schema::{
     constants::{aggregations::*, args},
@@ -256,18 +257,46 @@ pub(crate) fn get_relation_load_strategy(
     distinct: Option<&FieldSelection>,
     nested_queries: &[ReadQuery],
     query_schema: &QuerySchema,
-) -> RelationLoadStrategy {
-    if query_schema.can_resolve_relation_with_joins()
-        && cursor.is_none()
+) -> QueryGraphBuilderResult<RelationLoadStrategy> {
+    match query_schema.join_strategy_support() {
+        // Connector and database version supports the `Join` strategy...
+        JoinStrategySupport::Yes => match requested_strategy {
+            // But incoming query cannot be resolved with joins.
+            _ if !query_can_be_resolved_with_joins(cursor, distinct, nested_queries) => {
+                // So we fallback to the `Query` one.
+                Ok(RelationLoadStrategy::Query)
+            }
+            // But requested strategy is `Query`.
+            Some(RelationLoadStrategy::Query) => Ok(RelationLoadStrategy::Query),
+            // And requested strategy is `Join` or there's none selected, in which case the default is still `Join`.
+            Some(RelationLoadStrategy::Join) | None => Ok(RelationLoadStrategy::Join),
+        },
+        // Connector supports `Join` strategy but database version does not...
+        JoinStrategySupport::UnsupportedDbVersion => match requested_strategy {
+            // So we error out if the requested strategy is `Join`.
+            Some(RelationLoadStrategy::Join) => Err(QueryGraphBuilderError::InputError(
+                "`relationLoadStrategy: join` is not available for MySQL < 8.0.14 and MariaDB.".into(),
+            )),
+            // Otherwise we fallback to the `Query` one. (This makes the default relation load strategy `Query` for database versions that do not support joins.)
+            Some(RelationLoadStrategy::Query) | None => Ok(RelationLoadStrategy::Query),
+        },
+        // Connectors does not support the join strategy so we always fallback to the `Query` one.
+        JoinStrategySupport::No => Ok(RelationLoadStrategy::Query),
+        JoinStrategySupport::UnknownYet => {
+            unreachable!("Connector should have resolved the join strategy support by now.")
+        }
+    }
+}
+
+fn query_can_be_resolved_with_joins(
+    cursor: Option<&SelectionResult>,
+    distinct: Option<&FieldSelection>,
+    nested_queries: &[ReadQuery],
+) -> bool {
+    cursor.is_none()
         && distinct.is_none()
         && !nested_queries.iter().any(|q| match q {
             ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.has_distinct(),
             _ => false,
         })
-        && requested_strategy != Some(RelationLoadStrategy::Query)
-    {
-        RelationLoadStrategy::Join
-    } else {
-        RelationLoadStrategy::Query
-    }
 }

--- a/query-engine/core/src/relation_load_strategy.rs
+++ b/query-engine/core/src/relation_load_strategy.rs
@@ -43,7 +43,7 @@ impl TryFrom<Option<&str>> for DatabaseVersion {
                     }))
                 };
 
-                let mut iter = version.split('/');
+                let mut iter = version.split('-');
 
                 let version = iter.next().ok_or_else(|| build_err("Missing version"))?;
                 let is_mariadb = iter.next().map(|s| s.contains("MariaDB")).unwrap_or(false);

--- a/query-engine/core/src/relation_load_strategy.rs
+++ b/query-engine/core/src/relation_load_strategy.rs
@@ -1,0 +1,70 @@
+use connector::error::{ConnectorError, ErrorKind};
+
+use crate::CoreError;
+
+/// Returns whether the database supports joins given its version.
+/// Only versions of the MySQL connector are currently parsed at runtime.
+pub fn db_version_supports_joins_strategy(db_version: Option<String>) -> crate::Result<bool> {
+    DatabaseVersion::try_from(db_version.as_deref()).map(|version| version.supports_join_relation_load_strategy())
+}
+
+/// Parsed database version.
+#[derive(Debug)]
+enum DatabaseVersion {
+    Mysql(u16, u16, u16),
+    Mariadb,
+    Unknown,
+}
+
+impl DatabaseVersion {
+    /// Returns whether the database supports joins given its version.
+    /// Only versions of the MySQL connector are currently parsed at runtime.
+    pub(crate) fn supports_join_relation_load_strategy(&self) -> bool {
+        match self {
+            // Prior to MySQL 8.0.14, a derived table cannot contain outer references.
+            // Source: https://dev.mysql.com/doc/refman/8.0/en/derived-tables.html
+            DatabaseVersion::Mysql(major, minor, patch) => (*major, *minor, *patch) >= (8, 0, 14),
+            DatabaseVersion::Mariadb => false,
+            DatabaseVersion::Unknown => true,
+        }
+    }
+}
+
+impl TryFrom<Option<&str>> for DatabaseVersion {
+    type Error = crate::CoreError;
+
+    fn try_from(version: Option<&str>) -> crate::Result<Self> {
+        match version {
+            Some(version) => {
+                let build_err = |reason: &str| {
+                    CoreError::ConnectorError(ConnectorError::from_kind(ErrorKind::UnexpectedDatabaseVersion {
+                        version: version.into(),
+                        reason: reason.into(),
+                    }))
+                };
+
+                let mut iter = version.split('/');
+
+                let version = iter.next().ok_or_else(|| build_err("Missing version"))?;
+                let is_mariadb = iter.next().map(|s| s.contains("MariaDB")).unwrap_or(false);
+
+                if is_mariadb {
+                    return Ok(DatabaseVersion::Mariadb);
+                }
+
+                let mut version_iter = version.split('.');
+
+                let major = version_iter.next().ok_or_else(|| build_err("Missing major version"))?;
+                let minor = version_iter.next().ok_or_else(|| build_err("Missing minor version"))?;
+                let patch = version_iter.next().ok_or_else(|| build_err("Missing patch version"))?;
+
+                let parsed_major = major.parse().map_err(|_| build_err("Major version is not a number"))?;
+                let parsed_minor = minor.parse().map_err(|_| build_err("Minor version is not a number"))?;
+                let parsed_patch = patch.parse().map_err(|_| build_err("Patch version is not a number"))?;
+
+                Ok(DatabaseVersion::Mysql(parsed_major, parsed_minor, parsed_patch))
+            }
+            None => Ok(DatabaseVersion::Unknown),
+        }
+    }
+}

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -11,6 +11,7 @@ use psl::ConnectorRegistry;
 use quaint::connector::ExternalConnector;
 use query_core::{
     protocol::EngineProtocol,
+    relation_load_strategy,
     schema::{self},
     telemetry, TransactionOptions, TxId,
 };
@@ -113,10 +114,16 @@ impl QueryEngine {
                     "db.type" = connector.name(),
                 );
 
-                connector.get_connection().instrument(conn_span).await?;
+                let conn = connector.get_connection().instrument(conn_span).await?;
+                let db_version = conn.version().await;
 
                 let query_schema_span = tracing::info_span!("prisma:engine:schema");
-                let query_schema = query_schema_span.in_scope(|| schema::build(arced_schema, true));
+
+                let query_schema = query_schema_span
+                    .in_scope(|| schema::build(arced_schema, true))
+                    .with_db_version_supports_join_strategy(
+                        relation_load_strategy::db_version_supports_joins_strategy(db_version)?,
+                    );
 
                 Ok(ConnectedEngine {
                     schema: builder.schema.clone(),

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -33,6 +33,7 @@ pub enum RelationLoadStrategy {
     Join,
     Query,
 }
+
 impl RelationLoadStrategy {
     pub fn is_query(&self) -> bool {
         matches!(self, RelationLoadStrategy::Query)

--- a/query-engine/schema/src/build.rs
+++ b/query-engine/schema/src/build.rs
@@ -20,6 +20,7 @@ use query_structure::{ast, Field as ModelField, Model, RelationFieldRef, TypeIde
 
 pub fn build(schema: Arc<psl::ValidatedSchema>, enable_raw_queries: bool) -> QuerySchema {
     let preview_features = schema.configuration.preview_features();
+
     build_with_features(schema, preview_features, enable_raw_queries)
 }
 
@@ -30,5 +31,6 @@ pub fn build_with_features(
 ) -> QuerySchema {
     let connector = schema.connector;
     let internal_data_model = query_structure::convert(schema);
+
     QuerySchema::new(enable_raw_queries, connector, preview_features, internal_data_model)
 }

--- a/query-engine/schema/src/build/enum_types.rs
+++ b/query-engine/schema/src/build/enum_types.rs
@@ -111,7 +111,7 @@ pub fn itx_isolation_levels(ctx: &'_ QuerySchema) -> Option<EnumType> {
 }
 
 pub(crate) fn relation_load_strategy(ctx: &QuerySchema) -> Option<EnumType> {
-    if !ctx.has_feature(psl::PreviewFeature::RelationJoins) {
+    if !ctx.can_resolve_relation_with_joins() {
         return None;
     }
 


### PR DESCRIPTION
## Overview

closes https://github.com/prisma/team-orm/issues/704

MySQL and MariaDB's database versions are now parsed at runtime as soon as we get a connection to the database. This version is given for free since it's shared by the database at connection during the handshake.

I would've loved to have it stored in the PSL Schema, where it belongs, but it's currently impossible because:
1. We first parse the Prisma Schema and build the PSL Schema
2. We then, in parallel, get the database connection _and_ build the Query Schema
3. Query Schema depends on the PSL schema. But the PSL schema is currently unclonable. So we rely on Arcs.
4. This means that by the time we get the database version (and the Query Schema), there's no way anymore for us to mutate the PSL schema inside the Query Schema. (Again, because PSL is ARCed inside the Query Schema)

For these reasons, we've decided to:
1. Add a new `JoinStrategySupport` enum to `psl::Connector`. This enum represents the _static_ knowledge of JoinStrategySupport. For MySQL, it is set to `JoinStrategySupport::UnknownYet`, because we don't know yet whether the runtime version of the database supports it.
2. After grabbing a database connection, we read the database version and compute whether the db version supports the join strategy and update `QuerySchema::JoinStrategySupport` to either `UnsupportedDbVersion` or `Yes`.

We then use this new field to decide which `RelationLoadStrategy` to choose when parsing an incoming query. For `UnsupportedDbVersion` we either error if the `RelationLoadStrategy::Join` is selected, or we default to the `Query` variant.

Overall, what it means is:

1. When the MySQL connector is loaded and a connection to the database is created, we read the database version (that was shared at connection)
3. We then compute a boolean that indicates whether the MySQL/MariaDB/Planetscale version is compatible with the `RelationLoadStrategy::Join`
4. Regardless of whether it's compatible with the specific database version, we build the Query Schema based on whether the _PSL connector_ supports it only (to avoid desync with the Prisma Client).
5. When comes the time of parsing a query, we use that new `join_strategy_support` to _error_ if the requested `RelationLoadStrategy` is explicitly set to `Join` but the database version does not support it.
6. If no `RelationLoadStrategy` is requested, we fallback to the `RelationLoadStrategy::Query`.