### PR TITLE
qe-wasm: Remove `Buffer` usage

### DIFF
--- a/query-engine/driver-adapters/src/napi/conversion.rs
+++ b/query-engine/driver-adapters/src/napi/conversion.rs
@@ -18,7 +18,12 @@ impl ToNapiValue for JSArg {
         match value {
             JSArg::Value(v) => ToNapiValue::to_napi_value(env, v),
             JSArg::Buffer(bytes) => {
-                ToNapiValue::to_napi_value(env, napi::Env::from_raw(env).create_buffer_with_data(bytes)?.into_raw())
+                let env = napi::Env::from_raw(env);
+                let length = bytes.len();
+                let buffer = env.create_arraybuffer_with_data(bytes)?.into_raw();
+                let byte_array = buffer.into_typedarray(napi::TypedArrayType::Uint8, length, 0)?;
+
+                ToNapiValue::to_napi_value(env.raw(), byte_array)
             }
             // While arrays are encodable as JSON generally, their element might not be, or may be
             // represented in a different way than we need. We use this custom logic for all arrays

--- a/query-engine/driver-adapters/src/wasm/conversion.rs
+++ b/query-engine/driver-adapters/src/wasm/conversion.rs
@@ -3,16 +3,7 @@ use crate::conversion::JSArg;
 use super::to_js::{serde_serialize, ToJsValue};
 use crate::types::Query;
 use js_sys::{Array, JsString, Object, Reflect, Uint8Array};
-use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(extends = Object)]
-    pub type Buffer;
-
-    #[wasm_bindgen(static_method_of = Buffer)]
-    pub fn from(array: &Uint8Array) -> Buffer;
-}
+use wasm_bindgen::JsValue;
 
 impl ToJsValue for Query {
     fn to_js_value(&self) -> Result<wasm_bindgen::prelude::JsValue, wasm_bindgen::prelude::JsValue> {
@@ -36,7 +27,7 @@ impl ToJsValue for JSArg {
             JSArg::Value(value) => serde_serialize(value),
             JSArg::Buffer(buf) => {
                 let array = Uint8Array::from(buf.as_slice());
-                Ok(Buffer::from(&array).into())
+                Ok(array.into())
             }
             JSArg::Array(value) => {
                 let array = Array::new();


### PR DESCRIPTION
Convert `Byte` arguments to `Uint8Array` instead.

Allows us to stop polyfilling `Buffer` for `_bg.js` fiels in engine.
