### PR TITLE
qe: `--enable-playground` automatically enables graphql protocol

### DIFF
--- a/query-engine/query-engine/src/opt.rs
+++ b/query-engine/query-engine/src/opt.rs
@@ -224,7 +224,13 @@ impl PrismaOpt {
         self.engine_protocol
             .as_ref()
             .map(EngineProtocol::from)
-            .unwrap_or(EngineProtocol::Json)
+            .unwrap_or_else(|| {
+                if self.enable_playground {
+                    EngineProtocol::Graphql
+                } else {
+                    EngineProtocol::Json
+                }
+            })
     }
 }
 


### PR DESCRIPTION
If protocol is not specified explicitly and `--enable-playground` flag
is used, engine will default to GraphQL instead of JSON.

Close #4679
