### PR TITLE
driver-adapters: Pin drivers to the versions, used in prisma/prisma

### DIFF
--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: "Setup Node.js"
         uses: actions/setup-node@v4
@@ -43,9 +45,17 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      
+      - name: Extract Branch Name
+        id: extract-branch
+        run: |
+          branch="$(git show -s --format=%s | grep -o "DRIVER_ADAPTERS_BRANCH=[^ ]*" | cut -f2 -d=)"
+          if [ -n "$branch" ]; then
+            echo "Using $branch branch of driver adapters"
+            echo "DRIVER_ADAPTERS_BRANCH=$branch" >> "$GITHUB_ENV"
+          fi
 
       - uses: cachix/install-nix-action@v24
-
       - name: Setup benchmark
         run: make setup-pg-bench
 

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -47,7 +47,6 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       
       - name: Extract Branch Name
-        id: extract-branch
         run: |
           branch="$(git show -s --format=%s | grep -o "DRIVER_ADAPTERS_BRANCH=[^ ]*" | cut -f2 -d=)"
           if [ -n "$branch" ]; then

--- a/query-engine/driver-adapters/executor/package.json
+++ b/query-engine/driver-adapters/executor/package.json
@@ -22,9 +22,6 @@
   "sideEffects": false,
   "license": "Apache-2.0",
   "dependencies": {
-    "@libsql/client": "0.3.6",
-    "@neondatabase/serverless": "0.8.1",
-    "@planetscale/database": "1.16.0",
     "query-engine-wasm-latest": "npm:@prisma/query-engine-wasm@latest",
     "query-engine-wasm-baseline": "npm:@prisma/query-engine-wasm@0.0.19",
     "@prisma/adapter-libsql": "workspace:*",
@@ -32,9 +29,8 @@
     "@prisma/adapter-pg": "workspace:*",
     "@prisma/adapter-planetscale": "workspace:*",
     "@prisma/driver-adapter-utils": "workspace:*",
-    "@types/pg": "8.10.9",
+    "@prisma/bundled-js-drivers": "workspace:*",
     "mitata": "^0.1.6",
-    "pg": "8.11.3",
     "undici": "6.0.1",
     "ws": "8.14.2"
   },

--- a/query-engine/driver-adapters/executor/src/bench.ts
+++ b/query-engine/driver-adapters/executor/src/bench.ts
@@ -9,7 +9,7 @@ import { fileURLToPath } from "node:url";
 
 import * as qe from "./qe";
 
-import pgDriver from "pg";
+import { pg } from "@prisma/bundled-js-drivers";
 import * as prismaPg from "@prisma/adapter-pg";
 import { bindAdapter, DriverAdapter } from "@prisma/driver-adapter-utils";
 
@@ -176,7 +176,7 @@ async function pgAdapter(url: string): Promise<DriverAdapter> {
   if (schemaName != null) {
     args.options = `--search_path="${schemaName}"`;
   }
-  const pool = new pgDriver.Pool(args);
+  const pool = new pg.Pool(args);
 
   return new prismaPg.PrismaPg(pool, {
     schema: schemaName,

--- a/query-engine/driver-adapters/executor/src/testd.ts
+++ b/query-engine/driver-adapters/executor/src/testd.ts
@@ -3,21 +3,18 @@ import * as readline from 'node:readline'
 import * as jsonRpc from './jsonRpc'
 
 // pg dependencies
-import pgDriver from 'pg'
 import * as prismaPg from '@prisma/adapter-pg'
 
 // neon dependencies
-import { Pool as NeonPool, neonConfig } from '@neondatabase/serverless'
 import { fetch } from 'undici'
 import { WebSocket } from 'ws'
+import { pg, neon, planetScale, libSql } from '@prisma/bundled-js-drivers'
 import * as prismaNeon from '@prisma/adapter-neon'
 
 // libsql dependencies
-import { createClient } from '@libsql/client'
 import { PrismaLibSQL } from '@prisma/adapter-libsql'
 
 // planetscale dependencies
-import { Client as PlanetscaleClient } from '@planetscale/database'
 import { PrismaPlanetScale } from '@prisma/adapter-planetscale'
 
 
@@ -256,7 +253,7 @@ function postgresSchemaName(url: string) {
 
 async function pgAdapter(url: string): Promise<DriverAdapter> {
     const schemaName = postgresSchemaName(url)
-    const pool = new pgDriver.Pool(postgres_options(url))
+    const pool = new pg.Pool(postgres_options(url))
     return new prismaPg.PrismaPg(pool, {
         schema: schemaName
     })
@@ -264,6 +261,7 @@ async function pgAdapter(url: string): Promise<DriverAdapter> {
 }
 
 async function neonWsAdapter(url: string): Promise<DriverAdapter> {
+    const { neonConfig, Pool: NeonPool } = neon
     const proxyURL = JSON.parse(process.env.DRIVER_ADAPTER_CONFIG || '{}').proxy_url ?? ''
     if (proxyURL == '') {
         throw new Error("DRIVER_ADAPTER_CONFIG is not defined or empty, but its required for neon adapter.");
@@ -281,7 +279,7 @@ async function neonWsAdapter(url: string): Promise<DriverAdapter> {
 }
 
 async function libsqlAdapter(url: string): Promise<DriverAdapter> {
-    const libsql = createClient({ url, intMode: 'bigint' })
+    const libsql = libSql.createClient({ url, intMode: 'bigint' })
     return new PrismaLibSQL(libsql)
 }
 
@@ -291,7 +289,7 @@ async function planetscaleAdapter(url: string): Promise<DriverAdapter> {
         throw new Error("DRIVER_ADAPTER_CONFIG is not defined or empty, but its required for planetscale adapter.");
     }
 
-    const client = new PlanetscaleClient({
+    const client = new planetScale.Client({
         // preserving path name so proxy url would look like real DB url
         url: copyPathName(url, proxyUrl),
         fetch,

--- a/query-engine/driver-adapters/pnpm-workspace.yaml
+++ b/query-engine/driver-adapters/pnpm-workspace.yaml
@@ -5,4 +5,5 @@ packages:
   - '../../../prisma/packages/adapter-planetscale'
   - '../../../prisma/packages/driver-adapter-utils'
   - '../../../prisma/packages/debug'
+  - '../../../prisma/packages/bundled-js-drivers'
   - './executor'


### PR DESCRIPTION
See https://github.com/prisma/prisma/pull/23087
Removes direct depenencies on the driver packages and picks them from
the meta-package in prisma/prisma. Should avoid disaster on every
update.

Fix prisma/team-orm#940
