### PR TITLE
ci(wasm comments): only create comments if the branch is from the repo

### DIFF
--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -129,9 +129,9 @@ jobs:
 
       - name: Create or update report
         uses: peter-evans/create-or-update-comment@v3
-        # Only run on our repository
+        # Only run on branches from our repository
         # It avoids an expected failure on forks
-        if: github.repository == 'prisma/prisma-engines'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           comment-id: ${{ steps.findReportComment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -106,9 +106,9 @@ jobs:
 
       - name: Create or update report
         uses: peter-evans/create-or-update-comment@v3
-        # Only run on our repository
+        # Only run on branches from our repository
         # It avoids an expected failure on forks
-        if: github.repository == 'prisma/prisma-engines'
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           comment-id: ${{ steps.findReportComment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Turns out that https://github.com/prisma/prisma-engines/pull/4723 was not what was needed, so here is a new PR