### PR TITLE
qe: fix a compiler warning when driver adapters are disabled

### DIFF
--- a/query-engine/request-handlers/src/load_executor.rs
+++ b/query-engine/request-handlers/src/load_executor.rs
@@ -25,13 +25,13 @@ pub async fn load(
     features: PreviewFeatures,
 ) -> query_core::Result<Box<dyn QueryExecutor + Send + Sync + 'static>> {
     match connector_kind {
-        ConnectorKind::Js { adapter, _phantom } => {
-            #[cfg(not(feature = "driver-adapters"))]
+        #[cfg(not(feature = "driver-adapters"))]
+        ConnectorKind::Js { .. } => {
             panic!("Driver adapters are not enabled, but connector mode is set to JS");
-
-            #[cfg(feature = "driver-adapters")]
-            driver_adapter(adapter, features).await
         }
+
+        #[cfg(feature = "driver-adapters")]
+        ConnectorKind::Js { adapter, _phantom } => driver_adapter(adapter, features).await,
 
         #[cfg(feature = "native")]
         ConnectorKind::Rust { url, datasource } => {


### PR DESCRIPTION
Fixes the following warning when compiling the tests:

```
warning: unused variable: `adapter`
  --> query-engine/request-handlers/src/load_executor.rs:28:29
   |
28 |         ConnectorKind::Js { adapter, _phantom } => {
   |                             ^^^^^^^ help: try ignoring the field: `adapter: _`
   |
   = note: `#[warn(unused_variables)]` on by default
```
