### PR TITLE
ci(wasm-size): compare with the base branch and not self

### DIFF
--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -50,8 +50,8 @@ jobs:
     steps:
       - name: Checkout base branch
         uses: actions/checkout@v4
-        # with:
-        #   ref: ${{ github.event.pull_request.base.sha }}
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - uses: ./.github/workflows/include/rust-wasm-setup
 


### PR DESCRIPTION
This was commented out in https://github.com/prisma/prisma-engines/pull/4713 to make the pipeline pass in the PR because the changes weren't compatible with the pipeline on `main` with the intention to uncomment immediately after landing the changes, see https://github.com/prisma/prisma-engines/pull/4713#discussion_r1486369523.
