### PR TITLE
qe: implement DISTINCT ON for joins

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/query_builder/select/lateral.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select/lateral.rs
@@ -247,6 +247,7 @@ impl LateralJoinSelectBuilder {
             .with_m2m_join_conditions(&rf.related_field(), m2m_table_alias, parent_alias, ctx) // adds join condition to the child table
             // TODO: avoid clone filter
             .with_filters(rs.args.filter.clone(), Some(m2m_join_alias), ctx) // adds query filters
+            .with_distinct(&rs.args, m2m_join_alias)
             .with_ordering(&rs.args, Some(m2m_join_alias.to_table_string()), ctx) // adds ordering stmts
             .with_pagination(rs.args.take_abs(), rs.args.skip)
             .comment("inner"); // adds pagination

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select/mod.rs
@@ -490,10 +490,6 @@ impl<'a> SelectBuilderExt<'a> for Select<'a> {
         let Some(ref distinct) = args.distinct else { return self };
 
         let distinct_fields = distinct
-            // TODO: do we want to use the existing `as_scalar_fields` here? It has slightly
-            // different semantics (enforces all fields must be scalars) and requires an
-            // allocation. The new `scalars` method is cheaper and has semantics equivalent to
-            // `ModelProjection::from` which the old query builder uses for distinct fields.
             .scalars()
             .map(|sf| Expression::from(Column::from((table_alias.to_table_string(), sf.db_name().to_owned()))))
             .collect();

--- a/query-engine/connectors/sql-query-connector/src/query_builder/select/mod.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/select/mod.rs
@@ -170,19 +170,25 @@ pub(crate) trait JoinSelectBuilder {
         let linking_fields = rs.field.related_field().linking_fields();
 
         if rs.field.relation().is_many_to_many() {
-            let selection: Vec<Column<'_>> =
-                FieldSelection::union(vec![order_by_selection(rs), linking_fields, filtering_selection(rs)])
-                    .into_projection()
-                    .as_columns(ctx)
-                    .map(|c| c.table(root_alias.to_table_string()))
-                    .collect();
+            let selection: Vec<Column<'_>> = FieldSelection::union(vec![
+                order_by_selection(rs),
+                distinct_selection(rs),
+                linking_fields,
+                filtering_selection(rs),
+            ])
+            .into_projection()
+            .as_columns(ctx)
+            .map(|c| c.table(root_alias.to_table_string()))
+            .collect();
 
             // SELECT <foreign_keys>, <orderby columns>
             inner.with_columns(selection.into())
         } else {
-            // select ordering, filtering & join fields from child selections to order, filter & join them on the outer query
+            // select ordering, distinct, filtering & join fields from child selections to order,
+            // filter & join them on the outer query
             let inner_selection: Vec<Column<'_>> = FieldSelection::union(vec![
                 order_by_selection(rs),
+                distinct_selection(rs),
                 filtering_selection(rs),
                 relation_selection(rs),
             ])
@@ -204,6 +210,8 @@ pub(crate) trait JoinSelectBuilder {
             let middle = Select::from_table(Table::from(inner).alias(inner_alias.to_table_string()))
                 // SELECT <inner_alias>.<JSON_ADD_IDENT>
                 .column(Column::from((inner_alias.to_table_string(), JSON_AGG_IDENT)))
+                // DISTINCT ON
+                .with_distinct(&rs.args, inner_alias)
                 // ORDER BY ...
                 .with_ordering(&rs.args, Some(inner_alias.to_table_string()), ctx)
                 // WHERE ...
@@ -255,11 +263,11 @@ pub(crate) trait JoinSelectBuilder {
 
         // SELECT ... FROM Table "t1"
         let select = Select::from_table(table)
+            .with_distinct(args, table_alias)
             .with_ordering(args, Some(table_alias.to_table_string()), ctx)
             .with_filters(args.filter.clone(), Some(table_alias), ctx)
             .with_pagination(args.take_abs(), args.skip)
-            .append_trace(&Span::current())
-            .add_trace_id(ctx.trace_id);
+            .append_trace(&Span::current());
 
         (select, table_alias)
     }
@@ -409,6 +417,7 @@ pub(crate) trait SelectBuilderExt<'a> {
     fn with_filters(self, filter: Option<Filter>, parent_alias: Option<Alias>, ctx: &Context<'_>) -> Select<'a>;
     fn with_pagination(self, take: Option<i64>, skip: Option<i64>) -> Select<'a>;
     fn with_ordering(self, args: &QueryArguments, parent_alias: Option<String>, ctx: &Context<'_>) -> Select<'a>;
+    fn with_distinct(self, args: &QueryArguments, table_alias: Alias) -> Select<'a>;
     fn with_join_conditions(
         self,
         rf: &RelationField,
@@ -471,6 +480,25 @@ impl<'a> SelectBuilderExt<'a> for Select<'a> {
         order_by_definitions
             .iter()
             .fold(select, |acc, o| acc.order_by(o.order_definition.clone()))
+    }
+
+    fn with_distinct(self, args: &QueryArguments, table_alias: Alias) -> Select<'a> {
+        if !args.can_distinct_in_db_with_joins() {
+            return self;
+        }
+
+        let Some(ref distinct) = args.distinct else { return self };
+
+        let distinct_fields = distinct
+            // TODO: do we want to use the existing `as_scalar_fields` here? It has slightly
+            // different semantics (enforces all fields must be scalars) and requires an
+            // allocation. The new `scalars` method is cheaper and has semantics equivalent to
+            // `ModelProjection::from` which the old query builder uses for distinct fields.
+            .scalars()
+            .map(|sf| Expression::from(Column::from((table_alias.to_table_string(), sf.db_name().to_owned()))))
+            .collect();
+
+        self.distinct_on(distinct_fields)
     }
 
     fn with_join_conditions(
@@ -566,6 +594,10 @@ fn filtering_selection(rs: &RelationSelection) -> FieldSelection {
     } else {
         FieldSelection::default()
     }
+}
+
+fn distinct_selection(rs: &RelationSelection) -> FieldSelection {
+    rs.args.distinct.as_ref().cloned().unwrap_or_default()
 }
 
 fn extract_filter_scalars(f: &Filter) -> Vec<ScalarFieldRef> {

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -227,7 +227,6 @@ impl RelatedRecordsQuery {
         self.args.cursor.is_some() || self.nested.iter().any(|q| q.has_cursor())
     }
 
-    // TODO: might need to be removed afterwards
     pub fn has_distinct(&self) -> bool {
         self.args.distinct.is_some() || self.nested.iter().any(|q| q.has_distinct())
     }

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -227,6 +227,7 @@ impl RelatedRecordsQuery {
         self.args.cursor.is_some() || self.nested.iter().any(|q| q.has_cursor())
     }
 
+    // TODO: might need to be removed afterwards
     pub fn has_distinct(&self) -> bool {
         self.args.distinct.is_some() || self.nested.iter().any(|q| q.has_distinct())
     }

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -65,11 +65,11 @@ impl ReadQuery {
         }
     }
 
-    pub(crate) fn requires_inmemory_processing_for_distinct_with_joins(&self) -> bool {
+    pub(crate) fn requires_inmemory_distinct_with_joins(&self) -> bool {
         match self {
             ReadQuery::RecordQuery(_) => false,
-            ReadQuery::ManyRecordsQuery(q) => q.requires_inmemory_processing_for_distinct_with_joins(),
-            ReadQuery::RelatedRecordsQuery(q) => q.requires_inmemory_processing_for_distinct_with_joins(),
+            ReadQuery::ManyRecordsQuery(q) => q.requires_inmemory_distinct_with_joins(),
+            ReadQuery::RelatedRecordsQuery(q) => q.requires_inmemory_distinct_with_joins(),
             ReadQuery::AggregateRecordsQuery(_) => false,
         }
     }
@@ -208,12 +208,9 @@ pub struct ManyRecordsQuery {
 }
 
 impl ManyRecordsQuery {
-    pub fn requires_inmemory_processing_for_distinct_with_joins(&self) -> bool {
-        self.args.distinct.is_some() && !self.args.can_distinct_in_db_with_joins()
-            || self
-                .nested
-                .iter()
-                .any(|q| q.requires_inmemory_processing_for_distinct_with_joins())
+    pub fn requires_inmemory_distinct_with_joins(&self) -> bool {
+        self.args.requires_inmemory_distinct_with_joins()
+            || self.nested.iter().any(|q| q.requires_inmemory_distinct_with_joins())
     }
 }
 
@@ -237,12 +234,9 @@ impl RelatedRecordsQuery {
         self.args.cursor.is_some() || self.nested.iter().any(|q| q.has_cursor())
     }
 
-    pub fn requires_inmemory_processing_for_distinct_with_joins(&self) -> bool {
-        self.args.distinct.is_some() && !self.args.can_distinct_in_db_with_joins()
-            || self
-                .nested
-                .iter()
-                .any(|q| q.requires_inmemory_processing_for_distinct_with_joins())
+    pub fn requires_inmemory_distinct_with_joins(&self) -> bool {
+        self.args.requires_inmemory_distinct_with_joins()
+            || self.nested.iter().any(|q| q.requires_inmemory_distinct_with_joins())
     }
 }
 

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -41,6 +41,7 @@ fn find_many_with_options(
         args.relation_load_strategy,
         args.cursor.as_ref(),
         args.distinct.as_ref(),
+        &args.order_by,
         &nested,
         query_schema,
     );

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -37,13 +37,8 @@ fn find_many_with_options(
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
     let selected_fields = utils::merge_cursor_fields(selected_fields, &args.cursor);
 
-    let relation_load_strategy = get_relation_load_strategy(
-        args.relation_load_strategy,
-        args.cursor.as_ref(),
-        args.distinct.as_ref(),
-        &nested,
-        query_schema,
-    );
+    let relation_load_strategy =
+        get_relation_load_strategy(args.relation_load_strategy, args.cursor.as_ref(), &nested, query_schema);
 
     Ok(ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/many.rs
+++ b/query-engine/core/src/query_graph_builder/read/many.rs
@@ -37,8 +37,13 @@ fn find_many_with_options(
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
     let selected_fields = utils::merge_cursor_fields(selected_fields, &args.cursor);
 
-    let relation_load_strategy =
-        get_relation_load_strategy(args.relation_load_strategy, args.cursor.as_ref(), &nested, query_schema);
+    let relation_load_strategy = get_relation_load_strategy(
+        args.relation_load_strategy,
+        args.cursor.as_ref(),
+        args.distinct.as_ref(),
+        &nested,
+        query_schema,
+    );
 
     Ok(ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -50,7 +50,8 @@ fn find_unique_with_options(
     let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
-    let relation_load_strategy = get_relation_load_strategy(requested_rel_load_strategy, None, &nested, query_schema);
+    let relation_load_strategy =
+        get_relation_load_strategy(requested_rel_load_strategy, None, None, &nested, query_schema);
 
     Ok(ReadQuery::RecordQuery(RecordQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -51,7 +51,7 @@ fn find_unique_with_options(
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
     let relation_load_strategy =
-        get_relation_load_strategy(requested_rel_load_strategy, None, None, &nested, query_schema);
+        get_relation_load_strategy(requested_rel_load_strategy, None, None, &[], &nested, query_schema);
 
     Ok(ReadQuery::RecordQuery(RecordQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/one.rs
+++ b/query-engine/core/src/query_graph_builder/read/one.rs
@@ -50,8 +50,7 @@ fn find_unique_with_options(
     let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
-    let relation_load_strategy =
-        get_relation_load_strategy(requested_rel_load_strategy, None, None, &nested, query_schema);
+    let relation_load_strategy = get_relation_load_strategy(requested_rel_load_strategy, None, &nested, query_schema);
 
     Ok(ReadQuery::RecordQuery(RecordQuery {
         name,

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -253,15 +253,13 @@ pub fn merge_cursor_fields(selected_fields: FieldSelection, cursor: &Option<Sele
 pub(crate) fn get_relation_load_strategy(
     requested_strategy: Option<RelationLoadStrategy>,
     cursor: Option<&SelectionResult>,
-    distinct: Option<&FieldSelection>,
     nested_queries: &[ReadQuery],
     query_schema: &QuerySchema,
 ) -> RelationLoadStrategy {
     if query_schema.can_resolve_relation_with_joins()
         && cursor.is_none()
-        && distinct.is_none()
         && !nested_queries.iter().any(|q| match q {
-            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.has_distinct(),
+            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor(),
             _ => false,
         })
         && requested_strategy != Some(RelationLoadStrategy::Query)

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -270,7 +270,7 @@ pub(crate) fn get_relation_load_strategy(
         && (distinct.is_none() || can_distinct_in_db)
         && !nested_queries.iter().any(|q| match q {
             ReadQuery::RelatedRecordsQuery(q) => {
-                q.has_cursor() || (q.has_distinct() && !q.args.can_distinct_in_db_with_joins())
+                q.has_cursor() || q.requires_inmemory_processing_for_distinct_with_joins()
             }
             _ => false,
         })

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -263,15 +263,13 @@ pub(crate) fn get_relation_load_strategy(
         return RelationLoadStrategy::Query;
     }
 
-    let can_distinct_in_db = query_schema.has_capability(ConnectorCapability::DistinctOn)
+    let can_distinct_in_db_with_joins = query_schema.has_capability(ConnectorCapability::DistinctOn)
         && native_distinct_compatible_with_order_by(distinct, order_by);
 
     if cursor.is_none()
-        && (distinct.is_none() || can_distinct_in_db)
+        && (distinct.is_none() || can_distinct_in_db_with_joins)
         && !nested_queries.iter().any(|q| match q {
-            ReadQuery::RelatedRecordsQuery(q) => {
-                q.has_cursor() || q.requires_inmemory_distinct_with_joins()
-            }
+            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.requires_inmemory_distinct_with_joins(),
             _ => false,
         })
     {

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -270,7 +270,7 @@ pub(crate) fn get_relation_load_strategy(
         && (distinct.is_none() || can_distinct_in_db)
         && !nested_queries.iter().any(|q| match q {
             ReadQuery::RelatedRecordsQuery(q) => {
-                q.has_cursor() || q.requires_inmemory_processing_for_distinct_with_joins()
+                q.has_cursor() || q.requires_inmemory_distinct_with_joins()
             }
             _ => false,
         })

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -274,7 +274,6 @@ pub(crate) fn get_relation_load_strategy(
             }
             _ => false,
         })
-        && requested_strategy != Some(RelationLoadStrategy::Query)
     {
         RelationLoadStrategy::Join
     } else {

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -253,13 +253,15 @@ pub fn merge_cursor_fields(selected_fields: FieldSelection, cursor: &Option<Sele
 pub(crate) fn get_relation_load_strategy(
     requested_strategy: Option<RelationLoadStrategy>,
     cursor: Option<&SelectionResult>,
+    distinct: Option<&FieldSelection>,
     nested_queries: &[ReadQuery],
     query_schema: &QuerySchema,
 ) -> RelationLoadStrategy {
     if query_schema.can_resolve_relation_with_joins()
         && cursor.is_none()
+        && distinct.is_none()
         && !nested_queries.iter().any(|q| match q {
-            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor(),
+            ReadQuery::RelatedRecordsQuery(q) => q.has_cursor() || q.has_distinct(),
             _ => false,
         })
         && requested_strategy != Some(RelationLoadStrategy::Query)

--- a/query-engine/query-structure/src/distinct.rs
+++ b/query-engine/query-structure/src/distinct.rs
@@ -8,10 +8,17 @@ use crate::{FieldSelection, OrderBy};
 /// before non-distinct fields in the order by clause.
 ///
 /// If there's no order by, then DISTINCT ON is allowed for any fields.
-pub fn native_distinct_compatible_with_order_by(distinct_fields: &FieldSelection, order_by_fields: &[OrderBy]) -> bool {
+pub fn native_distinct_compatible_with_order_by(
+    distinct_fields: Option<&FieldSelection>,
+    order_by_fields: &[OrderBy],
+) -> bool {
     if order_by_fields.is_empty() {
         return true;
     }
+
+    let Some(distinct_fields) = distinct_fields else {
+        return true;
+    };
 
     let count_leftmost_matching = order_by_fields
         .iter()

--- a/query-engine/query-structure/src/distinct.rs
+++ b/query-engine/query-structure/src/distinct.rs
@@ -21,7 +21,7 @@ pub fn native_distinct_compatible_with_order_by(distinct_fields: &FieldSelection
         })
         .count();
 
-    count_leftmost_matching == distinct_fields.len()
+    count_leftmost_matching == distinct_fields.as_ref().len()
 }
 
 #[cfg(test)]

--- a/query-engine/query-structure/src/distinct.rs
+++ b/query-engine/query-structure/src/distinct.rs
@@ -1,0 +1,32 @@
+use crate::{FieldSelection, OrderBy};
+
+/// Checks that the ordering is compatible with native DISTINCT ON in connectors that support it.
+///
+/// If order by is present, distinct fields must match leftmost order by fields in the query. The
+/// order of the distinct fields does not necessarily have to be the same as the order of the
+/// corresponding fields in the leftmost subset of `order_by` but all distinct fields must come
+/// before non-distinct fields in the order by clause.
+///
+/// If there's no order by, then DISTINCT ON is allowed for any fields.
+pub fn native_distinct_compatible_with_order_by(distinct_fields: &FieldSelection, order_by_fields: &[OrderBy]) -> bool {
+    if order_by_fields.is_empty() {
+        return true;
+    }
+
+    let count_leftmost_matching = order_by_fields
+        .iter()
+        .take_while(|order_by| match order_by {
+            OrderBy::Scalar(scalar) => distinct_fields.scalars().any(|sf| *sf == scalar.field),
+            _ => false,
+        })
+        .count();
+
+    count_leftmost_matching == distinct_fields.len()
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: figure out how to write unit tests here
+    #[test]
+    fn empty_order_by() {}
+}

--- a/query-engine/query-structure/src/distinct.rs
+++ b/query-engine/query-structure/src/distinct.rs
@@ -30,10 +30,3 @@ pub fn native_distinct_compatible_with_order_by(
 
     count_leftmost_matching == distinct_fields.as_ref().len()
 }
-
-#[cfg(test)]
-mod tests {
-    // TODO: figure out how to write unit tests here
-    #[test]
-    fn empty_order_by() {}
-}

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -23,10 +23,6 @@ impl FieldSelection {
         self.selections
     }
 
-    pub fn len(&self) -> usize {
-        self.selections.len()
-    }
-
     /// Returns `true` if self contains (at least) all fields specified in `other`. `false` otherwise.
     /// Recurses into composite selections and ensures that composite selections are supersets as well.
     pub fn is_superset_of(&self, other: &Self) -> bool {
@@ -246,6 +242,12 @@ impl FieldSelection {
     pub fn has_virtual_fields(&self) -> bool {
         self.selections()
             .any(|field| matches!(field, SelectedField::Virtual(_)))
+    }
+}
+
+impl AsRef<[SelectedField]> for FieldSelection {
+    fn as_ref(&self) -> &[SelectedField] {
+        &self.selections
     }
 }
 

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -531,8 +531,8 @@ impl CompositeSelection {
     }
 }
 
-impl From<Vec<ScalarFieldRef>> for FieldSelection {
-    fn from(fields: Vec<ScalarFieldRef>) -> Self {
+impl<T: IntoIterator<Item = ScalarFieldRef>> From<T> for FieldSelection {
+    fn from(fields: T) -> Self {
         Self {
             selections: fields.into_iter().map(Into::into).collect(),
         }

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -23,6 +23,10 @@ impl FieldSelection {
         self.selections
     }
 
+    pub fn len(&self) -> usize {
+        self.selections.len()
+    }
+
     /// Returns `true` if self contains (at least) all fields specified in `other`. `false` otherwise.
     /// Recurses into composite selections and ensures that composite selections are supersets as well.
     pub fn is_superset_of(&self, other: &Self) -> bool {
@@ -41,6 +45,10 @@ impl FieldSelection {
 
     pub fn selections(&self) -> impl Iterator<Item = &SelectedField> + '_ {
         self.selections.iter()
+    }
+
+    pub fn scalars(&self) -> impl Iterator<Item = &ScalarFieldRef> + '_ {
+        self.selections().filter_map(SelectedField::as_scalar)
     }
 
     pub fn virtuals(&self) -> impl Iterator<Item = &VirtualSelection> {
@@ -416,6 +424,13 @@ impl SelectedField {
         match self {
             SelectedField::Virtual(_) => Some((TypeIdentifier::Json, FieldArity::Required)),
             _ => self.type_identifier_with_arity(),
+        }
+    }
+
+    pub fn as_scalar(&self) -> Option<&ScalarFieldRef> {
+        match self {
+            SelectedField::Scalar(sf) => Some(sf),
+            _ => None,
         }
     }
 

--- a/query-engine/query-structure/src/lib.rs
+++ b/query-engine/query-structure/src/lib.rs
@@ -1,6 +1,7 @@
 mod composite_type;
 mod convert;
 mod default_value;
+mod distinct;
 mod error;
 mod field;
 mod field_selection;
@@ -25,6 +26,7 @@ pub mod prelude;
 pub use self::{default_value::*, native_type_instance::*, zipper::*};
 pub use composite_type::*;
 pub use convert::convert;
+pub use distinct::*;
 pub use error::*;
 pub use field::*;
 pub use field_selection::*;

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -107,11 +107,7 @@ impl QueryArguments {
 
     pub fn can_distinct_in_db_with_joins(&self) -> bool {
         self.connector_supports_distinct_on()
-            && self
-                .distinct
-                .as_ref()
-                .map(|distinct| native_distinct_compatible_with_order_by(distinct, &self.order_by))
-                .unwrap_or(true)
+            && native_distinct_compatible_with_order_by(self.distinct.as_ref(), &self.order_by)
     }
 
     fn connector_supports_distinct_on(&self) -> bool {

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -93,6 +93,10 @@ impl QueryArguments {
         self.distinct.is_some() && !self.can_distinct_in_db()
     }
 
+    pub fn requires_inmemory_distinct_with_joins(&self) -> bool {
+        self.distinct.is_some() && !self.can_distinct_in_db_with_joins()
+    }
+
     fn can_distinct_in_db(&self) -> bool {
         let has_distinct_feature = self
             .model()

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -22,7 +22,7 @@ pub struct QueryArguments {
     pub skip: Option<i64>,
     pub filter: Option<Filter>,
     pub order_by: Vec<OrderBy>,
-    pub distinct: Option<FieldSelection>, // TODO: should we make it `Vec<ScalarFieldRef>`?
+    pub distinct: Option<FieldSelection>,
     pub ignore_skip: bool,
     pub ignore_take: bool,
     pub relation_load_strategy: Option<RelationLoadStrategy>,

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -109,6 +109,8 @@ impl QueryArguments {
         has_distinct_feature && self.connector_supports_distinct_on() && self.order_by.is_empty()
     }
 
+    // TODO: separation between `can_distinct_in_db` and `can_distinct_in_db_with_joins` shouldn't
+    // be necessary once nativeDistinct is GA.
     pub fn can_distinct_in_db_with_joins(&self) -> bool {
         self.connector_supports_distinct_on()
             && native_distinct_compatible_with_order_by(self.distinct.as_ref(), &self.order_by)


### PR DESCRIPTION
## Description

Implement native `DISTINCT ON` support for queries with JOINs when it can be used (i.e. the provider supports `DISTINCT ON` and distinct is compatible with order by).

Closes: https://github.com/prisma/team-orm/issues/701

Next step:

- Implement in-memory processing instead of falling back to the query strategy when native `DISTINCT ON` can't be used: https://github.com/prisma/team-orm/issues/954

## Examples

### top-level

```graphql
{
  findManyPost(distinct: title) {
    id
    title
  }
}
```

```sql
SELECT
  DISTINCT ON ("t1"."title") "t1"."id",
  "t1"."title"
FROM
  "public"."Post" AS "t1"
```

### 1:m

```graphql
{
  findManyUser {
    id
    posts(distinct: [title], orderBy: [{title: asc}, {id: desc}]) {
      id
      title
    }
  }
}
```

```sql
SELECT
  "t1"."id",
  "User_posts"."__prisma_data__" AS "posts"
FROM
  "public"."User" AS "t1"
  LEFT JOIN LATERAL (
    SELECT
      COALESCE(JSONB_AGG("__prisma_data__"), '[]') AS "__prisma_data__"
    FROM
      (
        SELECT
          DISTINCT ON ("t4"."title") "t4"."__prisma_data__"
        FROM
          (
            SELECT
              JSONB_BUILD_OBJECT('id', "t3"."id", 'title', "t3"."title") AS "__prisma_data__",
              "t3"."title",
              "t3"."id"
            FROM
              (
                SELECT
                  "t2".*
                FROM
                  "public"."Post" AS "t2"
                WHERE
                  "t1"."id" = "t2"."userId"
                  /* root select */
              ) AS "t3"
              /* inner select */
          ) AS "t4"
        ORDER BY
          "t4"."title" ASC,
          "t4"."id" DESC
          /* middle select */
      ) AS "t5"
      /* outer select */
  ) AS "User_posts" ON true
```

### m:n

```graphql
{
  findManyUser {
    follows(distinct: login, orderBy: [{ login: desc }]) {
      id
      login
    }
  }
}
```

```sql
SELECT
  "t1"."id",
  "User_follows_m2m"."__prisma_data__" AS "follows"
FROM
  "public"."User" AS "t1"
  LEFT JOIN LATERAL (
    SELECT
      COALESCE(JSONB_AGG("__prisma_data__"), '[]') AS "__prisma_data__"
    FROM
      (
        SELECT
          DISTINCT ON ("t3"."login") "t3"."__prisma_data__"
        FROM
          "public"."_UserFollows" AS "t2"
          LEFT JOIN LATERAL (
            SELECT
              JSONB_BUILD_OBJECT('id', "t6"."id", 'login', "t6"."login") AS "__prisma_data__",
              "t6"."login",
              "t6"."id"
            FROM
              (
                SELECT
                  "t5".*
                FROM
                  "public"."User" AS "t5"
                WHERE
                  "t2"."A" = "t5"."id"
                  /* root select */
              ) AS "t6"
          ) AS "t3" ON true
        WHERE
          "t2"."B" = "t1"."id"
        ORDER BY
          "t3"."login" DESC
          /* inner */
      ) AS "t4"
      /* outer */
  ) AS "User_follows_m2m" ON true
```
