### PR TITLE
fix: query graph should extract join results using prisma field name

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -10,6 +10,7 @@ mod prisma_13405;
 mod prisma_14001;
 mod prisma_14696;
 mod prisma_14703;
+mod prisma_15177;
 mod prisma_15204;
 mod prisma_15264;
 mod prisma_15467;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15177.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15177.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema))]
+#[test_suite(schema(schema), exclude(MongoDb))]
 mod prisma_15177 {
     fn schema() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15177.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15177.rs
@@ -1,0 +1,41 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(schema(schema))]
+mod prisma_15177 {
+    fn schema() -> String {
+        let schema = indoc! {
+            r#"model Customer {
+              #id(userId, Int, @id  @map("user id"))
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // Should allow CRUD methods on a table column that has a space
+    #[connector_test]
+    async fn repro(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneCustomer(data: { userId: 1 }) { userId } }"#),
+          @r###"{"data":{"createOneCustomer":{"userId":1}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyCustomer { userId } }"#),
+          @r###"{"data":{"findManyCustomer":[{"userId":1}]}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { updateOneCustomer(where: { userId: 1 }, data: { userId: 2 }) { userId } }"#),
+          @r###"{"data":{"updateOneCustomer":{"userId":2}}}"###
+        );
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { deleteOneCustomer(where: { userId: 2 }) { userId } }"#),
+          @r###"{"data":{"deleteOneCustomer":{"userId":2}}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -74,7 +74,7 @@ impl ExpressionResult {
                 ),
                 QueryResult::RecordSelectionWithRelations(rsr) => Some(
                     rsr.records
-                        .extract_selection_results(field_selection)
+                        .extract_selection_results_from_prisma_name(field_selection)
                         .expect("Expected record selection to contain required model ID fields.")
                         .into_iter()
                         .collect(),


### PR DESCRIPTION
## Overview

Follow-up fix for https://github.com/prisma/prisma-engines/pull/4732. Now that results coming from JOINed queries use prisma field names instead of db field names, the query graph couldn't extract the relevant rows to pass from one node to another.