### PR TITLE
qe: tidy up `extract_selection_result` family of methods

### DIFF
--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -67,7 +67,7 @@ impl ExpressionResult {
                 // We always select IDs, the unwraps are safe.
                 QueryResult::RecordSelection(Some(rs)) => Some(
                     rs.records
-                        .extract_selection_results(field_selection)
+                        .extract_selection_results_from_db_name(field_selection)
                         .expect("Expected record selection to contain required model ID fields.")
                         .into_iter()
                         .collect(),

--- a/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
@@ -109,7 +109,7 @@ impl InMemoryRecordProcessor {
                         .into_iter()
                         .unique_by(|record| {
                             record
-                                .extract_selection_result(field_names, &distinct_selection)
+                                .extract_selection_result_from_db_name(field_names, &distinct_selection)
                                 .unwrap()
                         })
                         .collect();
@@ -123,7 +123,7 @@ impl InMemoryRecordProcessor {
                 .into_iter()
                 .unique_by(|record| {
                     record
-                        .extract_selection_result(field_names, &distinct_selection)
+                        .extract_selection_result_from_db_name(field_names, &distinct_selection)
                         .unwrap()
                 })
                 .collect()
@@ -148,7 +148,9 @@ impl InMemoryRecordProcessor {
             let mut cursor_seen = false;
 
             many_records.records.retain(|record| {
-                let cursor_comparator = record.extract_selection_result(field_names, &cursor_selection).unwrap();
+                let cursor_comparator = record
+                    .extract_selection_result_from_db_name(field_names, &cursor_selection)
+                    .unwrap();
                 let record_values: Vec<_> = cursor_comparator.values().collect();
 
                 // Reset, new parent

--- a/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/nested_read.rs
@@ -22,7 +22,7 @@ pub(crate) async fn m2m(
             let parent_model_id = query.parent_field.model().primary_identifier();
             parent_result
                 .expect("[ID retrieval] No parent results present in the query graph for reading related records.")
-                .extract_selection_results(&parent_model_id)?
+                .extract_selection_results_from_db_name(&parent_model_id)?
         }
     };
 
@@ -94,7 +94,7 @@ pub(crate) async fn m2m(
     let mut additional_records: Vec<(usize, Vec<Record>)> = vec![];
 
     for (index, record) in scalars.records.iter_mut().enumerate() {
-        let record_id = record.extract_selection_result(fields, &child_model_id)?;
+        let record_id = record.extract_selection_result_from_db_name(fields, &child_model_id)?;
         let mut parent_ids = id_map.remove(&record_id).expect("1");
         let first = parent_ids.pop().expect("2");
 
@@ -150,7 +150,7 @@ pub async fn one2m(
             let extractor = parent_model_id.clone().merge(parent_link_id.clone());
             parent_result
                 .expect("[ID retrieval] No parent results present in the query graph for reading related records.")
-                .extract_selection_results(&extractor)?
+                .extract_selection_results_from_db_name(&extractor)?
         }
     };
 
@@ -219,7 +219,8 @@ pub async fn one2m(
         let mut additional_records = vec![];
 
         for record in scalars.records.iter_mut() {
-            let child_link: SelectionResult = record.extract_selection_result(&scalars.field_names, &child_link_id)?;
+            let child_link: SelectionResult =
+                record.extract_selection_result_from_db_name(&scalars.field_names, &child_link_id)?;
             let child_link_values: Vec<PrismaValue> = child_link.pairs.into_iter().map(|(_, v)| v).collect();
 
             if let Some(parent_ids) = link_mapping.get_mut(&child_link_values) {
@@ -244,7 +245,7 @@ pub async fn one2m(
 
         for record in scalars.records.iter_mut() {
             let child_link: SelectionResult =
-                record.extract_selection_result(&scalars.field_names, &child_link_fields)?;
+                record.extract_selection_result_from_db_name(&scalars.field_names, &child_link_fields)?;
             let child_link_values: Vec<PrismaValue> = child_link.pairs.into_iter().map(|(_, v)| v).collect();
 
             if let Some(parent_ids) = link_mapping.get(&child_link_values) {

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -564,7 +564,8 @@ fn serialize_objects(
     // Write all fields, nested and list fields unordered into a map, afterwards order all into the final order.
     // If nothing is written to the object, write null instead.
     for record in result.records.records {
-        let record_id = Some(record.extract_selection_result(&db_field_names, &model.primary_identifier())?);
+        let record_id =
+            Some(record.extract_selection_result_from_db_name(&db_field_names, &model.primary_identifier())?);
 
         if !object_mapping.contains_key(&record.parent_id) {
             object_mapping.insert(record.parent_id.clone(), Vec::new());

--- a/query-engine/query-structure/src/record.rs
+++ b/query-engine/query-structure/src/record.rs
@@ -182,7 +182,7 @@ impl Record {
     /// Extracts a `SelectionResult` from this `Record`.
     /// `field_names`: Database names of the fields contained in this `Record`.
     /// `selected_fields`: The selection to extract.
-    #[inline]
+    // #[inline]
     pub fn extract_selection_result_from_db_name(
         &self,
         field_names: &[String],
@@ -193,7 +193,7 @@ impl Record {
 
     /// Extracts a `SelectionResult` from this `Record` using Prisma field names rather than
     /// database names.
-    #[inline]
+    // #[inline]
     pub fn extract_selection_result_from_prisma_name(
         &self,
         field_names: &[String],

--- a/query-engine/query-structure/src/record.rs
+++ b/query-engine/query-structure/src/record.rs
@@ -1,4 +1,6 @@
-use crate::{DomainError, FieldSelection, ModelProjection, OrderBy, PrismaValue, SelectionResult, SortOrder};
+use crate::{
+    DomainError, FieldSelection, ModelProjection, OrderBy, PrismaValue, SelectedField, SelectionResult, SortOrder,
+};
 use itertools::Itertools;
 use std::collections::HashMap;
 
@@ -24,7 +26,7 @@ impl SingleRecord {
 
     pub fn extract_selection_result(&self, extraction_selection: &FieldSelection) -> crate::Result<SelectionResult> {
         self.record
-            .extract_selection_result(&self.field_names, extraction_selection)
+            .extract_selection_result_from_db_name(&self.field_names, extraction_selection)
     }
 
     pub fn get_field_value(&self, field: &str) -> crate::Result<&PrismaValue> {
@@ -91,22 +93,34 @@ impl ManyRecords {
         self.records.push(record);
     }
 
-    /// Builds `SelectionResults` from this `ManyRecords` based on the given FieldSelection.
-    pub fn extract_selection_results(&self, selections: &FieldSelection) -> crate::Result<Vec<SelectionResult>> {
-        self.records
-            .iter()
-            .map(|record| record.extract_selection_result(&self.field_names, selections))
-            .collect()
+    /// Builds `SelectionResult`s from this `ManyRecords` based on the given `FieldSelection`
+    /// using the database field names.
+    #[inline]
+    pub fn extract_selection_results_from_db_name(
+        &self,
+        selections: &FieldSelection,
+    ) -> crate::Result<Vec<SelectionResult>> {
+        self.extract_selection_results(selections, Record::extract_selection_result_from_db_name)
     }
 
-    /// Builds `SelectionResults` from this `ManyRecords` based on the given FieldSelection.
+    /// Builds `SelectionResult`s from this `ManyRecords` based on the given `FieldSelection`
+    /// using the Prisma field names.
+    #[inline]
     pub fn extract_selection_results_from_prisma_name(
         &self,
         selections: &FieldSelection,
     ) -> crate::Result<Vec<SelectionResult>> {
+        self.extract_selection_results(selections, Record::extract_selection_result_from_prisma_name)
+    }
+
+    fn extract_selection_results(
+        &self,
+        selections: &FieldSelection,
+        extract_result: impl Fn(&Record, &[String], &FieldSelection) -> crate::Result<SelectionResult>,
+    ) -> crate::Result<Vec<SelectionResult>> {
         self.records
             .iter()
-            .map(|record| record.extract_selection_result_from_prisma_name(&self.field_names, selections))
+            .map(|record| extract_result(record, &self.field_names, selections))
             .collect()
     }
 
@@ -172,34 +186,39 @@ impl Record {
         }
     }
 
-    /// Extract a `SelectionResult` from this `Record`
+    /// Extracts a `SelectionResult` from this `Record`.
     /// `field_names`: Database names of the fields contained in this `Record`.
     /// `selected_fields`: The selection to extract.
-    pub fn extract_selection_result(
+    #[inline]
+    pub fn extract_selection_result_from_db_name(
         &self,
         field_names: &[String],
         extraction_selection: &FieldSelection,
     ) -> crate::Result<SelectionResult> {
-        let pairs: Vec<_> = extraction_selection
-            .selections()
-            .map(|selection| {
-                self.get_field_value(field_names, &selection.db_name())
-                    .and_then(|val| Ok((selection.clone(), selection.coerce_value(val.clone())?)))
-            })
-            .collect::<crate::Result<Vec<_>>>()?;
-
-        Ok(SelectionResult::new(pairs))
+        self.extract_selection_result(field_names, extraction_selection, SelectedField::db_name)
     }
 
+    /// Extracts a `SelectionResult` from this `Record` using Prisma field names rather than
+    /// database names.
+    #[inline]
     pub fn extract_selection_result_from_prisma_name(
         &self,
         field_names: &[String],
         extraction_selection: &FieldSelection,
     ) -> crate::Result<SelectionResult> {
+        self.extract_selection_result(field_names, extraction_selection, SelectedField::prisma_name)
+    }
+
+    fn extract_selection_result<'a, S: AsRef<str> + 'a>(
+        &self,
+        field_names: &[String],
+        extraction_selection: &'a FieldSelection,
+        map_name: impl Fn(&'a SelectedField) -> S,
+    ) -> crate::Result<SelectionResult> {
         let pairs: Vec<_> = extraction_selection
             .selections()
             .map(|selection| {
-                self.get_field_value(field_names, &selection.prisma_name())
+                self.get_field_value(field_names, map_name(selection).as_ref())
                     .and_then(|val| Ok((selection.clone(), selection.coerce_value(val.clone())?)))
             })
             .collect::<crate::Result<Vec<_>>>()?;

--- a/query-engine/query-structure/src/record.rs
+++ b/query-engine/query-structure/src/record.rs
@@ -95,32 +95,25 @@ impl ManyRecords {
 
     /// Builds `SelectionResult`s from this `ManyRecords` based on the given `FieldSelection`
     /// using the database field names.
-    #[inline]
     pub fn extract_selection_results_from_db_name(
         &self,
         selections: &FieldSelection,
     ) -> crate::Result<Vec<SelectionResult>> {
-        self.extract_selection_results(selections, Record::extract_selection_result_from_db_name)
+        self.records
+            .iter()
+            .map(|record| record.extract_selection_result_from_db_name(&self.field_names, selections))
+            .collect()
     }
 
     /// Builds `SelectionResult`s from this `ManyRecords` based on the given `FieldSelection`
     /// using the Prisma field names.
-    #[inline]
     pub fn extract_selection_results_from_prisma_name(
         &self,
         selections: &FieldSelection,
     ) -> crate::Result<Vec<SelectionResult>> {
-        self.extract_selection_results(selections, Record::extract_selection_result_from_prisma_name)
-    }
-
-    fn extract_selection_results(
-        &self,
-        selections: &FieldSelection,
-        extract_result: impl Fn(&Record, &[String], &FieldSelection) -> crate::Result<SelectionResult>,
-    ) -> crate::Result<Vec<SelectionResult>> {
         self.records
             .iter()
-            .map(|record| extract_result(record, &self.field_names, selections))
+            .map(|record| record.extract_selection_result_from_prisma_name(&self.field_names, selections))
             .collect()
     }
 

--- a/query-engine/query-structure/src/record.rs
+++ b/query-engine/query-structure/src/record.rs
@@ -182,7 +182,6 @@ impl Record {
     /// Extracts a `SelectionResult` from this `Record`.
     /// `field_names`: Database names of the fields contained in this `Record`.
     /// `selected_fields`: The selection to extract.
-    // #[inline]
     pub fn extract_selection_result_from_db_name(
         &self,
         field_names: &[String],
@@ -193,7 +192,6 @@ impl Record {
 
     /// Extracts a `SelectionResult` from this `Record` using Prisma field names rather than
     /// database names.
-    // #[inline]
     pub fn extract_selection_result_from_prisma_name(
         &self,
         field_names: &[String],


### PR DESCRIPTION
- Rename `extract_selection_result` to
  `extract_selection_result_from_db_name` for symmetry with the
  existing `extract_selection_result_from_prisma_name`.

- Likewise, `extract_selection_results_from_db_name`.

- Factor out duplicate code into private `extract_selection_result`.

Follow-up to https://github.com/prisma/prisma-engines/pull/4743.