### PR TITLE
qe: remove duplicate `InMemoryRecordProcessor::take_abs` method

### DIFF
--- a/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/inmemory_record_processor.rs
@@ -34,10 +34,6 @@ impl InMemoryRecordProcessor {
         processor
     }
 
-    fn take_abs(&self) -> Option<i64> {
-        self.take.map(|t| if t < 0 { -t } else { t })
-    }
-
     /// Checks whether or not we need to take records going backwards in the record list,
     /// which requires reversing the list of records at some point.
     fn needs_reversed_order(&self) -> bool {

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -218,7 +218,7 @@ impl QueryArguments {
     }
 
     pub fn take_abs(&self) -> Option<i64> {
-        self.take.map(|t| if t < 0 { -t } else { t })
+        self.take.map(|t| t.abs())
     }
 
     pub fn has_unbatchable_ordering(&self) -> bool {


### PR DESCRIPTION
`InMemoryRecordProcessor` derefs to `QueryArguments`, and `QueryArguments` already has an identical `take_abs` method.

Additionally, hand-written `abs` implementation was replaced with a call to `i64::abs` method.

Tangentially: using `Deref` to emulate class inheritance, although somewhat popular in early Rust, is considered an anti-pattern nowadays. There's also no need for it here (except making access to the individual arguments and `QueryArguments` methods a tiny bit shorter), it would've been preferable for the `InMemoryRecordProcessor` to encapsulate `args` and not expose any of its API externally even in a language with inheritance. We should change that as a tech debt item.