### PR TITLE
feat: enable createMany-related capabilities and tests for SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ prisma-gpg-private.asc
 .test_config
 *.pending-snap
 .pending.md
+dev.db
 
 *.class
 *.log

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,6 +3813,7 @@ dependencies = [
  "futures",
  "indoc 2.0.3",
  "insta",
+ "itertools 0.12.0",
  "once_cell",
  "paste",
  "prisma-value",

--- a/psl/psl-core/src/builtin_connectors/cockroach_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/cockroach_datamodel_connector.rs
@@ -62,7 +62,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     RowIn |
     DeleteReturning |
     SupportsFiltersOnRelationsWithoutJoins |
-    LateralJoin
+    LateralJoin |
+    SupportsDefaultInInsert
 });
 
 const SCALAR_TYPE_DEFAULTS: &[(ScalarType, CockroachType)] = &[

--- a/psl/psl-core/src/builtin_connectors/mongodb.rs
+++ b/psl/psl-core/src/builtin_connectors/mongodb.rs
@@ -31,7 +31,11 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     DefaultValueAuto |
     TwoWayEmbeddedManyToManyRelation |
     UndefinedType |
-    DeleteReturning
+    DeleteReturning |
+    // MongoDB does not have a notion of default values for fields.
+    // This capability is enabled as a performance optimisation to avoid issuing multiple queries
+    // when using `createMany()` with MongoDB.
+    SupportsDefaultInInsert
 });
 
 pub(crate) struct MongoDbDatamodelConnector;

--- a/psl/psl-core/src/builtin_connectors/mssql_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/mssql_datamodel_connector.rs
@@ -51,7 +51,8 @@ const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Connector
     SupportsTxIsolationRepeatableRead |
     SupportsTxIsolationSerializable |
     SupportsTxIsolationSnapshot |
-    SupportsFiltersOnRelationsWithoutJoins
+    SupportsFiltersOnRelationsWithoutJoins |
+    SupportsDefaultInInsert
     // InsertReturning | DeleteReturning - unimplemented.
 });
 

--- a/psl/psl-core/src/builtin_connectors/mysql_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/mysql_datamodel_connector.rs
@@ -68,7 +68,8 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     SupportsTxIsolationSerializable |
     RowIn |
     SupportsFiltersOnRelationsWithoutJoins |
-    CorrelatedSubqueries
+    CorrelatedSubqueries |
+    SupportsDefaultInInsert
 });
 
 const CONSTRAINT_SCOPES: &[ConstraintScope] = &[ConstraintScope::GlobalForeignKey, ConstraintScope::ModelKeyIndex];

--- a/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
@@ -71,7 +71,8 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     DistinctOn |
     DeleteReturning |
     SupportsFiltersOnRelationsWithoutJoins |
-    LateralJoin
+    LateralJoin |
+    SupportsDefaultInInsert
 });
 
 pub struct PostgresDatamodelConnector;

--- a/psl/psl-core/src/builtin_connectors/sqlite_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/sqlite_datamodel_connector.rs
@@ -28,7 +28,9 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     InsertReturning |
     DeleteReturning |
     UpdateReturning |
-    SupportsFiltersOnRelationsWithoutJoins
+    SupportsFiltersOnRelationsWithoutJoins |
+    CreateMany |
+    CreateManyWriteableAutoIncId
 });
 
 pub struct SqliteDatamodelConnector;

--- a/psl/psl-core/src/builtin_connectors/sqlite_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/sqlite_datamodel_connector.rs
@@ -30,7 +30,8 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     UpdateReturning |
     SupportsFiltersOnRelationsWithoutJoins |
     CreateMany |
-    CreateManyWriteableAutoIncId
+    CreateManyWriteableAutoIncId |
+    CreateManyRequiresSplitByShape
 });
 
 pub struct SqliteDatamodelConnector;

--- a/psl/psl-core/src/builtin_connectors/sqlite_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/sqlite_datamodel_connector.rs
@@ -30,8 +30,7 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     UpdateReturning |
     SupportsFiltersOnRelationsWithoutJoins |
     CreateMany |
-    CreateManyWriteableAutoIncId |
-    CreateManyRequiresSplitByShape
+    CreateManyWriteableAutoIncId
 });
 
 pub struct SqliteDatamodelConnector;

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -74,6 +74,8 @@ capabilities!(
     InsensitiveFilters,
     CreateMany,
     CreateManyWriteableAutoIncId,
+    // TODO laplab: comment.
+    CreateManyRequiresSplitByShape,
     WritableAutoincField,
     CreateSkipDuplicates,
     UpdateableId,

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -74,8 +74,7 @@ capabilities!(
     InsensitiveFilters,
     CreateMany,
     CreateManyWriteableAutoIncId,
-    // TODO laplab: comment.
-    CreateManyRequiresSplitByShape,
+    SupportsDefaultInInsert, // This capability is set if connector supports using `DEFAULT` instead of a value in the list of `INSERT` arguments.
     WritableAutoincField,
     CreateSkipDuplicates,
     UpdateableId,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/Cargo.toml
@@ -27,3 +27,4 @@ paste = "1.0.14"
 
 [dev-dependencies]
 insta = "1.7.1"
+itertools.workspace = true

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/metrics.rs
@@ -1,0 +1,23 @@
+use serde_json::Value;
+
+pub fn get_counter(json: &Value, name: &str) -> u64 {
+    let metric_value = get_metric_value(json, "counters", name);
+    metric_value.as_u64().unwrap()
+}
+
+pub fn get_gauge(json: &Value, name: &str) -> f64 {
+    let metric_value = get_metric_value(json, "gauges", name);
+    metric_value.as_f64().unwrap()
+}
+
+pub fn get_metric_value(json: &Value, metric_type: &str, name: &str) -> serde_json::Value {
+    let metrics = json.get(metric_type).unwrap().as_array().unwrap();
+    let metric = metrics
+        .iter()
+        .find(|metric| metric.get("key").unwrap().as_str() == Some(name))
+        .unwrap()
+        .as_object()
+        .unwrap();
+
+    metric.get("value").unwrap().clone()
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/src/utils/mod.rs
@@ -1,6 +1,7 @@
 mod batch;
 mod bytes;
 mod json;
+pub mod metrics;
 mod querying;
 mod raw;
 mod string;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/create_many.rs
@@ -64,7 +64,7 @@ mod cockroachdb {
 mod single_col {
     use query_engine_tests::run_query;
 
-    #[connector_test(exclude(CockroachDb))]
+    #[connector_test(exclude(CockroachDb, Sqlite("cfd1")))]
     async fn foo(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, "mutation { createManyTestModel(data: [{},{}]) { count }}"),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -14,7 +14,6 @@ mod metrics {
     };
     use query_engine_tests::ConnectorVersion::*;
     use query_engine_tests::*;
-    use serde_json::Value;
 
     #[connector_test]
     async fn metrics_are_recorded(runner: Runner) -> TestResult<()> {
@@ -30,8 +29,8 @@ mod metrics {
 
         let json = runner.get_metrics().to_json(Default::default());
         // We cannot assert the full response it will be slightly different per database
-        let total_queries = get_counter(&json, PRISMA_DATASOURCE_QUERIES_TOTAL);
-        let total_operations = get_counter(&json, PRISMA_CLIENT_QUERIES_TOTAL);
+        let total_queries = utils::metrics::get_counter(&json, PRISMA_DATASOURCE_QUERIES_TOTAL);
+        let total_operations = utils::metrics::get_counter(&json, PRISMA_CLIENT_QUERIES_TOTAL);
 
         match runner.connector_version() {
             Sqlite(_) => assert_eq!(total_queries, 2),
@@ -63,7 +62,7 @@ mod metrics {
         let _ = runner.commit_tx(tx_id).await?;
 
         let json = runner.get_metrics().to_json(Default::default());
-        let active_transactions = get_gauge(&json, PRISMA_CLIENT_QUERIES_ACTIVE);
+        let active_transactions = utils::metrics::get_gauge(&json, PRISMA_CLIENT_QUERIES_ACTIVE);
         assert_eq!(active_transactions, 0.0);
 
         let tx_id = runner.start_tx(5000, 5000, None).await?;
@@ -80,30 +79,8 @@ mod metrics {
         let _ = runner.rollback_tx(tx_id.clone()).await?;
 
         let json = runner.get_metrics().to_json(Default::default());
-        let active_transactions = get_gauge(&json, PRISMA_CLIENT_QUERIES_ACTIVE);
+        let active_transactions = utils::metrics::get_gauge(&json, PRISMA_CLIENT_QUERIES_ACTIVE);
         assert_eq!(active_transactions, 0.0);
         Ok(())
-    }
-
-    fn get_counter(json: &Value, name: &str) -> u64 {
-        let metric_value = get_metric_value(json, "counters", name);
-        metric_value.as_u64().unwrap()
-    }
-
-    fn get_gauge(json: &Value, name: &str) -> f64 {
-        let metric_value = get_metric_value(json, "gauges", name);
-        metric_value.as_f64().unwrap()
-    }
-
-    fn get_metric_value(json: &Value, metric_type: &str, name: &str) -> serde_json::Value {
-        let metrics = json.get(metric_type).unwrap().as_array().unwrap();
-        let metric = metrics
-            .iter()
-            .find(|metric| metric.get("key").unwrap().as_str() == Some(name))
-            .unwrap()
-            .as_object()
-            .unwrap();
-
-        metric.get("value").unwrap().clone()
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14001.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14001.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite))]
+#[test_suite(schema(schema))]
 mod prisma_14001 {
     fn schema() -> String {
         r#"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_7434.rs
@@ -4,7 +4,7 @@ use query_engine_tests::*;
 mod not_in_chunking {
     use query_engine_tests::Runner;
 
-    #[connector_test(exclude(CockroachDb))]
+    #[connector_test(exclude(CockroachDb, Sqlite("cfd1")))]
     async fn not_in_batch_filter(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/relation_load_strategy.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/relation_load_strategy.rs
@@ -438,8 +438,7 @@ mod relation_load_strategy {
                 count
             }
         }
-        "#,
-        exclude(Sqlite)
+        "#
     );
 
     relation_load_strategy_not_available_test!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
@@ -25,7 +25,7 @@ mod nested_create_many {
     }
 
     // "A basic createMany on a create top level" should "work"
-    #[connector_test(exclude(Sqlite))]
+    #[connector_test]
     async fn create_many_on_create(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -53,7 +53,7 @@ mod nested_create_many {
     }
 
     // "A basic createMany on a create top level" should "work"
-    #[connector_test(exclude(Sqlite))]
+    #[connector_test]
     async fn create_many_shorthand_on_create(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -78,7 +78,7 @@ mod nested_create_many {
 
     // "Nested createMany" should "error on duplicates by default"
     // TODO(dom): Not working for mongo
-    #[connector_test(exclude(Sqlite, MongoDb))]
+    #[connector_test(exclude(MongoDb))]
     async fn nested_createmany_fail_dups(runner: Runner) -> TestResult<()> {
         assert_error!(
             &runner,
@@ -140,7 +140,7 @@ mod nested_create_many {
     // Each DB allows a certain amount of params per single query, and a certain number of rows.
     // We create 1000 nested records.
     // "Nested createMany" should "allow creating a large number of records (horizontal partitioning check)"
-    #[connector_test(exclude(Sqlite))]
+    #[connector_test]
     async fn allow_create_large_number_records(runner: Runner) -> TestResult<()> {
         let records: Vec<_> = (1..=1000).map(|i| format!(r#"{{ id: {i}, str1: "{i}" }}"#)).collect();
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
@@ -140,7 +140,7 @@ mod nested_create_many {
     // Each DB allows a certain amount of params per single query, and a certain number of rows.
     // We create 1000 nested records.
     // "Nested createMany" should "allow creating a large number of records (horizontal partitioning check)"
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn allow_create_large_number_records(runner: Runner) -> TestResult<()> {
         let records: Vec<_> = (1..=1000).map(|i| format!(r#"{{ id: {i}, str1: "{i}" }}"#)).collect();
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -65,7 +65,11 @@ mod create_many {
     }
 
     // Covers: AutoIncrement ID working with basic autonincrement functionality.
-    #[connector_test(schema(schema_2), capabilities(CreateManyWriteableAutoIncId), exclude(CockroachDb))]
+    #[connector_test(
+        schema(schema_2),
+        capabilities(CreateManyWriteableAutoIncId),
+        exclude(CockroachDb, Sqlite("cfd1"))
+    )]
     async fn basic_create_many_autoincrement(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -1,6 +1,7 @@
 use query_engine_tests::*;
 
-#[test_suite(capabilities(CreateMany))]
+// TODO: create many returns the wrong count for CFD1
+#[test_suite(capabilities(CreateMany), exclude(Sqlite("cfd1")))]
 mod create_many {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -348,7 +348,8 @@ mod create_many {
         Ok(())
     }
 
-    #[connector_test(schema(schema_7), only(Sqlite))]
+    // LibSQL & co are ignored because they don't support metrics
+    #[connector_test(schema(schema_7), only(Sqlite("3")))]
     async fn create_many_by_shape_counter_1(runner: Runner) -> TestResult<()> {
         use query_engine_metrics::PRISMA_DATASOURCE_QUERIES_TOTAL;
 
@@ -389,7 +390,8 @@ mod create_many {
         Ok(())
     }
 
-    #[connector_test(schema(schema_7), only(Sqlite))]
+    // LibSQL & co are ignored because they don't support metrics
+    #[connector_test(schema(schema_7), only(Sqlite("3")))]
     async fn create_many_by_shape_counter_2(runner: Runner) -> TestResult<()> {
         use query_engine_metrics::PRISMA_DATASOURCE_QUERIES_TOTAL;
 
@@ -418,16 +420,17 @@ mod create_many {
         let counter = metrics::get_counter(&json, PRISMA_DATASOURCE_QUERIES_TOTAL);
 
         match runner.max_bind_values() {
-          Some(x) if x >= 18 => assert_eq!(counter, 3), // 1 createMany queries (BEGIN/COMMIT are counted)
-          // Some queries are being split because of `QUERY_BATCH_SIZE` being set to `10` in dev.
-          Some(_) => assert_eq!(counter, 4), // 2 createMany queries (BEGIN/COMMIT are counted)
-          _ => panic!("Expected max bind values to be set"),
-      }
+            Some(x) if x >= 18 => assert_eq!(counter, 3), // 1 createMany queries (BEGIN/COMMIT are counted)
+            // Some queries are being split because of `QUERY_BATCH_SIZE` being set to `10` in dev.
+            Some(_) => assert_eq!(counter, 4), // 2 createMany queries (BEGIN/COMMIT are counted)
+            _ => panic!("Expected max bind values to be set"),
+        }
 
         Ok(())
     }
 
-    #[connector_test(schema(schema_7), only(Sqlite))]
+    // LibSQL & co are ignored because they don't support metrics
+    #[connector_test(schema(schema_7), only(Sqlite("3")))]
     async fn create_many_by_shape_counter_3(runner: Runner) -> TestResult<()> {
         use query_engine_metrics::PRISMA_DATASOURCE_QUERIES_TOTAL;
 
@@ -458,11 +461,11 @@ mod create_many {
         let counter = metrics::get_counter(&json, PRISMA_DATASOURCE_QUERIES_TOTAL);
 
         match runner.max_bind_values() {
-          Some(x) if x > 21 => assert_eq!(counter, 4), // 3 createMany queries in total (BEGIN/COMMIT are counted)
-          // Some queries are being split because of `QUERY_BATCH_SIZE` being set to `10` in dev.
-          Some(_) => assert_eq!(counter, 5), // 3 createMany queries in total (BEGIN/COMMIT are counted)
-          _ => panic!("Expected max bind values to be set"),
-      }
+            Some(x) if x > 21 => assert_eq!(counter, 4), // 3 createMany queries in total (BEGIN/COMMIT are counted)
+            // Some queries are being split because of `QUERY_BATCH_SIZE` being set to `10` in dev.
+            Some(_) => assert_eq!(counter, 5), // 3 createMany queries in total (BEGIN/COMMIT are counted)
+            _ => panic!("Expected max bind values to be set"),
+        }
 
         Ok(())
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -316,6 +316,9 @@ mod create_many {
 
         let mut id = 1;
 
+        // Generates a powerset of all combinations of these fields
+        // In an attempt to ensure that we never generate invalid insert statements
+        // because of the grouping logic.
         for sets in vec!["req_default", "opt", "opt_default"]
             .into_iter()
             .powerset()

--- a/query-engine/connectors/query-connector/src/write_args.rs
+++ b/query-engine/connectors/query-connector/src/write_args.rs
@@ -16,7 +16,7 @@ pub struct WriteArgs {
 /// Wrapper struct to force a bit of a reflection whether or not the string passed
 /// to the write arguments is the data source field name, not the model field name.
 /// Also helps to avoid errors with convenient from-field conversions.
-#[derive(Debug, PartialEq, Clone, Hash, Eq)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq, PartialOrd, Ord)]
 pub struct DatasourceFieldName(pub String);
 
 impl Deref for DatasourceFieldName {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -59,6 +59,7 @@ pub(crate) fn create_records_nonempty(
 
             for field in affected_fields.iter() {
                 let value = arg.take_field_value(field.db_name());
+
                 match value {
                     Some(write_op) => {
                         let value: PrismaValue = write_op
@@ -67,7 +68,10 @@ pub(crate) fn create_records_nonempty(
 
                         row.push(field.value(value, ctx).into());
                     }
-
+                    // We can't use `DEFAULT` for SQLite so we provided an explicit `NULL` instead.
+                    None if !field.is_required() && field.default_value().is_none() => {
+                        row.push(Value::null_int32().raw().into())
+                    }
                     None => row.push(default_value()),
                 }
             }

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -63,87 +63,101 @@ async fn create_many(
     q: CreateManyRecords,
     trace_id: Option<String>,
 ) -> InterpretationResult<QueryResult> {
-    // TODO laplab: split into two functions.
     if q.split_by_shape {
-        let mut args_by_shape: HashMap<Vec<DatasourceFieldName>, Vec<WriteArgs>> = Default::default();
-        for write_args in q.args {
-            let mut shape: Vec<_> = write_args.args.keys().cloned().collect();
-            // This ensures that shapes is not dependent on order of fields.
-            shape.sort_unstable();
-            args_by_shape.entry(shape).or_default().push(write_args);
-        }
+        return create_many_split_by_shape(tx, q, trace_id).await;
+    }
 
-        if let Some(selected_fields) = q.selected_fields {
-            let mut result: Option<ManyRecords> = None;
-            for args in args_by_shape.into_values() {
-                let current_batch = tx
-                    .create_records_returning(
-                        &q.model,
-                        args,
-                        q.skip_duplicates,
-                        selected_fields.fields.clone(),
-                        trace_id.clone(),
-                    )
-                    .await?;
+    if let Some(selected_fields) = q.selected_fields {
+        let records = tx
+            .create_records_returning(&q.model, q.args, q.skip_duplicates, selected_fields.fields, trace_id)
+            .await?;
 
-                if let Some(result) = &mut result {
-                    // We assume that all records have the same set and order of fields,
-                    // since we pass the same `selected_fields.fields` to the
-                    // `create_records_returning()` above.
-                    result.records.extend(current_batch.records.into_iter());
-                } else {
-                    result = Some(current_batch);
-                }
-            }
+        let selection = RecordSelection {
+            name: q.name,
+            fields: selected_fields.order,
+            records,
+            nested: vec![],
+            model: q.model,
+            virtual_fields: vec![],
+        };
 
-            let records = if let Some(result) = result {
-                result
-            } else {
-                // Empty result means that the list of arguments was empty as well.
-                tx.create_records_returning(&q.model, vec![], q.skip_duplicates, selected_fields.fields, trace_id)
-                    .await?
-            };
-
-            let selection = RecordSelection {
-                name: q.name,
-                fields: selected_fields.order,
-                records,
-                nested: vec![],
-                model: q.model,
-                virtual_fields: vec![],
-            };
-
-            Ok(QueryResult::RecordSelection(Some(Box::new(selection))))
-        } else {
-            let mut result = 0;
-            for args in args_by_shape.into_values() {
-                let affected_records = tx
-                    .create_records(&q.model, args, q.skip_duplicates, trace_id.clone())
-                    .await?;
-                result += affected_records;
-            }
-            Ok(QueryResult::Count(result))
-        }
+        Ok(QueryResult::RecordSelection(Some(Box::new(selection))))
     } else {
-        if let Some(selected_fields) = q.selected_fields {
-            let records = tx
-                .create_records_returning(&q.model, q.args, q.skip_duplicates, selected_fields.fields, trace_id)
+        let affected_records = tx.create_records(&q.model, q.args, q.skip_duplicates, trace_id).await?;
+        Ok(QueryResult::Count(affected_records))
+    }
+}
+
+/// Performs bulk inserts grouped by record shape.
+///
+/// By "record shape" we mean "unique set of fields". This is required to support connectors which
+/// do not support `DEFAULT` in the list of values for `INSERT`. For these, we need to rely on the
+/// fact that the database will use the default value for the column if it is not listed in `INSERT`
+/// statement. Grouping by record shape allows us to use this property, because each batch of fields
+/// has the same columns listed for the `INSERT` statement.
+async fn create_many_split_by_shape(
+    tx: &mut dyn ConnectionLike,
+    q: CreateManyRecords,
+    trace_id: Option<String>,
+) -> InterpretationResult<QueryResult> {
+    let mut args_by_shape: HashMap<Vec<DatasourceFieldName>, Vec<WriteArgs>> = Default::default();
+    for write_args in q.args {
+        let mut shape: Vec<_> = write_args.args.keys().cloned().collect();
+        // This ensures that shapes is not dependent on order of fields.
+        shape.sort_unstable();
+        args_by_shape.entry(shape).or_default().push(write_args);
+    }
+
+    if let Some(selected_fields) = q.selected_fields {
+        let mut result: Option<ManyRecords> = None;
+        for args in args_by_shape.into_values() {
+            let current_batch = tx
+                .create_records_returning(
+                    &q.model,
+                    args,
+                    q.skip_duplicates,
+                    selected_fields.fields.clone(),
+                    trace_id.clone(),
+                )
                 .await?;
 
-            let selection = RecordSelection {
-                name: q.name,
-                fields: selected_fields.order,
-                records,
-                nested: vec![],
-                model: q.model,
-                virtual_fields: vec![],
-            };
-
-            Ok(QueryResult::RecordSelection(Some(Box::new(selection))))
-        } else {
-            let affected_records = tx.create_records(&q.model, q.args, q.skip_duplicates, trace_id).await?;
-            Ok(QueryResult::Count(affected_records))
+            if let Some(result) = &mut result {
+                // We assume that all records have the same set and order of fields,
+                // since we pass the same `selected_fields.fields` to the
+                // `create_records_returning()` above.
+                result.records.extend(current_batch.records.into_iter());
+            } else {
+                result = Some(current_batch);
+            }
         }
+
+        let records = if let Some(result) = result {
+            result
+        } else {
+            // Empty result means that the list of arguments was empty as well.
+            tx.create_records_returning(&q.model, vec![], q.skip_duplicates, selected_fields.fields, trace_id)
+                .await?
+        };
+
+        let selection = RecordSelection {
+            name: q.name,
+            fields: selected_fields.order,
+            records,
+            nested: vec![],
+            model: q.model,
+            virtual_fields: vec![],
+        };
+
+        Ok(QueryResult::RecordSelection(Some(Box::new(selection))))
+    } else {
+        let mut result = 0;
+        for args in args_by_shape.into_values() {
+            let affected_records = tx
+                .create_records(&q.model, args, q.skip_duplicates, trace_id.clone())
+                .await?;
+            result += affected_records;
+        }
+        Ok(QueryResult::Count(result))
     }
 }
 

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -272,6 +272,8 @@ pub struct CreateManyRecords {
     /// Fields of created records that client has requested to return.
     /// `None` if the connector does not support returning the created rows.
     pub selected_fields: Option<CreateManyRecordsFields>,
+    // TODO laplab: comment.
+    pub split_by_shape: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -272,7 +272,13 @@ pub struct CreateManyRecords {
     /// Fields of created records that client has requested to return.
     /// `None` if the connector does not support returning the created rows.
     pub selected_fields: Option<CreateManyRecordsFields>,
-    // TODO laplab: comment.
+    /// If set to true, connector will perform the operation using multiple bulk `INSERT` queries.
+    /// One query will be issued per a unique set of fields present in the batch. For example, if
+    /// `args` contains records:
+    ///   {a: 1, b: 1}
+    ///   {a: 2, b: 2}
+    ///   {a: 3, b: 3, c: 3}
+    /// Two queries will be issued: one containing first two records and one for the last record.
     pub split_by_shape: bool,
 }
 

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -683,15 +683,6 @@ impl QueryDocumentParser {
                                 argument_path.segments(),
                                 &conversions::input_types_to_input_type_descriptions(field.field_types()),
                             )))
-                        } else if field
-                            .field_types()
-                            .iter()
-                            .any(|field_type| matches!(field_type, InputType::Scalar(ScalarType::Null)))
-                        {
-                            // The fact that the field is not required does not mean it is nullable. For example,
-                            // logical operators like "AND", "OR" and "NOT" are considered fields in this context.
-                            // They are not required, but they do not accept null as an input.
-                            Some(Ok((field.name.clone(), ParsedInputValue::Single(PrismaValue::Null))))
                         } else {
                             None
                         }

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -683,6 +683,16 @@ impl QueryDocumentParser {
                                 argument_path.segments(),
                                 &conversions::input_types_to_input_type_descriptions(field.field_types()),
                             )))
+                        } else
+                        // The fact that the field is not required does not mean it is nullable. For example,
+                        // logical operators like "AND", "OR" and "NOT" are considered fields in this context.
+                        // They are not required, but they do not accept null as an input.
+                        if field
+                            .field_types()
+                            .iter()
+                            .any(|field_type| matches!(field_type, InputType::Scalar(ScalarType::Null)))
+                        {
+                            Some(Ok((field.name.clone(), ParsedInputValue::Single(PrismaValue::Null))))
                         } else {
                             None
                         }

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -683,15 +683,14 @@ impl QueryDocumentParser {
                                 argument_path.segments(),
                                 &conversions::input_types_to_input_type_descriptions(field.field_types()),
                             )))
-                        } else
-                        // The fact that the field is not required does not mean it is nullable. For example,
-                        // logical operators like "AND", "OR" and "NOT" are considered fields in this context.
-                        // They are not required, but they do not accept null as an input.
-                        if field
+                        } else if field
                             .field_types()
                             .iter()
                             .any(|field_type| matches!(field_type, InputType::Scalar(ScalarType::Null)))
                         {
+                            // The fact that the field is not required does not mean it is nullable. For example,
+                            // logical operators like "AND", "OR" and "NOT" are considered fields in this context.
+                            // They are not required, but they do not accept null as an input.
                             Some(Ok((field.name.clone(), ParsedInputValue::Single(PrismaValue::Null))))
                         } else {
                             None

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -99,7 +99,7 @@ pub(crate) fn create_many_records(
         args,
         skip_duplicates,
         selected_fields: None,
-        split_by_shape: query_schema.has_capability(ConnectorCapability::CreateManyRequiresSplitByShape),
+        split_by_shape: !query_schema.has_capability(ConnectorCapability::SupportsDefaultInInsert),
     };
 
     graph.create_node(Query::Write(WriteQuery::CreateManyRecords(query)));

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -66,7 +66,7 @@ pub(crate) fn create_record(
 /// Creates a create record query and adds it to the query graph, together with it's nested queries and companion read query.
 pub(crate) fn create_many_records(
     graph: &mut QueryGraph,
-    _query_schema: &QuerySchema,
+    query_schema: &QuerySchema,
     model: Model,
     mut field: ParsedField<'_>,
 ) -> QueryGraphBuilderResult<()> {
@@ -99,6 +99,7 @@ pub(crate) fn create_many_records(
         args,
         skip_duplicates,
         selected_fields: None,
+        split_by_shape: query_schema.has_capability(ConnectorCapability::CreateManyRequiresSplitByShape),
     };
 
     graph.create_node(Query::Write(WriteQuery::CreateManyRecords(query)));

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -75,6 +75,7 @@ pub fn nested_create(
             args: data_maps.into_iter().map(|(args, _nested)| args).collect(),
             skip_duplicates: false,
             selected_fields,
+            split_by_shape: query_schema.has_capability(ConnectorCapability::CreateManyRequiresSplitByShape),
         };
         let create_many_node = graph.create_node(Query::Write(WriteQuery::CreateManyRecords(query)));
 
@@ -554,6 +555,7 @@ fn handle_one_to_one(
 
 pub fn nested_create_many(
     graph: &mut QueryGraph,
+    query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
     value: ParsedInputValue<'_>,
@@ -585,6 +587,7 @@ pub fn nested_create_many(
         args,
         skip_duplicates,
         selected_fields: None,
+        split_by_shape: query_schema.has_capability(ConnectorCapability::CreateManyRequiresSplitByShape),
     };
 
     let create_node = graph.create_node(Query::Write(WriteQuery::CreateManyRecords(query)));

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -75,7 +75,7 @@ pub fn nested_create(
             args: data_maps.into_iter().map(|(args, _nested)| args).collect(),
             skip_duplicates: false,
             selected_fields,
-            split_by_shape: query_schema.has_capability(ConnectorCapability::CreateManyRequiresSplitByShape),
+            split_by_shape: !query_schema.has_capability(ConnectorCapability::SupportsDefaultInInsert),
         };
         let create_many_node = graph.create_node(Query::Write(WriteQuery::CreateManyRecords(query)));
 
@@ -587,7 +587,7 @@ pub fn nested_create_many(
         args,
         skip_duplicates,
         selected_fields: None,
-        split_by_shape: query_schema.has_capability(ConnectorCapability::CreateManyRequiresSplitByShape),
+        split_by_shape: !query_schema.has_capability(ConnectorCapability::SupportsDefaultInInsert),
     };
 
     let create_node = graph.create_node(Query::Write(WriteQuery::CreateManyRecords(query)));

--- a/query-engine/core/src/query_graph_builder/write/nested/mod.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/mod.rs
@@ -36,7 +36,7 @@ pub fn connect_nested_query(
     for (field_name, value) in data_map {
         match field_name.as_ref() {
             operations::CREATE => nested_create(graph, query_schema,parent, &parent_relation_field, value, &child_model)?,
-            operations::CREATE_MANY => nested_create_many(graph, parent, &parent_relation_field, value, &child_model)?,
+            operations::CREATE_MANY => nested_create_many(graph, query_schema, parent, &parent_relation_field, value, &child_model)?,
             operations::UPDATE => nested_update(graph, query_schema, &parent, &parent_relation_field, value, &child_model)?,
             operations::UPSERT => nested_upsert(graph, query_schema, parent, &parent_relation_field, value)?,
             operations::DELETE => nested_delete(graph, query_schema, &parent, &parent_relation_field, value, &child_model)?,


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/1029

Note: D1 does not return the correct count and has a too low `max_bind_values` which prevents our chunking mechanism to work. Tests are excluded intentionally. See issues:
- https://github.com/prisma/team-orm/issues/1069
- https://github.com/prisma/team-orm/issues/1070