### PR TITLE
feat(migrate/sqlite): ignore Cloudflare D1 specific tables

### DIFF
--- a/schema-engine/sql-schema-describer/src/sqlite.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite.rs
@@ -162,7 +162,7 @@ impl<'a> SqlSchemaDescriber<'a> {
 
                 (name, r#type, definition)
             })
-            .filter(|(table_name, _, _)| !is_system_table(table_name));
+            .filter(|(table_name, _, _)| !is_table_ignored(table_name));
 
         let mut map = IndexMap::default();
 
@@ -603,18 +603,22 @@ fn unquote_sqlite_string_default(s: &str) -> Cow<'_, str> {
     }
 }
 
-/// Returns whether a table is one of the SQLite system tables.
-fn is_system_table(table_name: &str) -> bool {
-    SQLITE_SYSTEM_TABLES
-        .iter()
-        .any(|system_table| table_name == *system_table)
+/// Returns whether a table is one of the SQLite system tables or a Cloudflare D1 specific table.
+fn is_table_ignored(table_name: &str) -> bool {
+    SQLITE_IGNORED_TABLES.iter().any(|table| table_name == *table)
 }
 
 /// See https://www.sqlite.org/fileformat2.html
-const SQLITE_SYSTEM_TABLES: &[&str] = &[
+/// + Cloudflare D1 specific tables
+const SQLITE_IGNORED_TABLES: &[&str] = &[
+    // SQLite system tables
     "sqlite_sequence",
     "sqlite_stat1",
     "sqlite_stat2",
     "sqlite_stat3",
     "sqlite_stat4",
+    // Cloudflare D1 specific tables
+    "_cf_KV",
+    // This is the default but can be configured by the user
+    "d1_migrations",
 ];


### PR DESCRIPTION
When using `migrate diff` it would try to drop these tables, but it should not.

```
npx prisma migrate diff --script --from-url="file:./.wrangler/state/v3/d1/miniflare-D1DatabaseObject/91071d5c84932afa3154bfc8f999a00c88bfb6c136c7b0041534796fa6a3e725.sqlite" --to-schema-datamodel ./prisma/schema.prisma

# output

-- DropTable
PRAGMA foreign_keys=off;
DROP TABLE "_cf_KV";
PRAGMA foreign_keys=on;

-- DropTable
PRAGMA foreign_keys=off;
DROP TABLE "d1_migrations";
PRAGMA foreign_keys=on;
```