### PR TITLE
feat(adapter-d1): allow parsing bool from double + safe return values for booleans

### DIFF
--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -147,6 +147,7 @@ fn row_value_to_prisma_value(p_value: Value, meta: ColumnMetadata<'_>) -> Result
             ValueType::Boolean(Some(b)) => PrismaValue::Boolean(b),
             ValueType::Bytes(Some(bytes)) if bytes.as_ref() == [0u8] => PrismaValue::Boolean(false),
             ValueType::Bytes(Some(bytes)) if bytes.as_ref() == [1u8] => PrismaValue::Boolean(true),
+            ValueType::Double(Some(i)) => PrismaValue::Boolean(i.to_i64().unwrap() != 0),
             _ => return Err(create_error(&p_value)),
         },
         TypeIdentifier::Enum(_) => match p_value.typed {


### PR DESCRIPTION
This PR closes https://github.com/prisma/team-orm/issues/1059, and follows up on https://github.com/prisma/prisma/pull/23472.

Before this PR,

```typescript
await prisma.testModel.create({
  data: {
    bool: false,
  },
})
```

would yield `{ bool: 0 }`,

and 

```typescript
await prisma.testModel.create({
  data: {
    bool: true,
  },
})
```

would yield `{ bool: 1 }`.

This meant Prisma was returning `number` values, even though they were typed as `bool`, causing type soundness issues.

/integration