### PR TITLE
fix(adapter-d1): fix tests

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/cursor.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/cursor.rs
@@ -17,7 +17,7 @@ mod bigint_cursor {
         schema.to_owned()
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn bigint_id_must_work(runner: Runner) -> TestResult<()> {
         test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/disconnect.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/disconnect.rs
@@ -7,7 +7,7 @@ use query_engine_tests::*;
 mod disconnect_security {
     use query_engine_tests::assert_query;
 
-    #[connector_test(schema(schemas::a1_to_bm_opt), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(schemas::a1_to_bm_opt))]
     async fn must_honor_connect_scope_one2m(runner: Runner) -> TestResult<()> {
         one_to_many_test_data(&runner).await?;
 
@@ -35,7 +35,7 @@ mod disconnect_security {
         Ok(())
     }
 
-    #[connector_test(schema(schemas::posts_categories), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(schemas::posts_categories))]
     async fn must_honor_connect_scope_m2m(runner: Runner) -> TestResult<()> {
         many_to_many_test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 #[test_suite(capabilities(NativeUpsert))]
 mod native_upsert {
 
-    #[connector_test(schema(user), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(user))]
     async fn should_upsert_on_single_unique(mut runner: Runner) -> TestResult<()> {
         let upsert = r#"
           mutation {
@@ -42,7 +42,7 @@ mod native_upsert {
         Ok(())
     }
 
-    #[connector_test(schema(user), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(user))]
     async fn should_upsert_on_id(mut runner: Runner) -> TestResult<()> {
         let upsert = r#"
           mutation {
@@ -85,7 +85,7 @@ mod native_upsert {
         Ok(())
     }
 
-    #[connector_test(schema(user), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(user))]
     async fn should_upsert_on_unique_list(mut runner: Runner) -> TestResult<()> {
         let upsert = r#"
           mutation {
@@ -129,7 +129,7 @@ mod native_upsert {
         Ok(())
     }
 
-    #[connector_test(schema(user), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(user))]
     async fn should_not_use_native_upsert_on_two_uniques(mut runner: Runner) -> TestResult<()> {
         let upsert = r#"
           mutation {
@@ -175,7 +175,7 @@ mod native_upsert {
 
     // Should not use native upsert when the unique field values defined in the where clause
     // do not match the same uniques fields in the create clause
-    #[connector_test(schema(user), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(user))]
     async fn should_not_use_if_where_and_create_different(mut runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -228,7 +228,7 @@ mod native_upsert {
         Ok(())
     }
 
-    #[connector_test(schema(user), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(user))]
     async fn should_not_if_missing_update(mut runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -278,7 +278,7 @@ mod native_upsert {
         schema.to_owned()
     }
 
-    #[connector_test(schema(relations), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(relations))]
     async fn should_not_if_has_nested_select(mut runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -322,7 +322,7 @@ mod native_upsert {
         schema.to_owned()
     }
 
-    #[connector_test(schema(compound_id), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(compound_id))]
     async fn should_upsert_on_compound_id(mut runner: Runner) -> TestResult<()> {
         let upsert = r#"
           mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/occ.rs
@@ -112,10 +112,19 @@ mod occ {
         assert_eq!(booked_user_id, found_booked_user_id);
     }
 
-    // On PlanetScale:
-    //   assertion `left == right` failed
-    //   left: 6
-    //   right: 1
+    // On PlanetScale, this fails with:
+    // ```
+    // assertion `left == right` failed
+    // left: 6
+    // right: 1
+    // ```
+    //
+    // On D1, this fails with:
+    // ```
+    // assertion `left == right` failed
+    // left: 3
+    // right: 1
+    // ```
     #[connector_test(
         schema(occ_simple),
         exclude(
@@ -141,7 +150,7 @@ mod occ {
 
     #[connector_test(
         schema(occ_simple),
-        exclude(CockroachDb, Vitess("planetscale.js", "planetscale.js.wasm"), Sqlite("cfd1"))
+        exclude(CockroachDb, Vitess("planetscale.js", "planetscale.js.wasm"))
     )]
     async fn occ_update_test(runner: Runner) -> TestResult<()> {
         let runner = Arc::new(runner);
@@ -173,10 +182,7 @@ mod occ {
         Ok(())
     }
 
-    #[connector_test(
-        schema(occ_simple),
-        exclude(Vitess("planetscale.js", "planetscale.js.wasm"), Sqlite("cfd1"))
-    )]
+    #[connector_test(schema(occ_simple), exclude(Vitess("planetscale.js", "planetscale.js.wasm")))]
     async fn occ_delete_test(runner: Runner) -> TestResult<()> {
         let runner = Arc::new(runner);
 
@@ -208,7 +214,7 @@ mod occ {
         Ok(())
     }
 
-    #[connector_test(schema(occ_simple), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(occ_simple))]
     async fn occ_delete_many_test(runner: Runner) -> TestResult<()> {
         let runner = Arc::new(runner);
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/cascade.rs
@@ -23,7 +23,7 @@ mod one2one_req {
     }
 
     /// Deleting the parent deletes child as well.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn delete_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, child: { create: { id: 1 }}}) { id }}"#),
@@ -67,7 +67,7 @@ mod one2one_opt {
     }
 
     /// Deleting the parent deletes child as well.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn delete_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, child: { create: { id: 1 }}}) { id }}"#),
@@ -107,7 +107,7 @@ mod one2one_opt {
 
     /// Deleting the parent deletes child as well.
     /// Checks that it works even with different parent/child primary identifier names.
-    #[connector_test(schema(diff_id_name), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(diff_id_name))]
     async fn delete_parent_diff_id_name(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -151,7 +151,7 @@ mod one2many_req {
     }
 
     /// Deleting the parent deletes all children.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn delete_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, children: { create: [ { id: 1 }, { id: 2 } ] }}) { id }}"#),
@@ -195,7 +195,7 @@ mod one2many_opt {
     }
 
     /// Deleting the parent deletes all children.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn delete_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, children: { create: [ { id: 1 }, { id: 2 } ] }}) { id }}"#),
@@ -216,7 +216,7 @@ mod one2many_opt {
     }
 }
 
-#[test_suite(schema(schema), exclude(SqlServer, Sqlite("cfd1")), relation_mode = "prisma")]
+#[test_suite(schema(schema), exclude(SqlServer), relation_mode = "prisma")]
 mod multiple_cascading_paths {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/restrict.rs
@@ -6,7 +6,7 @@ use query_engine_tests::*;
 #[test_suite(
     suite = "restrict_onD_1to1_req",
     schema(required),
-    exclude(SqlServer, Sqlite("cfd1")),
+    exclude(SqlServer),
     relation_mode = "prisma"
 )]
 mod one2one_req {
@@ -49,7 +49,7 @@ mod one2one_req {
 #[test_suite(
     suite = "restrict_onD_1to1_opt",
     schema(optional),
-    exclude(SqlServer, Sqlite("cfd1")),
+    exclude(SqlServer),
     relation_mode = "prisma"
 )]
 mod one2one_opt {
@@ -153,7 +153,7 @@ mod one2one_opt {
 #[test_suite(
     suite = "restrict_onD_1toM_req",
     schema(required),
-    exclude(SqlServer, Sqlite("cfd1")),
+    exclude(SqlServer),
     relation_mode = "prisma"
 )]
 mod one2many_req {
@@ -222,7 +222,7 @@ mod one2many_req {
 #[test_suite(
     suite = "restrict_onD_1toM_opt",
     schema(optional),
-    exclude(SqlServer, Sqlite("cfd1")),
+    exclude(SqlServer),
     relation_mode = "prisma"
 )]
 mod one2many_opt {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_default.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_default.rs
@@ -4,7 +4,7 @@ use query_engine_tests::*;
 
 #[test_suite(
     suite = "setdefault_onD_1to1_req",
-    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"), Sqlite("cfd1"))
+    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"))
 )]
 mod one2one_req {
     fn required_with_default() -> String {
@@ -108,7 +108,7 @@ mod one2one_req {
 
 #[test_suite(
     suite = "setdefault_onD_1to1_opt",
-    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"), Sqlite("cfd1"))
+    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"))
 )]
 mod one2one_opt {
     fn optional_with_default() -> String {
@@ -217,7 +217,7 @@ mod one2one_opt {
 
 #[test_suite(
     suite = "setdefault_onD_1toM_req",
-    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"), Sqlite("cfd1"))
+    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"))
 )]
 mod one2many_req {
     fn required_with_default() -> String {
@@ -321,7 +321,7 @@ mod one2many_req {
 
 #[test_suite(
     suite = "setdefault_onD_1toM_opt",
-    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"), Sqlite("cfd1"))
+    exclude(MongoDb, MySQL, Vitess("planetscale.js", "planetscale.js.wasm"))
 )]
 mod one2many_opt {
     fn optional_with_default() -> String {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_delete/set_null.rs
@@ -23,7 +23,7 @@ mod one2one_opt {
     }
 
     /// Deleting the parent suceeds and sets the FK null.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn delete_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, child: { create: { id: 1 }}}) { id }}"#),
@@ -63,7 +63,7 @@ mod one2one_opt {
 
     /// Deleting the parent suceeds and sets the FK null.
     /// Checks that it works even with different parent/child primary identifier names.
-    #[connector_test(schema(diff_id_name), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(diff_id_name))]
     async fn delete_parent_diff_id_name(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -111,7 +111,7 @@ mod one2one_opt {
     }
 
     // SET_NULL should also apply to child relations sharing a common fk
-    #[connector_test(schema(one2one2one_opt_set_null), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(one2one2one_opt_set_null))]
     async fn delete_parent_recurse_set_null(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -181,7 +181,7 @@ mod one2one_opt {
     }
 
     // SET_NULL should also apply to child relations sharing a common fk
-    #[connector_test(schema(one2one2one_opt_set_null_restrict), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(one2one2one_opt_set_null_restrict))]
     async fn delete_parent_set_null_restrict(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -246,11 +246,7 @@ mod one2one_opt {
     }
 
     // SET_NULL should also apply to child relations sharing a common fk
-    #[connector_test(
-        schema(one2one2one_opt_set_null_cascade),
-        exclude_features("relationJoins"),
-        exclude(Sqlite("cfd1"))
-    )]
+    #[connector_test(schema(one2one2one_opt_set_null_cascade), exclude_features("relationJoins"))]
     async fn delete_parent_set_null_cascade(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -320,7 +316,7 @@ mod one2many_opt {
     }
 
     /// Deleting the parent suceeds and sets the FK null.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn delete_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, children: { create: { id: 1 }}}) { id }}"#),
@@ -368,7 +364,7 @@ mod one2many_opt {
     }
 
     // Do not recurse when relations have no fks in common
-    #[connector_test(schema(prisma_17255_schema), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(prisma_17255_schema))]
     async fn prisma_17255(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -114,7 +114,7 @@ mod one2one_req {
         schema.to_owned()
     }
 
-    #[connector_test(schema(required_compound), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(required_compound))]
     async fn update_parent_compound_cascade(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -248,7 +248,7 @@ mod one2one_opt {
         schema.to_owned()
     }
 
-    #[connector_test(schema(optional_compound), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(optional_compound))]
     async fn update_parent_compound_cascade(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -292,7 +292,7 @@ mod one2one_opt {
 
     // Updating the parent updates the child FK as well.
     // Checks that it works even with different parent/child primary identifier names
-    #[connector_test(schema(diff_id_name), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(diff_id_name))]
     async fn update_parent_diff_id_name(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -342,7 +342,7 @@ mod one2many_req {
     }
 
     /// Updating the parent updates the child as well.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
@@ -387,7 +387,7 @@ mod one2many_opt {
     }
 
     /// Updating the parent updates the child as well.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
@@ -431,7 +431,7 @@ mod one2many_opt {
         schema.to_owned()
     }
 
-    #[connector_test(schema(optional_compound_uniq), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(optional_compound_uniq))]
     async fn update_compound_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -456,7 +456,7 @@ mod one2many_opt {
     }
 }
 
-#[test_suite(schema(schema), exclude(SqlServer, Sqlite("cfd1")), relation_mode = "prisma")]
+#[test_suite(schema(schema), exclude(SqlServer), relation_mode = "prisma")]
 mod multiple_cascading_paths {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/cascade.rs
@@ -34,6 +34,12 @@ mod one2one_req {
     }
 
     #[connector_test(schema(required), exclude(Sqlite("cfd1")))]
+    /// On D1, this fails with:
+    ///
+    /// ```diff
+    /// - {"data":{"updateManyParent":{"count":1}}}
+    /// + {"data":{"updateManyParent":{"count":2}}}
+    /// ```
     async fn update_parent_cascade(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation {
@@ -170,8 +176,14 @@ mod one2one_opt {
         schema.to_owned()
     }
 
-    // Updating the parent updates the child FK as well.
     #[connector_test(schema(optional), exclude(Sqlite("cfd1")))]
+    // Updating the parent updates the child FK as well.
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"updateManyParent":{"count":1}}}
+    // + {"data":{"updateManyParent":{"count":2}}}
+    // ```
     async fn update_parent_cascade(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
             run_query!(&runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
@@ -31,7 +31,7 @@ mod one2one_req {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -48,7 +48,7 @@ mod one2one_req {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -65,7 +65,7 @@ mod one2one_req {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn upsert_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -94,7 +94,7 @@ mod one2one_req {
 #[test_suite(
     suite = "restrict_onU_1to1_opt",
     schema(optional),
-    exclude(SqlServer, Sqlite("cfd1")),
+    exclude(SqlServer),
     relation_mode = "prisma"
 )]
 mod one2one_opt {
@@ -135,7 +135,7 @@ mod one2one_opt {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -181,7 +181,7 @@ mod one2one_opt {
 #[test_suite(
     suite = "restrict_onU_1toM_req",
     schema(required),
-    exclude(SqlServer, Sqlite("cfd1")),
+    exclude(SqlServer),
     relation_mode = "prisma"
 )]
 mod one2many_req {
@@ -256,7 +256,7 @@ mod one2many_req {
     }
 
     /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn update_parent(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
         run_query!(
@@ -328,7 +328,7 @@ mod one2many_opt {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -345,7 +345,7 @@ mod one2many_opt {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_many_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -362,7 +362,7 @@ mod one2many_opt {
     }
 
     /// Updating the parent must fail if a child is connected.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn upsert_parent_failure(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/restrict.rs
@@ -255,8 +255,13 @@ mod one2many_req {
         Ok(())
     }
 
-    /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
     #[connector_test(exclude(Sqlite("cfd1")))]
+    /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
+    ///
+    /// ```diff
+    /// - {"data":{"updateManyParent":{"count":1}}}
+    /// + {"data":{"updateManyParent":{"count":2}}}
+    /// ```
     async fn update_parent(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
         run_query!(
@@ -378,8 +383,13 @@ mod one2many_opt {
         Ok(())
     }
 
-    /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
     #[connector_test(exclude(Sqlite("cfd1")))]
+    /// Updating the parent succeeds if no child is connected or if the linking fields aren't part of the update payload.
+    ///
+    /// ```diff
+    /// - {"data":{"updateManyParent":{"count":1}}}
+    /// + {"data":{"updateManyParent":{"count":2}}}
+    /// ```
     async fn update_parent(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_default.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_default.rs
@@ -2,7 +2,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(suite = "setdefault_onU_1to1_req", exclude(MongoDb, MySQL, Vitess, Sqlite("cfd1")))]
+#[test_suite(suite = "setdefault_onU_1to1_req", exclude(MongoDb, MySQL, Vitess))]
 mod one2one_req {
     fn required_with_default() -> String {
         let schema = indoc! {
@@ -105,7 +105,7 @@ mod one2one_req {
     }
 }
 
-#[test_suite(suite = "setdefault_onU_1to1_opt", exclude(MongoDb, MySQL, Vitess, Sqlite("cfd1")))]
+#[test_suite(suite = "setdefault_onU_1to1_opt", exclude(MongoDb, MySQL, Vitess))]
 mod one2one_opt {
     fn optional_with_default() -> String {
         let schema = indoc! {
@@ -210,7 +210,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(suite = "setdefault_onU_1toM_req", exclude(MongoDb, MySQL, Vitess, Sqlite("cfd1")))]
+#[test_suite(suite = "setdefault_onU_1toM_req", exclude(MongoDb, MySQL, Vitess))]
 mod one2many_req {
     fn required_with_default() -> String {
         let schema = indoc! {
@@ -313,7 +313,7 @@ mod one2many_req {
     }
 }
 
-#[test_suite(suite = "setdefault_onU_1toM_opt", exclude(MongoDb, MySQL, Vitess, Sqlite("cfd1")))]
+#[test_suite(suite = "setdefault_onU_1toM_opt", exclude(MongoDb, MySQL, Vitess))]
 mod one2many_opt {
     fn optional_with_default() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
@@ -25,7 +25,7 @@ mod one2one_opt {
     }
 
     /// Updating the parent suceeds and sets the FK null.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
@@ -112,7 +112,7 @@ mod one2one_opt {
     }
 
     // SET_NULL should recurse if there are relations sharing a common fk
-    #[connector_test(schema(one2one2one_opt_set_null), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(one2one2one_opt_set_null))]
     async fn update_parent_recurse_set_null(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -181,7 +181,7 @@ mod one2one_opt {
     }
 
     // SET_NULL should recurse if there are relations sharing a common fk
-    #[connector_test(schema(one2one2one_opt_restrict), exclude(SqlServer, Sqlite("cfd1")))]
+    #[connector_test(schema(one2one2one_opt_restrict), exclude(SqlServer))]
     async fn update_parent_recurse_restrict_failure(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -253,7 +253,7 @@ mod one2one_opt {
     }
 
     // SET_NULL should not recurse if there is no relation sharing a common fk
-    #[connector_test(schema(one2one2one_no_shared_fk), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(one2one2one_no_shared_fk))]
     async fn update_parent_no_recursion(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -318,7 +318,7 @@ mod one2one_opt {
 
     // Updating the parent updates the child FK as well.
     // Checks that it works even with different parent/child primary identifier names.
-    #[connector_test(schema(diff_id_name), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(diff_id_name))]
     async fn update_parent_diff_id_name(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -344,12 +344,7 @@ mod one2one_opt {
     }
 }
 
-#[test_suite(
-    suite = "setnull_onU_1toM_opt",
-    schema(optional),
-    exclude(Sqlite("cfd1")),
-    relation_mode = "prisma"
-)]
+#[test_suite(suite = "setnull_onU_1toM_opt", schema(optional), relation_mode = "prisma")]
 mod one2many_opt {
     fn optional() -> String {
         let schema = indoc! {
@@ -500,7 +495,7 @@ mod one2many_opt {
         schema.to_owned()
     }
 
-    #[connector_test(schema(optional_compound_uniq), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(optional_compound_uniq))]
     async fn update_compound_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/ref_actions/on_update/set_null.rs
@@ -66,6 +66,12 @@ mod one2one_opt {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"updateManyParent":{"count":1}}}
+    // + {"data":{"updateManyParent":{"count":2}}}
+    // ```
     async fn update_many_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", child: { create: { id: 1 }}}) { id }}"#),
@@ -386,7 +392,7 @@ mod one2many_opt {
     }
 
     /// Updating the parent succeeds and sets the FK null.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn update_parent_nested(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
@@ -406,7 +412,7 @@ mod one2many_opt {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn upsert_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
@@ -426,7 +432,7 @@ mod one2many_opt {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn upsert_parent_nested(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
@@ -452,6 +458,12 @@ mod one2many_opt {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"updateManyParent":{"count":1}}}
+    // + {"data":{"updateManyParent":{"count":2}}}
+    // ```
     async fn update_many_parent(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneParent(data: { id: 1, uniq: "1", children: { create: { id: 1 }}}) { id }}"#),
@@ -621,7 +633,7 @@ mod one2many_opt {
     }
 
     // SET_NULL should recurse if there are relations sharing a common fk
-    #[connector_test(schema(one2m2m_opt_restrict), exclude(SqlServer, Sqlite("cfd1")))]
+    #[connector_test(schema(one2m2m_opt_restrict), exclude(SqlServer))]
     async fn update_parent_recurse_restrict_failure(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -694,7 +706,7 @@ mod one2many_opt {
     }
 
     // SET_NULL should not recurse if there is no relation sharing a common fk
-    #[connector_test(schema(one2m2m_no_shared_fk), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(one2m2m_no_shared_fk))]
     async fn update_parent_no_recursion(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {
@@ -781,7 +793,7 @@ mod one2many_opt {
     }
 
     // Relation fields with at least one shared compound should also be set to null
-    #[connector_test(schema(one2m2m_compound_opt_set_null), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(one2m2m_compound_opt_set_null))]
     async fn update_parent_compound_recurse(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
@@ -33,7 +33,7 @@ mod max_integer {
     const U32_OVERFLOW_MAX: i64 = (u32::MAX as i64) + 1;
     const OVERFLOW_MIN: i8 = -1;
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn transform_gql_parser_too_large(runner: Runner) -> TestResult<()> {
         match runner.protocol() {
             query_engine_tests::EngineProtocol::Graphql => {
@@ -115,7 +115,7 @@ mod max_integer {
 
     // The document parser does not crash on encountering an exponent-notation-serialized int.
     // This triggers a 2009 instead of 2033 as this is in the document parser.
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn document_parser_no_crash_too_large(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,
@@ -127,7 +127,7 @@ mod max_integer {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn document_parser_no_crash_too_small(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/max_integer.rs
@@ -158,6 +158,11 @@ mod max_integer {
     // MongoDB is excluded because it automatically upcasts a value as an i64 if doesn't fit in an i32.
     // MySQL 5.6 is excluded because it never overflows but inserts the min or max of the range of the column type instead.
     // D1 doesn't fail.
+    //
+    // On D1, this panics with
+    // ```
+    // Expected result to return an error, but found success: {"data":{"createOneTest":{"id":1,"int":2147483648}}}
+    // ```
     #[connector_test(exclude(MongoDb, MySql(5.6), Sqlite("cfd1")))]
     async fn unfitted_int_should_fail(runner: Runner) -> TestResult<()> {
         assert_error!(
@@ -784,7 +789,7 @@ mod float_serialization_issues {
         schema.to_string()
     }
 
-    #[connector_test(exclude(SqlServer, Sqlite("cfd1")))]
+    #[connector_test(exclude(SqlServer))]
     async fn int_range_overlap_works(runner: Runner) -> TestResult<()> {
         runner
             .query("mutation { createOneTest(data: { id: 1, float: 1e20 }) { id float } }")

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_12572.rs
@@ -26,7 +26,7 @@ mod prisma_12572 {
         .to_owned()
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn all_generated_timestamps_are_the_same(runner: Runner) -> TestResult<()> {
         runner
             .query(r#"mutation { createOneTest1(data: {id:"one", test2s: { create: {id: "two"}}}) { id }}"#)

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13089.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_13089.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod prisma_13097 {
     fn schema() -> String {
         r#"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14696.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_14696.rs
@@ -2,7 +2,7 @@ use query_engine_tests::*;
 
 // mongodb has very specific constraint on id fields
 // mssql fails with a multiple cascading referential actions paths error
-#[test_suite(schema(schema), exclude(MongoDB, SqlServer, Sqlite("cfd1")))]
+#[test_suite(schema(schema), exclude(MongoDB, SqlServer))]
 mod prisma_14696 {
     fn schema() -> String {
         include_str!("./prisma_14696.prisma").to_string()

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15177.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15177.rs
@@ -1,7 +1,7 @@
 use indoc::indoc;
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(MongoDb, Sqlite("cfd1")))]
+#[test_suite(schema(schema), exclude(MongoDb))]
 mod prisma_15177 {
     fn schema() -> String {
         let schema = indoc! {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15581.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15581.rs
@@ -88,7 +88,7 @@ mod prisma_15581 {
         .to_owned()
     }
 
-    #[connector_test(schema(single_field_id_schema), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(single_field_id_schema))]
     async fn single_create_one_model_with_default_now_in_id(runner: Runner) -> TestResult<()> {
         run_query!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/relation_load_strategy.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/relation_load_strategy.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod relation_load_strategy {
     fn schema() -> String {
         indoc! {r#"
@@ -139,7 +139,7 @@ mod relation_load_strategy {
                     $query,
                     $result,
                     capabilities(CorrelatedSubqueries),
-                    exclude(Mysql("5.6", "5.7", "mariadb"), Sqlite("cfd1"))
+                    exclude(Mysql("5.6", "5.7", "mariadb"))
                 );
                 relation_load_strategy_test!(
                     [<$name _lateral>],

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/update_no_select.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/update_no_select.rs
@@ -6,7 +6,7 @@ mod update_with_no_select {
         include_str!("occ_simple.prisma").to_owned()
     }
 
-    #[connector_test(schema(occ_simple), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(occ_simple))]
     async fn update_with_no_select(mut runner: Runner) -> TestResult<()> {
         let create_one_resource = r#"
         mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/avg.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/avg.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schemas::common_numeric_types), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schemas::common_numeric_types))]
 mod aggregation_avg {
     use query_engine_tests::run_query;
 
@@ -97,7 +97,7 @@ mod decimal_aggregation_avg {
         schema.to_owned()
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn avg_no_records(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
             run_query!(
@@ -110,7 +110,7 @@ mod decimal_aggregation_avg {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn avg_some_records(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, decimal: "5.5" }"#).await?;
         create_row(&runner, r#"{ id: 2, decimal: "4.5" }"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/combination_spec.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/combination_spec.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod combinations {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query};
@@ -337,7 +337,7 @@ mod decimal_combinations {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn some_records(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ dec: "5.5" }"#).await?;
         create_row(&runner, r#"{ dec: "4.5" }"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/count.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/count.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schemas::common_nullable_types), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schemas::common_nullable_types))]
 mod aggregation_count {
     use query_engine_tests::run_query;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schemas::numeric_text_optional_one2m), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schemas::numeric_text_optional_one2m))]
 mod aggregation_group_by {
     use query_engine_tests::{assert_error, run_query};
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -383,8 +383,7 @@ mod aggr_group_by_having {
     #[connector_test(exclude(Sqlite("cfd1")))]
     // On D1, this panics with:
     //
-    // ```sh
-    // thread 'queries::aggregation::group_by_having::aggr_group_by_having::having_without_aggr_sel' panicked at query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs:392:9:
+    // ```
     // assertion `left == right` failed: Query result: {"data":{"groupByTestModel":[]}} is not part of the expected results: ["{\"data\":{\"groupByTestModel\":[{\"string\":\"group1\"},{\"string\":\"group2\"}]}}", "{\"data\":{\"groupByTestModel\":[{\"string\":\"group2\"},{\"string\":\"group1\"}]}}"] for connector SQLite (cfd1)
     //   left: false
     //  right: true

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs
@@ -53,6 +53,12 @@ mod aggr_group_by_having {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"groupByTestModel":[{"string":"group1","_count":{"int":2}}]}}
+    // + {"data":{"groupByTestModel":[]}}
+    // ```
     async fn having_count_scalar_filter(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, int: 1, string: "group1" }"#).await?;
         create_row(&runner, r#"{ id: 2, int: 2, string: "group1" }"#).await?;
@@ -128,6 +134,12 @@ mod aggr_group_by_having {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"groupByTestModel":[{"string":"group1","_sum":{"float":16.0,"int":16}}]}}
+    // + {"data":{"groupByTestModel":[]}}
+    // ```
     async fn having_sum_scalar_filter(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, float: 10, int: 10, string: "group1" }"#).await?;
         create_row(&runner, r#"{ id: 2, float: 6, int: 6, string: "group1" }"#).await?;
@@ -197,6 +209,12 @@ mod aggr_group_by_having {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"groupByTestModel":[{"string":"group1","_min":{"float":0.0,"int":0}},{"string":"group2","_min":{"float":0.0,"int":0}}]}}
+    // + {"data":{"groupByTestModel":[]}}
+    // ```
     async fn having_min_scalar_filter(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, float: 10, int: 10, string: "group1" }"#).await?;
         create_row(&runner, r#"{ id: 2, float: 0, int: 0, string: "group1" }"#).await?;
@@ -265,6 +283,12 @@ mod aggr_group_by_having {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"groupByTestModel":[{"string":"group1","_max":{"float":10.0,"int":10}},{"string":"group2","_max":{"float":10.0,"int":10}}]}}
+    // + {"data":{"groupByTestModel":[]}}
+    // ```
     async fn having_max_scalar_filter(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, float: 10, int: 10, string: "group1" }"#).await?;
         create_row(&runner, r#"{ id: 2, float: 0, int: 0, string: "group1" }"#).await?;
@@ -333,6 +357,12 @@ mod aggr_group_by_having {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"groupByTestModel":[{"string":"group1","_count":{"string":2}}]}}
+    // + {"data":{"groupByTestModel":[]}}
+    // ```
     async fn having_count_non_numerical_field(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, float: 10, int: 10, string: "group1" }"#).await?;
         create_row(&runner, r#"{ id: 2, float: 0, int: 0, string: "group1" }"#).await?;
@@ -351,6 +381,16 @@ mod aggr_group_by_having {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this panics with:
+    //
+    // ```sh
+    // thread 'queries::aggregation::group_by_having::aggr_group_by_having::having_without_aggr_sel' panicked at query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/group_by_having.rs:392:9:
+    // assertion `left == right` failed: Query result: {"data":{"groupByTestModel":[]}} is not part of the expected results: ["{\"data\":{\"groupByTestModel\":[{\"string\":\"group1\"},{\"string\":\"group2\"}]}}", "{\"data\":{\"groupByTestModel\":[{\"string\":\"group2\"},{\"string\":\"group1\"}]}}"] for connector SQLite (cfd1)
+    //   left: false
+    //  right: true
+    // note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+    // FAILED
+    // ```
     async fn having_without_aggr_sel(runner: Runner) -> TestResult<()> {
         create_row(&runner, r#"{ id: 1, float: 10, int: 10, string: "group1" }"#).await?;
         create_row(&runner, r#"{ id: 2, float: 0, int: 0, string: "group1" }"#).await?;
@@ -394,7 +434,7 @@ mod aggr_group_by_having {
 
     /// Error cases
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn having_filter_mismatch_selection(runner: Runner) -> TestResult<()> {
         assert_error!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/many_count_relation.rs
@@ -143,7 +143,7 @@ mod many_count_rel {
     }
 
     // Counting with skip should not affect the count
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn count_with_skip(runner: Runner) -> TestResult<()> {
         // 4 comment / 4 categories
         create_row(
@@ -201,7 +201,7 @@ mod many_count_rel {
     }
 
     // Counting with distinct should not affect the count
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn count_with_distinct(runner: Runner) -> TestResult<()> {
         create_row(
             &runner,
@@ -272,7 +272,7 @@ mod many_count_rel {
     }
 
     // Counting nested one2m and m2m should work
-    #[connector_test(schema(schema_nested), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(schema_nested))]
     async fn nested_count_one2m_m2m(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -619,11 +619,7 @@ mod many_count_rel {
     }
 
     // Regression test for: https://github.com/prisma/prisma/issues/7299
-    #[connector_test(
-        schema(schema_one2m_multi_fks),
-        capabilities(CompoundIds),
-        exclude(CockroachDb, Sqlite("cfd1"))
-    )]
+    #[connector_test(schema(schema_one2m_multi_fks), capabilities(CompoundIds), exclude(CockroachDb))]
     async fn count_one2m_compound_ids(runner: Runner) -> TestResult<()> {
         run_query!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/sum.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/sum.rs
@@ -94,7 +94,7 @@ mod decimal_aggregation_sum {
         schema.to_owned()
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn sum_no_records(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, "query { aggregateTestModel { _sum { decimal } } }"),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/uniq_count_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/aggregation/uniq_count_relation.rs
@@ -114,7 +114,7 @@ mod uniq_count_rel {
     }
 
     // Counting with take should not affect the count
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn count_with_take(runner: Runner) -> TestResult<()> {
         // 4 comment / 4 categories
         create_row(
@@ -172,7 +172,7 @@ mod uniq_count_rel {
     }
 
     // Counting with filters should not affect the count
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn count_with_filters(runner: Runner) -> TestResult<()> {
         // 4 comment / 4 categories
         create_row(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/select_one_compound.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/select_one_compound.rs
@@ -191,7 +191,7 @@ mod compound_batch {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn two_equal_queries(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -237,7 +237,7 @@ mod compound_batch {
     }
 
     // Ensures non compactable batch are not compacted
-    #[connector_test(schema(should_batch_schema), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(should_batch_schema))]
     async fn should_only_batch_if_possible(runner: Runner) -> TestResult<()> {
         runner
             .query(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/select_one_singular.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/select_one_singular.rs
@@ -92,7 +92,7 @@ mod singular_batch {
     }
 
     // "Two successful queries and one failing with different selection set" should "work"
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn two_success_one_fail_diff_set(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -143,7 +143,7 @@ mod singular_batch {
         Ok(())
     }
 
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
     async fn relation_traversal_filtered(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -268,7 +268,7 @@ mod singular_batch {
     }
 
     // Regression test for https://github.com/prisma/prisma/issues/18096
-    #[connector_test(schema(bigint_id), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(bigint_id))]
     async fn batch_bigint_id(runner: Runner) -> TestResult<()> {
         run_query!(&runner, r#"mutation { createOneTestModel(data: { id: 1 }) { id } }"#);
         run_query!(&runner, r#"mutation { createOneTestModel(data: { id: 2 }) { id } }"#);

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/transactional_batch.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/transactional_batch.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod transactional {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -44,7 +44,13 @@ mod transactional {
         Ok(())
     }
 
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyModelA":[]}}
+    // + {"data":{"findManyModelA":[{"id":1}]}}
+    // ```
     async fn one_success_one_fail(runner: Runner) -> TestResult<()> {
         let queries = vec![
             r#"mutation { createOneModelA(data: { id: 1 }) { id }}"#.to_string(),
@@ -77,7 +83,13 @@ mod transactional {
         Ok(())
     }
 
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyModelB":[]}}
+    // + {"data":{"findManyModelB":[{"id":1}]}}
+    // ```
     async fn one_query(runner: Runner) -> TestResult<()> {
         // Existing ModelA in the DB will prevent the nested ModelA creation in the batch.
         insta::assert_snapshot!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -182,6 +182,14 @@ mod scalar_relations {
     }
 
     #[connector_test(schema(schema_decimal), capabilities(DecimalType), exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"dec":"1"},{"childId":2,"dec":"-1"},{"childId":3,"dec":"123.4567891"},{"childId":4,"dec":"95993.57"}]}]}}
+    // + {"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"dec":"1"},{"childId":2,"dec":"-1"},{"childId":3,"dec":"123.4567891"},{"childId":4,"dec":"95993.57000000001"}]}]}}
+    // ```
+    //
+    // Basically, decimals are treated as doubles (and lose precision) due to D1 not providing column type information on queries.
     async fn decimal_type(runner: Runner) -> TestResult<()> {
         create_child(&runner, r#"{ childId: 1, dec: "1" }"#).await?;
         create_child(&runner, r#"{ childId: 2, dec: "-1" }"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/self_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/self_relation.rs
@@ -43,8 +43,12 @@ mod self_relation_filters {
         schema.to_owned()
     }
 
-    // Filter Queries along self relations should succeed with one level.
     #[connector_test(exclude(SqlServer, Sqlite("cfd1")))]
+    // Filter Queries along self relations should succeed with one level.
+    // On D1, this test fails with a panic:
+    // ```
+    // {"errors":[{"error":"RecordNotFound(\"Expected 1 records to be connected after connect operation on one-to-many relation 'Cuckoo', found 4.\")","user_facing_error":{"is_panic":false,"message":"The required connected records were not found. Expected 1 records to be connected after connect operation on one-to-many relation 'Cuckoo', found 4.","meta":{"details":"Expected 1 records to be connected after connect operation on one-to-many relation 'Cuckoo', found 4."},"error_code":"P2018"}}]}
+    // ```
     async fn l1_query(runner: Runner) -> TestResult<()> {
         test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -34,6 +34,12 @@ mod order_by_aggr {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyUser":[{"id":3,"posts":[]},{"id":1,"posts":[{"title":"alice_post_1"}]},{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}
+    // + {"data":{"findManyUser":[{"id":1,"posts":[{"title":"alice_post_1"}]},{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":3,"posts":[]}]}}
+    // ```
     async fn one2m_count_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -53,6 +59,12 @@ mod order_by_aggr {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyUser":[{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":1,"posts":[{"title":"alice_post_1"}]},{"id":3,"posts":[]}]}}
+    // + {"data":{"findManyUser":[{"id":3,"posts":[]},{"id":2,"posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":1,"posts":[{"title":"alice_post_1"}]}]}}
+    // ```
     async fn one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -110,6 +122,12 @@ mod order_by_aggr {
     }
 
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyUser":[{"id":3,"name":"Motongo","posts":[]},{"id":1,"name":"Alice","posts":[{"title":"alice_post_1"}]},{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}
+    // + {"data":{"findManyUser":[{"id":1,"name":"Alice","posts":[{"title":"alice_post_1"}]},{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":3,"name":"Motongo","posts":[]}]}}
+    // ```
     async fn one2m_count_asc_field_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -438,7 +456,13 @@ mod order_by_aggr {
     // With pagination tests
 
     // "[Cursor] Ordering by one2m count asc" should "work"
-    #[connector_test(exclude(Sqlite("cfd1")))]
+    #[connector_test]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyUser":[{"id":1,"posts":[{"id":1}]},{"id":2,"posts":[{"id":2},{"id":3}]}]}}
+    // + {"data":{"findManyUser":[{"id":1,"posts":[{"id":1}]},{"id":2,"posts":[{"id":2},{"id":3}]},{"id":3,"posts":[]}]}}
+    // ```
     async fn cursor_one2m_count_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -459,6 +483,12 @@ mod order_by_aggr {
 
     // "[Cursor] Ordering by one2m count desc" should "work"
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyUser":[{"id":1,"posts":[{"id":1}]},{"id":2,"posts":[{"id":2},{"id":3}]}]}}
+    // + {"data":{"findManyUser":[{"id":1,"posts":[{"id":1}]},{"id":2,"posts":[{"id":2},{"id":3}]},{"id":3,"posts":[]}]}}
+    // ```
     async fn cursor_one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -521,6 +551,12 @@ mod order_by_aggr {
 
     // "[Cursor][Combo] Ordering by one2m count asc + field asc"
     #[connector_test(exclude(Sqlite("cfd1")))]
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyUser":[{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]}]}}
+    // + {"data":{"findManyUser":[{"id":2,"name":"Bob","posts":[{"title":"bob_post_1"},{"title":"bob_post_2"}]},{"id":3,"name":"Motongo","posts":[]}]}}
+    // ```
     async fn cursor_one2m_count_asc_field_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -456,7 +456,7 @@ mod order_by_aggr {
     // With pagination tests
 
     // "[Cursor] Ordering by one2m count asc" should "work"
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     // On D1, this fails with:
     //
     // ```diff

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -769,8 +769,14 @@ mod order_by_aggr {
         schema.to_owned()
     }
 
-    // Regression test for: // https://github.com/prisma/prisma/issues/8036
     #[connector_test(schema(schema_regression_8036), exclude(Sqlite("cfd1")))]
+    // Regression test for: // https://github.com/prisma/prisma/issues/8036
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findManyPost":[{"id":2,"title":"Second","_count":{"LikedPeople":0}},{"id":3,"title":"Third","_count":{"LikedPeople":0}},{"id":4,"title":"Fourth","_count":{"LikedPeople":0}},{"id":5,"title":"Fifth","_count":{"LikedPeople":0}}]}}
+    // + {"data":{"findManyPost":[]}}
+    // ```
     async fn count_m2m_records_not_connected(runner: Runner) -> TestResult<()> {
         run_query!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_aggregation.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod order_by_aggr {
     use indoc::indoc;
     use query_engine_tests::{match_connector_result, run_query};
@@ -33,7 +33,7 @@ mod order_by_aggr {
         schema.to_owned()
     }
 
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn one2m_count_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -52,7 +52,7 @@ mod order_by_aggr {
         Ok(())
     }
 
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -109,7 +109,7 @@ mod order_by_aggr {
         Ok(())
     }
 
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn one2m_count_asc_field_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -438,7 +438,7 @@ mod order_by_aggr {
     // With pagination tests
 
     // "[Cursor] Ordering by one2m count asc" should "work"
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn cursor_one2m_count_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -458,7 +458,7 @@ mod order_by_aggr {
     }
 
     // "[Cursor] Ordering by one2m count desc" should "work"
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn cursor_one2m_count_desc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -520,7 +520,7 @@ mod order_by_aggr {
     }
 
     // "[Cursor][Combo] Ordering by one2m count asc + field asc"
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
     async fn cursor_one2m_count_asc_field_asc(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -770,7 +770,7 @@ mod order_by_aggr {
     }
 
     // Regression test for: // https://github.com/prisma/prisma/issues/8036
-    #[connector_test(schema(schema_regression_8036))]
+    #[connector_test(schema(schema_regression_8036), exclude(Sqlite("cfd1")))]
     async fn count_m2m_records_not_connected(runner: Runner) -> TestResult<()> {
         run_query!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/bigint.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/bigint.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod bigint {
     use indoc::indoc;
     use query_engine_tests::run_query;
@@ -16,8 +16,14 @@ mod bigint {
         schema.to_owned()
     }
 
-    // "Using a BigInt field" should "work"
-    #[connector_test]
+    #[connector_test(exclude(Sqlite("cfd1")))]
+    // "Using a BigInt field" should "work".
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"createOneModel":{"field":"123456789012341234"}}}
+    // + {"data":{"createOneModel":{"field":"123456789012341200"}}}
+    // ```
     async fn using_bigint_field(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_create.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod connect_inside_create {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_update.rs
@@ -6,7 +6,7 @@ mod connect_inside_update {
     use query_test_macros::relation_link_test;
 
     // "a P1 to C1  relation with the child already in a relation" should "be connectable through a nested mutation if the child is already in a relation"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(SqlServer, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(SqlServer))]
     async fn p1_c1_child_in_rel_connect_mut(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let loose_child = t.child().parse(
             run_query_json!(
@@ -166,7 +166,7 @@ mod connect_inside_update {
     }
 
     // "a P1 to C1 relation with the child without a relation" should "be connectable through a nested mutation"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(SqlServer, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(SqlServer))]
     async fn p1_c1_child_wo_rel_connect_mut(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let child = t.child().parse(
             run_query_json!(
@@ -218,7 +218,7 @@ mod connect_inside_update {
     }
 
     // "a P1 to C1  relation with the parent without a relation" should "be connectable through a nested mutation"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(SqlServer, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(SqlServer))]
     async fn p1_c1_parnt_wo_rel_connect_mut(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
             run_query_json!(
@@ -1142,10 +1142,7 @@ mod connect_inside_update {
     // Regression test for https://github.com/prisma/prisma/issues/18173
     // Excluded on MongoDB because all models require an @id attribute
     // Excluded on SQLServer because models with unique nulls can't have multiple NULLs, unlike other dbs.
-    #[connector_test(
-        schema(p1_c1_child_compound_unique_schema),
-        exclude(MongoDb, SqlServer, Sqlite("cfd1"))
-    )]
+    #[connector_test(schema(p1_c1_child_compound_unique_schema), exclude(MongoDb, SqlServer))]
     async fn p1_c1_child_compound_unique(runner: Runner) -> TestResult<()> {
         run_query!(&runner, r#"mutation { createOneParent(data: { id: 1 }) { id } }"#);
         run_query!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_create.rs
@@ -1,7 +1,7 @@
 use query_engine_tests::*;
 
 // TODO(dom): All failings except one (only a couple of tests is failing per test)
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod create_inside_create {
     use query_engine_tests::{run_query, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_update.rs
@@ -2,7 +2,7 @@ use query_engine_tests::*;
 
 //TODO: which tests to keep and which ones to delete???? Some do not really test the compound unique functionality
 // TODO(dom): All failing except one
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod create_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_update.rs
@@ -782,7 +782,7 @@ mod delete_inside_update {
     // ----------------------------------
 
     // "a P1 to CM  relation " should "work"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToMany", exclude(SqlServer, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToMany", exclude(SqlServer))]
     async fn p1_cm_by_id_should_work(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
             run_query_json!(
@@ -828,7 +828,7 @@ mod delete_inside_update {
     }
 
     // "a P1 to CM  relation "should "work"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToMany", exclude(SqlServer, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToMany", exclude(SqlServer))]
     async fn p1_cm_by_id_and_filters_should_work(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
             run_query_json!(
@@ -912,7 +912,7 @@ mod delete_inside_update {
     }
 
     // "a P1 to CM  relation" should "error if the node is connected but the additional filters don't match it"
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToMany", exclude(SqlServer, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToMany", exclude(SqlServer))]
     async fn p1_cm_error_if_filter_not_match(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let parent = t.parent().parse(
             run_query_json!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_upsert.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod delete_inside_upsert {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_many_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_many_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod delete_many_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod disconnect_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod disconnect_inside_upsert {
     use query_engine_tests::{assert_error, run_query, run_query_json};
     use query_test_macros::relation_link_test;
@@ -116,7 +116,7 @@ mod disconnect_inside_upsert {
 
     // "a P1 to C1 relation " should "be disconnectable through a nested mutation by id"
     // TODO: MongoDB doesn't support joins on top-level updates. It should be un-excluded once we fix that.
-    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(MongoDb, Sqlite("cfd1")))]
+    #[relation_link_test(on_parent = "ToOneOpt", on_child = "ToOneOpt", exclude(MongoDb))]
     async fn p1_c1_by_fails_if_filter_no_match(runner: &Runner, t: &DatamodelWithParams) -> TestResult<()> {
         let res = run_query_json!(
             runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_set_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_set_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod set_inside_update {
     use query_engine_tests::{run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_update_many_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_update_many_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 // update_many_inside_update
 mod um_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams, Runner, TestResult};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_upsert_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_upsert_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod upsert_inside_update {
     use query_engine_tests::{run_query, run_query_json};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/combining_different_nested_mutations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/combining_different_nested_mutations.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod many_nested_muts {
     use query_engine_tests::{run_query, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/nested_atomic_number_ops.rs
@@ -25,7 +25,7 @@ mod atomic_number_ops {
     }
 
     // "An updateOne mutation with number operations on the top and updates on the child (inl. child)" should "handle id changes correctly"
-    #[connector_test(schema(schema_1), capabilities(UpdateableId), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(schema_1), capabilities(UpdateableId))]
     async fn update_number_ops_on_child(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -110,7 +110,7 @@ mod atomic_number_ops {
     }
 
     //"An updateOne mutation with number operations on the top and updates on the child (inl. parent)" should "handle id changes correctly"
-    #[connector_test(schema(schema_2), capabilities(UpdateableId), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(schema_2), capabilities(UpdateableId))]
     async fn update_number_ops_on_parent(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,
@@ -195,7 +195,7 @@ mod atomic_number_ops {
     }
 
     // "A nested updateOne mutation" should "correctly apply all number operations for Int"
-    #[connector_test(schema(schema_3), exclude(CockroachDb, Sqlite("cfd1")))]
+    #[connector_test(schema(schema_3), exclude(CockroachDb))]
     async fn nested_update_int_ops(runner: Runner) -> TestResult<()> {
         create_test_model(&runner, 1, None, None).await?;
         create_test_model(&runner, 2, Some(3), None).await?;
@@ -324,7 +324,7 @@ mod atomic_number_ops {
     }
 
     // "A nested updateOne mutation" should "correctly apply all number operations for Int"
-    #[connector_test(schema(schema_3), exclude(MongoDb, Sqlite("cfd1")))]
+    #[connector_test(schema(schema_3), exclude(MongoDb))]
     async fn nested_update_float_ops(runner: Runner) -> TestResult<()> {
         create_test_model(&runner, 1, None, None).await?;
         create_test_model(&runner, 2, None, Some("5.5")).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_connect_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_connect_inside_upsert.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod connect_inside_upsert {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query, run_query_json};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_connect_or_create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_connect_or_create.rs
@@ -3,7 +3,7 @@ use query_engine_tests::*;
 // Note: Except for m:n cases that are always resolved using the primary identifier of the models, we use different
 // relation links to ensure that the underlying QE logic correctly uses link resolvers instead of
 // only primary id resolvers.
-#[test_suite(exclude(Sqlite("cfd1")))]
+#[test_suite]
 mod connect_or_create {
     use indoc::indoc;
     use query_engine_tests::run_query;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_create_many.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(schema(schema), exclude(Sqlite("cfd1")))]
+#[test_suite(schema(schema))]
 mod nested_create_many {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
@@ -590,8 +590,14 @@ mod update_inside_update {
 
     // Transactionality
 
-    // "TRANSACTIONAL: a many to many relation" should "fail gracefully on wrong where and assign error correctly and not execute partially"
     #[connector_test(schema(schema_1), exclude(Sqlite("cfd1")))]
+    // "TRANSACTIONAL: a many to many relation" should "fail gracefully on wrong where and assign error correctly and not execute partially"
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"findUniqueNote":{"text":"Some Text"}}}
+    // + {"data":{"findUniqueNote":{"text":"Some Changed Text"}}}
+    // ```
     async fn tx_m2m_fail_wrong_where(runner: Runner) -> TestResult<()> {
         let res = run_query_json!(
             &runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
@@ -793,7 +793,7 @@ mod update_inside_update {
     }
 
     // "a deeply nested mutation" should "execute all levels of the mutation if there are only node edges on the path"
-    #[connector_test(schema(schema_3), exclude(Sqlite("cfd1")))]
+    #[connector_test(schema(schema_3))]
     async fn deep_nested_mutation_exec_all_muts(runner: Runner) -> TestResult<()> {
         run_query!(
             &runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many_relations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many_relations.rs
@@ -6,13 +6,19 @@ mod delete_many_rels {
     use query_engine_tests::{run_query, Runner};
     use query_test_macros::relation_link_test;
 
-    // "a P1 to C1  relation " should "succeed when trying to delete the parent"
     #[relation_link_test(
         on_parent = "ToOneOpt",
         on_child = "ToOneOpt",
         id_only = true,
         exclude(Sqlite("cfd1"))
     )]
+    // "a P1 to C1  relation " should "succeed when trying to delete the parent"
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"deleteManyParent":{"count":1}}}
+    // + {"data":{"deleteManyParent":{"count":3}}}
+    // ```
     async fn p1_c1(runner: &Runner, _t: &DatamodelWithParams) -> TestResult<()> {
         runner
             .query(indoc! { r#"
@@ -120,8 +126,14 @@ mod delete_many_rels {
         Ok(())
     }
 
-    // "a PM to C1 " should "succeed in deleting the parent"
     #[relation_link_test(on_parent = "ToMany", on_child = "ToOneOpt", exclude(Sqlite("cfd1")))]
+    // "a PM to C1 relation " should "succeed in deleting the parent"
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"deleteManyParent":{"count":1}}}
+    // + {"data":{"deleteManyParent":{"count":3}}}
+    // ```
     async fn pm_c1(runner: &Runner, _t: &DatamodelWithParams) -> TestResult<()> {
         runner
             .query(indoc! { r#"
@@ -267,8 +279,14 @@ mod delete_many_rels {
         Ok(())
     }
 
-    // "a PM to CM  relation" should "succeed in deleting the parent"
     #[relation_link_test(on_parent = "ToMany", on_child = "ToMany", exclude(Sqlite("cfd1")))]
+    // "a PM to CM relation" should "succeed in deleting the parent"
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"deleteManyParent":{"count":1}}}
+    // + {"data":{"deleteManyParent":{"count":3}}}
+    // ```
     async fn pm_cm(runner: &Runner, _t: &DatamodelWithParams) -> TestResult<()> {
         runner
             .query(indoc! { r#"
@@ -354,8 +372,14 @@ mod delete_many_rels {
         schema.to_owned()
     }
 
-    // "a PM to CM  relation" should "delete the parent from other relations as well"
     #[connector_test(schema(additional_schema), exclude(Sqlite("cfd1")))]
+    // "a PM to CM  relation" should "delete the parent from other relations as well"
+    // On D1, this fails with:
+    //
+    // ```diff
+    // - {"data":{"deleteManyParent":{"count":1}}}
+    // + {"data":{"deleteManyParent":{"count":3}}}
+    // ```
     async fn pm_cm_other_relations(runner: Runner) -> TestResult<()> {
         runner
             .query(


### PR DESCRIPTION
This PR contributes to the investigation of:
- https://github.com/prisma/team-orm/issues/1049
- https://github.com/prisma/team-orm/issues/1050

This PR:
- Uncomments tests that now work locally (after changes to the D1 migration pipeline / datatype handling in `@prisma/adapter-d1`)
- Adds more context (in comments) about how certain tests fail