### PR TITLE
chore(renovate): fix JSON

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,57 +11,35 @@
   "sbt": {
     "enabled": false
   },
-  "schedule": [
-    "every weekend"
-  ],
+  "schedule": ["every weekend"],
   "minimumReleaseAge": "7 days",
   "rangeStrategy": "pin",
   "separateMinorPatch": true,
   "configMigration": true,
-  "ignoreDeps": [
-    "query-engine-wasm-baseline",
-  ],
+  "ignoreDeps": ["query-engine-wasm-baseline"],
   "packageRules": [
     {
-      "matchFileNames": [
-        "docker-compose.yml"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "major"
-      ],
+      "matchFileNames": ["docker-compose.yml"],
+      "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
     {
       "groupName": "Weekly vitess docker image version update",
-      "matchPackageNames": [
-        "vitess/vttestserver"
-      ],
-      "schedule": [
-        "before 7am on Wednesday"
-      ]
+      "matchPackageNames": ["vitess/vttestserver"],
+      "schedule": ["before 7am on Wednesday"]
     },
     {
       "groupName": "Prisma Driver Adapters",
-      "matchPackageNames": [
-        "@prisma/driver-adapter-utils"
-      ],
-      "matchPackagePrefixes": [
-        "@prisma/adapter"
-      ],
-      "schedule": [
-        "at any time"
-      ]
+      "matchPackageNames": ["@prisma/driver-adapter-utils"],
+      "matchPackagePrefixes": ["@prisma/adapter"],
+      "schedule": ["at any time"]
     },
     {
       "groupName": "Driver Adapters directory",
       "matchFileNames": ["query-engine/driver-adapters/**"]
     },
     {
-      "matchPackageNames": [
-        "node",
-        "pnpm"
-      ],
+      "matchPackageNames": ["node", "pnpm"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
Fixes https://github.com/prisma/prisma-engines/issues/2179
>WARN: File contents are invalid JSON but parse using JSON5. Support for this will be removed in a future release so please change to a support .json5 file name or ensure correct JSON syntax.

[skip ci]