### PR TITLE
ci: update pnpm/action-setup to v3

### DIFF
--- a/.github/workflows/test-query-engine-driver-adapters.yml
+++ b/.github/workflows/test-query-engine-driver-adapters.yml
@@ -70,7 +70,7 @@ jobs:
           node-version: ${{ matrix.node_version }}
 
       - name: "Setup pnpm"
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3.0.0
         with:
           version: 8
 

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v4
 
       - name: "Setup pnpm"
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3.0.0
         with:
           version: 8
 


### PR DESCRIPTION
We can now say goodbye to the warning:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: pnpm/action-setup@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```