### PR TITLE
fix: make expression log syntax easier to understand

### DIFF
--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -184,20 +184,31 @@ impl<'conn> QueryInterpreter<'conn> {
             Expression::Func { func } => {
                 let expr = func(env.clone());
 
-                Box::pin(async move { self.interpret(expr?, env, level, trace_id).await })
+                Box::pin(async move {
+                    self.log_line(level, || "execute <lambda function> {");
+                    let result = self.interpret(expr?, env, level + 1, trace_id).await;
+                    self.log_line(level, || "}");
+                    result
+                })
             }
 
-            Expression::Sequence { seq } if seq.is_empty() => Box::pin(async { Ok(ExpressionResult::Empty) }),
+            Expression::Sequence { seq } if seq.is_empty() => Box::pin(async move {
+                self.log_line(level, || "[]");
+                Ok(ExpressionResult::Empty)
+            }),
 
             Expression::Sequence { seq } => {
                 Box::pin(async move {
-                    self.log_line(level, || "SEQ");
+                    self.log_line(level, || "[");
 
                     let mut results = Vec::with_capacity(seq.len());
 
                     for expr in seq {
                         results.push(self.interpret(expr, env.clone(), level + 1, trace_id.clone()).await?);
+                        self.log_line(level + 1, || ",");
                     }
+
+                    self.log_line(level, || "]");
 
                     // Last result gets returned
                     Ok(results.pop().unwrap())
@@ -210,15 +221,17 @@ impl<'conn> QueryInterpreter<'conn> {
             } => {
                 Box::pin(async move {
                     let mut inner_env = env.clone();
-                    self.log_line(level, || "LET");
+                    self.log_line(level, || "let");
 
                     for binding in bindings {
-                        self.log_line(level + 1, || format!("bind {} ", &binding.name));
+                        self.log_line(level + 1, || format!("{} = {{", &binding.name));
 
                         let result = self
                             .interpret(binding.expr, env.clone(), level + 2, trace_id.clone())
                             .await?;
                         inner_env.insert(binding.name, result);
+
+                        self.log_line(level + 1, || "} ,");
                     }
 
                     // the unwrapping improves the readability of the log significantly
@@ -228,14 +241,17 @@ impl<'conn> QueryInterpreter<'conn> {
                         Expression::Sequence { seq: expressions }
                     };
 
-                    self.interpret(next_expression, inner_env, level + 1, trace_id).await
+                    self.log_line(level, || "in {");
+                    let result = self.interpret(next_expression, inner_env, level + 1, trace_id).await;
+                    self.log_line(level, || "}");
+                    result
                 })
             }
 
             Expression::Query { query } => Box::pin(async move {
                 match *query {
                     Query::Read(read) => {
-                        self.log_line(level, || format!("READ {read}"));
+                        self.log_line(level, || format!("readExecute {read}"));
                         let span = info_span!("prisma:engine:read-execute");
                         Ok(read::execute(self.conn, read, None, trace_id)
                             .instrument(span)
@@ -244,7 +260,7 @@ impl<'conn> QueryInterpreter<'conn> {
                     }
 
                     Query::Write(write) => {
-                        self.log_line(level, || format!("WRITE {write}"));
+                        self.log_line(level, || format!("writeExecute {write}"));
                         let span = info_span!("prisma:engine:write-execute");
                         Ok(write::execute(self.conn, write, trace_id)
                             .instrument(span)
@@ -255,12 +271,12 @@ impl<'conn> QueryInterpreter<'conn> {
             }),
 
             Expression::Get { binding_name } => Box::pin(async move {
-                self.log_line(level, || format!("GET {binding_name}"));
+                self.log_line(level, || format!("getVariable {binding_name}"));
                 env.clone().remove(&binding_name)
             }),
 
             Expression::GetFirstNonEmpty { binding_names } => Box::pin(async move {
-                self.log_line(level, || format!("GET FIRST NON EMPTY {binding_names:?}"));
+                self.log_line(level, || format!("getFirstNonEmpty {binding_names:?}"));
 
                 Ok(binding_names
                     .into_iter()
@@ -276,19 +292,22 @@ impl<'conn> QueryInterpreter<'conn> {
                 then,
                 else_: elze,
             } => Box::pin(async move {
-                self.log_line(level, || "IF");
+                let predicate = func();
+                self.log_line(level, || format!("if <lambda condition> = {predicate} {{"));
 
-                if func() {
+                let result = if predicate {
                     self.interpret(Expression::Sequence { seq: then }, env, level + 1, trace_id)
                         .await
                 } else {
                     self.interpret(Expression::Sequence { seq: elze }, env, level + 1, trace_id)
                         .await
-                }
+                };
+                self.log_line(level, || "}");
+                result
             }),
 
             Expression::Return { result } => Box::pin(async move {
-                self.log_line(level, || "RETURN");
+                self.log_line(level, || format!("return {result:?}"));
                 Ok(*result)
             }),
         }
@@ -297,7 +316,7 @@ impl<'conn> QueryInterpreter<'conn> {
     pub(crate) fn log_output(&self) -> String {
         let mut output = String::with_capacity(self.log.len() * 30);
 
-        for s in self.log.iter().rev() {
+        for s in self.log.iter() {
             output.push_str(s)
         }
 

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -306,7 +306,10 @@ impl<'conn> QueryInterpreter<'conn> {
                 result
             }),
 
-            Expression::Return { result } => Box::pin(async move { Ok(*result) }),
+            Expression::Return { result } => Box::pin(async move {
+                self.log_line(level, || "returnValue");
+                Ok(*result)
+            }),
         }
     }
 

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -231,7 +231,7 @@ impl<'conn> QueryInterpreter<'conn> {
                             .await?;
                         inner_env.insert(binding.name, result);
 
-                        self.log_line(level + 1, || "} ,");
+                        self.log_line(level + 1, || "},");
                     }
 
                     // the unwrapping improves the readability of the log significantly
@@ -306,10 +306,7 @@ impl<'conn> QueryInterpreter<'conn> {
                 result
             }),
 
-            Expression::Return { result } => Box::pin(async move {
-                self.log_line(level, || format!("return {result:?}"));
-                Ok(*result)
-            }),
+            Expression::Return { result } => Box::pin(async move { Ok(*result) }),
         }
     }
 

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -30,6 +30,8 @@ fn read_one(
     query: RecordQuery,
     trace_id: Option<String>,
 ) -> BoxFuture<'_, InterpretationResult<QueryResult>> {
+    println!("laplab: executing record query {query:#?}");
+
     let fut = async move {
         let model = query.model;
         let filter = query.filter.expect("Expected filter to be set for ReadOne query.");
@@ -42,6 +44,8 @@ fn read_one(
                 trace_id,
             )
             .await?;
+
+        println!("laplab: got single record: {record:#?}");
 
         match record {
             Some(record) if query.relation_load_strategy.is_query() => {

--- a/query-engine/core/src/interpreter/query_interpreters/read.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/read.rs
@@ -30,8 +30,6 @@ fn read_one(
     query: RecordQuery,
     trace_id: Option<String>,
 ) -> BoxFuture<'_, InterpretationResult<QueryResult>> {
-    println!("laplab: executing record query {query:#?}");
-
     let fut = async move {
         let model = query.model;
         let filter = query.filter.expect("Expected filter to be set for ReadOne query.");
@@ -44,8 +42,6 @@ fn read_one(
                 trace_id,
             )
             .await?;
-
-        println!("laplab: got single record: {record:#?}");
 
         match record {
             Some(record) if query.relation_load_strategy.is_query() => {


### PR DESCRIPTION
<details>
<summary>main branch</summary>

```
              GET FIRST NON EMPTY ["5"]
                GET FIRST NON EMPTY ["10", "8"]
                      GET FIRST NON EMPTY ["7"]
                              GET FIRST NON EMPTY ["4"]
                                READ RecordQuery(name: 'upsertOneNode', selection: FieldSelection { fields: [Node.id] }, filter: Some(And([Scalar(ScalarFilter { projection: SingleProjection("Node.id"), condition: Equals(Value(Int(1))), mode: Default })])))
                              bind 4
                            LET
                              WRITE UpdateRecord(model: Node, filter: RecordFilter { filter: And([And([Scalar(ScalarFilter { projection: SingleProjection("Node.id"), condition: Equals(Value(Int(1))), mode: Default })]), Empty]), selectors: Some([[("Node.id", Int(1))]]) }, args: WriteArgs { request_now: DateTime(2024-04-09T14:37:52.357+00:00), args: {DatasourceFieldName("value"): Scalar(Set(Int(5)))} }, selected_fields: Some("FieldSelection { fields: [Node.id] }"))
                            bind 2
                          LET
                        SEQ
                      bind 7
                    LET
                      READ RelatedRecordsQuery(name: 'find_children_by_parent', parent model: 'Node', parent relation field: 'leftOf', selection: FieldSelection { fields: [Node.id, Node.leftId] })
                    bind 8
                  LET
                bind 8
                      GET FIRST NON EMPTY ["9"]
                      bind 9
                    LET
                      READ RelatedRecordsQuery(name: 'find_children_by_parent', parent model: 'Node', parent relation field: 'rightOf', selection: FieldSelection { fields: [Node.id, Node.rightId] })
                    bind 10
                  LET
                bind 10
              LET
                RETURN
              bind 6
            LET
          SEQ
        IF
      bind 5
    LET
      READ ManyRecordsQuery(name: 'read_ids_infallible', model: 'Node', selection: FieldSelection { fields: [Node.id] }, args: QueryArguments { model: "Node", cursor: None, take: None, skip: None, filter: Some(And([And([Scalar(ScalarFilter { projection: SingleProjection("Node.id"), condition: Equals(Value(Int(1))), mode: Default })]), Empty])), order_by: [], distinct: None, ignore_skip: false, ignore_take: false, relation_load_strategy: None })
    bind 0
  LET
SEQ
```

</details>

<details>
<summary>This PR</summary>

```
[
  let
    0 = {
      readExecute ManyRecordsQuery(name: 'read_ids_infallible', model: 'Node', selection: FieldSelection { fields: [Node.id] }, args: QueryArguments { model: "Node", cursor: None, take: None, skip: None, filter: Some(And([And([Scalar(ScalarFilter { projection: SingleProjection("Node.id"), condition: Equals(Value(Int(1))), mode: Default })]), Empty])), order_by: [], distinct: None, ignore_skip: false, ignore_take: false, relation_load_strategy: None })
    },
  in {
    let
      5 = {
        execute <lambda function> {
          if <lambda condition> = true {
            [
              let
                6 = {
                  execute <lambda function> {
                  }
                },
              in {
                let
                  10 = {
                    let
                      10 = {
                        execute <lambda function> {
                          readExecute RelatedRecordsQuery(name: 'find_children_by_parent', parent model: 'Node', parent relation field: 'rightOf', selection: FieldSelection { fields: [Node.id, Node.rightId] })
                        }
                      },
                    in {
                      let
                        9 = {
                          execute <lambda function> {
                            []
                          }
                        },
                      in {
                        getFirstNonEmpty ["9"]
                      }
                    }
                  },
                  8 = {
                    let
                      8 = {
                        execute <lambda function> {
                          readExecute RelatedRecordsQuery(name: 'find_children_by_parent', parent model: 'Node', parent relation field: 'leftOf', selection: FieldSelection { fields: [Node.id, Node.leftId] })
                        }
                      },
                    in {
                      let
                        7 = {
                          execute <lambda function> {
                            [
                              let
                                2 = {
                                  execute <lambda function> {
                                    writeExecute UpdateRecord(model: Node, filter: RecordFilter { filter: And([And([Scalar(ScalarFilter { projection: SingleProjection("Node.id"), condition: Equals(Value(Int(1))), mode: Default })]), Empty]), selectors: Some([[("Node.id", Int(1))]]) }, args: WriteArgs { request_now: DateTime(2024-04-09T14:34:01.261+00:00), args: {DatasourceFieldName("value"): Scalar(Set(Int(5)))} }, selected_fields: Some("FieldSelection { fields: [Node.id] }"))
                                  }
                                },
                              in {
                                let
                                  4 = {
                                    execute <lambda function> {
                                      readExecute RecordQuery(name: 'upsertOneNode', selection: FieldSelection { fields: [Node.id] }, filter: Some(And([Scalar(ScalarFilter { projection: SingleProjection("Node.id"), condition: Equals(Value(Int(1))), mode: Default })])))
                                    }
                                  },
                                in {
                                  getFirstNonEmpty ["4"]
                                }
                              }
                              ,
                            ]
                          }
                        },
                      in {
                        getFirstNonEmpty ["7"]
                      }
                    }
                  },
                in {
                  getFirstNonEmpty ["10", "8"]
                }
              }
              ,
            ]
          }
        }
      },
    in {
      getFirstNonEmpty ["5"]
    }
  }
  ,
]
```

</details>