### PR TITLE
fix: make `getFirstNonEmpty` actually filter out empty results

### DIFF
--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -267,8 +267,9 @@ impl<'conn> QueryInterpreter<'conn> {
                     .find_map(|binding_name| {
                         env.get(&binding_name)
                             .map(|_| env.clone().remove(&binding_name).unwrap())
+                            .filter(|result| !matches!(result, ExpressionResult::Empty))
                     })
-                    .unwrap())
+                    .unwrap_or(ExpressionResult::Empty))
             }),
 
             Expression::If {


### PR DESCRIPTION
Closes https://github.com/prisma/team-orm/issues/1077