### PR TITLE
Revert "qe: add json serialization span in binary engine"

### DIFF
--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -173,7 +173,7 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
         match serialized_body {
             Ok(body) => {
                 let handler = RequestHandler::new(cx.executor(), cx.query_schema(), cx.engine_protocol());
-                let mut result = handler.handle(body, tx_id, traceparent).await;
+                let mut result = handler.handle(body, tx_id, traceparent).instrument(span).await;
 
                 if let telemetry::capturing::Capturer::Enabled(capturer) = &capture_config {
                     let telemetry = capturer.fetch_captures().await;
@@ -183,8 +183,7 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
                     }
                 }
 
-                let json_span = tracing::info_span!("prisma:engine:response_json_serialization", user_facing = true);
-                let res = json_span.in_scope(|| build_json_response(StatusCode::OK, &result));
+                let res = build_json_response(StatusCode::OK, &result);
 
                 Ok(res)
             }
@@ -203,7 +202,7 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
         }
     };
 
-    work.instrument(span).await
+    work.await
 }
 
 /// Expose the GraphQL playground if enabled.


### PR DESCRIPTION
Reverts prisma/prisma-engines#4339

This works with normal binary engine but breaks tracing with data proxy (i.e. `mini-proxy` and Accelerate) because these changes are not compatible with `TracingConfig::Captured` and sending traces as part of the response.

With the widened scope of the `prisma:engine` span, it is not closed by the time the traces are captured to be added to the response. In addition, it is fundamentally impossible to send the added `prisma:engine:response_json_serialization` with captured traces as it will pose a chicken and egg problem: the information about the time it took to prepare the JSON response would need to be a part of the same response.

While it is possible to add some conditional logic to keep the new (consistent with the Node-API) behaviour for the normal binary engine (without data proxy / accelerate) with traces in stdout but revert to the old behaviour when captured traces in HTTP response are enabled, for now it is easier to just revert the commit. We don't use binary engine except to power Accelerate nowadays much anyway.