### PR TITLE
fix prisma/prisma#23902

### DIFF
--- a/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -230,7 +230,7 @@ fn handle_one_to_many(
                 let query_result = parent_result.as_query_result().unwrap();
 
                 if let QueryResult::Count(c) = query_result {
-                    if c != &expected_id_count {
+                    if c < &expected_id_count {
                         return Err(QueryGraphBuilderError::RecordNotFound(format!(
                             "Expected {expected_id_count} records to be connected after connect operation on one-to-many relation '{relation_name}', found {c}.",
                         )));


### PR DESCRIPTION
Hi all,
this should fix prisma/prisma#23902. As the `rows_written` return field by D1 includes writes to index tables, the number of `rows_written` might be greater than the expected count.

It would of course be better to either
a) get the index fields in this context and calculate the expected number of writes differently for D1 or
b) only apply that fix if the D1 adapter is used.

Unfortunately, I'm not familiar enough with Rust to do either of those.

Thanks for looking into this!