### PR TITLE
chore: upgrade to Docker Compose v2

### DIFF
--- a/.github/workflows/test-quaint.yml
+++ b/.github/workflows/test-quaint.yml
@@ -38,7 +38,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.features }}
 
       - name: Start Databases
-        run: docker-compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d
         working-directory: ./quaint
 
       - name: Sleep for 20s

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -18,7 +18,7 @@ pub(crate) struct DbUnderTest {
 const MISSING_TEST_DATABASE_URL_MSG: &str = r#"
 Missing TEST_DATABASE_URL from environment.
 
-If you are developing with the docker-compose based setup, you can find the environment variables under .test_database_urls at the project root.
+If you are developing with the docker compose based setup, you can find the environment variables under .test_database_urls at the project root.
 
 Example usage:
 

--- a/quaint/.github/workflows/test.yml
+++ b/quaint/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.features }}
 
       - name: Start Databases
-        run: docker-compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d
 
       - name: Sleep for 20s
         uses: juliangruber/sleep-action@v2

--- a/query-engine/connector-test-kit-rs/README.md
+++ b/query-engine/connector-test-kit-rs/README.md
@@ -354,7 +354,7 @@ Let's say you already have connector tests for MongoDB but right now it runs onl
 2. Create a connector file in the `query-engine/connector-test-kit-rs/test-configs/` with the connector data (see other examples in that director), name it with something that makes sense, for example `mongo5`
 3. Add the credentials to access the _data store service_ from the docker compose file, this is done creating the required file in `.test_database_urls`, for example `.test_database_urls/mongo5`
 4. Make sure this image is available to build and prepare the environment in the `Makefile`, in the query engine we depend in two Make targets, `dev-` and `start-`
-   - The `start-` target (for example `start-mongo5`) will execute the _data store service_ in docker compose, for example `docker-compose -f docker-compose.yml up -d --remove-orphans mongo5`
+   - The `start-` target (for example `start-mongo5`) will execute the _data store service_ in docker compose, for example `docker compose -f docker-compose.yml up -d --remove-orphans mongo5`
    - The `dev-` target (for example `dev-mongo5`) will depend on the `start-` target and copy the correct _connector file_, for example `cp $(CONFIG_PATH)/mongodb5 $(CONFIG_FILE)`
 5. Add the new test data store source to the `query-engine/connector-test-kit-rs/query-test-setup/src/connector_tag` file, if it is a completely new data store create the required file, in our case we need to modify `mongodb.rs`
    - Add the new version to the version enum (ex. `MongoDbVersion`)

--- a/schema-engine/sql-introspection-tests/tests/simple.rs
+++ b/schema-engine/sql-introspection-tests/tests/simple.rs
@@ -73,7 +73,7 @@ fn run_simple_test(test_file_path: &str, test_function_name: &'static str) {
     let mut database_url = std::env::var("TEST_DATABASE_URL").expect(r#"
 Missing TEST_DATABASE_URL from environment.
 
-If you are developing with the docker-compose based setup, you can find the environment variables under .test_database_urls at the project root.
+If you are developing with the docker compose based setup, you can find the environment variables under .test_database_urls at the project root.
 
 Example usage:
 


### PR DESCRIPTION
See https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/