### PR TITLE
fix(se): Empty dbgenerated() breaking for Unsupported() types

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -414,16 +414,10 @@ fn push_column_for_model_unsupported_scalar_field(
     table_id: sql::TableId,
     ctx: &mut Context<'_>,
 ) {
-    let default = field.default_value().and_then(|def| {
+    let default = field.default_value().map(|def| {
         // This is validated as @default(dbgenerated("...")), we can unwrap.
-        let dbgenerated_contents = unwrap_dbgenerated(def.value());
-        if let Some(value) = dbgenerated_contents {
-            let default =
-                sql::DefaultValue::db_generated(value).with_constraint_name(ctx.flavour.default_constraint_name(def));
-            Some(default)
-        } else {
-            None
-        }
+        sql::DefaultValue::db_generated::<String>(unwrap_dbgenerated(def.value()))
+            .with_constraint_name(ctx.flavour.default_constraint_name(def))
     });
 
     if let Some(default) = default {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_unsupported_dbgenerated.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_unsupported_dbgenerated.prisma
@@ -7,15 +7,15 @@ datasource testds {
 }
 
 model table {
-    id            String @id
-    hereBeDragons String @default(dbgenerated())
+    id            String                   @id
+    hereBeDragons Unsupported("tsvector")? @default(dbgenerated())
 }
 
 // Expected Migration:
 // -- CreateTable
 // CREATE TABLE "table" (
 //     "id" TEXT NOT NULL,
-//     "hereBeDragons" TEXT NOT NULL,
+//     "hereBeDragons" tsvector,
 // 
 //     CONSTRAINT "table_pkey" PRIMARY KEY ("id")
 // );

--- a/schema-engine/sql-schema-describer/src/lib.rs
+++ b/schema-engine/sql-schema-describer/src/lib.rs
@@ -825,8 +825,8 @@ pub enum DefaultKind {
 }
 
 impl DefaultValue {
-    pub fn db_generated(val: impl Into<String>) -> Self {
-        Self::new(DefaultKind::DbGenerated(Some(val.into())))
+    pub fn db_generated<S: Into<String>>(val: impl Into<Option<S>>) -> Self {
+        Self::new(DefaultKind::DbGenerated(val.into().map(Into::into)))
     }
 
     pub fn constraint_name(&self) -> Option<&str> {


### PR DESCRIPTION
fixes [#15654](https://github.com/prisma/prisma/issues/15654)