### PR TITLE
ci(test-schema-engine): use MySQL-LTS scoop version

### DIFF
--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -206,9 +206,9 @@ jobs:
       fail-fast: false
       matrix:
         db:
-          - name: "mysql@8.3.0"
+          - name: "mysql-lts"
             url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"
-          - name: "mariadb@11.3.2"
+          - name: "mariadb"
             url: "mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60"
         rust:
           - stable


### PR DESCRIPTION
Follows https://github.com/prisma/prisma-engines/pull/4845

It turns out we were not testing against the LTS version in that test.