### PR TITLE
prisma-fmt: Add file name into lint errors

### DIFF
--- a/prisma-fmt/src/lint.rs
+++ b/prisma-fmt/src/lint.rs
@@ -4,6 +4,7 @@ use crate::schema_file_input::SchemaFileInput;
 
 #[derive(serde::Serialize)]
 pub struct MiniError {
+    file_name: String,
     start: usize,
     end: usize,
     text: String,
@@ -21,6 +22,7 @@ pub(crate) fn run(schema: SchemaFileInput) -> String {
         .errors()
         .iter()
         .map(|err: &DatamodelError| MiniError {
+            file_name: schema.db.file_name(err.span().file_id).to_owned(),
             start: err.span().start,
             end: err.span().end,
             text: err.message().to_string(),
@@ -32,6 +34,7 @@ pub(crate) fn run(schema: SchemaFileInput) -> String {
         .warnings()
         .iter()
         .map(|warn: &DatamodelWarning| MiniError {
+            file_name: schema.db.file_name(warn.span().file_id).to_owned(),
             start: warn.span().start,
             end: warn.span().end,
             text: warn.message().to_owned(),
@@ -83,6 +86,7 @@ mod tests {
         let expected = expect![[r#"
             [
               {
+                "file_name": "schema.prisma",
                 "start": 149,
                 "end": 163,
                 "text": "Preview feature \"createMany\" is deprecated. The functionality can be used without specifying it as a preview feature.",
@@ -121,6 +125,7 @@ mod tests {
         let expected = expect![[r#"
             [
               {
+                "file_name": "schema1.prisma",
                 "start": 149,
                 "end": 163,
                 "text": "Preview feature \"createMany\" is deprecated. The functionality can be used without specifying it as a preview feature.",


### PR DESCRIPTION
Needed for `language-tools` multiple schemas
