### PR TITLE
Support multiple files in text-document completions and code actions

### DIFF
--- a/prisma-fmt/src/code_actions/mongodb.rs
+++ b/prisma-fmt/src/code_actions/mongodb.rs
@@ -25,18 +25,14 @@ pub(super) fn add_at_map_for_id(
     let file_id = model.ast_model().span().file_id;
     let file_uri = model.db.file_name(file_id);
     let file_content = model.db.source(file_id);
-    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
-        Some(sd) => sd,
-        None => return,
-    };
-
-    let diagnostics = match super::filter_diagnostics(
-        span_diagnostics,
+    let diagnostics = context.diagnostics_for_span_with_message(
+        model.ast_model().span(),
         r#"MongoDB model IDs must have an @map("_id") annotation."#,
-    ) {
-        Some(value) => value,
-        None => return,
-    };
+    );
+
+    if diagnostics.is_empty() {
+        return;
+    }
 
     let formatted_attribute = super::format_field_attribute(r#"@map("_id")"#);
 
@@ -85,18 +81,14 @@ pub(super) fn add_native_for_auto_id(
     let file_uri = model.db.file_name(file_id);
     let file_content = model.db.source(file_id);
 
-    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
-        Some(sd) => sd,
-        None => return,
-    };
-
-    let diagnostics = match super::filter_diagnostics(
-        span_diagnostics,
+    let diagnostics = context.diagnostics_for_span_with_message(
+        model.ast_model().span(),
         r#"MongoDB `@default(auto())` fields must have `ObjectId` native type."#,
-    ) {
-        Some(value) => value,
-        None => return,
-    };
+    );
+
+    if diagnostics.is_empty() {
+        return;
+    }
 
     let formatted_attribute = super::format_field_attribute(format!("@{}.ObjectId", source.name).as_str());
 

--- a/prisma-fmt/src/code_actions/mongodb.rs
+++ b/prisma-fmt/src/code_actions/mongodb.rs
@@ -1,10 +1,11 @@
 use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand};
 use psl::{parser_database::walkers::ModelWalker, schema_ast::ast::WithSpan, Datasource};
 
+use super::CodeActionsContext;
+
 pub(super) fn add_at_map_for_id(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &lsp_types::CodeActionParams,
-    schema: &str,
+    context: &CodeActionsContext<'_>,
     model: ModelWalker<'_>,
 ) {
     let pk = match model.primary_key() {
@@ -21,11 +22,13 @@ pub(super) fn add_at_map_for_id(
         None => return,
     };
 
-    let span_diagnostics =
-        match super::diagnostics_for_span(schema, &params.context.diagnostics, model.ast_model().span()) {
-            Some(sd) => sd,
-            None => return,
-        };
+    let file_id = model.ast_model().span().file_id;
+    let file_uri = model.db.file_name(file_id);
+    let file_content = model.db.source(file_id);
+    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
+        Some(sd) => sd,
+        None => return,
+    };
 
     let diagnostics = match super::filter_diagnostics(
         span_diagnostics,
@@ -37,7 +40,15 @@ pub(super) fn add_at_map_for_id(
 
     let formatted_attribute = super::format_field_attribute(r#"@map("_id")"#);
 
-    let edit = super::create_text_edit(schema, formatted_attribute, true, field.ast_field().span(), params);
+    let Ok(edit) = super::create_text_edit(
+        file_uri,
+        file_content,
+        formatted_attribute,
+        true,
+        field.ast_field().span(),
+    ) else {
+        return;
+    };
 
     let action = CodeAction {
         title: r#"Add @map("_id")"#.to_owned(),
@@ -52,8 +63,7 @@ pub(super) fn add_at_map_for_id(
 
 pub(super) fn add_native_for_auto_id(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &lsp_types::CodeActionParams,
-    schema: &str,
+    context: &CodeActionsContext<'_>,
     model: ModelWalker<'_>,
     source: &Datasource,
 ) {
@@ -71,11 +81,14 @@ pub(super) fn add_native_for_auto_id(
         None => return,
     };
 
-    let span_diagnostics =
-        match super::diagnostics_for_span(schema, &params.context.diagnostics, model.ast_model().span()) {
-            Some(sd) => sd,
-            None => return,
-        };
+    let file_id = model.ast_model().span().file_id;
+    let file_uri = model.db.file_name(file_id);
+    let file_content = model.db.source(file_id);
+
+    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
+        Some(sd) => sd,
+        None => return,
+    };
 
     let diagnostics = match super::filter_diagnostics(
         span_diagnostics,
@@ -87,7 +100,15 @@ pub(super) fn add_native_for_auto_id(
 
     let formatted_attribute = super::format_field_attribute(format!("@{}.ObjectId", source.name).as_str());
 
-    let edit = super::create_text_edit(schema, formatted_attribute, true, field.ast_field().span(), params);
+    let Ok(edit) = super::create_text_edit(
+        file_uri,
+        file_content,
+        formatted_attribute,
+        true,
+        field.ast_field().span(),
+    ) else {
+        return;
+    };
 
     let action = CodeAction {
         title: r#"Add @db.ObjectId"#.to_owned(),

--- a/prisma-fmt/src/code_actions/multi_schema.rs
+++ b/prisma-fmt/src/code_actions/multi_schema.rs
@@ -29,16 +29,14 @@ pub(super) fn add_schema_block_attribute_model(
     let file_uri = model.db.file_name(file_id);
     let file_content = model.db.source(file_id);
 
-    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
-        Some(sd) => sd,
-        None => return,
-    };
+    let diagnostics = context.diagnostics_for_span_with_message(
+        model.ast_model().span(),
+        "This model is missing an `@@schema` attribute.",
+    );
 
-    let diagnostics =
-        match super::filter_diagnostics(span_diagnostics, "This model is missing an `@@schema` attribute.") {
-            Some(value) => value,
-            None => return,
-        };
+    if diagnostics.is_empty() {
+        return;
+    }
 
     let formatted_attribute = super::format_block_attribute(
         "schema()",
@@ -90,16 +88,14 @@ pub(super) fn add_schema_block_attribute_enum(
     let file_uri = enumerator.db.file_name(file_id);
     let file_content = enumerator.db.source(file_id);
 
-    let span_diagnostics = match context.diagnostics_for_span(enumerator.ast_enum().span()) {
-        Some(sd) => sd,
-        None => return,
-    };
+    let diagnostics = context.diagnostics_for_span_with_message(
+        enumerator.ast_enum().span(),
+        "This enum is missing an `@@schema` attribute.",
+    );
 
-    let diagnostics = match super::filter_diagnostics(span_diagnostics, "This enum is missing an `@@schema` attribute.")
-    {
-        Some(value) => value,
-        None => return,
-    };
+    if diagnostics.is_empty() {
+        return;
+    }
 
     let formatted_attribute = super::format_block_attribute(
         "schema()",
@@ -139,16 +135,14 @@ pub(super) fn add_schema_to_schemas(
         None => return,
     };
 
-    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
-        Some(sd) => sd,
-        None => return,
-    };
+    let diagnostics = context.diagnostics_for_span_with_message(
+        model.ast_model().span(),
+        "This schema is not defined in the datasource.",
+    );
 
-    let diagnostics = match super::filter_diagnostics(span_diagnostics, "This schema is not defined in the datasource.")
-    {
-        Some(value) => value,
-        None => return,
-    };
+    if diagnostics.is_empty() {
+        return;
+    }
 
     let datasource_file_id = datasource.span.file_id;
     let datasource_file_uri = context.db.file_name(datasource_file_id);

--- a/prisma-fmt/src/code_actions/multi_schema.rs
+++ b/prisma-fmt/src/code_actions/multi_schema.rs
@@ -1,19 +1,18 @@
-use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams};
+use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand};
 use psl::{
     diagnostics::Span,
     parser_database::walkers::{EnumWalker, ModelWalker},
     schema_ast::ast::WithSpan,
-    Configuration,
 };
+
+use super::CodeActionsContext;
 
 pub(super) fn add_schema_block_attribute_model(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &CodeActionParams,
-    schema: &str,
-    config: &Configuration,
+    context: &CodeActionsContext<'_>,
     model: ModelWalker<'_>,
 ) {
-    let datasource = match config.datasources.first() {
+    let datasource = match context.datasource() {
         Some(ds) => ds,
         None => return,
     };
@@ -26,11 +25,14 @@ pub(super) fn add_schema_block_attribute_model(
         return;
     }
 
-    let span_diagnostics =
-        match super::diagnostics_for_span(schema, &params.context.diagnostics, model.ast_model().span()) {
-            Some(sd) => sd,
-            None => return,
-        };
+    let file_id = model.ast_model().span().file_id;
+    let file_uri = model.db.file_name(file_id);
+    let file_content = model.db.source(file_id);
+
+    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
+        Some(sd) => sd,
+        None => return,
+    };
 
     let diagnostics =
         match super::filter_diagnostics(span_diagnostics, "This model is missing an `@@schema` attribute.") {
@@ -45,7 +47,15 @@ pub(super) fn add_schema_block_attribute_model(
         &model.ast_model().attributes,
     );
 
-    let edit = super::create_text_edit(schema, formatted_attribute, true, model.ast_model().span(), params);
+    let Ok(edit) = super::create_text_edit(
+        file_uri,
+        file_content,
+        formatted_attribute,
+        true,
+        model.ast_model().span(),
+    ) else {
+        return;
+    };
 
     let action = CodeAction {
         title: String::from("Add `@@schema` attribute"),
@@ -60,12 +70,10 @@ pub(super) fn add_schema_block_attribute_model(
 
 pub(super) fn add_schema_block_attribute_enum(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &CodeActionParams,
-    schema: &str,
-    config: &Configuration,
+    context: &CodeActionsContext<'_>,
     enumerator: EnumWalker<'_>,
 ) {
-    let datasource = match config.datasources.first() {
+    let datasource = match context.datasource() {
         Some(ds) => ds,
         None => return,
     };
@@ -78,11 +86,14 @@ pub(super) fn add_schema_block_attribute_enum(
         return;
     }
 
-    let span_diagnostics =
-        match super::diagnostics_for_span(schema, &params.context.diagnostics, enumerator.ast_enum().span()) {
-            Some(sd) => sd,
-            None => return,
-        };
+    let file_id = enumerator.ast_enum().span().file_id;
+    let file_uri = enumerator.db.file_name(file_id);
+    let file_content = enumerator.db.source(file_id);
+
+    let span_diagnostics = match context.diagnostics_for_span(enumerator.ast_enum().span()) {
+        Some(sd) => sd,
+        None => return,
+    };
 
     let diagnostics = match super::filter_diagnostics(span_diagnostics, "This enum is missing an `@@schema` attribute.")
     {
@@ -97,7 +108,15 @@ pub(super) fn add_schema_block_attribute_enum(
         &enumerator.ast_enum().attributes,
     );
 
-    let edit = super::create_text_edit(schema, formatted_attribute, true, enumerator.ast_enum().span(), params);
+    let Ok(edit) = super::create_text_edit(
+        file_uri,
+        file_content,
+        formatted_attribute,
+        true,
+        enumerator.ast_enum().span(),
+    ) else {
+        return;
+    };
 
     let action = CodeAction {
         title: String::from("Add `@@schema` attribute"),
@@ -112,21 +131,18 @@ pub(super) fn add_schema_block_attribute_enum(
 
 pub(super) fn add_schema_to_schemas(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &CodeActionParams,
-    schema: &str,
-    config: &Configuration,
+    context: &CodeActionsContext<'_>,
     model: ModelWalker<'_>,
 ) {
-    let datasource = match config.datasources.first() {
+    let datasource = match context.datasource() {
         Some(ds) => ds,
         None => return,
     };
 
-    let span_diagnostics =
-        match super::diagnostics_for_span(schema, &params.context.diagnostics, model.ast_model().span()) {
-            Some(sd) => sd,
-            None => return,
-        };
+    let span_diagnostics = match context.diagnostics_for_span(model.ast_model().span()) {
+        Some(sd) => sd,
+        None => return,
+    };
 
     let diagnostics = match super::filter_diagnostics(span_diagnostics, "This schema is not defined in the datasource.")
     {
@@ -134,16 +150,20 @@ pub(super) fn add_schema_to_schemas(
         None => return,
     };
 
+    let datasource_file_id = datasource.span.file_id;
+    let datasource_file_uri = context.db.file_name(datasource_file_id);
+    let datasource_content = context.db.source(datasource_file_id);
+
     let edit = match datasource.schemas_span {
         Some(span) => {
             let formatted_attribute = format!(r#"", "{}""#, model.schema_name().unwrap());
             super::create_text_edit(
-                schema,
+                datasource_file_uri,
+                datasource_content,
                 formatted_attribute,
                 true,
                 // todo: update spans so that we can just append to the end of the _inside_ of the array. Instead of needing to re-append the `]` or taking the span end -1
                 Span::new(span.start, span.end - 1, psl::parser_database::FileId::ZERO),
-                params,
             )
         }
         None => {
@@ -161,8 +181,18 @@ pub(super) fn add_schema_to_schemas(
                 has_properties,
             );
 
-            super::create_text_edit(schema, formatted_attribute, true, datasource.url_span, params)
+            super::create_text_edit(
+                datasource_file_uri,
+                datasource_content,
+                formatted_attribute,
+                true,
+                datasource.url_span,
+            )
         }
+    };
+
+    let Ok(edit) = edit else {
+        return;
     };
 
     let action = CodeAction {

--- a/prisma-fmt/src/code_actions/relation_mode.rs
+++ b/prisma-fmt/src/code_actions/relation_mode.rs
@@ -1,13 +1,11 @@
 use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand};
-use psl::{
-    diagnostics::FileId, parser_database::walkers::CompleteInlineRelationWalker, schema_ast::ast::SourceConfig,
-    Configuration,
-};
+use psl::{parser_database::walkers::CompleteInlineRelationWalker, schema_ast::ast::SourceConfig};
+
+use super::CodeActionsContext;
 
 pub(crate) fn edit_referential_integrity(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &lsp_types::CodeActionParams,
-    schema: &str,
+    context: &CodeActionsContext<'_>,
     source: &SourceConfig,
 ) {
     let prop = match source.properties.iter().find(|p| p.name.name == "referentialIntegrity") {
@@ -15,7 +13,7 @@ pub(crate) fn edit_referential_integrity(
         None => return,
     };
 
-    let span_diagnostics = match super::diagnostics_for_span(schema, &params.context.diagnostics, source.span) {
+    let span_diagnostics = match context.diagnostics_for_span(source.span) {
         Some(sd) => sd,
         None => return,
     };
@@ -26,7 +24,15 @@ pub(crate) fn edit_referential_integrity(
             None => return,
         };
 
-    let edit = super::create_text_edit(schema, "relationMode".to_owned(), false, prop.name.span, params);
+    let Ok(edit) = super::create_text_edit(
+        context.initiating_file_uri(),
+        context.initiating_file_source(),
+        "relationMode".to_owned(),
+        false,
+        prop.name.span,
+    ) else {
+        return;
+    };
 
     let action = CodeAction {
         title: String::from("Rename property to relationMode"),
@@ -41,13 +47,10 @@ pub(crate) fn edit_referential_integrity(
 
 pub(crate) fn replace_set_default_mysql(
     actions: &mut Vec<CodeActionOrCommand>,
-    params: &lsp_types::CodeActionParams,
-    file_id: FileId,
-    schema: &str,
+    context: &CodeActionsContext<'_>,
     relation: CompleteInlineRelationWalker<'_>,
-    config: &Configuration,
 ) {
-    let datasource = match config.datasources.first() {
+    let datasource = match context.datasource() {
         Some(ds) => ds,
         None => return,
     };
@@ -61,11 +64,14 @@ pub(crate) fn replace_set_default_mysql(
         None => return,
     };
 
-    if span.file_id != file_id {
+    if span.file_id != context.initiating_file_id {
         return;
     }
 
-    let span_diagnostics = match super::diagnostics_for_span(schema, &params.context.diagnostics, span) {
+    let file_name = context.initiating_file_uri();
+    let file_content = context.initiating_file_source();
+
+    let span_diagnostics = match context.diagnostics_for_span(span) {
         Some(sd) => sd,
         None => return,
     };
@@ -78,7 +84,9 @@ pub(crate) fn replace_set_default_mysql(
             None => return,
         };
 
-    let edit = super::create_text_edit(schema, "NoAction".to_owned(), false, span, params);
+    let Ok(edit) = super::create_text_edit(file_name, file_content, "NoAction".to_owned(), false, span) else {
+        return;
+    };
 
     let action = CodeAction {
         title: r#"Replace SetDefault with NoAction"#.to_owned(),

--- a/prisma-fmt/src/code_actions/relation_mode.rs
+++ b/prisma-fmt/src/code_actions/relation_mode.rs
@@ -13,16 +13,8 @@ pub(crate) fn edit_referential_integrity(
         None => return,
     };
 
-    let span_diagnostics = match context.diagnostics_for_span(source.span) {
-        Some(sd) => sd,
-        None => return,
-    };
-
     let diagnostics =
-        match super::filter_diagnostics(span_diagnostics, "The `referentialIntegrity` attribute is deprecated.") {
-            Some(value) => value,
-            None => return,
-        };
+        context.diagnostics_for_span_with_message(source.span, "The `referentialIntegrity` attribute is deprecated.");
 
     let Ok(edit) = super::create_text_edit(
         context.initiating_file_uri(),
@@ -71,18 +63,15 @@ pub(crate) fn replace_set_default_mysql(
     let file_name = context.initiating_file_uri();
     let file_content = context.initiating_file_source();
 
-    let span_diagnostics = match context.diagnostics_for_span(span) {
-        Some(sd) => sd,
-        None => return,
-    };
+    let diagnostics =
+        context.diagnostics_for_span_with_message(
+            span,
+            "MySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors."
+        );
 
-    let diagnostics = match
-        super::filter_diagnostics(
-            span_diagnostics,
-            "MySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors.") {
-            Some(value) => value,
-            None => return,
-        };
+    if diagnostics.is_empty() {
+        return;
+    }
 
     let Ok(edit) = super::create_text_edit(file_name, file_content, "NoAction".to_owned(), false, span) else {
         return;

--- a/prisma-fmt/src/code_actions/relation_mode.rs
+++ b/prisma-fmt/src/code_actions/relation_mode.rs
@@ -1,5 +1,8 @@
 use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand};
-use psl::{parser_database::walkers::CompleteInlineRelationWalker, schema_ast::ast::SourceConfig, Configuration};
+use psl::{
+    diagnostics::FileId, parser_database::walkers::CompleteInlineRelationWalker, schema_ast::ast::SourceConfig,
+    Configuration,
+};
 
 pub(crate) fn edit_referential_integrity(
     actions: &mut Vec<CodeActionOrCommand>,
@@ -39,6 +42,7 @@ pub(crate) fn edit_referential_integrity(
 pub(crate) fn replace_set_default_mysql(
     actions: &mut Vec<CodeActionOrCommand>,
     params: &lsp_types::CodeActionParams,
+    file_id: FileId,
     schema: &str,
     relation: CompleteInlineRelationWalker<'_>,
     config: &Configuration,
@@ -56,6 +60,10 @@ pub(crate) fn replace_set_default_mysql(
         Some(span) => span,
         None => return,
     };
+
+    if span.file_id != file_id {
+        return;
+    }
 
     let span_diagnostics = match super::diagnostics_for_span(schema, &params.context.diagnostics, span) {
         Some(sd) => sd,

--- a/prisma-fmt/src/code_actions/relations.rs
+++ b/prisma-fmt/src/code_actions/relations.rs
@@ -1,4 +1,4 @@
-use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand, TextEdit, Url, WorkspaceEdit};
+use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand, TextEdit, WorkspaceEdit};
 use psl::parser_database::{
     ast::WithSpan,
     walkers::{CompleteInlineRelationWalker, RelationFieldWalker},

--- a/prisma-fmt/src/code_actions/relations.rs
+++ b/prisma-fmt/src/code_actions/relations.rs
@@ -5,7 +5,7 @@ use psl::parser_database::{
 };
 use std::collections::HashMap;
 
-use super::{format_block_attribute, CodeActionsContext};
+use super::{format_block_attribute, parse_url, CodeActionsContext};
 
 /// If the referencing side of the one-to-one relation does not point
 /// to a unique constraint, the action adds the attribute.
@@ -166,8 +166,10 @@ pub(super) fn add_referenced_side_unique(
     );
 
     let mut changes = HashMap::new();
-    // TODO: don't unwrap
-    changes.insert(Url::parse(file_uri).unwrap(), vec![text]);
+    let Ok(url) = parse_url(file_uri) else {
+        return;
+    };
+    changes.insert(url, vec![text]);
 
     let edit = WorkspaceEdit {
         changes: Some(changes),

--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -43,8 +43,8 @@ pub(crate) fn get_config(params: &str) -> Result<String, String> {
 }
 
 fn get_config_impl(params: GetConfigParams) -> Result<serde_json::Value, GetConfigError> {
-    let (files, mut config) =
-        psl::parse_configuration_multi_file(params.prisma_schema.into()).map_err(create_get_config_error)?;
+    let prisma_schema: Vec<_> = params.prisma_schema.into();
+    let (files, mut config) = psl::parse_configuration_multi_file(&prisma_schema).map_err(create_get_config_error)?;
 
     if !params.ignore_env_var_errors {
         let overrides: Vec<(_, _)> = params.datasource_overrides.into_iter().collect();

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -12,14 +12,14 @@ mod validate;
 
 use log::*;
 use lsp_types::{Position, Range};
-use psl::parser_database::ast;
+use psl::{diagnostics::FileId, parser_database::ast};
 use schema_file_input::SchemaFileInput;
 
 /// The API is modelled on an LSP [completion
 /// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_completion).
 /// Input and output are both JSON, the request being a `CompletionParams` object and the response
 /// being a `CompletionList` object.
-pub fn text_document_completion(schema_files: String, initiating_file_name: String, params: &str) -> String {
+pub fn text_document_completion(schema_files: String, initiating_file_name: &str, params: &str) -> String {
     let params = if let Ok(params) = serde_json::from_str::<lsp_types::CompletionParams>(params) {
         params
     } else {
@@ -38,7 +38,7 @@ pub fn text_document_completion(schema_files: String, initiating_file_name: Stri
 }
 
 /// This API is modelled on an LSP [code action request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_codeAction=). Input and output are both JSON, the request being a `CodeActionParams` object and the response being a list of `CodeActionOrCommand` objects.
-pub fn code_actions(schema_files: String, initiating_file_name: String, params: &str) -> String {
+pub fn code_actions(schema_files: String, initiating_file_name: &str, params: &str) -> String {
     let params = if let Ok(params) = serde_json::from_str::<lsp_types::CodeActionParams>(params) {
         params
     } else {
@@ -264,11 +264,11 @@ pub(crate) fn position_to_offset(position: &Position, document: &str) -> Option<
 
 #[track_caller]
 /// Converts an LSP range to a span.
-pub(crate) fn range_to_span(range: Range, document: &str) -> ast::Span {
+pub(crate) fn range_to_span(range: Range, document: &str, file_id: FileId) -> ast::Span {
     let start = position_to_offset(&range.start, document).unwrap();
     let end = position_to_offset(&range.end, document).unwrap();
 
-    ast::Span::new(start, end, psl::parser_database::FileId::ZERO)
+    ast::Span::new(start, end, file_id)
 }
 
 /// Gives the LSP position right after the given span.

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -19,7 +19,7 @@ use schema_file_input::SchemaFileInput;
 /// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_completion).
 /// Input and output are both JSON, the request being a `CompletionParams` object and the response
 /// being a `CompletionList` object.
-pub fn text_document_completion(schema_files: String, initiating_file_name: &str, params: &str) -> String {
+pub fn text_document_completion(schema_files: String, params: &str) -> String {
     let params = if let Ok(params) = serde_json::from_str::<lsp_types::CompletionParams>(params) {
         params
     } else {
@@ -32,13 +32,13 @@ pub fn text_document_completion(schema_files: String, initiating_file_name: &str
         return serde_json::to_string(&text_document_completion::empty_completion_list()).unwrap();
     };
 
-    let completion_list = text_document_completion::completion(input.into(), &initiating_file_name, params);
+    let completion_list = text_document_completion::completion(input.into(), params);
 
     serde_json::to_string(&completion_list).unwrap()
 }
 
 /// This API is modelled on an LSP [code action request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_codeAction=). Input and output are both JSON, the request being a `CodeActionParams` object and the response being a list of `CodeActionOrCommand` objects.
-pub fn code_actions(schema_files: String, initiating_file_name: &str, params: &str) -> String {
+pub fn code_actions(schema_files: String, params: &str) -> String {
     let params = if let Ok(params) = serde_json::from_str::<lsp_types::CodeActionParams>(params) {
         params
     } else {
@@ -51,7 +51,7 @@ pub fn code_actions(schema_files: String, initiating_file_name: &str, params: &s
         return serde_json::to_string(&text_document_completion::empty_completion_list()).unwrap();
     };
 
-    let actions = code_actions::available_actions(input.into(), &initiating_file_name, params);
+    let actions = code_actions::available_actions(input.into(), params);
     serde_json::to_string(&actions).unwrap()
 }
 

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -20,11 +20,7 @@ pub(crate) fn empty_completion_list() -> CompletionList {
     }
 }
 
-pub(crate) fn completion(
-    schema_files: Vec<(String, SourceFile)>,
-    initiating_file_name: &str,
-    params: CompletionParams,
-) -> CompletionList {
+pub(crate) fn completion(schema_files: Vec<(String, SourceFile)>, params: CompletionParams) -> CompletionList {
     let config = parse_configuration_multi_file(&schema_files)
         .ok()
         .map(|(_, config)| config);
@@ -39,7 +35,7 @@ pub(crate) fn completion(
         ParserDatabase::new(&schema_files, &mut diag)
     };
 
-    let Some(initiating_file_id) = db.file_id(initiating_file_name) else {
+    let Some(initiating_file_id) = db.file_id(params.text_document_position.text_document.uri.as_str()) else {
         warn!("Initiating file name is not found in the schema");
         return empty_completion_list();
     };

--- a/prisma-fmt/src/text_document_completion/datasource.rs
+++ b/prisma-fmt/src/text_document_completion/datasource.rs
@@ -144,7 +144,7 @@ pub(super) fn url_env_db_completion(completion_list: &mut CompletionList, kind: 
         _ => unreachable!(),
     };
 
-    let insert_text = if add_quotes(ctx.params, ctx.db.source_assert_single()) {
+    let insert_text = if add_quotes(ctx.params, ctx.db.source(ctx.initiating_file_id)) {
         format!(r#""{text}""#)
     } else {
         text.to_owned()

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/_target.prisma
@@ -1,0 +1,3 @@
+model Kattbjorn {
+    id String @id
+}

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/config.prisma
@@ -1,0 +1,8 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "mongodb"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/config.prisma
@@ -1,5 +1,6 @@
 generator client {
-    provider = "prisma-client-js"
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder"]
 }
 
 datasource db {

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Add @map(\"_id\")",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 1,
+            "character": 4
+          },
+          "end": {
+            "line": 2,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error validating field `id` in model `Kattbjorn`: MongoDB model IDs must have an @map(\"_id\") annotation."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 1,
+                "character": 17
+              },
+              "end": {
+                "line": 2,
+                "character": 0
+              }
+            },
+            "newText": " @map(\"_id\")\n"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/_target.prisma
@@ -1,0 +1,5 @@
+model A {
+    id Int @id
+
+    @@schema("base")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/datasource.prisma
@@ -1,0 +1,6 @@
+datasource db {
+    provider     = "postgresql"
+    url          = env("DATABASE_URL")
+    schemas      = ["a", "b"]
+    relationMode = "prisma"
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/generator.prisma
@@ -1,4 +1,4 @@
 generator client {
     provider        = "prisma-client-js"
-    previewFeatures = ["multiSchema"]
+    previewFeatures = ["multiSchema", "prismaSchemaFolder"]
 }

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/generator.prisma
@@ -1,0 +1,4 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Add schema to schemas",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 13
+          },
+          "end": {
+            "line": 3,
+            "character": 19
+          }
+        },
+        "severity": 1,
+        "message": "This schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema"
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/datasource.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 3,
+                "character": 27
+              },
+              "end": {
+                "line": 3,
+                "character": 28
+              }
+            },
+            "newText": "\", \"base\""
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/_target.prisma
@@ -1,0 +1,3 @@
+model User {
+    id Int @id
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/datasource.prisma
@@ -1,0 +1,5 @@
+datasource db {
+    provider = "postgresql"
+    url      = env("TEST_DATABASE_URL")
+    schemas  = ["one", "two"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/generator.prisma
@@ -1,4 +1,4 @@
 generator client {
     provider        = "prisma-client-js"
-    previewFeatures = ["multiSchema"]
+    previewFeatures = ["multiSchema", "prismaSchemaFolder"]
 }

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/generator.prisma
@@ -1,0 +1,4 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Add `@@schema` attribute",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 1
+          }
+        },
+        "severity": 1,
+        "message": "Error validating model \"User\": This model is missing an `@@schema` attribute."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 2,
+                "character": 0
+              },
+              "end": {
+                "line": 2,
+                "character": 1
+              }
+            },
+            "newText": "\n    @@schema()\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/_target.prisma
@@ -1,0 +1,7 @@
+model User {
+    id Int @id
+}
+
+enum Colour {
+    Red
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/config.prisma
@@ -1,0 +1,10 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["multiSchema"]
+}
+
+datasource db {
+    provider = "postgresql"
+    url      = env("TEST_DATABASE_URL")
+    schemas  = ["one", "two"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/config.prisma
@@ -1,6 +1,6 @@
 generator client {
     provider        = "prisma-client-js"
-    previewFeatures = ["multiSchema"]
+    previewFeatures = ["multiSchema", "prismaSchemaFolder"]
 }
 
 datasource db {

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/result.json
@@ -1,0 +1,80 @@
+[
+  {
+    "title": "Add `@@schema` attribute",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 0,
+            "character": 0
+          },
+          "end": {
+            "line": 2,
+            "character": 1
+          }
+        },
+        "severity": 1,
+        "message": "Error validating model \"User\": This model is missing an `@@schema` attribute."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 2,
+                "character": 0
+              },
+              "end": {
+                "line": 2,
+                "character": 1
+              }
+            },
+            "newText": "\n    @@schema()\n}"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Add `@@schema` attribute",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 0
+          },
+          "end": {
+            "line": 6,
+            "character": 1
+          }
+        },
+        "severity": 1,
+        "message": "This enum is missing an `@@schema` attribute."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 6,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 1
+              }
+            },
+            "newText": "\n  @@schema()\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/A.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/A.prisma
@@ -1,0 +1,6 @@
+model A {
+    id     Int @id
+    field1 Int
+    field2 Int
+    B      B[]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/_target.prisma
@@ -1,0 +1,8 @@
+model B {
+  id   Int @id
+  bId1 Int
+  bId2 Int
+  A    A   @relation(fields: [bId1, bId2], references: [field1, field2])
+
+  @@unique([bId1, bId2])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Make referenced field(s) unique",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 2
+          },
+          "end": {
+            "line": 5,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error parsing attribute \"@relation\": The argument `references` must refer to a unique criterion in the related model. Consider adding an `@@unique([field1, field2])` attribute to the model `A`."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/A.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 0
+              },
+              "end": {
+                "line": 5,
+                "character": 1
+              }
+            },
+            "newText": "\n    @@unique([field1, field2])\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/A.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/A.prisma
@@ -1,0 +1,5 @@
+model A {
+    id    Int @id
+    field Int
+    B     B[]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/_target.prisma
@@ -1,0 +1,5 @@
+model B {
+  id  Int @id
+  bId Int
+  A   A   @relation(fields: [bId], references: [field])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Make referenced field(s) unique",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 2
+          },
+          "end": {
+            "line": 4,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error parsing attribute \"@relation\": The argument `references` must refer to a unique criterion in the related model. Consider adding an `@unique` attribute to the field `field` in the model `A`."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/A.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 2,
+                "character": 13
+              },
+              "end": {
+                "line": 2,
+                "character": 13
+              }
+            },
+            "newText": " @unique"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/A.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/A.prisma
@@ -1,0 +1,6 @@
+model A {
+  id     Int @id
+  field1 Int
+  field2 Int
+  B      B?
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/_target.prisma
@@ -1,0 +1,8 @@
+model B {
+  id   Int @id
+  bId1 Int
+  bId2 Int
+  A    A   @relation(fields: [bId1, bId2], references: [field1, field2])
+
+  @@unique([bId1, bId2])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/generator.prisma
@@ -1,0 +1,4 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Make referenced field(s) unique",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 2
+          },
+          "end": {
+            "line": 5,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error parsing attribute \"@relation\": The argument `references` must refer to a unique criterion in the related model. Consider adding an `@@unique([field1, field2])` attribute to the model `A`."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/A.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 0
+              },
+              "end": {
+                "line": 5,
+                "character": 1
+              }
+            },
+            "newText": "\n  @@unique([field1, field2])\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/A.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/A.prisma
@@ -1,0 +1,5 @@
+model A {
+  id    Int @id
+  field Int
+  B     B?
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/_target.prisma
@@ -1,0 +1,5 @@
+model B {
+  id  Int @id
+  bId Int @unique
+  A   A   @relation(fields: [bId], references: [field])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/generator.prisma
@@ -1,0 +1,4 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Make referenced field(s) unique",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 2
+          },
+          "end": {
+            "line": 4,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error parsing attribute \"@relation\": The argument `references` must refer to a unique criterion in the related model. Consider adding an `@unique` attribute to the field `field` in the model `A`."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/A.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 2,
+                "character": 11
+              },
+              "end": {
+                "line": 2,
+                "character": 11
+              }
+            },
+            "newText": " @unique"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/A.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/A.prisma
@@ -1,0 +1,8 @@
+model A {
+  id     Int @id
+  field1 Int
+  field2 Int
+  B      B?
+
+  @@unique([field1, field2])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/_target.prisma
@@ -1,0 +1,6 @@
+model B {
+  id   Int @id
+  bId1 Int
+  bId2 Int
+  A    A   @relation(fields: [bId1, bId2], references: [field1, field2])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/generator.prisma
@@ -1,0 +1,4 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Make referencing fields unique",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 2
+          },
+          "end": {
+            "line": 5,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error parsing attribute \"@relation\": A one-to-one relation must use unique fields on the defining side. Either add an `@@unique([bId1, bId2])` attribute to the model, or change the relation to one-to-many."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 0
+              },
+              "end": {
+                "line": 5,
+                "character": 1
+              }
+            },
+            "newText": "\n  @@unique([bId1, bId2])\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/A.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/A.prisma
@@ -1,0 +1,5 @@
+model A {
+  id    Int @id
+  field Int @unique
+  B     B?
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/_target.prisma
@@ -1,0 +1,5 @@
+model B {
+  id  Int @id
+  bId Int
+  A   A   @relation(fields: [bId], references: [field])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/generator.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/generator.prisma
@@ -1,0 +1,4 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder"]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Make referencing fields unique",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 2
+          },
+          "end": {
+            "line": 4,
+            "character": 0
+          }
+        },
+        "severity": 1,
+        "message": "Error parsing attribute \"@relation\": A one-to-one relation must use unique fields on the defining side. Either add an `@unique` attribute to the field `bId`, or change the relation to one-to-many."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 2,
+                "character": 9
+              },
+              "end": {
+                "line": 2,
+                "character": 9
+              }
+            },
+            "newText": " @unique"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/Bar.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/Bar.prisma
@@ -1,0 +1,4 @@
+model Bar {
+    id  Int  @id
+    foo Foo?
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/Test.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/Test.prisma
@@ -1,0 +1,5 @@
+// This is a test enum.
+enum Test {
+    TestUno
+    TestDue
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/_target.prisma
@@ -1,0 +1,8 @@
+/// multi line
+/// commennttt
+model Foo {
+    id     Int  @id
+    bar    Bar  @relation(fields: [bar_id], references: [id], onUpdate: SetDefault)
+    bar_id Int  @unique
+    t      Test
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/config.prisma
@@ -1,5 +1,6 @@
 generator client {
-    provider = "prisma-client-js"
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder"]
 }
 
 datasource db {

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/config.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider     = "mysql"
+    url          = env("DATABASE_URL")
+    relationMode = "foreignKeys"
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Replace SetDefault with NoAction",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 4,
+            "character": 62
+          },
+          "end": {
+            "line": 4,
+            "character": 82
+          }
+        },
+        "severity": 2,
+        "message": "MySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default "
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 4,
+                "character": 72
+              },
+              "end": {
+                "line": 4,
+                "character": 82
+              }
+            },
+            "newText": "NoAction"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/SomeUser.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/SomeUser.prisma
@@ -1,0 +1,4 @@
+model SomeUser {
+    id    Int    @id
+    posts Post[]
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/_target.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/_target.prisma
@@ -1,0 +1,5 @@
+model Post {
+    id     Int      @id
+    userId Int
+    user   SomeUser @relation(fields: [userId], references: [id])
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/config.prisma
@@ -1,5 +1,6 @@
 generator client {
-    provider = "prisma-client-js"
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder"]
 }
 
 datasource db {

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/config.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider     = "mysql"
+    url          = env("TEST_DATABASE_URL")
+    relationMode = "prisma"
+}

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Add an index for the relation's field(s)",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 3,
+            "character": 20
+          },
+          "end": {
+            "line": 3,
+            "character": 65
+          }
+        },
+        "severity": 2,
+        "message": "With `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes\" "
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/_target.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 4,
+                "character": 0
+              },
+              "end": {
+                "line": 4,
+                "character": 1
+              }
+            },
+            "newText": "\n    @@index([userId])\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/test_api.rs
+++ b/prisma-fmt/tests/code_actions/test_api.rs
@@ -77,7 +77,12 @@ pub(crate) fn test_scenario(scenario_name: &str) {
         },
     };
 
-    let result = prisma_fmt::code_actions(schema, &serde_json::to_string_pretty(&params).unwrap());
+    let schema_files = serde_json::to_string_pretty(&[("schema.prisma", schema)]).unwrap();
+    let result = prisma_fmt::code_actions(
+        schema_files,
+        "schema.prisma".into(),
+        &serde_json::to_string_pretty(&params).unwrap(),
+    );
     // Prettify the JSON
     let result =
         serde_json::to_string_pretty(&serde_json::from_str::<Vec<lsp_types::CodeActionOrCommand>>(&result).unwrap())

--- a/prisma-fmt/tests/code_actions/test_api.rs
+++ b/prisma-fmt/tests/code_actions/test_api.rs
@@ -113,7 +113,6 @@ pub(crate) fn test_scenario(scenario_name: &str) {
 
     let result = prisma_fmt::code_actions(
         serde_json::to_string_pretty(&schema_files).unwrap(),
-        initiating_file_name,
         &serde_json::to_string_pretty(&params).unwrap(),
     );
     // Prettify the JSON

--- a/prisma-fmt/tests/code_actions/test_api.rs
+++ b/prisma-fmt/tests/code_actions/test_api.rs
@@ -83,7 +83,7 @@ pub(crate) fn test_scenario(scenario_name: &str) {
                     None
                 }
             })
-            .expect(&format!("Expected to have {TARGET_SCHEMA_FILE} in multifile schemas"))
+            .unwrap_or_else(|| panic!("Expected to have {TARGET_SCHEMA_FILE} in when multi-file schema are used"))
             .as_str()
     };
 

--- a/prisma-fmt/tests/code_actions/tests.rs
+++ b/prisma-fmt/tests/code_actions/tests.rs
@@ -13,25 +13,37 @@ macro_rules! scenarios {
 
 scenarios! {
     one_to_many_referenced_side_misses_unique_single_field
+    one_to_many_referenced_side_misses_unique_single_field_multifile
     one_to_many_referenced_side_misses_unique_single_field_broken_relation
     one_to_many_referenced_side_misses_unique_compound_field
+    one_to_many_referenced_side_misses_unique_compound_field_multifile
     one_to_many_referenced_side_misses_unique_compound_field_existing_arguments
     one_to_many_referenced_side_misses_unique_compound_field_indentation_four_spaces
     one_to_many_referenced_side_misses_unique_compound_field_broken_relation
     one_to_one_referenced_side_misses_unique_single_field
+    one_to_one_referenced_side_misses_unique_single_field_multifile
     one_to_one_referenced_side_misses_unique_compound_field
+    one_to_one_referenced_side_misses_unique_compound_field_multifile
     one_to_one_referencing_side_misses_unique_single_field
+    one_to_one_referencing_side_misses_unique_single_field_multifile
     one_to_one_referencing_side_misses_unique_compound_field
+    one_to_one_referencing_side_misses_unique_compound_field_multifile
     one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces
     relation_mode_prisma_missing_index
+    relation_mode_prisma_missing_index_multifile
     relation_mode_referential_integrity
     relation_mode_mysql_foreign_keys_set_default
+    relation_mode_mysql_foreign_keys_set_default_multifile
     multi_schema_one_model
+    multi_schema_one_model_multifile
     multi_schema_one_model_one_enum
+    multi_schema_one_model_one_enum_multifile
     multi_schema_two_models
     multi_schema_add_to_existing_schemas
+    multi_schema_add_to_existing_schemas_multifile
     multi_schema_add_to_nonexisting_schemas
     mongodb_at_map
+    mongodb_at_map_multifile
     mongodb_at_map_with_validation_errors
     mongodb_auto_native
 }

--- a/prisma-fmt/tests/code_actions_tests.rs
+++ b/prisma-fmt/tests/code_actions_tests.rs
@@ -1,1 +1,2 @@
 mod code_actions;
+mod helpers;

--- a/prisma-fmt/tests/helpers.rs
+++ b/prisma-fmt/tests/helpers.rs
@@ -4,7 +4,6 @@ pub fn load_schema_files(dir: impl AsRef<Path>) -> Vec<(String, String)> {
     let schema_files = {
         std::fs::read_dir(dir.as_ref())
             .unwrap()
-            .into_iter()
             .map(Result::unwrap)
             .filter_map(|entry| {
                 let ft = entry.file_type().ok()?;
@@ -25,7 +24,7 @@ pub fn load_schema_files(dir: impl AsRef<Path>) -> Vec<(String, String)> {
             })
             .collect::<Vec<_>>()
     };
-    assert!(schema_files.len() > 0);
+    assert!(!schema_files.is_empty());
 
     schema_files
 }

--- a/prisma-fmt/tests/helpers.rs
+++ b/prisma-fmt/tests/helpers.rs
@@ -1,0 +1,31 @@
+use std::path::Path;
+
+pub fn load_schema_files(dir: impl AsRef<Path>) -> Vec<(String, String)> {
+    let schema_files = {
+        std::fs::read_dir(dir.as_ref())
+            .unwrap()
+            .into_iter()
+            .map(Result::unwrap)
+            .filter_map(|entry| {
+                let ft = entry.file_type().ok()?;
+                if ft.is_dir() {
+                    return None;
+                }
+                let path = entry.path();
+                let name = path.file_name()?.to_str()?;
+                let ext = path.extension()?;
+                if ext != "prisma" {
+                    return None;
+                }
+
+                Some((
+                    format!("file:///path/to/{name}"),
+                    std::fs::read_to_string(&path).unwrap(),
+                ))
+            })
+            .collect::<Vec<_>>()
+    };
+    assert!(schema_files.len() > 0);
+
+    schema_files
+}

--- a/prisma-fmt/tests/regressions/language_tools_1466.rs
+++ b/prisma-fmt/tests/regressions/language_tools_1466.rs
@@ -27,5 +27,9 @@ fn code_actions_should_not_crash_on_validation_errors_with_mongodb() {
         },
     };
 
-    prisma_fmt::code_actions(schema.to_owned(), &serde_json::to_string_pretty(&params).unwrap());
+    prisma_fmt::code_actions(
+        serde_json::to_string_pretty(&[("schema.prisma", schema.to_owned())]).unwrap(),
+        "schema.prisma".into(),
+        &serde_json::to_string_pretty(&params).unwrap(),
+    );
 }

--- a/prisma-fmt/tests/regressions/language_tools_1466.rs
+++ b/prisma-fmt/tests/regressions/language_tools_1466.rs
@@ -29,7 +29,6 @@ fn code_actions_should_not_crash_on_validation_errors_with_mongodb() {
 
     prisma_fmt::code_actions(
         serde_json::to_string_pretty(&[("schema.prisma", schema.to_owned())]).unwrap(),
-        "schema.prisma".into(),
         &serde_json::to_string_pretty(&params).unwrap(),
     );
 }

--- a/prisma-fmt/tests/regressions/language_tools_1473.rs
+++ b/prisma-fmt/tests/regressions/language_tools_1473.rs
@@ -32,7 +32,6 @@ fn code_actions_should_not_crash_on_validation_errors_with_multi_schema() {
 
     prisma_fmt::code_actions(
         serde_json::to_string_pretty(&[("schema.prisma", schema.to_owned())]).unwrap(),
-        "schema.prisma".into(),
         &serde_json::to_string_pretty(&params).unwrap(),
     );
 }

--- a/prisma-fmt/tests/regressions/language_tools_1473.rs
+++ b/prisma-fmt/tests/regressions/language_tools_1473.rs
@@ -30,5 +30,9 @@ fn code_actions_should_not_crash_on_validation_errors_with_multi_schema() {
         },
     };
 
-    prisma_fmt::code_actions(schema.to_owned(), &serde_json::to_string_pretty(&params).unwrap());
+    prisma_fmt::code_actions(
+        serde_json::to_string_pretty(&[("schema.prisma", schema.to_owned())]).unwrap(),
+        "schema.prisma".into(),
+        &serde_json::to_string_pretty(&params).unwrap(),
+    );
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/Test.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/Test.prisma
@@ -1,0 +1,4 @@
+model Test {
+    id Int @id
+    name String @default(<|>)
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/TestB.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/TestB.prisma
@@ -1,0 +1,4 @@
+model TestB {
+    id   String @id
+    name Int
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/config.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/config.prisma
@@ -1,0 +1,4 @@
+datasource db {
+    provider = "sqlserver"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/result.json
@@ -1,0 +1,9 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "map: ",
+      "kind": 10
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/A.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/A.prisma
@@ -1,0 +1,6 @@
+model A {
+  id  Int    @id
+  val String
+
+  @@index([val], type: <|>)
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/datasource.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/datasource.prisma
@@ -1,0 +1,4 @@
+datasource db {
+  provider = "postgres"
+  url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/generator.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/generator.prisma
@@ -1,0 +1,3 @@
+generator js {
+  provider = "prisma-client-js"
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/result.json
@@ -1,0 +1,35 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "BTree",
+      "kind": 13,
+      "detail": "Can handle equality and range queries on data that can be sorted into some ordering (default)."
+    },
+    {
+      "label": "Hash",
+      "kind": 13,
+      "detail": "Can handle simple equality queries, but no ordering. Faster than BTree, if ordering is not needed."
+    },
+    {
+      "label": "Gist",
+      "kind": 13,
+      "detail": "Generalized Search Tree. A framework for building specialized indices for custom data types."
+    },
+    {
+      "label": "Gin",
+      "kind": 13,
+      "detail": "Generalized Inverted Index. Useful for indexing composite items, such as arrays or text."
+    },
+    {
+      "label": "SpGist",
+      "kind": 13,
+      "detail": "Space-partitioned Generalized Search Tree. For implenting a wide range of different non-balanced data structures."
+    },
+    {
+      "label": "Brin",
+      "kind": 13,
+      "detail": "Block Range Index. If the data has some natural correlation with their physical location within the table, can compress very large amount of data into a small space."
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/Test.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/Test.prisma
@@ -1,0 +1,4 @@
+model Test {
+    id Int @id
+    name String @default(<|>)
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/TestB.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/TestB.prisma
@@ -1,0 +1,4 @@
+model TestB {
+    id   String @id
+    name Int
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/config.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/config.prisma
@@ -1,0 +1,4 @@
+datasource db {
+    provider = "postgresql"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/result.json
@@ -1,0 +1,4 @@
+{
+  "isIncomplete": false,
+  "items": []
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/config.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/config.prisma
@@ -1,0 +1,5 @@
+datasource db {
+    provider     = "mysql"
+    url          = env("DATABASE_URL")
+    relationMode = "prisma"
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/models.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/models.prisma
@@ -1,0 +1,11 @@
+model Post {
+    id       Int    @id @default(autoincrement())
+    title    String
+    author   User   @relation(fields: [authorId], references: [id], onDelete: <|>)
+    authorId Int
+}
+
+model User {
+    id    Int    @id @default(autoincrement())
+    posts Post[]
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/result.json
@@ -1,0 +1,25 @@
+{
+  "isIncomplete": false,
+  "items": [
+    {
+      "label": "Cascade",
+      "kind": 13,
+      "detail": "Delete the child records when the parent record is deleted."
+    },
+    {
+      "label": "Restrict",
+      "kind": 13,
+      "detail": "Prevent deleting a parent record as long as it is referenced."
+    },
+    {
+      "label": "NoAction",
+      "kind": 13,
+      "detail": "Prevent deleting a parent record as long as it is referenced."
+    },
+    {
+      "label": "SetNull",
+      "kind": 13,
+      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
+    }
+  ]
+}

--- a/prisma-fmt/tests/text_document_completion/test_api.rs
+++ b/prisma-fmt/tests/text_document_completion/test_api.rs
@@ -32,7 +32,12 @@ pub(crate) fn test_scenario(scenario_name: &str) {
         context: None,
     };
 
-    let result = prisma_fmt::text_document_completion(schema, &serde_json::to_string_pretty(&params).unwrap());
+    let schema_files = serde_json::to_string_pretty(&[("schema.prisma", schema)]).unwrap();
+    let result = prisma_fmt::text_document_completion(
+        schema_files,
+        "schema.prisma".into(),
+        &serde_json::to_string_pretty(&params).unwrap(),
+    );
     // Prettify the JSON
     let result =
         serde_json::to_string_pretty(&serde_json::from_str::<lsp_types::CompletionList>(&result).unwrap()).unwrap();

--- a/prisma-fmt/tests/text_document_completion/test_api.rs
+++ b/prisma-fmt/tests/text_document_completion/test_api.rs
@@ -18,11 +18,11 @@ pub(crate) fn test_scenario(scenario_name: &str) {
     write!(path, "{SCENARIOS_PATH}/{scenario_name}/result.json").unwrap();
     let expected_result = std::fs::read_to_string(&path).unwrap_or_else(|_| String::new());
 
-    let (initiating_file_name, cursor_position, schema_files) = take_cursor(schema_files);
+    let (initiating_file_uri, cursor_position, schema_files) = take_cursor(schema_files);
     let params = lsp_types::CompletionParams {
         text_document_position: lsp_types::TextDocumentPositionParams {
             text_document: lsp_types::TextDocumentIdentifier {
-                uri: "https://example.com/meow".parse().unwrap(),
+                uri: initiating_file_uri.parse().unwrap(),
             }, // ignored
             position: cursor_position,
         },
@@ -35,7 +35,6 @@ pub(crate) fn test_scenario(scenario_name: &str) {
 
     let result = prisma_fmt::text_document_completion(
         serde_json::to_string_pretty(&schema_files).unwrap(),
-        &initiating_file_name,
         &serde_json::to_string_pretty(&params).unwrap(),
     );
     // Prettify the JSON

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -15,9 +15,11 @@ scenarios! {
     argument_after_trailing_comma
     default_map_end_of_args_list
     default_map_mssql
+    default_map_mssql_multifile
     empty_schema
     extended_indexes_basic
     extended_indexes_types_postgres
+    extended_indexes_types_postgres_multifile
     extended_indexes_types_mysql
     extended_indexes_types_sqlserver
     extended_indexes_types_sqlite
@@ -30,6 +32,8 @@ scenarios! {
     extended_indexes_operators_cockroach_gin
     language_tools_relation_directive
     no_default_map_on_postgres
+    no_default_map_on_postgres_multifile
+    referential_actions_multifile
     referential_actions_end_of_args_list
     referential_actions_in_progress
     referential_actions_in_progress_2

--- a/prisma-fmt/tests/text_document_completion_tests.rs
+++ b/prisma-fmt/tests/text_document_completion_tests.rs
@@ -1,1 +1,2 @@
+mod helpers;
 mod text_document_completion;

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -87,9 +87,9 @@ pub fn preview_features() -> String {
 /// Input and output are both JSON, the request being a `CompletionParams` object and the response
 /// being a `CompletionList` object.
 #[wasm_bindgen]
-pub fn text_document_completion(schema: String, params: String) -> String {
+pub fn text_document_completion(schema_files: String, initiating_file_id: u32, params: String) -> String {
     register_panic_hook();
-    prisma_fmt::text_document_completion(schema, &params)
+    prisma_fmt::text_document_completion(schema_files, initiating_file_id, &params)
 }
 
 /// This API is modelled on an LSP [code action

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -87,9 +87,9 @@ pub fn preview_features() -> String {
 /// Input and output are both JSON, the request being a `CompletionParams` object and the response
 /// being a `CompletionList` object.
 #[wasm_bindgen]
-pub fn text_document_completion(schema_files: String, initiating_file_id: u32, params: String) -> String {
+pub fn text_document_completion(schema_files: String, params: String) -> String {
     register_panic_hook();
-    prisma_fmt::text_document_completion(schema_files, initiating_file_id, &params)
+    prisma_fmt::text_document_completion(schema_files, &params)
 }
 
 /// This API is modelled on an LSP [code action

--- a/psl/diagnostics/src/span.rs
+++ b/psl/diagnostics/src/span.rs
@@ -38,7 +38,7 @@ impl Span {
 
     /// Is the given span overlapping with the current span.
     pub fn overlaps(self, other: Span) -> bool {
-        self.contains(other.start) || self.contains(other.end)
+        self.file_id == other.file_id && (self.contains(other.start) || self.contains(other.end))
     }
 }
 

--- a/psl/parser-database/src/files.rs
+++ b/psl/parser-database/src/files.rs
@@ -13,7 +13,7 @@ impl Files {
     /// Create a new Files instance from multiple files.
     pub fn new(files: &[(String, schema_ast::SourceFile)], diagnostics: &mut Diagnostics) -> Self {
         let asts = files
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(file_idx, (path, source))| {
                 let id = FileId(file_idx as u32);

--- a/psl/parser-database/src/files.rs
+++ b/psl/parser-database/src/files.rs
@@ -11,14 +11,14 @@ pub struct Files(pub Vec<(String, schema_ast::SourceFile, ast::SchemaAst)>);
 
 impl Files {
     /// Create a new Files instance from multiple files.
-    pub fn new(files: Vec<(String, schema_ast::SourceFile)>, diagnostics: &mut Diagnostics) -> Self {
+    pub fn new(files: &[(String, schema_ast::SourceFile)], diagnostics: &mut Diagnostics) -> Self {
         let asts = files
             .into_iter()
             .enumerate()
             .map(|(file_idx, (path, source))| {
                 let id = FileId(file_idx as u32);
                 let ast = schema_ast::parse_schema(source.as_str(), diagnostics, id);
-                (path, source, ast)
+                (path.to_owned(), source.clone(), ast)
             })
             .collect();
         Self(asts)

--- a/psl/parser-database/src/lib.rs
+++ b/psl/parser-database/src/lib.rs
@@ -89,7 +89,7 @@ impl ParserDatabase {
 
     /// See the docs on [ParserDatabase](/struct.ParserDatabase.html).
     pub fn new(schemas: &[(String, schema_ast::SourceFile)], diagnostics: &mut Diagnostics) -> Self {
-        let asts = Files::new(&schemas, diagnostics);
+        let asts = Files::new(schemas, diagnostics);
 
         let mut interner = Default::default();
         let mut names = Default::default();

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -24,6 +24,7 @@ pub use r#enum::*;
 pub use relation::*;
 pub use relation_field::*;
 pub use scalar_field::*;
+use schema_ast::ast::WithSpan;
 
 use crate::{ast, FileId};
 
@@ -90,6 +91,12 @@ impl crate::ParserDatabase {
             .map(move |enum_id| self.walk(enum_id))
     }
 
+    /// walk all enums in specified file
+    pub fn walk_enums_in_file(&self, file_id: FileId) -> impl Iterator<Item = EnumWalker<'_>> {
+        self.walk_enums()
+            .filter(move |walker| walker.ast_enum().span().file_id == file_id)
+    }
+
     /// Walk all the models in the schema.
     pub fn walk_models(&self) -> impl Iterator<Item = ModelWalker<'_>> + '_ {
         self.iter_tops()
@@ -98,12 +105,24 @@ impl crate::ParserDatabase {
             .filter(|m| !m.ast_model().is_view())
     }
 
+    /// walk all models in specified file
+    pub fn walk_models_in_file(&self, file_id: FileId) -> impl Iterator<Item = ModelWalker<'_>> {
+        self.walk_models()
+            .filter(move |walker| walker.is_defined_in_file(file_id))
+    }
+
     /// Walk all the views in the schema.
     pub fn walk_views(&self) -> impl Iterator<Item = ModelWalker<'_>> + '_ {
         self.iter_tops()
             .filter_map(|(file_id, top_id, _)| top_id.as_model_id().map(|id| (file_id, id)))
             .map(move |model_id| self.walk(model_id))
             .filter(|m| m.ast_model().is_view())
+    }
+
+    /// walk all views in specified file
+    pub fn walk_views_in_file(&self, file_id: FileId) -> impl Iterator<Item = ModelWalker<'_>> {
+        self.walk_views()
+            .filter(move |walker| walker.is_defined_in_file(file_id))
     }
 
     /// Walk all the composite types in the schema.

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -70,7 +70,6 @@ impl<'db> ModelWalker<'db> {
         &self.db.asts[self.id]
     }
 
-
     /// The parsed attributes.
     #[track_caller]
     pub(crate) fn attributes(self) -> &'db ModelAttributes {

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -60,10 +60,16 @@ impl<'db> ModelWalker<'db> {
             .is_some()
     }
 
+    /// Is the model defined in specific file?
+    pub fn is_defined_in_file(self, file_id: FileId) -> bool {
+        return self.ast_model().span().file_id == file_id;
+    }
+
     /// The AST node.
     pub fn ast_model(self) -> &'db ast::Model {
         &self.db.asts[self.id]
     }
+
 
     /// The parsed attributes.
     #[track_caller]

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -60,7 +60,7 @@ impl<'db> ModelWalker<'db> {
             .is_some()
     }
 
-    /// Is the model defined in specific file?
+    /// Is the model defined in a specific file?
     pub fn is_defined_in_file(self, file_id: FileId) -> bool {
         return self.ast_model().span().file_id == file_id;
     }

--- a/psl/parser-database/src/walkers/relation/inline/complete.rs
+++ b/psl/parser-database/src/walkers/relation/inline/complete.rs
@@ -11,7 +11,8 @@ use schema_ast::ast;
 pub struct CompleteInlineRelationWalker<'db> {
     pub(crate) side_a: RelationFieldId,
     pub(crate) side_b: RelationFieldId,
-    pub(crate) db: &'db ParserDatabase,
+    /// The parser database being traversed.
+    pub db: &'db ParserDatabase,
 }
 
 #[allow(missing_docs)]

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -9,6 +9,7 @@ use std::{any::Any, borrow::Cow, path::Path};
 /// a `datasource` from the prisma schema.
 pub struct Datasource {
     pub name: String,
+    pub span: Span,
     /// The provider string
     pub provider: String,
     /// The provider that was selected as active from all specified providers

--- a/psl/psl-core/src/configuration/datasource.rs
+++ b/psl/psl-core/src/configuration/datasource.rs
@@ -9,6 +9,7 @@ use std::{any::Any, borrow::Cow, path::Path};
 /// a `datasource` from the prisma schema.
 pub struct Datasource {
     pub name: String,
+    /// Span of the whole datasource block (including `datasource` keyword and braces)
     pub span: Span,
     /// The provider string
     pub provider: String,

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -84,7 +84,7 @@ pub fn validate_multi_file(files: Vec<(String, SourceFile)>, connectors: Connect
         "psl::validate_multi_file() must be called with at least one file"
     );
     let mut diagnostics = Diagnostics::new();
-    let db = ParserDatabase::new(files, &mut diagnostics);
+    let db = ParserDatabase::new(&files, &mut diagnostics);
 
     // TODO: the bulk of configuration block analysis should be part of ParserDatabase::new().
     let mut configuration = Configuration::default();
@@ -139,7 +139,7 @@ pub fn parse_configuration(
 }
 
 pub fn parse_configuration_multi_file(
-    files: Vec<(String, SourceFile)>,
+    files: &[(String, SourceFile)],
     connectors: ConnectorRegistry<'_>,
 ) -> Result<(Files, Configuration), (Files, diagnostics::Diagnostics)> {
     let mut diagnostics = Diagnostics::default();

--- a/psl/psl-core/src/reformat.rs
+++ b/psl/psl-core/src/reformat.rs
@@ -26,7 +26,7 @@ pub fn reformat_validated_schema_into_single(schema: ValidatedSchema, indent_wid
 
 pub fn reformat_multiple(sources: Vec<(String, SourceFile)>, indent_width: usize) -> Vec<(String, String)> {
     let mut diagnostics = diagnostics::Diagnostics::new();
-    let db = parser_database::ParserDatabase::new(sources, &mut diagnostics);
+    let db = parser_database::ParserDatabase::new(&sources, &mut diagnostics);
 
     if diagnostics.has_errors() {
         db.iter_file_ids()

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -10,6 +10,7 @@ use parser_database::{
     ast::{Expression, WithDocumentation},
     coerce, coerce_array, coerce_opt,
 };
+use schema_ast::ast::WithSpan;
 use std::{borrow::Cow, collections::HashMap};
 
 const PREVIEW_FEATURES_KEY: &str = "previewFeatures";
@@ -219,6 +220,7 @@ fn lift_datasource(
 
     Some(Datasource {
         namespaces: schemas.into_iter().map(|(s, span)| (s.to_owned(), span)).collect(),
+        span: ast_source.span(),
         schemas_span,
         name: source_name.to_owned(),
         provider: provider.to_owned(),

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -44,7 +44,7 @@ pub fn parse_configuration(schema: &str) -> Result<Configuration, Diagnostics> {
 /// Parses and validates Prisma schemas, but skip analyzing everything except datasource and generator
 /// blocks.
 pub fn parse_configuration_multi_file(
-    files: Vec<(String, SourceFile)>,
+    files: &[(String, SourceFile)],
 ) -> Result<(Files, Configuration), (Files, Diagnostics)> {
     psl_core::parse_configuration_multi_file(files, builtin_connectors::BUILTIN_CONNECTORS)
 }


### PR DESCRIPTION
You should know the drill for now: instead of a single schema text, we accept a list of `(name, content)` tuples, adapt the rest of the code to use `*_multi` methods and point the edits to the correct files.

Notable changes here are done to the test setups:

For completions, several prisma files could be put into the test directory. Only one of them suppsed to have cursor marker - that file will be used as a target for completion request, rest of the files will be used for building up the schema.

For code actions, several files in prisma directory are supported. In case more than one file is found, one of the files is expected to be named `_target.prisma` and it will be used as a target for code action request.

Other changes in this PR include accepting slices rather than vectors in several `*_multi` method to avoid unnecessary cloning.

Close prisma/team-orm#1041