### PR TITLE
query-engine-c-abi: Fix build warnings after update

### DIFF
--- a/quaint/src/connector/sqlite/native/conversion.rs
+++ b/quaint/src/connector/sqlite/native/conversion.rs
@@ -82,6 +82,7 @@ impl TypeIdentifier for Column<'_> {
         )
     }
 
+    #[cfg(feature = "mysql")]
     fn is_time(&self) -> bool {
         false
     }
@@ -118,9 +119,12 @@ impl TypeIdentifier for Column<'_> {
         matches!(self.decl_type(), Some("BOOLEAN") | Some("boolean"))
     }
 
+    #[cfg(feature = "mysql")]
     fn is_json(&self) -> bool {
         false
     }
+
+    #[cfg(feature = "mysql")]
     fn is_enum(&self) -> bool {
         false
     }

--- a/quaint/src/connector/type_identifier.rs
+++ b/quaint/src/connector/type_identifier.rs
@@ -5,12 +5,15 @@ pub(crate) trait TypeIdentifier {
     fn is_int32(&self) -> bool;
     fn is_int64(&self) -> bool;
     fn is_datetime(&self) -> bool;
+    #[cfg(feature = "mysql")]
     fn is_time(&self) -> bool;
     fn is_date(&self) -> bool;
     fn is_text(&self) -> bool;
     fn is_bytes(&self) -> bool;
     fn is_bool(&self) -> bool;
+    #[cfg(feature = "mysql")]
     fn is_json(&self) -> bool;
+    #[cfg(feature = "mysql")]
     fn is_enum(&self) -> bool;
     fn is_null(&self) -> bool;
 }

--- a/query-engine/connectors/sql-query-connector/src/query_arguments_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_arguments_ext.rs
@@ -7,6 +7,7 @@ pub(crate) trait QueryArgumentsExt {
     /// Checks whether any form of memory processing is needed, or we could just return the records
     /// as they are. This is useful to avoid turning an existing collection of records into an
     /// iterator and re-collecting it back with no changes.
+    #[cfg(feature = "relation_joins")]
     fn needs_inmemory_processing_with_joins(&self) -> bool;
 }
 
@@ -15,6 +16,7 @@ impl QueryArgumentsExt for QueryArguments {
         self.take.map(|t| t < 0).unwrap_or(false)
     }
 
+    #[cfg(feature = "relation_joins")]
     fn needs_inmemory_processing_with_joins(&self) -> bool {
         self.needs_reversed_order()
             || self.requires_inmemory_distinct_with_joins()


### PR DESCRIPTION
`rustc` now detects unused trait methods, which means we need to make a
new offering to the gods of `cfg[feature=]`.
