### PR TITLE
Revert rust 1.78 update

### DIFF
--- a/query-engine/driver-adapters/src/types.rs
+++ b/query-engine/driver-adapters/src/types.rs
@@ -1,5 +1,6 @@
 // `clippy::empty_docs` is required because of the `tsify` crate.
-#![allow(unused_imports, clippy::empty_docs)]
+// TODO: uncomment after rust 1.78 update
+#![allow(unused_imports/*, clippy::empty_docs*/)]
 
 use std::str::FromStr;
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.77.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.


### PR DESCRIPTION
Panics when integrated into the client.
https://github.com/prisma/prisma/actions/runs/9033927478/job/24825328380?pr=24151

This reverts commit e162a5269909648ad707462d90715ea0dce60f18.
