### PR TITLE
prisma-fmt: Correctly skip clrf line endings when computing field position

### DIFF
--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -271,9 +271,15 @@ pub(crate) fn range_to_span(range: Range, document: &str, file_id: FileId) -> as
     ast::Span::new(start, end, file_id)
 }
 
-/// Gives the LSP position right after the given span.
+/// Gives the LSP position right after the given span, skipping any trailing newlines
 pub(crate) fn position_after_span(span: ast::Span, document: &str) -> Position {
-    offset_to_position(span.end - 1, document)
+    let end = match (document.chars().nth(span.end - 2), document.chars().nth(span.end - 1)) {
+        (Some('\r'), Some('\n')) => span.end - 2,
+        (_, Some('\n')) => span.end - 1,
+        _ => span.end,
+    };
+
+    offset_to_position(end, document)
 }
 
 /// Converts a byte offset to an LSP position, if the given offset
@@ -302,6 +308,9 @@ pub fn offset_to_position(offset: usize, document: &str) -> Position {
 #[cfg(test)]
 mod tests {
     use lsp_types::Position;
+    use psl::diagnostics::{FileId, Span};
+
+    use crate::position_after_span;
 
     // On Windows, a newline is actually two characters.
     #[test]
@@ -312,5 +321,32 @@ mod tests {
         let found_offset = super::position_to_offset(&Position { line: 2, character: 4 }, schema).unwrap();
 
         assert_eq!(found_offset, expected_offset);
+    }
+
+    #[test]
+    fn position_after_span_no_newline() {
+        let str = "some string";
+        let span = Span::new(0, str.len(), FileId::ZERO);
+        let pos = position_after_span(span, &str);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.character, 11);
+    }
+
+    #[test]
+    fn position_after_span_lf() {
+        let str = "some string\n";
+        let span = Span::new(0, str.len(), FileId::ZERO);
+        let pos = position_after_span(span, &str);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.character, 11);
+    }
+
+    #[test]
+    fn position_after_span_crlf() {
+        let str = "some string\r\n";
+        let span = Span::new(0, str.len(), FileId::ZERO);
+        let pos = position_after_span(span, &str);
+        assert_eq!(pos.line, 0);
+        assert_eq!(pos.character, 11);
     }
 }


### PR DESCRIPTION
Fixes the failure on Windows in prisma/language-tools#1731
