### PR TITLE
fix(schema-engine): fix sqlite migrations on D1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5109,6 +5109,7 @@ dependencies = [
  "datamodel-renderer",
  "either",
  "enumflags2",
+ "indexmap 2.2.2",
  "indoc 2.0.3",
  "once_cell",
  "prisma-value",

--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -18,6 +18,7 @@ tokio.workspace = true
 serde.workspace = true
 indoc.workspace = true
 uuid.workspace = true
+indexmap.workspace = true
 
 prisma-value = { path = "../../../libs/prisma-value" }
 schema-connector = { path = "../schema-connector" }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/sqlite_renderer.rs
@@ -183,14 +183,21 @@ impl SqlRenderer for SqliteFlavour {
     }
 
     fn render_redefine_tables(&self, tables: &[RedefineTable], schemas: MigrationPair<&SqlSchema>) -> Vec<String> {
-        // Based on 'Making Other Kinds Of Table Schema Changes' from https://www.sqlite.org/lang_altertable.html
-        let mut result = vec!["PRAGMA foreign_keys=OFF".to_string()];
+        // Based on 'Making Other Kinds Of Table Schema Changes' from https://www.sqlite.org/lang_altertable.html,
+        // and on https://developers.cloudflare.com/d1/reference/database-commands/#pragma-defer_foreign_keys--onoff.
+        let mut result: Vec<String> = vec![];
+
+        // disables foreign key constraint enforcement
+        result.push("PRAGMA defer_foreign_keys=ON".to_string());
+        result.push("PRAGMA foreign_keys=OFF".to_string());
+
         let mut foreign_key_checks = vec![];
 
         for redefine_table in tables {
             let tables = schemas.walk(redefine_table.table_ids);
             let temporary_table_name = format!("new_{}", &tables.next.name());
 
+            // maybe use render_create_table_for_migration?
             result.push(self.render_create_table_as(
                 tables.next,
                 QuotedWithPrefix(None, Quoted::sqlite_ident(&temporary_table_name)),
@@ -218,9 +225,13 @@ impl SqlRenderer for SqliteFlavour {
             ));
         }
 
-        result.extend(foreign_key_checks);
+        // Checks the database for foreign key constraint violations.
+        // Note: this code is probably useless, pending foreign constraint violations are checked fine even without it.
+        // result.extend(foreign_key_checks);
 
+        // resumes immediate enforcement of foreign key constraints.
         result.push("PRAGMA foreign_keys=ON".to_string());
+        result.push("PRAGMA defer_foreign_keys=OFF".to_string());
 
         result
     }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/differ_database.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/differ_database.rs
@@ -1,5 +1,6 @@
 use super::{column, enums::EnumDiffer, table::TableDiffer};
 use crate::{flavour::SqlFlavour, migration_pair::MigrationPair, SqlDatabaseSchema};
+use indexmap::IndexMap;
 use sql_schema_describer::{
     postgres::{ExtensionId, ExtensionWalker, PostgresSchemaExt},
     walkers::{EnumWalker, TableColumnWalker, TableWalker},
@@ -18,9 +19,9 @@ pub(crate) struct DifferDatabase<'a> {
     /// The schemas being diffed
     pub(crate) schemas: MigrationPair<&'a SqlDatabaseSchema>,
     /// Namespace name -> namespace indexes.
-    namespaces: HashMap<Cow<'a, str>, MigrationPair<Option<NamespaceId>>>,
+    namespaces: IndexMap<Cow<'a, str>, MigrationPair<Option<NamespaceId>>>,
     /// Table name -> table indexes.
-    tables: HashMap<Table<'a>, MigrationPair<Option<TableId>>>,
+    tables: IndexMap<Table<'a>, MigrationPair<Option<TableId>>>,
     /// (table_idxs, column_name) -> column_idxs. BTreeMap because we want range
     /// queries (-> all the columns in a table).
     columns: BTreeMap<(MigrationPair<TableId>, &'a str), MigrationPair<Option<TableColumnId>>>,
@@ -47,8 +48,8 @@ impl<'a> DifferDatabase<'a> {
         let mut db = DifferDatabase {
             flavour,
             schemas,
-            namespaces: HashMap::with_capacity(namespace_count_lb),
-            tables: HashMap::with_capacity(table_count_lb),
+            namespaces: IndexMap::with_capacity(namespace_count_lb),
+            tables: IndexMap::with_capacity(table_count_lb),
             columns: BTreeMap::new(),
             column_changes: Default::default(),
             extensions: Default::default(),


### PR DESCRIPTION
This PR:
- Fixes https://github.com/prisma/prisma/issues/24208 on the engines' side
- Still passes every Rust migration test (via cargo test --package sql-migration-tests --test migration_tests)

Context: [Slack](https://prisma-company.slack.com/archives/C06DNBFN943/p1715790793722279).

/integration