### PR TITLE
fix(validation): Reword validation msg

### DIFF
--- a/prisma-fmt/src/validate.rs
+++ b/prisma-fmt/src/validate.rs
@@ -183,7 +183,7 @@ mod tests {
         });
 
         let expected = expect![[
-            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError parsing attribute \"@relation\": The relation field `a` on Model `B` is required. This is no longer valid because it's not possible to enforce this constraint on the database level. Please change the field type from `A` to `A?` to fix this.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mb.prisma:4\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 3 | \u001b[0m                    id String @id\n\u001b[1;94m 4 | \u001b[0m                    \u001b[1;91ma A\u001b[0m\n\u001b[1;94m 5 | \u001b[0m                }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
+            r#"{"error_code":"P1012","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError parsing attribute \"@relation\": The relation field `a` on Model `B` is required. This is not valid because it's not possible to enforce this constraint on the database level. Please change the field type from `A` to `A?` to fix this.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mb.prisma:4\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 3 | \u001b[0m                    id String @id\n\u001b[1;94m 4 | \u001b[0m                    \u001b[1;91ma A\u001b[0m\n\u001b[1;94m 5 | \u001b[0m                }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1"}"#
         ]];
 
         let response = validate(&request.to_string()).unwrap_err();

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
@@ -237,7 +237,7 @@ pub(crate) fn back_relation_arity_is_optional(relation: InlineRelationWalker<'_>
 
     if back.ast_field().arity.is_required() {
         let message = format!(
-            "The relation field `{}` on Model `{}` is required. This is no longer valid because it's not possible to enforce this constraint on the database level. Please change the field type from `{}` to `{}?` to fix this.",
+            "The relation field `{}` on Model `{}` is required. This is not valid because it's not possible to enforce this constraint on the database level. Please change the field type from `{}` to `{}?` to fix this.",
             back.name(), back.model().name(), forward.model().name(), forward.model().name(),
         );
 

--- a/psl/psl/tests/attributes/relations/relations_new.rs
+++ b/psl/psl/tests/attributes/relations/relations_new.rs
@@ -232,7 +232,7 @@ fn required_relation_field_must_error_if_it_is_virtual() {
     "#;
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": The relation field `address` on Model `User` is required. This is no longer valid because it's not possible to enforce this constraint on the database level. Please change the field type from `Address` to `Address?` to fix this.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": The relation field `address` on Model `User` is required. This is not valid because it's not possible to enforce this constraint on the database level. Please change the field type from `Address` to `Address?` to fix this.[0m
           [1;94m-->[0m  [4mschema.prisma:4[0m
         [1;94m   | [0m
         [1;94m 3 | [0m        id      Int     @id
@@ -747,7 +747,7 @@ fn must_error_for_required_one_to_one_self_relations() {
     "#;
 
     let expect = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@relation": The relation field `friendOf` on Model `User` is required. This is no longer valid because it's not possible to enforce this constraint on the database level. Please change the field type from `User` to `User?` to fix this.[0m
+        [1;91merror[0m: [1mError parsing attribute "@relation": The relation field `friendOf` on Model `User` is required. This is not valid because it's not possible to enforce this constraint on the database level. Please change the field type from `User` to `User?` to fix this.[0m
           [1;94m-->[0m  [4mschema.prisma:6[0m
         [1;94m   | [0m
         [1;94m 5 | [0m      friend   User @relation("Friends", fields: friendId, references: id)


### PR DESCRIPTION
"no longer" without any version as reference has no meaning, so better just tell the user that it does not work and needs to be fixed.