### PR TITLE
prisma-fmt: Make `get_config` error tolerant

### DIFF
--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -1,4 +1,4 @@
-use psl::{diagnostics::DatamodelError, infallible_parse_configuration, parser_database::Files, Diagnostics};
+use psl::{diagnostics::DatamodelError, error_tolerant_parse_configuration, parser_database::Files, Diagnostics};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -38,7 +38,7 @@ pub(crate) fn get_config(params: &str) -> String {
 
     let schema: Vec<_> = params.prisma_schema.into();
 
-    let (files, mut configuration, diagnostics) = infallible_parse_configuration(&schema);
+    let (files, mut configuration, diagnostics) = error_tolerant_parse_configuration(&schema);
 
     let override_diagnostics = if params.ignore_env_var_errors {
         Diagnostics::default()

--- a/prisma-fmt/src/get_config.rs
+++ b/prisma-fmt/src/get_config.rs
@@ -1,9 +1,8 @@
-use psl::{parser_database::Files, Diagnostics};
-use serde::Deserialize;
-use serde_json::json;
+use psl::{diagnostics::DatamodelError, infallible_parse_configuration, parser_database::Files, Diagnostics};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::{schema_file_input::SchemaFileInput, validate::SCHEMA_PARSER_ERROR_CODE};
+use crate::schema_file_input::SchemaFileInput;
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -17,13 +16,19 @@ struct GetConfigParams {
     datasource_overrides: HashMap<String, String>,
 }
 
-#[derive(Debug)]
-struct GetConfigError {
-    error_code: Option<&'static str>,
+#[derive(Serialize)]
+struct GetConfigResult<'a> {
+    config: serde_json::Value,
+    errors: Vec<ValidationError<'a>>,
+}
+
+#[derive(Serialize)]
+struct ValidationError<'a> {
+    file_name: Option<&'a str>,
     message: String,
 }
 
-pub(crate) fn get_config(params: &str) -> Result<String, String> {
+pub(crate) fn get_config(params: &str) -> String {
     let params: GetConfigParams = match serde_json::from_str(params) {
         Ok(params) => params,
         Err(serde_err) => {
@@ -31,56 +36,67 @@ pub(crate) fn get_config(params: &str) -> Result<String, String> {
         }
     };
 
-    get_config_impl(params)
-        .map_err(|err| {
-            json!({
-                "message": err.message,
-                "error_code": err.error_code,
-            })
-            .to_string()
-        })
-        .map(|value| value.to_string())
-}
+    let schema: Vec<_> = params.prisma_schema.into();
 
-fn get_config_impl(params: GetConfigParams) -> Result<serde_json::Value, GetConfigError> {
-    let prisma_schema: Vec<_> = params.prisma_schema.into();
-    let (files, mut config) = psl::parse_configuration_multi_file(&prisma_schema).map_err(create_get_config_error)?;
+    let (files, mut configuration, diagnostics) = infallible_parse_configuration(&schema);
 
-    if !params.ignore_env_var_errors {
+    let override_diagnostics = if params.ignore_env_var_errors {
+        Diagnostics::default()
+    } else {
         let overrides: Vec<(_, _)> = params.datasource_overrides.into_iter().collect();
-        config
-            .resolve_datasource_urls_prisma_fmt(&overrides, |key| params.env.get(key).map(String::from))
-            .map_err(|diagnostics| create_get_config_error((files, diagnostics)))?;
-    }
+        let override_result =
+            configuration.resolve_datasource_urls_prisma_fmt(&overrides, |key| params.env.get(key).map(String::from));
 
-    Ok(psl::get_config(&config))
+        match override_result {
+            Err(diagnostics) => diagnostics,
+            _ => Diagnostics::default(),
+        }
+    };
+
+    let config = psl::get_config(&configuration);
+    let all_errors = diagnostics.errors().iter().chain(override_diagnostics.errors().iter());
+
+    let result = GetConfigResult {
+        config,
+        errors: serialize_errors(all_errors, &files),
+    };
+
+    serde_json::to_string(&result).unwrap()
 }
 
-fn create_get_config_error((files, diagnostics): (Files, Diagnostics)) -> GetConfigError {
-    use std::fmt::Write as _;
+fn serialize_errors<'a>(
+    errors: impl Iterator<Item = &'a DatamodelError>,
+    files: &'a Files,
+) -> Vec<ValidationError<'a>> {
+    errors
+        .map(move |error| {
+            let file_id = error.span().file_id;
+            let (file_name, source, _) = &files[file_id];
+            let mut message_pretty: Vec<u8> = vec![];
+            error.pretty_print(&mut message_pretty, file_name, source.as_str())?;
 
-    let mut rendered_diagnostics = files.render_diagnostics(&diagnostics);
-    write!(
-        rendered_diagnostics,
-        "\nValidation Error Count: {}",
-        diagnostics.errors().len()
-    )
-    .unwrap();
-
-    GetConfigError {
-        // this mirrors user_facing_errors::common::SchemaParserError
-        error_code: Some(SCHEMA_PARSER_ERROR_CODE),
-        message: rendered_diagnostics,
-    }
+            Ok(ValidationError {
+                file_name: Some(file_name),
+                message: String::from_utf8_lossy(&message_pretty).into_owned(),
+            })
+        })
+        .collect::<Result<Vec<_>, std::io::Error>>()
+        .unwrap_or_else(|error| {
+            vec![ValidationError {
+                file_name: None,
+                message: format!("Could not serialize validation errors: {error}"),
+            }]
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use expect_test::expect;
+    use serde_json::json;
 
     #[test]
-    fn get_config_invalid_schema() {
+    fn invalid_schema() {
         let schema = r#"
             generator js {
             }
@@ -94,10 +110,127 @@ mod tests {
         });
 
         let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 3","error_code":"P1012"}"#
+            r#"{"config":{"generators":[],"datasources":[],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            \u001b[1;91mdatasøurce yolo {\u001b[0m\n\u001b[1;94m 6 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n"},{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:6\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 5 | \u001b[0m            datasøurce yolo {\n\u001b[1;94m 6 | \u001b[0m            \u001b[1;91m}\u001b[0m\n\u001b[1;94m 7 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n"},{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mArgument \"provider\" is missing in generator block \"js\".\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:2\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 1 | \u001b[0m\n\u001b[1;94m 2 | \u001b[0m            \u001b[1;91mgenerator js {\u001b[0m\n\u001b[1;94m 3 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n"}]}"#
         ]];
+        let response = get_config(&request.to_string());
+        expected.assert_eq(&response);
+    }
 
-        let response = get_config(&request.to_string()).unwrap_err();
+    #[test]
+    fn valid_generator_block() {
+        let schema = r#"
+            generator js {
+                provider = "prisma-client-js"
+                previewFeatures = ["prismaSchemaFolder"]
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[
+            r#"{"config":{"generators":[{"name":"js","provider":{"fromEnvVar":null,"value":"prisma-client-js"},"output":null,"config":{},"binaryTargets":[],"previewFeatures":["prismaSchemaFolder"]}],"datasources":[],"warnings":[]},"errors":[]}"#
+        ]];
+        let response = get_config(&request.to_string());
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn valid_generator_block_invalid_model() {
+        let schema = r#"
+            generator js {
+                provider = "prisma-client-js"
+                previewFeatures = ["prismaSchemaFolder"]
+            }
+
+            model M {
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[
+            r#"{"config":{"generators":[{"name":"js","provider":{"fromEnvVar":null,"value":"prisma-client-js"},"output":null,"config":{},"binaryTargets":[],"previewFeatures":["prismaSchemaFolder"]}],"datasources":[],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:7\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 6 | \u001b[0m\n\u001b[1;94m 7 | \u001b[0m            \u001b[1;91mmodel M {\u001b[0m\n\u001b[1;94m 8 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n"}]}"#
+        ]];
+        let response = get_config(&request.to_string());
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn valid_generator_block_invalid_model_field() {
+        let schema = r#"
+            generator js {
+                provider = "prisma-client-js"
+                previewFeatures = ["prismaSchemaFolder"]
+            }
+
+            model M {
+                field
+            }
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[
+            r#"{"config":{"generators":[{"name":"js","provider":{"fromEnvVar":null,"value":"prisma-client-js"},"output":null,"config":{},"binaryTargets":[],"previewFeatures":["prismaSchemaFolder"]}],"datasources":[],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating model \"M\": This field declaration is invalid. It is either missing a name or a type.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:8\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 7 | \u001b[0m            model M {\n\u001b[1;94m 8 | \u001b[0m                \u001b[1;91mfield\u001b[0m\n\u001b[1;94m 9 | \u001b[0m            }\n\u001b[1;94m   | \u001b[0m\n"}]}"#
+        ]];
+        let response = get_config(&request.to_string());
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn valid_generator_block_invalid_datasource() {
+        let schema = r#"
+            generator js {
+                provider = "prisma-client-js"
+                previewFeatures = ["prismaSchemaFolder"]
+            }
+
+            datasource D {
+        "#;
+
+        let request = json!({
+            "prismaSchema": schema,
+        });
+
+        let expected = expect![[
+            r#"{"config":{"generators":[{"name":"js","provider":{"fromEnvVar":null,"value":"prisma-client-js"},"output":null,"config":{},"binaryTargets":[],"previewFeatures":["prismaSchemaFolder"]}],"datasources":[],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating: This line is invalid. It does not start with any known Prisma schema keyword.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:7\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 6 | \u001b[0m\n\u001b[1;94m 7 | \u001b[0m            \u001b[1;91mdatasource D {\u001b[0m\n\u001b[1;94m 8 | \u001b[0m        \n\u001b[1;94m   | \u001b[0m\n"}]}"#
+        ]];
+        let response = get_config(&request.to_string());
+        expected.assert_eq(&response);
+    }
+
+    #[test]
+    fn multifile() {
+        let schemas = &[
+            (
+                "generator.prisma",
+                r#"generator js {
+                    provider = "prisma-client-js"
+                    previewFeatures = ["prismaSchemaFolder"]
+                }"#,
+            ),
+            (
+                "datasource.prisma",
+                r#"datasource db {
+                    provider = "postgresql"
+                    url = "postgresql://example.com/db"
+                }"#,
+            ),
+        ];
+
+        let request = json!({
+            "prismaSchema": schemas,
+        });
+
+        let expected = expect![[
+            r#"{"config":{"generators":[{"name":"js","provider":{"fromEnvVar":null,"value":"prisma-client-js"},"output":null,"config":{},"binaryTargets":[],"previewFeatures":["prismaSchemaFolder"]}],"datasources":[{"name":"db","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":null,"value":"postgresql://example.com/db"},"schemas":[]}],"warnings":[]},"errors":[]}"#
+        ]];
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -114,9 +247,9 @@ mod tests {
             "prismaSchema": schema,
         });
         let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:4\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 3 | \u001b[0m                provider = \"postgresql\"\n\u001b[1;94m 4 | \u001b[0m                url = \u001b[1;91menv(\"NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST","value":null},"schemas":[]}],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:4\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 3 | \u001b[0m                provider = \"postgresql\"\n\u001b[1;94m 4 | \u001b[0m                url = \u001b[1;91menv(\"NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n"}]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap_err();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -134,9 +267,9 @@ mod tests {
             "ignoreEnvVarErrors": true,
         });
         let expected = expect![[
-            r#"{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST","value":null},"schemas":[]}],"warnings":[]}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"NON_EXISTING_ENV_VAR_WE_COUNT_ON_IT_AT_LEAST","value":null},"schemas":[]}],"warnings":[]},"errors":[]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -156,9 +289,9 @@ mod tests {
             }
         });
         let expected = expect![[
-            r#"{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"schemas":[]}],"warnings":[]}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"schemas":[]}],"warnings":[]},"errors":[]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -179,9 +312,9 @@ mod tests {
             }
         });
         let expected = expect![[
-            r#"{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"directUrl":{"fromEnvVar":null,"value":"postgresql://example.com/direct"},"schemas":[]}],"warnings":[]}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"directUrl":{"fromEnvVar":null,"value":"postgresql://example.com/direct"},"schemas":[]}],"warnings":[]},"errors":[]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -203,9 +336,9 @@ mod tests {
             }
         });
         let expected = expect![[
-            r#"{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"directUrl":{"fromEnvVar":"DBDIRURL","value":"postgresql://example.com/direct"},"schemas":[]}],"warnings":[]}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":"postgresql://example.com/mydb"},"directUrl":{"fromEnvVar":"DBDIRURL","value":"postgresql://example.com/direct"},"schemas":[]}],"warnings":[]},"errors":[]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -226,9 +359,9 @@ mod tests {
             }
         });
         let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":null},"directUrl":{"fromEnvVar":null,"value":""},"schemas":[]}],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91m\"\"\u001b[0m\n\u001b[1;94m   | \u001b[0m\n"}]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap_err();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -249,9 +382,9 @@ mod tests {
             }
         });
         let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":null},"directUrl":{"fromEnvVar":"DOES_NOT_EXIST","value":null},"schemas":[]}],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mEnvironment variable not found: DOES_NOT_EXIST.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n"}]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap_err();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 
@@ -273,9 +406,9 @@ mod tests {
             }
         });
         let expected = expect![[
-            r#"{"message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\nValidation Error Count: 1","error_code":"P1012"}"#
+            r#"{"config":{"generators":[],"datasources":[{"name":"thedb","provider":"postgresql","activeProvider":"postgresql","url":{"fromEnvVar":"DBURL","value":null},"directUrl":{"fromEnvVar":"DOES_NOT_EXIST","value":null},"schemas":[]}],"warnings":[]},"errors":[{"file_name":"schema.prisma","message":"\u001b[1;91merror\u001b[0m: \u001b[1mError validating datasource `thedb`: You must provide a nonempty direct URL. The environment variable `DOES_NOT_EXIST` resolved to an empty string.\u001b[0m\n  \u001b[1;94m-->\u001b[0m  \u001b[4mschema.prisma:5\u001b[0m\n\u001b[1;94m   | \u001b[0m\n\u001b[1;94m 4 | \u001b[0m                url = env(\"DBURL\")\n\u001b[1;94m 5 | \u001b[0m                directUrl = \u001b[1;91menv(\"DOES_NOT_EXIST\")\u001b[0m\n\u001b[1;94m   | \u001b[0m\n"}]}"#
         ]];
-        let response = get_config(&request.to_string()).unwrap_err();
+        let response = get_config(&request.to_string());
         expected.assert_eq(&response);
     }
 }

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -182,7 +182,7 @@ pub fn referential_actions(schema: String) -> String {
 /// type GetConfigResponse = GetConfigErrorResponse | GetConfigSuccessResponse
 ///
 /// ```
-pub fn get_config(get_config_params: String) -> Result<String, String> {
+pub fn get_config(get_config_params: String) -> String {
     get_config::get_config(&get_config_params)
 }
 

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -4,7 +4,7 @@ use lsp_types::*;
 use psl::{
     datamodel_connector::Connector,
     diagnostics::{FileId, Span},
-    infallible_parse_configuration,
+    error_tolerant_parse_configuration,
     parser_database::{ast, ParserDatabase, SourceFile},
     Configuration, Datasource, Diagnostics, Generator, PreviewFeature,
 };
@@ -21,7 +21,7 @@ pub(crate) fn empty_completion_list() -> CompletionList {
 }
 
 pub(crate) fn completion(schema_files: Vec<(String, SourceFile)>, params: CompletionParams) -> CompletionList {
-    let (_, config, _) = infallible_parse_configuration(&schema_files);
+    let (_, config, _) = error_tolerant_parse_configuration(&schema_files);
 
     let mut list = CompletionList {
         is_incomplete: false,

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -4,7 +4,7 @@ use lsp_types::*;
 use psl::{
     datamodel_connector::Connector,
     diagnostics::{FileId, Span},
-    parse_configuration_multi_file,
+    infallible_parse_configuration,
     parser_database::{ast, ParserDatabase, SourceFile},
     Configuration, Datasource, Diagnostics, Generator, PreviewFeature,
 };
@@ -21,9 +21,7 @@ pub(crate) fn empty_completion_list() -> CompletionList {
 }
 
 pub(crate) fn completion(schema_files: Vec<(String, SourceFile)>, params: CompletionParams) -> CompletionList {
-    let config = parse_configuration_multi_file(&schema_files)
-        .ok()
-        .map(|(_, config)| config);
+    let (_, config, _) = infallible_parse_configuration(&schema_files);
 
     let mut list = CompletionList {
         is_incomplete: false,
@@ -50,7 +48,7 @@ pub(crate) fn completion(schema_files: Vec<(String, SourceFile)>, params: Comple
     };
 
     let ctx = CompletionContext {
-        config: config.as_ref(),
+        config: &config,
         params: &params,
         db: &db,
         position,
@@ -64,7 +62,7 @@ pub(crate) fn completion(schema_files: Vec<(String, SourceFile)>, params: Comple
 
 #[derive(Debug, Clone, Copy)]
 struct CompletionContext<'a> {
-    config: Option<&'a Configuration>,
+    config: &'a Configuration,
     params: &'a CompletionParams,
     db: &'a ParserDatabase,
     position: usize,
@@ -89,19 +87,19 @@ impl<'a> CompletionContext<'a> {
     }
 
     fn datasource(self) -> Option<&'a Datasource> {
-        self.config.and_then(|conf| conf.datasources.first())
+        self.config.datasources.first()
     }
 
     fn generator(self) -> Option<&'a Generator> {
-        self.config.and_then(|conf| conf.generators.first())
+        self.config.generators.first()
     }
 }
 
 fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut CompletionList) {
-    let relation_mode = match ctx.config.map(|c| c.relation_mode()) {
-        Some(Some(rm)) => rm,
-        _ => ctx.connector().default_relation_mode(),
-    };
+    let relation_mode = ctx
+        .config
+        .relation_mode()
+        .unwrap_or_else(|| ctx.connector().default_relation_mode());
 
     match ctx.db.ast(ctx.initiating_file_id).find_at_position(ctx.position) {
         ast::SchemaPosition::Model(
@@ -154,9 +152,7 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
                 datasource::relation_mode_completion(completion_list);
             }
 
-            if let Some(config) = ctx.config {
-                ctx.connector().datasource_completions(config, completion_list);
-            }
+            ctx.connector().datasource_completions(ctx.config, completion_list);
         }
 
         ast::SchemaPosition::DataSource(

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -34,9 +34,9 @@ pub fn format(schema: String, params: String) -> String {
 
 /// Docs: https://prisma.github.io/prisma-engines/doc/prisma_fmt/fn.get_config.html
 #[wasm_bindgen]
-pub fn get_config(params: String) -> Result<String, JsError> {
+pub fn get_config(params: String) -> String {
     register_panic_hook();
-    prisma_fmt::get_config(params).map_err(|e| JsError::new(&e))
+    prisma_fmt::get_config(params)
 }
 
 /// Docs: https://prisma.github.io/prisma-engines/doc/prisma_fmt/fn.get_dmmf.html

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -15,6 +15,8 @@ mod reformat;
 mod set_config_dir;
 mod validate;
 
+use std::sync::Arc;
+
 pub use crate::{
     common::{PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES},
     configuration::{
@@ -130,9 +132,9 @@ pub fn parse_configuration(
     schema: &str,
     connectors: ConnectorRegistry<'_>,
 ) -> Result<Configuration, diagnostics::Diagnostics> {
-    let mut diagnostics = Diagnostics::default();
-    let ast = schema_ast::parse_schema(schema, &mut diagnostics, diagnostics::FileId::ZERO);
-    let out = validate_configuration(&ast, &mut diagnostics, connectors);
+    let source_file = SourceFile::new_allocated(Arc::from(schema.to_owned().into_boxed_str()));
+    let (_, out, mut diagnostics) =
+        infallible_parse_configuration(&[("schema.prisma".into(), source_file)], connectors);
     diagnostics.to_result().map(|_| out)
 }
 
@@ -140,6 +142,17 @@ pub fn parse_configuration_multi_file(
     files: &[(String, SourceFile)],
     connectors: ConnectorRegistry<'_>,
 ) -> Result<(Files, Configuration), (Files, diagnostics::Diagnostics)> {
+    let (files, configuration, mut diagnostics) = infallible_parse_configuration(files, connectors);
+    match diagnostics.to_result() {
+        Ok(_) => Ok((files, configuration)),
+        Err(err) => Err((files, err)),
+    }
+}
+
+pub fn infallible_parse_configuration(
+    files: &[(String, SourceFile)],
+    connectors: ConnectorRegistry<'_>,
+) -> (Files, Configuration, Diagnostics) {
     let mut diagnostics = Diagnostics::default();
     let mut configuration = Configuration::default();
 
@@ -150,10 +163,7 @@ pub fn parse_configuration_multi_file(
         configuration.extend(out);
     }
 
-    match diagnostics.to_result() {
-        Ok(_) => Ok((asts, configuration)),
-        Err(err) => Err((asts, err)),
-    }
+    (asts, configuration, diagnostics)
 }
 
 fn validate_configuration(

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -134,7 +134,7 @@ pub fn parse_configuration(
 ) -> Result<Configuration, diagnostics::Diagnostics> {
     let source_file = SourceFile::new_allocated(Arc::from(schema.to_owned().into_boxed_str()));
     let (_, out, mut diagnostics) =
-        infallible_parse_configuration(&[("schema.prisma".into(), source_file)], connectors);
+        error_tolerant_parse_configuration(&[("schema.prisma".into(), source_file)], connectors);
     diagnostics.to_result().map(|_| out)
 }
 
@@ -142,14 +142,14 @@ pub fn parse_configuration_multi_file(
     files: &[(String, SourceFile)],
     connectors: ConnectorRegistry<'_>,
 ) -> Result<(Files, Configuration), (Files, diagnostics::Diagnostics)> {
-    let (files, configuration, mut diagnostics) = infallible_parse_configuration(files, connectors);
+    let (files, configuration, mut diagnostics) = error_tolerant_parse_configuration(files, connectors);
     match diagnostics.to_result() {
         Ok(_) => Ok((files, configuration)),
         Err(err) => Err((files, err)),
     }
 }
 
-pub fn infallible_parse_configuration(
+pub fn error_tolerant_parse_configuration(
     files: &[(String, SourceFile)],
     connectors: ConnectorRegistry<'_>,
 ) -> (Files, Configuration, Diagnostics) {

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -53,8 +53,8 @@ pub fn parse_configuration_multi_file(
 /// blocks. It never fails, but when the returned `Diagnostics` contains errors, it implies that the
 /// `Configuration` content is partial.
 /// Consumers may then decide  whether to convert `Diagnostics` into an error.
-pub fn infallible_parse_configuration(files: &[(String, SourceFile)]) -> (Files, Configuration, Diagnostics) {
-    psl_core::infallible_parse_configuration(files, builtin_connectors::BUILTIN_CONNECTORS)
+pub fn error_tolerant_parse_configuration(files: &[(String, SourceFile)]) -> (Files, Configuration, Diagnostics) {
+    psl_core::error_tolerant_parse_configuration(files, builtin_connectors::BUILTIN_CONNECTORS)
 }
 
 /// Parse and analyze a Prisma schema.

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -49,6 +49,14 @@ pub fn parse_configuration_multi_file(
     psl_core::parse_configuration_multi_file(files, builtin_connectors::BUILTIN_CONNECTORS)
 }
 
+/// Parses and validates Prisma schemas, but skip analyzing everything except datasource and generator
+/// blocks. It never fails, but when the returned `Diagnostics` contains errors, it implies that the
+/// `Configuration` content is partial.
+/// Consumers may then decide  whether to convert `Diagnostics` into an error.
+pub fn infallible_parse_configuration(files: &[(String, SourceFile)]) -> (Files, Configuration, Diagnostics) {
+    psl_core::infallible_parse_configuration(files, builtin_connectors::BUILTIN_CONNECTORS)
+}
+
 /// Parse and analyze a Prisma schema.
 pub fn parse_schema(file: impl Into<SourceFile>) -> Result<ValidatedSchema, String> {
     let mut schema = validate(file.into());


### PR DESCRIPTION
Adds new function `infallible_parse_configuration` that never fails and always returns both `Config` and
`Diagnostics`. In case of errors, `Diagnostic` would be non-empty, but
it will still try to return as much of a config as it was able to parse.

This is useful mostly for dev tools - they need to be able to read
preview feature from more invalid files than old `get_config` would've
allowed. It also improves diagnostics in the CLI since we are now also
able to tell that user wanted to have more cases.

This is a breaking change to consumers of `prisma-fmt`: both prisma cli
and language-tools would need to be adapted to the new signature.

Contributes to prisma/team-orm#1143
Contributes to prisma/team-orm#1127 (opportunistic refactor)
