### PR TITLE
Add support for UUIDv7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6080,6 +6080,7 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.11",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6074,9 +6074,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.11",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1.25", features = [
 ] }
 chrono = { version = "0.4.38", features = ["serde"] }
 user-facing-errors = { path = "./libs/user-facing-errors" }
-uuid = { version = "1", features = ["serde", "v4", "v7"] }
+uuid = { version = "1", features = ["serde", "v4", "v7", "js"] }
 indoc = "2.0.1"
 indexmap = { version = "2.2.2", features = ["serde"] }
 itertools = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tokio = { version = "1.25", features = [
 ] }
 chrono = { version = "0.4.38", features = ["serde"] }
 user-facing-errors = { path = "./libs/user-facing-errors" }
-uuid = { version = "1", features = ["serde", "v4"] }
+uuid = { version = "1", features = ["serde", "v4", "v7"] }
 indoc = "2.0.1"
 indexmap = { version = "2.2.2", features = ["serde"] }
 itertools = "0.12"

--- a/psl/psl/tests/attributes/id_negative.rs
+++ b/psl/psl/tests/attributes/id_negative.rs
@@ -45,6 +45,26 @@ fn id_should_error_multiple_ids_are_provided() {
 }
 
 #[test]
+fn id_should_error_on_invalid_uuid_version() {
+    let dml = indoc! {r#"
+        model Model {
+          id String   @id @default(uuid(1))
+        }
+    "#};
+
+    let expectation = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@default": `uuid()` takes either no argument, or a single integer argument which is either 4 or 7.[0m
+          [1;94m-->[0m  [4mschema.prisma:2[0m
+        [1;94m   | [0m
+        [1;94m 1 | [0mmodel Model {
+        [1;94m 2 | [0m  id String   @id [1;91m@default(uuid(1))[0m
+        [1;94m   | [0m
+    "#]];
+
+    expect_error(dml, &expectation)
+}
+
+#[test]
 fn id_must_error_when_single_and_multi_field_id_is_used() {
     let dml = indoc! {r#"
         model Model {

--- a/psl/psl/tests/attributes/id_positive.rs
+++ b/psl/psl/tests/attributes/id_positive.rs
@@ -71,6 +71,45 @@ fn should_allow_string_ids_with_uuid() {
 }
 
 #[test]
+fn should_allow_string_ids_with_uuid_version_specified() {
+    let dml = indoc! {r#"
+        model ModelA {
+          id String @id @default(uuid(4))
+        }
+
+        model ModelB {
+          id String @id @default(uuid(7))
+        }
+    "#};
+
+    let schema = psl::parse_schema(dml).unwrap();
+
+    {
+        let model = schema.assert_has_model("ModelA");
+
+        model
+            .assert_has_scalar_field("id")
+            .assert_scalar_type(ScalarType::String)
+            .assert_default_value()
+            .assert_uuid();
+
+        model.assert_id_on_fields(&["id"]);
+    }
+
+    {
+        let model = schema.assert_has_model("ModelB");
+
+        model
+            .assert_has_scalar_field("id")
+            .assert_scalar_type(ScalarType::String)
+            .assert_default_value()
+            .assert_uuid();
+
+        model.assert_id_on_fields(&["id"]);
+    }
+}
+
+#[test]
 fn should_allow_string_ids_without_default() {
     let dml = indoc! {r#"
         model Model {

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -631,9 +631,7 @@ impl DefaultValueAssert for ast::Expression {
 
     #[track_caller]
     fn assert_uuid(&self) -> &Self {
-        assert!(
-            matches!(self, ast::Expression::Function(name, args, _) if name == "uuid" && args.arguments.is_empty())
-        );
+        assert!(matches!(self, ast::Expression::Function(name, _, _) if name == "uuid"));
 
         self
     }

--- a/query-engine/query-structure/Cargo.toml
+++ b/query-engine/query-structure/Cargo.toml
@@ -22,4 +22,4 @@ features = ["js"]
 
 [features]
 # Support for generating default UUID, CUID, nanoid and datetime values.
-default_generators = ["uuid/v4", "cuid", "nanoid"]
+default_generators = ["uuid/v4", "uuid/v7", "cuid", "nanoid"]

--- a/query-engine/query-structure/src/default_value.rs
+++ b/query-engine/query-structure/src/default_value.rs
@@ -45,7 +45,7 @@ impl DefaultKind {
 
     /// Does this match @default(uuid(_))?
     pub fn is_uuid(&self) -> bool {
-        matches!(self, DefaultKind::Expression(generator) if generator.name == "uuid")
+        matches!(self, DefaultKind::Expression(generator) if generator.name.starts_with("uuid"))
     }
 
     pub fn unwrap_single(self) -> PrismaValue {
@@ -186,8 +186,8 @@ impl ValueGenerator {
         ValueGenerator::new("cuid".to_owned(), vec![]).unwrap()
     }
 
-    pub fn new_uuid() -> Self {
-        ValueGenerator::new("uuid".to_owned(), vec![]).unwrap()
+    pub fn new_uuid(version: u8) -> Self {
+        ValueGenerator::new(format!("uuid({version})"), vec![]).unwrap()
     }
 
     pub fn new_nanoid(length: Option<u8>) -> Self {
@@ -238,7 +238,7 @@ impl ValueGenerator {
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum ValueGeneratorFn {
-    Uuid,
+    Uuid(u8),
     Cuid,
     Nanoid(Option<u8>),
     Now,
@@ -251,7 +251,8 @@ impl ValueGeneratorFn {
     fn new(name: &str) -> std::result::Result<Self, String> {
         match name {
             "cuid" => Ok(Self::Cuid),
-            "uuid" => Ok(Self::Uuid),
+            "uuid" | "uuid(4)" => Ok(Self::Uuid(4)),
+            "uuid(7)" => Ok(Self::Uuid(7)),
             "now" => Ok(Self::Now),
             "autoincrement" => Ok(Self::Autoincrement),
             "sequence" => Ok(Self::Autoincrement),
@@ -265,7 +266,7 @@ impl ValueGeneratorFn {
     #[cfg(feature = "default_generators")]
     fn invoke(&self) -> Option<PrismaValue> {
         match self {
-            Self::Uuid => Some(Self::generate_uuid()),
+            Self::Uuid(version) => Some(Self::generate_uuid(*version)),
             Self::Cuid => Some(Self::generate_cuid()),
             Self::Nanoid(length) => Some(Self::generate_nanoid(length)),
             Self::Now => Some(Self::generate_now()),
@@ -282,8 +283,12 @@ impl ValueGeneratorFn {
     }
 
     #[cfg(feature = "default_generators")]
-    fn generate_uuid() -> PrismaValue {
-        PrismaValue::Uuid(uuid::Uuid::new_v4())
+    fn generate_uuid(version: u8) -> PrismaValue {
+        PrismaValue::Uuid(match version {
+            4 => uuid::Uuid::new_v4(),
+            7 => uuid::Uuid::now_v7(),
+            _ => panic!("Unknown UUID version: {}", version),
+        })
     }
 
     #[cfg(feature = "default_generators")]
@@ -337,8 +342,16 @@ mod tests {
     }
 
     #[test]
-    fn default_value_is_uuid() {
-        let uuid_default = DefaultValue::new_expression(ValueGenerator::new_uuid());
+    fn default_value_is_uuidv4() {
+        let uuid_default = DefaultValue::new_expression(ValueGenerator::new_uuid(4));
+
+        assert!(uuid_default.is_uuid());
+        assert!(!uuid_default.is_autoincrement());
+    }
+
+    #[test]
+    fn default_value_is_uuidv7() {
+        let uuid_default = DefaultValue::new_expression(ValueGenerator::new_uuid(7));
 
         assert!(uuid_default.is_uuid());
         assert!(!uuid_default.is_autoincrement());

--- a/query-engine/query-structure/src/field/scalar.rs
+++ b/query-engine/query-structure/src/field/scalar.rs
@@ -244,8 +244,15 @@ pub fn dml_default_kind(default_value: &ast::Expression, scalar_type: Option<Sca
         ast::Expression::Function(funcname, _args, _) if funcname == "sequence" => {
             DefaultKind::Expression(ValueGenerator::new_sequence(Vec::new()))
         }
-        ast::Expression::Function(funcname, _args, _) if funcname == "uuid" => {
-            DefaultKind::Expression(ValueGenerator::new_uuid())
+        ast::Expression::Function(funcname, args, _) if funcname == "uuid" => {
+            let version = args
+                .arguments
+                .first()
+                .and_then(|arg| arg.value.as_numeric_value())
+                .map(|(val, _)| val.parse::<u8>().unwrap())
+                .unwrap_or(4);
+
+            DefaultKind::Expression(ValueGenerator::new_uuid(version))
         }
         ast::Expression::Function(funcname, _args, _) if funcname == "cuid" => {
             DefaultKind::Expression(ValueGenerator::new_cuid())


### PR DESCRIPTION
This implements https://github.com/prisma/prisma/issues/24079. The change is pretty minimal, widening the support from `@default(uuid())` to `@default(uuid(7))`.

It leverages the existing `uuid` crate instead of adding a new one (`uuid7`).

~Right now this code is mostly untested (apart from the tests I added to `psl`), because I couldn't get the tests running locally. I'd appreciate some guidance in this area.~ CI runs fine