### PR TITLE
Revert "fix(quaint/DA): handle JSON parsing engines side so that we can correctly handle `i64`s (#4883)"

### DIFF
--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -59,7 +59,6 @@ jobs:
 
       - name: Run benchmarks
         id: bench
-        if: false
         run: |
           make run-bench | tee results.txt
 
@@ -123,7 +122,6 @@ jobs:
             echo EOF
           } >> "$GITHUB_OUTPUT"
       - name: Find past report comment
-        if: false
         uses: peter-evans/find-comment@v3
         id: findReportComment
         with:
@@ -134,9 +132,7 @@ jobs:
         uses: peter-evans/create-or-update-comment@v4
         # Only run on branches from our repository
         # It avoids an expected failure on forks
-        # if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        if: false
-
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           comment-id: ${{ steps.findReportComment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -156,8 +152,7 @@ jobs:
           edit-mode: replace
 
       - name: Fail workflow if regression detected
-        # if: steps.bench.outputs.status == 'failed'
-        if: false
+        if: steps.bench.outputs.status == 'failed'
         run: |
           echo "Workflow failed due to benchmark regression."
           exit 1

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -31,7 +31,13 @@ mod scalar_relations {
         schema.to_owned()
     }
 
-    #[connector_test(schema(schema_common))]
+    // TODO: fix https://github.com/prisma/team-orm/issues/684 and unexclude DAs.
+    // On napi, this currently fails with "P2023":
+    // `Inconsistent column data: Unexpected conversion failure for field Child.bInt from Number(14324324234324.0) to BigInt`.
+    #[connector_test(
+        schema(schema_common),
+        exclude(Postgres("pg.js", "neon.js"), Vitess("planetscale.js"))
+    )]
     async fn common_types(runner: Runner) -> TestResult<()> {
         create_common_children(&runner).await?;
 

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read/coerce.rs
@@ -111,11 +111,6 @@ fn coerce_json_relation_to_pv(value: serde_json::Value, rs: &RelationSelection) 
 
             Ok(PrismaValue::Object(map))
         }
-        serde_json::Value::String(s) => {
-            let v = serde_json::from_str(&s)?;
-
-            coerce_json_relation_to_pv(v, rs)
-        }
         x => unreachable!("Unexpected value when deserializing JSON relation data: {x:?}"),
     }
 }

--- a/query-engine/driver-adapters/src/conversion/js_to_quaint.rs
+++ b/query-engine/driver-adapters/src/conversion/js_to_quaint.rs
@@ -217,9 +217,8 @@ pub fn js_value_to_quaint(
             match json_value {
                 // DbNull
                 serde_json::Value::Null => Ok(QuaintValue::null_json()),
-                serde_json::Value::String(s) => serde_json::from_str(&s)
-                    .map_err(|_| conversion_error!("Failed to parse incoming json from a driver adapter"))
-                    .map(QuaintValue::json),
+                // JsonNull
+                serde_json::Value::String(s) if s == "$__prisma_null" => Ok(QuaintValue::json(serde_json::Value::Null)),
                 json => Ok(QuaintValue::json(json)),
             }
         }


### PR DESCRIPTION
This reverts commit f742678b0f8364ff07385479621aad7de5b47877.

Temporary reverting the change. It is interdependent with
prisma/prisma#24269 and neither PR works correctly without the other.
The plan was to let engines CI to temporarily go red and fix it
immediately by merging client PR. However, engine release pipeline is
broken for unrelated reason and this is not possible. Just to limit
amount of broken things in progress, we are reverting original PR. It is
expected we restore it with no changes once release pipeline is fixed.
