### PR TITLE
fix(mongo): default int native type should be long

### DIFF
--- a/psl/psl-core/src/builtin_connectors/mongodb/mongodb_types.rs
+++ b/psl/psl-core/src/builtin_connectors/mongodb/mongodb_types.rs
@@ -34,7 +34,7 @@ crate::native_type_definition! {
 
 static DEFAULT_MAPPING: Lazy<HashMap<ScalarType, MongoDbType>> = Lazy::new(|| {
     vec![
-        (ScalarType::Int, MongoDbType::Int),
+        (ScalarType::Int, MongoDbType::Long),
         (ScalarType::BigInt, MongoDbType::Long),
         (ScalarType::Float, MongoDbType::Double),
         (ScalarType::Boolean, MongoDbType::Bool),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mongodb.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/data_types/native_types/mongodb.rs
@@ -197,4 +197,25 @@ mod mongodb {
 
         Ok(())
     }
+
+    fn default_int_type() -> String {
+        let schema = indoc! {
+            r#"model Test {
+                #id(id, String, @id, @default(cuid()))
+                int  Int
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(default_int_type))]
+    async fn default_int_type_is_long(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createOneTest(data: { int: 9223372036854775807 }) { int } }"#),
+          @r###"{"data":{"createOneTest":{"int":9223372036854775807}}}"###
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/24262

Encode `Int` fields as `Int64` by default.

This fixes a regression introduced in https://github.com/prisma/prisma-engines/pull/4639 where `ScalarField::native_type()` always returns a native type now, even when it's not explicitly specified in the Prisma Schema. This caused the MongoDB connector to use a different code path to encode input values which encoded default `Int` fields as `Int32` although they were previously encoded as `Int64`s.