### PR TITLE
fix(fmt): quick-fix create new block

### DIFF
--- a/prisma-fmt/src/code_actions.rs
+++ b/prisma-fmt/src/code_actions.rs
@@ -102,7 +102,7 @@ pub(crate) fn available_actions(
         .walk_models_in_file(initiating_file_id)
         .chain(validated_schema.db.walk_views_in_file(initiating_file_id))
     {
-        block::create_missing_block(&mut actions, &context, model);
+        block::create_missing_block_for_model(&mut actions, &context, model);
 
         if config.preview_features().contains(PreviewFeature::MultiSchema) {
             multi_schema::add_schema_block_attribute_model(&mut actions, &context, model);
@@ -114,6 +114,12 @@ pub(crate) fn available_actions(
             mongodb::add_at_map_for_id(&mut actions, &context, model);
 
             mongodb::add_native_for_auto_id(&mut actions, &context, model, datasource.unwrap());
+        }
+    }
+
+    if matches!(datasource, Some(ds) if ds.active_provider == "mongodb") {
+        for composite_type in validated_schema.db.walk_composite_types_in_file(initiating_file_id) {
+            block::create_missing_block_for_type(&mut actions, &context, composite_type);
         }
     }
 

--- a/prisma-fmt/src/code_actions.rs
+++ b/prisma-fmt/src/code_actions.rs
@@ -1,3 +1,4 @@
+mod block;
 mod mongodb;
 mod multi_schema;
 mod relation_mode;
@@ -101,6 +102,8 @@ pub(crate) fn available_actions(
         .walk_models_in_file(initiating_file_id)
         .chain(validated_schema.db.walk_views_in_file(initiating_file_id))
     {
+        block::create_missing_block(&mut actions, &context, model);
+
         if config.preview_features().contains(PreviewFeature::MultiSchema) {
             multi_schema::add_schema_block_attribute_model(&mut actions, &context, model);
 
@@ -116,7 +119,7 @@ pub(crate) fn available_actions(
 
     for enumerator in validated_schema.db.walk_enums_in_file(initiating_file_id) {
         if config.preview_features().contains(PreviewFeature::MultiSchema) {
-            multi_schema::add_schema_block_attribute_enum(&mut actions, &context, enumerator)
+            multi_schema::add_schema_block_attribute_enum(&mut actions, &context, enumerator);
         }
     }
 

--- a/prisma-fmt/src/code_actions/block.rs
+++ b/prisma-fmt/src/code_actions/block.rs
@@ -1,0 +1,87 @@
+use std::collections::HashMap;
+
+use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, Range, TextEdit, Url, WorkspaceEdit};
+use psl::{diagnostics::Span, parser_database::walkers::ModelWalker, schema_ast::ast::WithSpan};
+
+use super::CodeActionsContext;
+
+pub(super) fn create_missing_block(
+    actions: &mut Vec<CodeActionOrCommand>,
+    context: &CodeActionsContext<'_>,
+    model: ModelWalker<'_>,
+) {
+    let span_model = model.ast_model().span();
+    let diagnostics = context
+        .diagnostics_for_span_with_message(span_model, "is neither a built-in type, nor refers to another model,");
+
+    if diagnostics.is_empty() {
+        return;
+    }
+
+    let span = Span {
+        start: model.ast_model().span().start,
+        end: model.ast_model().span().end + 1, // * otherwise it's still not outside the closing brace
+        file_id: model.ast_model().span().file_id,
+    };
+
+    let range = super::range_after_span(context.initiating_file_source(), span);
+
+    diagnostics.iter().for_each(|diag| {
+        push_missing_block(
+            diag,
+            context.lsp_params.text_document.uri.clone(),
+            range,
+            "model",
+            actions,
+        );
+        push_missing_block(
+            diag,
+            context.lsp_params.text_document.uri.clone(),
+            range,
+            "enum",
+            actions,
+        );
+
+        if let Some(ds) = context.datasource() {
+            if ds.active_provider == "mongodb" {
+                push_missing_block(
+                    diag,
+                    context.lsp_params.text_document.uri.clone(),
+                    range,
+                    "type",
+                    actions,
+                );
+            }
+        }
+    })
+}
+
+fn push_missing_block(
+    diag: &Diagnostic,
+    uri: Url,
+    range: Range,
+    block_type: &str,
+    actions: &mut Vec<CodeActionOrCommand>,
+) {
+    let name: &str = diag.message.split("\"").collect::<Vec<&str>>()[1];
+    let new_text = format!("\n{block_type} {name} {{\n\n}}\n");
+    let text = TextEdit { range, new_text };
+
+    let mut changes = HashMap::new();
+    changes.insert(uri, vec![text]);
+
+    let edit = WorkspaceEdit {
+        changes: Some(changes),
+        ..Default::default()
+    };
+
+    let action = CodeAction {
+        title: format!("Create new {block_type} '{name}'"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(edit),
+        diagnostics: Some(vec![diag.clone()]),
+        ..Default::default()
+    };
+
+    actions.push(CodeActionOrCommand::CodeAction(action))
+}

--- a/prisma-fmt/src/code_actions/block.rs
+++ b/prisma-fmt/src/code_actions/block.rs
@@ -63,7 +63,7 @@ fn push_missing_block(
     block_type: &str,
     actions: &mut Vec<CodeActionOrCommand>,
 ) {
-    let name: &str = diag.message.split("\"").collect::<Vec<&str>>()[1];
+    let name: &str = diag.message.split('\"').collect::<Vec<&str>>()[1];
     let new_text = format!("\n{block_type} {name} {{\n\n}}\n");
     let text = TextEdit { range, new_text };
 

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block/result.json
@@ -1,0 +1,80 @@
+[
+  {
+    "title": "Create new model 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\nmodel Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Create new enum 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\nenum Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}
+
+model Kattbjorn {
+    id     String @id
+    friend Animal
+}

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type/result.json
@@ -1,0 +1,80 @@
+[
+  {
+    "title": "Create new type 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\ntype Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Create new enum 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\nenum Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "mongodb"
+    url      = env("DATABASE_URL")
+}
+
+type Kattbjorn {
+    name   String
+    friend Animal
+}

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_mongodb/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_mongodb/result.json
@@ -1,0 +1,119 @@
+[
+  {
+    "title": "Create new model 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\nmodel Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Create new enum 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\nenum Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Create new type 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 13,
+                "character": 0
+              }
+            },
+            "newText": "\ntype Animal {\n\n}\n"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_mongodb/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_mongodb/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "mongodb"
+    url      = env("DATABASE_URL")
+}
+
+model Kattbjorn {
+    id     String @id @map("_id")
+    friend Animal
+}

--- a/prisma-fmt/tests/code_actions/tests.rs
+++ b/prisma-fmt/tests/code_actions/tests.rs
@@ -47,5 +47,6 @@ scenarios! {
     mongodb_at_map_with_validation_errors
     mongodb_auto_native
     create_missing_block
+    create_missing_block_composite_type
     create_missing_block_mongodb
 }

--- a/prisma-fmt/tests/code_actions/tests.rs
+++ b/prisma-fmt/tests/code_actions/tests.rs
@@ -46,4 +46,6 @@ scenarios! {
     mongodb_at_map_multifile
     mongodb_at_map_with_validation_errors
     mongodb_auto_native
+    create_missing_block
+    create_missing_block_mongodb
 }

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -141,6 +141,12 @@ impl crate::ParserDatabase {
             .map(|id| self.walk(id))
     }
 
+    /// Walk all composite types in specified file
+    pub fn walk_composite_types_in_file(&self, file_id: FileId) -> impl Iterator<Item = CompositeTypeWalker<'_>> + '_ {
+        self.walk_composite_types()
+            .filter(move |walker| walker.is_defined_in_file(file_id))
+    }
+
     /// Walk all scalar field defaults with a function not part of the common ones.
     pub fn walk_scalar_field_defaults_with_unknown_function(&self) -> impl Iterator<Item = DefaultValueWalker<'_>> {
         self.types

--- a/psl/parser-database/src/walkers/composite_type.rs
+++ b/psl/parser-database/src/walkers/composite_type.rs
@@ -33,6 +33,11 @@ impl<'db> CompositeTypeWalker<'db> {
         self.id.0
     }
 
+    /// Is the composite type defined in a specific file?
+    pub fn is_defined_in_file(self, file_id: FileId) -> bool {
+        self.ast_composite_type().span.file_id == file_id
+    }
+
     /// The composite type node in the AST.
     pub fn ast_composite_type(self) -> &'db ast::CompositeType {
         &self.db.asts[self.id]

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -67,7 +67,7 @@ impl<'db> ModelWalker<'db> {
 
     /// Is the model defined in a specific file?
     pub fn is_defined_in_file(self, file_id: FileId) -> bool {
-        return self.ast_model().span().file_id == file_id;
+        self.ast_model().span().file_id == file_id
     }
 
     /// The AST node.

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -26,7 +26,7 @@ schema = {
 // ######################################
 
 // At the syntax level, models and composite types are the same.
-model_declaration = { 
+model_declaration = {
     (MODEL_KEYWORD | TYPE_KEYWORD | VIEW_KEYWORD)
     ~ identifier
     ~ BLOCK_OPEN
@@ -100,7 +100,7 @@ enum_declaration = {
 
 enum_value_declaration = { identifier ~ field_attribute* ~ trailing_comment? ~ NEWLINE }
 enum_contents = {
-    (enum_value_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)* 
+    (enum_value_declaration | (block_attribute ~ NEWLINE) | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
 }
 
 // ######################################


### PR DESCRIPTION
Something broke in the definition for these quickfixes in language-tools so this is an opportunistic attempt to both fix and move them to engines.

Reference: https://github.com/prisma/language-tools/blob/53e70077abbcf26c03c8aabb416521dba248804b/packages/language-server/src/lib/code-actions/index.ts#L137-L166

fixes prisma/team-orm#1144