### PR TITLE
prisma-fmt: Accept multiple files as an input for native types hints

### DIFF
--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -132,8 +132,8 @@ pub fn merge_schemas(params: String) -> Result<String, String> {
     merge_schemas::merge_schemas(&params)
 }
 
-pub fn native_types(schema: String) -> String {
-    native::run(&schema)
+pub fn native_types(input: String) -> String {
+    native::run(&input)
 }
 
 pub fn preview_features() -> String {

--- a/prisma-fmt/src/main.rs
+++ b/prisma-fmt/src/main.rs
@@ -3,6 +3,7 @@ mod format;
 // mod lint;
 mod native;
 mod preview;
+mod schema_file_input;
 
 use std::{
     io::{self, Read},

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -15,7 +15,6 @@ pub(crate) fn run(input: &str) -> String {
     };
 
     if validated_configuration.datasources.len() != 1 {
-        dbg!(3);
         return "[]".to_owned();
     }
 

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -8,10 +8,9 @@ pub(crate) fn run(input: &str) -> String {
         Err(_) => return "[]".to_owned(),
     };
 
-    let schema: Vec<_> = schema.into();
     let validated_configuration = match psl::parse_configuration_multi_file(&schema) {
         Ok((_, validated_configuration)) => validated_configuration,
-        Err(_) => return "[]".to_owned()
+        Err(_) => return "[]".to_owned(),
     };
 
     if validated_configuration.datasources.len() != 1 {

--- a/prisma-fmt/src/native.rs
+++ b/prisma-fmt/src/native.rs
@@ -1,12 +1,21 @@
 use psl::datamodel_connector::NativeTypeConstructor;
 
-pub(crate) fn run(schema: &str) -> String {
-    let validated_configuration = match psl::parse_configuration(schema) {
-        Ok(validated_configuration) => validated_configuration,
+use crate::schema_file_input::SchemaFileInput;
+
+pub(crate) fn run(input: &str) -> String {
+    let schema: Vec<_> = match serde_json::from_str::<SchemaFileInput>(input) {
+        Ok(input) => input.into(),
         Err(_) => return "[]".to_owned(),
     };
 
+    let schema: Vec<_> = schema.into();
+    let validated_configuration = match psl::parse_configuration_multi_file(&schema) {
+        Ok((_, validated_configuration)) => validated_configuration,
+        Err(_) => return "[]".to_owned()
+    };
+
     if validated_configuration.datasources.len() != 1 {
+        dbg!(3);
         return "[]".to_owned();
     }
 

--- a/prisma-fmt/tests/native_types.rs
+++ b/prisma-fmt/tests/native_types.rs
@@ -9,9 +9,31 @@ fn test_native_types_list_on_crdb() {
         }
     "#;
 
-    let result = prisma_fmt::native_types(schema.to_owned());
+    let result = prisma_fmt::native_types(serde_json::to_string(schema).unwrap());
     let expected = expect![[
         r#"[{"name":"Bit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Bool","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Boolean"]},{"name":"Bytes","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Bytes"]},{"name":"Char","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Date","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["DateTime"]},{"name":"Decimal","_number_of_args":0,"_number_of_optional_args":2,"prisma_types":["Decimal"]},{"name":"Float4","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"Float8","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"Inet","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Int2","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Int4","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Int8","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["BigInt"]},{"name":"JsonB","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]},{"name":"Oid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"CatalogSingleChar","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"String","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Time","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timestamp","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timestamptz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timetz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Uuid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"VarBit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]}]"#
     ]];
+    expected.assert_eq(&result);
+}
+
+#[test]
+fn test_native_types_multifile() {
+    let schema = &[(
+        "A.prisma",
+        r#"
+        datasource mydb {
+            provider = "postgresql"
+            url = env("TEST_DATABASE_URL")
+        }"#,
+    ), (
+        "B.prisma",
+        r#"
+        model M {
+          id String @id
+        }"#,
+    )];
+
+    let result = prisma_fmt::native_types(serde_json::to_string(schema).unwrap());
+    let expected = expect![[r#"[{"name":"SmallInt","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Integer","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"BigInt","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["BigInt"]},{"name":"Decimal","_number_of_args":0,"_number_of_optional_args":2,"prisma_types":["Decimal"]},{"name":"Money","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Decimal"]},{"name":"Inet","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Oid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Citext","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Real","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"DoublePrecision","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"VarChar","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Char","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Text","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"ByteA","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Bytes"]},{"name":"Timestamp","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timestamptz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Date","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["DateTime"]},{"name":"Time","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timetz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Boolean","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Boolean"]},{"name":"Bit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"VarBit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Uuid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Xml","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Json","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]},{"name":"JsonB","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]}]"#]];
     expected.assert_eq(&result);
 }

--- a/prisma-fmt/tests/native_types.rs
+++ b/prisma-fmt/tests/native_types.rs
@@ -18,22 +18,27 @@ fn test_native_types_list_on_crdb() {
 
 #[test]
 fn test_native_types_multifile() {
-    let schema = &[(
-        "A.prisma",
-        r#"
+    let schema = &[
+        (
+            "A.prisma",
+            r#"
         datasource mydb {
             provider = "postgresql"
             url = env("TEST_DATABASE_URL")
         }"#,
-    ), (
-        "B.prisma",
-        r#"
+        ),
+        (
+            "B.prisma",
+            r#"
         model M {
           id String @id
         }"#,
-    )];
+        ),
+    ];
 
     let result = prisma_fmt::native_types(serde_json::to_string(schema).unwrap());
-    let expected = expect![[r#"[{"name":"SmallInt","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Integer","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"BigInt","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["BigInt"]},{"name":"Decimal","_number_of_args":0,"_number_of_optional_args":2,"prisma_types":["Decimal"]},{"name":"Money","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Decimal"]},{"name":"Inet","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Oid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Citext","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Real","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"DoublePrecision","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"VarChar","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Char","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Text","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"ByteA","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Bytes"]},{"name":"Timestamp","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timestamptz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Date","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["DateTime"]},{"name":"Time","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timetz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Boolean","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Boolean"]},{"name":"Bit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"VarBit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Uuid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Xml","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Json","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]},{"name":"JsonB","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]}]"#]];
+    let expected = expect![[
+        r#"[{"name":"SmallInt","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Integer","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"BigInt","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["BigInt"]},{"name":"Decimal","_number_of_args":0,"_number_of_optional_args":2,"prisma_types":["Decimal"]},{"name":"Money","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Decimal"]},{"name":"Inet","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Oid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Int"]},{"name":"Citext","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Real","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"DoublePrecision","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Float"]},{"name":"VarChar","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Char","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Text","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"ByteA","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Bytes"]},{"name":"Timestamp","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timestamptz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Date","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["DateTime"]},{"name":"Time","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Timetz","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["DateTime"]},{"name":"Boolean","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Boolean"]},{"name":"Bit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"VarBit","_number_of_args":0,"_number_of_optional_args":1,"prisma_types":["String"]},{"name":"Uuid","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Xml","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["String"]},{"name":"Json","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]},{"name":"JsonB","_number_of_args":0,"_number_of_optional_args":0,"prisma_types":["Json"]}]"#
+    ]];
     expected.assert_eq(&result);
 }


### PR DESCRIPTION
Autocomplete for native types is broken at the moment if schema folder
is used.
