### PR TITLE
fix(fmt): newlines for composite types (and enums)

### DIFF
--- a/prisma-fmt/src/code_actions/block.rs
+++ b/prisma-fmt/src/code_actions/block.rs
@@ -4,7 +4,7 @@ use lsp_types::{CodeAction, CodeActionKind, CodeActionOrCommand, Diagnostic, Ran
 use psl::{
     diagnostics::Span,
     parser_database::walkers::{CompositeTypeWalker, ModelWalker},
-    schema_ast::ast::WithSpan,
+    schema_ast::ast::{NewlineType, WithSpan},
 };
 
 use super::CodeActionsContext;
@@ -37,6 +37,7 @@ pub(super) fn create_missing_block_for_model(
             range,
             "model",
             actions,
+            model.newline(),
         );
         push_missing_block(
             diag,
@@ -44,6 +45,7 @@ pub(super) fn create_missing_block_for_model(
             range,
             "enum",
             actions,
+            model.newline(),
         );
 
         if let Some(ds) = context.datasource() {
@@ -54,6 +56,7 @@ pub(super) fn create_missing_block_for_model(
                     range,
                     "type",
                     actions,
+                    model.newline(),
                 );
             }
         }
@@ -88,6 +91,7 @@ pub(super) fn create_missing_block_for_type(
             range,
             "type",
             actions,
+            composite_type.newline(),
         );
         push_missing_block(
             diag,
@@ -95,6 +99,7 @@ pub(super) fn create_missing_block_for_type(
             range,
             "enum",
             actions,
+            composite_type.newline(),
         );
     })
 }
@@ -105,9 +110,10 @@ fn push_missing_block(
     range: Range,
     block_type: &str,
     actions: &mut Vec<CodeActionOrCommand>,
+    newline: NewlineType,
 ) {
     let name: &str = diag.message.split('\"').collect::<Vec<&str>>()[1];
-    let new_text = format!("\n{block_type} {name} {{\n\n}}\n");
+    let new_text = format!("\n{block_type} {name} {{{newline}{newline}}}{newline}");
     let text = TextEdit { range, new_text };
 
     let mut changes = HashMap::new();

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/.gitattributes
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/.gitattributes
@@ -1,0 +1,1 @@
+schema.prisma text eol=crlf

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/result.json
@@ -1,0 +1,80 @@
+[
+  {
+    "title": "Create new type 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 12,
+                "character": 2
+              }
+            },
+            "newText": "\ntype Animal {\r\n\r\n}\r\n"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "title": "Create new enum 'Animal'",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 11,
+            "character": 11
+          },
+          "end": {
+            "line": 11,
+            "character": 17
+          }
+        },
+        "severity": 1,
+        "message": "Type \"Animal\" is neither a built-in type, nor refers to another model, composite type, or enum."
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 12,
+                "character": 1
+              },
+              "end": {
+                "line": 12,
+                "character": 2
+              }
+            },
+            "newText": "\nenum Animal {\r\n\r\n}\r\n"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/schema.prisma
@@ -1,0 +1,13 @@
+generator client {
+    provider = "prisma-client-js"
+}
+
+datasource db {
+    provider = "mongodb"
+    url      = env("DATABASE_URL")
+}
+
+type Kattbjorn {
+    name   String
+    friend Animal
+}

--- a/prisma-fmt/tests/code_actions/tests.rs
+++ b/prisma-fmt/tests/code_actions/tests.rs
@@ -48,5 +48,6 @@ scenarios! {
     mongodb_auto_native
     create_missing_block
     create_missing_block_composite_type
+    create_missing_block_composite_type_crlf
     create_missing_block_mongodb
 }

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -17,6 +17,7 @@ mod scalar_field;
 
 pub use crate::types::RelationFieldId;
 pub use composite_type::*;
+use diagnostics::Span;
 pub use field::*;
 pub use index::*;
 pub use model::*;
@@ -24,7 +25,7 @@ pub use r#enum::*;
 pub use relation::*;
 pub use relation_field::*;
 pub use scalar_field::*;
-use schema_ast::ast::WithSpan;
+use schema_ast::ast::{NewlineType, WithSpan};
 
 use crate::{ast, FileId};
 
@@ -51,6 +52,16 @@ where
     #[allow(unconditional_recursion)]
     fn eq(&self, other: &Self) -> bool {
         self.id.eq(&other.id)
+    }
+}
+
+/// Retrieves newline variant for a block.
+pub(crate) fn newline(source: &str, span: Span) -> NewlineType {
+    let start = span.end - 2;
+
+    match source.chars().nth(start) {
+        Some('\r') => NewlineType::Windows,
+        _ => NewlineType::Unix,
     }
 }
 

--- a/psl/parser-database/src/walkers/composite_type.rs
+++ b/psl/parser-database/src/walkers/composite_type.rs
@@ -1,7 +1,9 @@
-use super::Walker;
-use crate::{ast, FileId, ScalarFieldType, ScalarType};
+use crate::{
+    ast::{self, NewlineType, WithDocumentation, WithName, WithSpan},
+    walkers::{newline, Walker},
+    FileId, ScalarFieldType, ScalarType,
+};
 use diagnostics::Span;
-use schema_ast::ast::{NewlineType, WithDocumentation, WithName, WithSpan};
 
 /// A composite type, introduced with the `type` keyword in the schema.
 ///
@@ -63,12 +65,9 @@ impl<'db> CompositeTypeWalker<'db> {
         };
 
         let src = self.db.source(self.id.0);
-        let start = field.ast_field().span().end - 2;
+        let span = field.ast_field().span();
 
-        match src.chars().nth(start) {
-            Some('\r') => NewlineType::Windows,
-            _ => NewlineType::Unix,
-        }
+        newline(src, span)
     }
 }
 

--- a/psl/parser-database/src/walkers/enum.rs
+++ b/psl/parser-database/src/walkers/enum.rs
@@ -54,7 +54,18 @@ impl<'db> EnumWalker<'db> {
 
     /// What kind of newlines the enum uses.
     pub fn newline(self) -> NewlineType {
-        NewlineType::Unix
+        let value = match self.ast_enum().values.last() {
+            Some(value) => value,
+            None => return NewlineType::default(),
+        };
+
+        let src = self.db.source(self.id.0);
+        let start = value.span.end - 2;
+
+        match src.chars().nth(start) {
+            Some('\r') => NewlineType::Windows,
+            _ => NewlineType::Unix,
+        }
     }
 
     /// The name of the schema the enum belongs to.

--- a/psl/parser-database/src/walkers/enum.rs
+++ b/psl/parser-database/src/walkers/enum.rs
@@ -1,5 +1,8 @@
-use crate::{ast, ast::WithDocumentation, types, walkers::Walker};
-use schema_ast::ast::{IndentationType, NewlineType};
+use crate::{
+    ast::{self, IndentationType, NewlineType, WithDocumentation},
+    types,
+    walkers::{newline, Walker},
+};
 
 /// An `enum` declaration in the schema.
 pub type EnumWalker<'db> = Walker<'db, crate::EnumId>;
@@ -60,12 +63,8 @@ impl<'db> EnumWalker<'db> {
         };
 
         let src = self.db.source(self.id.0);
-        let start = value.span.end - 2;
 
-        match src.chars().nth(start) {
-            Some('\r') => NewlineType::Windows,
-            _ => NewlineType::Unix,
-        }
+        newline(src, value.span)
     }
 
     /// The name of the schema the enum belongs to.

--- a/psl/parser-database/src/walkers/model.rs
+++ b/psl/parser-database/src/walkers/model.rs
@@ -6,15 +6,15 @@ pub use primary_key::*;
 pub(crate) use unique_criteria::*;
 
 use super::{
-    CompleteInlineRelationWalker, FieldWalker, IndexWalker, InlineRelationWalker, RelationFieldWalker, RelationWalker,
-    ScalarFieldWalker,
+    newline, CompleteInlineRelationWalker, FieldWalker, IndexWalker, InlineRelationWalker, RelationFieldWalker,
+    RelationWalker, ScalarFieldWalker,
 };
+
 use crate::{
-    ast::{self, WithName},
+    ast::{self, IndentationType, NewlineType, WithName, WithSpan},
     types::ModelAttributes,
     FileId,
 };
-use schema_ast::ast::{IndentationType, NewlineType, WithSpan};
 
 /// A `model` declaration in the Prisma schema.
 pub type ModelWalker<'db> = super::Walker<'db, (FileId, ast::ModelId)>;
@@ -248,12 +248,9 @@ impl<'db> ModelWalker<'db> {
         };
 
         let src = self.db.source(self.id.0);
-        let start = field.ast_field().span().end - 2;
+        let span = field.ast_field().span();
 
-        match src.chars().nth(start) {
-            Some('\r') => NewlineType::Windows,
-            _ => NewlineType::Unix,
-        }
+        newline(src, span)
     }
 
     /// The name of the schema the model belongs to.


### PR DESCRIPTION
Add newline parsing for composite types and enums
related: prisma/prisma-engines#4890