### PR TITLE
feat(query-engine): deprecate the "driverAdapters" feature flag, in preparation for GA

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -87,7 +87,6 @@ features!(
 pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
         Deno
-         | DriverAdapters
          | FullTextIndex
          | FullTextSearch
          | Metrics
@@ -108,6 +107,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | ConnectOrCreate
         | CreateMany
         | DataProxy
+        | DriverAdapters
         | Distinct
         | ExtendedIndexes
         | ExtendedWhereUnique

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -258,7 +258,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, fullTextIndex, fullTextSearch, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, fullTextIndex, fullTextSearch, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/query-engine/driver-adapters/executor/bench/schema.prisma
+++ b/query-engine/driver-adapters/executor/bench/schema.prisma
@@ -5,7 +5,7 @@ datasource db {
 
 generator foo {
     provider        = "prisma-client-js"
-    previewFeatures = ["driverAdapters", "relationJoins"]
+    previewFeatures = ["relationJoins"]
 }
 
 model Movie {

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -94,7 +94,6 @@ impl QueryEngine {
 
         let mut schema = psl::validate(datamodel.into());
         let config = &mut schema.configuration;
-        let preview_features = config.preview_features();
 
         let mut connector_mode = ConnectorMode::Rust;
 

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -98,23 +98,16 @@ impl QueryEngine {
 
         let mut connector_mode = ConnectorMode::Rust;
 
-        if !preview_features.contains(PreviewFeature::DriverAdapters) {
-            tracing::info!(
-                "Please enable the {} preview feature to use driver adapters.",
-                PreviewFeature::DriverAdapters
-            );
-        } else {
-            #[cfg(feature = "driver-adapters")]
-            if let Some(adapter) = maybe_adapter {
-                let js_queryable = driver_adapters::from_js(adapter);
+        #[cfg(feature = "driver-adapters")]
+        if let Some(adapter) = maybe_adapter {
+            let js_queryable = driver_adapters::from_js(adapter);
 
-                connector_mode = ConnectorMode::Js {
-                    adapter: Arc::new(js_queryable),
-                };
+            connector_mode = ConnectorMode::Js {
+                adapter: Arc::new(js_queryable),
+            };
 
-                let provider_name = schema.connector.provider_name();
-                tracing::info!("Registered driver adapter for {provider_name}.");
-            }
+            let provider_name = schema.connector.provider_name();
+            tracing::info!("Registered driver adapter for {provider_name}.");
         }
 
         let connector_mode = connector_mode;


### PR DESCRIPTION
This PR contributes to https://github.com/prisma/team-orm/issues/1180. 
It shouldn't be merged until we're ready to GA `driverAdapters`.
This PR was created before-hand to validate discoveries made in https://github.com/prisma/team-orm/issues/1173.
