### PR TITLE
feat(query-engine-c-abi): add Mac Catalyst support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3780,6 +3780,7 @@ dependencies = [
  "query-connector",
  "query-core",
  "query-engine-common",
+ "query-engine-metrics",
  "query-structure",
  "request-handlers",
  "rusqlite",

--- a/libs/query-engine-common/Cargo.toml
+++ b/libs/query-engine-common/Cargo.toml
@@ -3,6 +3,12 @@ name = "query-engine-common"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+metrics = [
+    "query-core/metrics",
+    "query-engine-metrics"
+]
+
 [dependencies]
 thiserror = "1"
 url.workspace = true
@@ -21,7 +27,7 @@ tracing-opentelemetry = "0.17.3"
 opentelemetry = { version = "0.17" }
 
 [target.'cfg(all(not(target_arch = "wasm32")))'.dependencies]
-query-engine-metrics = { path = "../../query-engine/metrics" }
+query-engine-metrics = { path = "../../query-engine/metrics", optional = true }
 napi.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/libs/query-engine-common/src/engine.rs
+++ b/libs/query-engine-common/src/engine.rs
@@ -59,6 +59,7 @@ pub struct EngineBuilder {
 pub struct ConnectedEngineNative {
     pub config_dir: PathBuf,
     pub env: HashMap<String, String>,
+    #[cfg(feature = "metrics")]
     pub metrics: Option<query_engine_metrics::MetricRegistry>,
 }
 

--- a/query-engine/query-engine-c-abi/Cargo.toml
+++ b/query-engine/query-engine-c-abi/Cargo.toml
@@ -8,6 +8,13 @@ doc = false
 crate-type = ["staticlib"]
 name = "query_engine"
 
+[features]
+metrics = [
+  "query-core/metrics",
+  "query-engine-common/metrics",
+  "query-engine-metrics"
+]
+
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
@@ -17,6 +24,7 @@ request-handlers = { path = "../request-handlers", features = [
 ] }
 query-connector = { path = "../connectors/query-connector" }
 query-engine-common = { path = "../../libs/query-engine-common" }
+query-engine-metrics = { path = "../../query-engine/metrics", optional = true }
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 psl = { workspace = true, features = ["sqlite"] }
 sql-connector = { path = "../connectors/sql-query-connector", package = "sql-query-connector" }

--- a/query-engine/query-engine-c-abi/Makefile
+++ b/query-engine/query-engine-c-abi/Makefile
@@ -1,14 +1,15 @@
-# rustup target add x86_64-apple-ios # intel simulator
-# rustup target add aarch64-apple-ios # actual iOS
-# rustup target add aarch64-apple-ios-sim # arm simulator
+# rustup target add x86_64-apple-ios         # intel simulator
+# rustup target add aarch64-apple-ios        # actual iOS
+# rustup target add aarch64-apple-ios-macabi # Mac Catalyst
+# rustup target add aarch64-apple-ios-sim    # arm simulator
 
-# rustup target add aarch64-linux-android # Android arm 64 bits
-# rustup target add x86_64-linux-android # Intel 64 bits emulator
-# rustup target add armv7-linux-androideabi # Android arm 32 bits
-# rustup target add i686-linux-android # Intel 32 bits emulator
+# rustup target add aarch64-linux-android    # Android arm 64 bits
+# rustup target add x86_64-linux-android     # Intel 64 bits emulator
+# rustup target add armv7-linux-androideabi  # Android arm 32 bits
+# rustup target add i686-linux-android       # Intel 32 bits emulator
 
 ARCH_IOS_SIM = aarch64-apple-ios-sim
-ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-sim
+ARCHS_IOS = x86_64-apple-ios aarch64-apple-ios aarch64-apple-ios-macabi aarch64-apple-ios-sim
 ARCHS_ANDROID = aarch64-linux-android armv7-linux-androideabi x86_64-linux-android i686-linux-android
 LIB = libquery_engine.a
 XCFRAMEWORK = QueryEngine.xcframework
@@ -54,8 +55,8 @@ sim-release: clean
 	xcodebuild -create-xcframework -library ../../target/$(ARCH_IOS_SIM)/release/libquery_engine.a -headers include -output ios/$(XCFRAMEWORK)
 
 $(ARCHS_IOS): %:
-	cargo build -p query-engine-c-abi --release --target $@ 
+	cargo +nightly build -Z build-std -p query-engine-c-abi --release --target $@
 
 $(XCFRAMEWORK): $(ARCHS_IOS)
 	lipo -create $(wildcard ../../target/x86_64-apple-ios/release/$(LIB)) $(wildcard ../../target/aarch64-apple-ios-sim/release/$(LIB)) -output simulator_fat/libquery_engine.a
-	xcodebuild -create-xcframework -library $(wildcard ../../target/aarch64-apple-ios/release/$(LIB)) -headers include -library simulator_fat/libquery_engine.a -headers include -output ios/$@
+	xcodebuild -create-xcframework -library $(wildcard ../../target/aarch64-apple-ios/release/$(LIB)) -headers include -library $(wildcard ../../target/aarch64-apple-ios-macabi/release/$(LIB)) -headers include -library simulator_fat/libquery_engine.a -headers include -output ios/$@

--- a/query-engine/query-engine-c-abi/src/engine.rs
+++ b/query-engine/query-engine-c-abi/src/engine.rs
@@ -264,6 +264,7 @@ impl QueryEngine {
                 native: ConnectedEngineNative {
                     config_dir: builder.native.config_dir.clone(),
                     env: builder.native.env.clone(),
+                    #[cfg(feature = "metrics")]
                     metrics: None,
                 },
             }) as Result<ConnectedEngine>

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -9,17 +9,22 @@ crate-type = ["cdylib"]
 name = "query_engine"
 
 [features]
-default = ["driver-adapters"]
+default = ["driver-adapters", "metrics"]
 vendored-openssl = ["sql-connector/vendored-openssl"]
 driver-adapters = [
     "request-handlers/driver-adapters",
     "sql-connector/driver-adapters",
 ]
+metrics = [
+    "query-core/metrics",
+    "query-engine-common/metrics",
+    "query-engine-metrics",
+]
 
 [dependencies]
 anyhow = "1"
 async-trait.workspace = true
-query-core = { path = "../core", features = ["metrics"] }
+query-core = { path = "../core" }
 request-handlers = { path = "../request-handlers", features = ["all"] }
 query-connector = { path = "../connectors/query-connector" }
 query-engine-common = { path = "../../libs/query-engine-common" }
@@ -52,7 +57,7 @@ opentelemetry = { version = "0.17" }
 quaint.workspace = true
 tokio.workspace = true
 futures = "0.3"
-query-engine-metrics = { path = "../metrics" }
+query-engine-metrics = { path = "../metrics", optional = true }
 
 [build-dependencies]
 napi-build = "1"

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -27,6 +27,10 @@ mysql = [
     "psl/mysql",
     "request-handlers/mysql",
 ]
+metrics = [
+#    "query-core/metrics",
+#    "query-engine-common/metrics"
+]
 
 [dependencies]
 

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -6,6 +6,10 @@ version = "0.1.0"
 [features]
 sql = ["sql-connector", "sql-connector/all-native"]
 vendored-openssl = ["sql-connector/vendored-openssl"]
+metrics = [
+    "query-core/metrics",
+    "query-engine-metrics"
+]
 
 [dependencies]
 tokio.workspace = true
@@ -18,7 +22,7 @@ enumflags2.workspace = true
 psl = { workspace = true, features = ["all"] }
 graphql-parser = { git = "https://github.com/prisma/graphql-parser" }
 mongodb-connector = { path = "../connectors/mongodb-query-connector", optional = true, package = "mongodb-query-connector" }
-query-core = { path = "../core", features = ["metrics"] }
+query-core = { path = "../core" }
 request-handlers = { path = "../request-handlers", features = ["all"] }
 serde.workspace = true
 serde_json.workspace = true
@@ -32,7 +36,7 @@ tracing-opentelemetry = "0.17.3"
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 opentelemetry = { version = "0.17.0", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.10", features = ["tls", "tls-roots"] }
-query-engine-metrics = { path = "../metrics" }
+query-engine-metrics = { path = "../metrics", optional = true }
 
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 


### PR DESCRIPTION
This PR contains two commits.

The first commit adds a Mac Catalyst target to `query-engine-c-abi`. Because the target is a [Tier 3 platform for Rust](https://doc.rust-lang.org/nightly/rustc/platform-support.html#tier-3), we have to compile the `std` crate ourselves, so we also need the nightly Rust compiler.

In an ideal world, the first commit would've been enough, however I had to make a second commit which does some horrible things to `query-engine-common` and `query-engine-metrics` to disable metrics for `query-engine-c-abi`. The libraries used by `query-engine-metrics` seem to have multiple versions installed according to the Cargo lockfile, and strangely the issue only manifests itself when building for the Mac Catalyst target.

I'm not a Rust expert by any means, and I am aware Tier 3 platforms might not be something @prisma is interested in, but if anyone with more knowledge could take a look and offer some advice, I'd be most appreciative 😀 

In the meantime, this branch does successfully build an `.xcframework` file for the Mac Catalyst platform and I have managed to successfully build and boot my Expo Mac Catalyst application, so I'm leaving this PR as a draft for anyone else that might want to do the same.