### PR TITLE
feat(se): allow model/table renaming in postgres and sqlserver

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/sql_destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_destructive_change_checker.rs
@@ -151,6 +151,7 @@ impl SqlSchemaConnector {
                             }
                             TableChange::AddPrimaryKey { .. } => (),
                             TableChange::RenamePrimaryKey { .. } => (),
+                            TableChange::RenameTo { .. } => (),
                         }
                     }
                 }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_migration.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_migration.rs
@@ -331,6 +331,13 @@ impl SqlMigration {
                                 out.push_str(")\n");
                                 out.push_str(")\n");
                             }
+                            TableChange::RenameTo => {
+                                out.push_str("  [+] Renamed table `");
+                                out.push_str(tables.previous.name());
+                                out.push_str("` to `");
+                                out.push_str(tables.next.name());
+                                out.push_str("`\n")
+                            }
                         }
                     }
                 }
@@ -580,6 +587,7 @@ pub(crate) enum TableChange {
     DropPrimaryKey,
     AddPrimaryKey,
     RenamePrimaryKey,
+    RenameTo,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/mssql_renderer/alter_table.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/mssql_renderer/alter_table.rs
@@ -34,6 +34,7 @@ pub(crate) fn create_statements(
         add_columns: Vec::new(),
         drop_columns: Vec::new(),
         column_mods: Vec::new(),
+        rename_table: false,
     };
 
     constructor.into_statements()
@@ -49,12 +50,16 @@ struct AlterTableConstructor<'a> {
     add_columns: Vec<String>,
     drop_columns: Vec<String>,
     column_mods: Vec<String>,
+    rename_table: bool,
 }
 
 impl<'a> AlterTableConstructor<'a> {
     fn into_statements(mut self) -> Vec<String> {
         for change in self.changes {
             match change {
+                TableChange::RenameTo => {
+                    self.rename_table = true;
+                }
                 TableChange::DropPrimaryKey => {
                     self.drop_primary_key();
                 }
@@ -139,6 +144,23 @@ impl<'a> AlterTableConstructor<'a> {
                 "ALTER TABLE {} ADD {}",
                 self.renderer.table_name(self.tables.previous),
                 self.add_columns.join(",\n"),
+            ));
+        }
+
+        if self.rename_table {
+            let with_schema = format!(
+                "{}.{}",
+                self.tables
+                    .previous
+                    .namespace()
+                    .unwrap_or_else(|| self.renderer.schema_name()),
+                self.tables.previous.name()
+            );
+
+            statements.push(format!(
+                "EXEC SP_RENAME N{}, N{}",
+                Quoted::mssql_string(with_schema),
+                Quoted::mssql_string(self.tables.next.name()),
             ));
         }
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/mysql_renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/mysql_renderer.rs
@@ -111,6 +111,7 @@ impl SqlRenderer for MysqlFlavour {
 
         for change in changes {
             match change {
+                TableChange::RenameTo => unreachable!("No Renaming Tables on Mysql"),
                 TableChange::DropPrimaryKey => lines.push(sql_ddl::mysql::AlterTableClause::DropPrimaryKey.to_string()),
                 TableChange::RenamePrimaryKey => unreachable!("No Renaming Primary Keys on Mysql"),
                 TableChange::AddPrimaryKey => lines.push(format!(

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/postgres_renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/postgres_renderer.rs
@@ -231,12 +231,14 @@ impl SqlRenderer for PostgresFlavour {
     fn render_alter_table(&self, alter_table: &AlterTable, schemas: MigrationPair<&SqlSchema>) -> Vec<String> {
         let AlterTable { changes, table_ids } = alter_table;
         let mut lines = Vec::new();
+        let mut separate_lines = Vec::new();
         let mut before_statements = Vec::new();
         let mut after_statements = Vec::new();
         let tables = schemas.walk(*table_ids);
 
         for change in changes {
             match change {
+                TableChange::RenameTo => separate_lines.push(format!("RENAME TO {}", self.quote(tables.next.name()))),
                 TableChange::DropPrimaryKey => lines.push(format!(
                     "DROP CONSTRAINT {}",
                     Quoted::postgres_ident(tables.previous.primary_key().unwrap().name())
@@ -304,14 +306,14 @@ impl SqlRenderer for PostgresFlavour {
             };
         }
 
-        if lines.is_empty() {
+        if lines.is_empty() && separate_lines.is_empty() {
             return Vec::new();
         }
 
         if self.is_cockroachdb() {
             let mut out = Vec::with_capacity(before_statements.len() + after_statements.len() + lines.len());
             out.extend(before_statements);
-            for line in lines {
+            for line in lines.into_iter().chain(separate_lines) {
                 out.push(format!(
                     "ALTER TABLE {} {}",
                     QuotedWithPrefix::pg_from_table_walker(tables.previous),
@@ -321,12 +323,16 @@ impl SqlRenderer for PostgresFlavour {
             out.extend(after_statements);
             out
         } else {
-            let alter_table = format!(
-                "ALTER TABLE {} {}",
-                QuotedWithPrefix::pg_new(tables.previous.namespace(), tables.previous.name()),
-                lines.join(",\n")
-            );
+            let table = QuotedWithPrefix::pg_new(tables.previous.namespace(), tables.previous.name());
+            for line in separate_lines {
+                after_statements.push(format!("ALTER TABLE {} {}", table, line))
+            }
 
+            if lines.is_empty() {
+                return before_statements.into_iter().chain(after_statements).collect();
+            }
+
+            let alter_table = format!("ALTER TABLE {} {}", table, lines.join(",\n"));
             before_statements
                 .into_iter()
                 .chain(std::iter::once(alter_table))

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/sqlite_renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/sqlite_renderer.rs
@@ -89,6 +89,7 @@ impl SqlRenderer for SqliteFlavour {
                 TableChange::DropColumn { .. } => unreachable!("DropColumn on SQLite"),
                 TableChange::DropPrimaryKey { .. } => unreachable!("DropPrimaryKey on SQLite"),
                 TableChange::RenamePrimaryKey { .. } => unreachable!("AddPrimaryKey on SQLite"),
+                TableChange::RenameTo => unreachable!("RenameTo on SQLite"),
             };
         }
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ.rs
@@ -132,6 +132,8 @@ fn push_altered_table_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
 
         // Order matters.
         let mut changes = Vec::new();
+        renamed_table(&table, &mut changes);
+
         if let Some(change) = dropped_primary_key(&table) {
             changes.push(change)
         }
@@ -303,6 +305,12 @@ fn renamed_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
         .transpose()
         .filter(|names| names.previous != names.next)
         .map(|_| TableChange::RenamePrimaryKey)
+}
+
+fn renamed_table(differ: &TableDiffer<'_, '_>, changes: &mut Vec<TableChange>) {
+    if differ.tables.previous.is_renamed_table(differ.tables.next) {
+        changes.push(TableChange::RenameTo)
+    }
 }
 
 fn push_alter_primary_key(differ: &TableDiffer<'_, '_>, steps: &mut Vec<SqlMigrationStep>) {

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -20,6 +20,11 @@ pub(crate) trait SqlSchemaDifferFlavour {
         false
     }
 
+    // Returns `true` if the database supports names for primary key constraints
+    fn can_rename_tables(&self) -> bool {
+        false
+    }
+
     /// If this returns `true`, the differ will generate
     /// SqlMigrationStep::RedefineIndex steps instead of
     /// SqlMigrationStep::AlterIndex.

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/mssql.rs
@@ -9,6 +9,10 @@ use psl::builtin_connectors::{MsSqlType, MsSqlTypeParameter};
 use sql_schema_describer::{self as sql, mssql::MssqlSchemaExt, ColumnTypeFamily, TableColumnId};
 
 impl SqlSchemaDifferFlavour for MssqlFlavour {
+    fn can_rename_tables(&self) -> bool {
+        true
+    }
+
     fn can_rename_foreign_key(&self) -> bool {
         true
     }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -40,6 +40,10 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
         self.is_cockroachdb()
     }
 
+    fn can_rename_tables(&self) -> bool {
+        true
+    }
+
     fn can_rename_foreign_key(&self) -> bool {
         true
     }

--- a/schema-engine/sql-schema-describer/src/walkers/table.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/table.rs
@@ -118,6 +118,14 @@ impl<'a> TableWalker<'a> {
             .is_ok()
     }
 
+    /// Returns whether two tables have same properties, belong to the same table, but have different name.
+    pub fn is_renamed_table(self, other: TableWalker<'_>) -> bool {
+        self.name() != other.name()
+            && self.table().namespace_id == other.table().namespace_id
+            && self.table().properties == other.table().properties
+            && self.primary_key().unwrap().name() == other.primary_key().unwrap().name()
+    }
+
     /// The check constraint names for the table.
     pub fn check_constraints(self) -> impl ExactSizeIterator<Item = &'a str> {
         let low = self.schema.check_constraints.partition_point(|(id, _)| *id < self.id);


### PR DESCRIPTION
if a developer wants to rename a model/table, Prisma Migrate currently diffs the two models and generates a migration to drop the previous table and create a new table.

This PR's purpose is to introduce a mechanism that knows if a table is renamed and for Prisma to generate a migration that renames the table properly. To do so, the renamed table must be identifiable with high certainty.

For databases that support naming primary key constraints (Postgres, SQLServer), we can check if the table is being renamed by looking at the key. If the key is the same, the table is the same.

So, this feature would apply to those supported databases, for now, and for cases when primary key is not given a specific name, the default behavior of dropping and recreating the table would apply.

Example:

```
// Before
model User {
  id           Int         @id
  email     String   @unique
}

//After
model Person {
  id           Int         @id
  email     String   @unique
}

```

Renaming table `User` to `Person`, will simply, as always, drop table `User` and create table `Person`. But:

```
// Before
model User {
  id           Int         @id(map: "custom_id")
  email     String   @unique
}

//After
model Person {
  id           Int         @id(map: "custom_id")
  email     String   @unique
}

```

By setting a name to the primary key of the table, renaming table `User` to `Person`, will generate the following query:

```
ALTER TABLE "User" RENAME TO "Person";
```

Related issues:
- https://github.com/prisma/prisma/issues/12387
- https://github.com/prisma/prisma/discussions/11170
- https://github.com/prisma/prisma/issues/7790 (but only for tables)