### PR TITLE
tech(quaint): surface mysql socket as host if in use

### DIFF
--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -82,7 +82,10 @@ impl MysqlUrl {
                     host
                 }
             }
-            (_, Some(host)) => host,
+            (_, Some(host)) => match &self.query_params.socket {
+                Some(socket) => socket,
+                None => host,
+            },
             _ => "localhost",
         }
     }
@@ -342,6 +345,13 @@ mod tests {
         let url = MysqlUrl::new(Url::parse("mysql://root@localhost/dbname?socket=(/tmp/mysql.sock)").unwrap()).unwrap();
         assert_eq!("dbname", url.dbname());
         assert_eq!(&Some(String::from("/tmp/mysql.sock")), url.socket());
+    }
+
+    #[test]
+    fn should_parse_socket_url_as_host() {
+        let url = MysqlUrl::new(Url::parse("mysql://root@localhost/dbname?socket=(/tmp/mysql.sock)").unwrap()).unwrap();
+        assert_eq!("dbname", url.dbname());
+        assert_eq!(&String::from("/tmp/mysql.sock"), url.host());
     }
 
     #[test]


### PR DESCRIPTION
Updated MySQL url parsing to surface the socket as host if in use, mirroring what we expect in PG and CRDB.

This means that errors will now surface the socket connection to users when encountering, for example, connectivity issues.

This was already happening by default for PG and CRDB as they expect sockets through the `host` query-arg, however our default host parsing was not picking this up for MySQL as it was expected through `socket` there instead.

Related PR: https://github.com/prisma/prisma/pull/24222