### PR TITLE
fix(mssql): varchar params should not cause high cpu usage

### DIFF
--- a/quaint/src/ast.rs
+++ b/quaint/src/ast.rs
@@ -53,5 +53,5 @@ pub use select::{DistinctType, Select};
 pub use table::*;
 pub use union::Union;
 pub use update::*;
-pub(crate) use values::Params;
 pub use values::{IntoRaw, Raw, Value, ValueType, Values};
+pub(crate) use values::{NativeColumnType, Params};

--- a/quaint/src/ast/column.rs
+++ b/quaint/src/ast/column.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::borrow::Cow;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TypeDataLength {
     Constant(u16),
     Maximum,

--- a/quaint/src/ast/values.rs
+++ b/quaint/src/ast/values.rs
@@ -35,19 +35,34 @@ where
 
 /// A native-column type, i.e. the connector-specific type of the column.
 #[derive(Debug, Clone, PartialEq)]
-pub struct NativeColumnType<'a>(Cow<'a, str>);
+pub struct NativeColumnType<'a> {
+    pub name: Cow<'a, str>,
+    pub length: Option<TypeDataLength>,
+}
 
 impl<'a> std::ops::Deref for NativeColumnType<'a> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.name
     }
 }
 
 impl<'a> From<&'a str> for NativeColumnType<'a> {
     fn from(s: &'a str) -> Self {
-        Self(Cow::Owned(s.to_uppercase()))
+        Self {
+            name: Cow::Owned(s.to_uppercase()),
+            length: None,
+        }
+    }
+}
+
+impl<'a> From<(&'a str, Option<TypeDataLength>)> for NativeColumnType<'a> {
+    fn from((name, length): (&'a str, Option<TypeDataLength>)) -> Self {
+        Self {
+            name: Cow::Owned(name.to_uppercase()),
+            length,
+        }
     }
 }
 

--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -165,11 +165,22 @@ pub trait Visitor<'a> {
         Ok(())
     }
 
+    fn visit_parameterized_text(&mut self, txt: Option<Cow<'a, str>>, nt: Option<NativeColumnType<'a>>) -> Result {
+        self.add_parameter(Value {
+            typed: ValueType::Text(txt),
+            native_column_type: nt,
+        });
+        self.parameter_substitution()?;
+
+        Ok(())
+    }
+
     /// A visit to a value we parameterize
     fn visit_parameterized(&mut self, value: Value<'a>) -> Result {
         match value.typed {
             ValueType::Enum(Some(variant), name) => self.visit_parameterized_enum(variant, name),
             ValueType::EnumArray(Some(variants), name) => self.visit_parameterized_enum_array(variants, name),
+            ValueType::Text(txt) => self.visit_parameterized_text(txt, value.native_column_type),
             _ => {
                 self.add_parameter(value);
                 self.parameter_substitution()

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mod.rs
@@ -1,2 +1,3 @@
+mod mssql;
 mod mysql;
 mod postgres;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mssql.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mssql.rs
@@ -1,0 +1,105 @@
+use indoc::indoc;
+use query_engine_tests::*;
+
+#[test_suite(only(SqlServer))]
+mod string {
+    fn schema_string() -> String {
+        let schema = indoc! {
+            r#"
+            model Parent {
+                #id(id, Int, @id)
+
+                vChar String @test.VarChar
+                vChar40 String @test.VarChar(40)
+                vCharMax String @test.VarChar(max)
+            }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // Regression test for https://github.com/prisma/prisma/issues/17565
+    #[connector_test(schema(schema_string))]
+    async fn native_string(mut runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+              id: 1,
+              vChar: "0"
+              vChar40: "0123456789012345678901234567890123456789"
+              vCharMax: "0123456789"
+            }"#,
+        )
+        .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent {
+            id
+            vChar
+            vChar40
+            vCharMax
+        }}"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"vChar":"0","vChar40":"0123456789012345678901234567890123456789","vCharMax":"0123456789"}]}}"###
+        );
+
+        // VARCHAR
+        // Ensure the VarChar is casted to VARCHAR to avoid implicit coercion
+        runner.clear_logs().await;
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent(where: { vChar: "0" }) {
+              id
+              vChar
+              }}"#),
+            @r###"{"data":{"findManyParent":[{"id":1,"vChar":"0"}]}}"###
+        );
+        assert!(runner
+            .get_logs()
+            .await
+            .iter()
+            .any(|log| log.contains("WHERE [string_native_string].[Parent].[vChar] = CAST(@P1 AS VARCHAR)")));
+
+        // VARCHAR(40)
+        runner.clear_logs().await;
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent(where: { vChar40: "0123456789012345678901234567890123456789" }) {
+            id
+            vChar40
+          }}"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"vChar40":"0123456789012345678901234567890123456789"}]}}"###
+        );
+
+        // Ensure the VarChar(40) is casted to VARCHAR(40) to avoid implicit coercion
+        assert!(runner
+            .get_logs()
+            .await
+            .iter()
+            .any(|log| log.contains("WHERE [string_native_string].[Parent].[vChar40] = CAST(@P1 AS VARCHAR(40))")));
+
+        // VARCHAR(MAX)
+        runner.clear_logs().await;
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent(where: { vCharMax: "0123456789" }) {
+            id
+            vCharMax
+          }}"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"vCharMax":"0123456789"}]}}"###
+        );
+
+        // Ensure the VarChar is casted to VARCHAR(MAX) to avoid implicit coercion
+        assert!(runner
+            .get_logs()
+            .await
+            .iter()
+            .any(|log| log.contains("WHERE [string_native_string].[Parent].[vCharMax] = CAST(@P1 AS VARCHAR(MAX))")));
+
+        Ok(())
+    }
+
+    async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
+        runner
+            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .await?
+            .assert_success();
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mssql.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mssql.rs
@@ -92,6 +92,18 @@ mod string {
             .iter()
             .any(|log| log.contains("WHERE [string_native_string].[Parent].[vCharMax] = CAST(@P1 AS VARCHAR(MAX))")));
 
+        // Ensure it works as well with gt
+        runner.clear_logs().await;
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ findManyParent(where: { vChar40: { gt: "0" } }) { id vChar40 } }"#),
+          @r###"{"data":{"findManyParent":[{"id":1,"vChar40":"0123456789012345678901234567890123456789"}]}}"###
+        );
+        assert!(runner
+            .get_logs()
+            .await
+            .iter()
+            .any(|log| log.contains("WHERE [string_native_string].[Parent].[vChar40] > CAST(@P1 AS VARCHAR(40))")));
+
         Ok(())
     }
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -331,4 +331,8 @@ impl TestLogCapture {
 
         logs
     }
+
+    pub async fn clear_logs(&mut self) {
+        while self.rx.try_recv().is_ok() {}
+    }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -599,6 +599,10 @@ impl Runner {
         }
     }
 
+    pub async fn clear_logs(&mut self) {
+        self.log_capture.clear_logs().await
+    }
+
     pub fn connector_version(&self) -> &ConnectorVersion {
         &self.version
     }

--- a/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
+++ b/query-engine/connectors/sql-query-connector/src/model_extensions/scalar_field.rs
@@ -78,7 +78,9 @@ impl ScalarFieldExt for ScalarField {
             },
         };
 
-        value.with_native_column_type(self.native_type().map(|nt| nt.name()))
+        let nt_col_type = self.native_type().map(|nt| (nt.name(), parse_scalar_length(self)));
+
+        value.with_native_column_type(nt_col_type)
     }
 
     fn type_family(&self) -> TypeFamily {


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/17565

Internal document: https://www.notion.so/prismaio/SQL-Server-VarChar-High-CPU-Usage-f9af6a0e705343788a525cc79d5d3bfb?pvs=4

Tiberius encodes varchar data as nvarchar(4000) or nvarchar(max). This triggers implicit conversions on SQL Server which then triggers Clustered Index Scans which consumes a lot of CPU.

This is a simple fix that casts `@db.VarChar` data to `VARCHAR` so that SQL Server does not have to perform implicit conversion and thus use a Clustered Index _Seek_ instead.