### PR TITLE
tech(fmt): use wasm logging

### DIFF
--- a/prisma-schema-wasm/Cargo.toml
+++ b/prisma-schema-wasm/Cargo.toml
@@ -10,7 +10,3 @@ crate-type = ["cdylib"]
 wasm-bindgen.workspace = true
 wasm-logger = { version = "0.2.0", optional = true }
 prisma-fmt = { path = "../prisma-fmt" }
-
-[features]
-default = []
-wasm-logger = ["dep:wasm-logger"]

--- a/prisma-schema-wasm/Cargo.toml
+++ b/prisma-schema-wasm/Cargo.toml
@@ -10,3 +10,7 @@ crate-type = ["cdylib"]
 wasm-bindgen.workspace = true
 wasm-logger = { version = "0.2.0", optional = true }
 prisma-fmt = { path = "../prisma-fmt" }
+
+[features]
+default = []
+wasm-logger = ["dep:wasm-logger"]

--- a/prisma-schema-wasm/scripts/update-schema-wasm.sh
+++ b/prisma-schema-wasm/scripts/update-schema-wasm.sh
@@ -14,7 +14,7 @@ language_tools_node="$language_tools_server/node_modules/@prisma/prisma-schema-w
 
 ## Script
 printf '%s\n' "Starting build :: prisma-schema-wasm"
-cargo build --release --target=wasm32-unknown-unknown --manifest-path=$prisma_schema_wasm_dir/Cargo.toml
+cargo build --features wasm-logger --release --target=wasm32-unknown-unknown --manifest-path=$prisma_schema_wasm_dir/Cargo.toml
 
 printf '%s\n' "Generating node module"
 out=$prisma_schema_wasm_dir/nodejs $prisma_schema_wasm_dir/scripts/install.sh

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -113,9 +113,3 @@ pub fn debug_panic() {
     register_panic_hook();
     panic!("This is the panic triggered by `prisma_fmt::debug_panic()`");
 }
-
-#[cfg(feature = "wasm_logger")]
-#[wasm_bindgen]
-pub fn enable_logs() {
-    wasm_logger::init(wasm_logger::Config::default());
-}

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -19,6 +19,9 @@ fn register_panic_hook() {
     static SET_HOOK: Once = Once::new();
 
     SET_HOOK.call_once(|| {
+        #[cfg(feature = "wasm-logger")]
+        wasm_logger::init(wasm_logger::Config::default());
+
         panic::set_hook(Box::new(|info| {
             let message = &info.to_string();
             prisma_set_wasm_panic_message(message);


### PR DESCRIPTION
Currently, we can only actively log in language-tools on the typescript side. When it comes to rust engines, we're pretty blind outside of some panic info and knowing which endpoint we're calling:
```ts
console.log('running lint() from prisma-schema-wasm')
```

This PR adds the feature and hook for our previously unused dep `wasm-logger`. Which means we can now see logs (note: not using `dbg!`) from prisma-fmt in the extension debug environment. 

Example:
```rs
pub(crate) fn run(schema: SchemaFileInput) -> String {
    let schema = match schema {
        SchemaFileInput::Single(file) => psl::validate(file.into()),
        SchemaFileInput::Multiple(files) => {
            log::debug!("{:?}", files);
            psl::validate_multi_file(&files)
        }
    };
    ...
```
```
running lint() from prisma-schema-wasm
%cDEBUG%c prisma-fmt/src/lint.rs:18%c [("file:///Users/soph/src/prisma_debug/prisma/schema.prisma", SourceFile { contents: Allocated("generator client ") })]
```

closes https://github.com/prisma/language-tools/issues/1193
