### PR TITLE
fix(fmt/psl): multibyte characters

### DIFF
--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multibyte/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multibyte/result.json
@@ -1,0 +1,41 @@
+[
+  {
+    "title": "Add an index for the relation's field(s)",
+    "kind": "quickfix",
+    "diagnostics": [
+      {
+        "range": {
+          "start": {
+            "line": 19,
+            "character": 18
+          },
+          "end": {
+            "line": 19,
+            "character": 63
+          }
+        },
+        "severity": 2,
+        "message": "With `relationMode = \"prisma\"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes\" "
+      }
+    ],
+    "edit": {
+      "changes": {
+        "file:///path/to/schema.prisma": [
+          {
+            "range": {
+              "start": {
+                "line": 20,
+                "character": 0
+              },
+              "end": {
+                "line": 20,
+                "character": 1
+              }
+            },
+            "newText": "\n    @@index([userId])\n}"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multibyte/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multibyte/schema.prisma
@@ -14,7 +14,7 @@ model SomeUser {
     posts Post[]
 }
 
-// comment
+/// абвгд
 model Post {
     id     Int      @id
     userId Int

--- a/prisma-fmt/tests/code_actions/tests.rs
+++ b/prisma-fmt/tests/code_actions/tests.rs
@@ -31,6 +31,7 @@ scenarios! {
     one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces
     relation_mode_prisma_missing_index
     relation_mode_prisma_missing_index_multifile
+    relation_mode_prisma_missing_index_multibyte
     relation_mode_referential_integrity
     relation_mode_mysql_foreign_keys_set_default
     relation_mode_mysql_foreign_keys_set_default_multifile


### PR DESCRIPTION
- Added test for missing index quick fix with multibyte characters comment

fixes https://github.com/prisma/language-tools/issues/1308