### PR TITLE
fix(query-engine): fix D1 tracing bug on comments

### DIFF
--- a/quaint/src/visitor/sqlite.rs
+++ b/quaint/src/visitor/sqlite.rs
@@ -224,7 +224,6 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         self.returning(insert.returning)?;
 
         if let Some(comment) = insert.comment {
-            self.write("; ")?;
             self.visit_comment(comment)?;
         }
 

--- a/quaint/src/visitor/sqlite.rs
+++ b/quaint/src/visitor/sqlite.rs
@@ -224,6 +224,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         self.returning(insert.returning)?;
 
         if let Some(comment) = insert.comment {
+            self.write(" ")?;
             self.visit_comment(comment)?;
         }
 
@@ -854,7 +855,7 @@ mod tests {
 
     #[test]
     fn test_comment_insert() {
-        let expected_sql = "INSERT INTO `users` DEFAULT VALUES; /* trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2' */";
+        let expected_sql = "INSERT INTO `users` DEFAULT VALUES /* trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2' */";
         let query = Insert::single_into("users");
         let insert =
             Insert::from(query).comment("trace_id='5bd66ef5095369c7b0d1f8f4bd33716a', parent_id='c532cb4098ac3dd2'");


### PR DESCRIPTION
This PR fixes https://github.com/prisma/team-orm/issues/880 and reverts https://github.com/prisma/quaint/pull/395.

This is fine, because the problem that https://github.com/prisma/quaint/pull/395 fixed is no longer problem in the SQLite version shipped with the native Rust SQLite driver (SQLite 3.41.2).

See [Slack thread](https://prisma-company.slack.com/archives/C06DNBFN943/p1718886635491599).

Co-author: @SevInf.