### PR TITLE
feat(fmt): lsp find references

### DIFF
--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -7,6 +7,7 @@ mod merge_schemas;
 mod native;
 mod offsets;
 mod preview;
+mod references;
 mod schema_file_input;
 mod text_document_completion;
 mod validate;
@@ -84,11 +85,28 @@ pub fn code_actions(schema_files: String, params: &str) -> String {
 
     let Ok(input) = serde_json::from_str::<SchemaFileInput>(&schema_files) else {
         warn!("Failed to parse schema file input");
-        return serde_json::to_string(&text_document_completion::empty_completion_list()).unwrap();
+        return serde_json::to_string(&code_actions::empty_code_actions()).unwrap();
     };
 
     let actions = code_actions::available_actions(input.into(), params);
     serde_json::to_string(&actions).unwrap()
+}
+
+pub fn references(schema_files: String, params: &str) -> String {
+    let params: lsp_types::ReferenceParams = if let Ok(params) = serde_json::from_str(params) {
+        params
+    } else {
+        warn!("Failed to parse params to references() as ReferenceParams.");
+        return serde_json::to_string(&references::empty_references()).unwrap();
+    };
+
+    let Ok(input) = serde_json::from_str::<SchemaFileInput>(&schema_files) else {
+        warn!("Failed to parse schema file input");
+        return serde_json::to_string(&references::empty_references()).unwrap();
+    };
+
+    let references = references::references(input.into(), params);
+    serde_json::to_string(&references).unwrap()
 }
 
 /// The two parameters are:

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -177,7 +177,7 @@ fn find_where_used_for_native_type<'ast>(
                 .1
                 .attributes
                 .iter()
-                .find(|attr| extract_ds_from_native_type(attr.name()) == name)
+                .find(|attr| extract_ds_from_native_type(attr.name()) == Some(name))
                 .map(|attr| attr.identifier())
         }))
     }
@@ -224,8 +224,8 @@ fn find_where_used_as_ds_name<'ast>(ctx: &'ast ReferencesContext<'_>, name: &'as
         .map(|source| ctx.db.ast(source.0)[source.1].identifier())
 }
 
-fn extract_ds_from_native_type(attr_name: &str) -> &str {
-    attr_name.split('.').next().unwrap_or("")
+fn extract_ds_from_native_type(attr_name: &str) -> Option<&str> {
+    attr_name.split('.').next()
 }
 
 fn ident_to_location<'ast>(id: &'ast Identifier, ctx: &'ast ReferencesContext<'_>) -> Option<Location> {

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -51,10 +51,10 @@ pub(crate) fn references(schema_files: Vec<(String, SourceFile)>, params: Refere
         params: &params,
     };
 
-    get_reference_target(ctx, target_position)
+    reference_locations_for_target(ctx, target_position)
 }
 
-fn get_reference_target(ctx: ReferencesContext<'_>, target: SchemaPosition) -> Vec<Location> {
+fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosition) -> Vec<Location> {
     info!("{:?}", target);
 
     match target {
@@ -68,7 +68,7 @@ fn get_reference_target(ctx: ReferencesContext<'_>, target: SchemaPosition) -> V
                 .collect()
         }
 
-        SchemaPosition::DataSource(_, SourcePosition::Name(name)) => find_where_used_for_native_type(ctx, name),
+        SchemaPosition::DataSource(_, SourcePosition::Name(name)) => find_where_used_for_native_type(&ctx, name),
 
         // Fields
         SchemaPosition::Model(_, ModelPosition::Field(_, FieldPosition::Type(r#type)))
@@ -94,7 +94,7 @@ fn get_reference_target(ctx: ReferencesContext<'_>, target: SchemaPosition) -> V
     }
 }
 
-fn find_where_used_for_native_type(ctx: ReferencesContext<'_>, name: &str) -> Vec<Location> {
+fn find_where_used_for_native_type(ctx: &ReferencesContext<'_>, name: &str) -> Vec<Location> {
     info!("Get references for native types");
 
     let references = ctx

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -109,15 +109,10 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
             _ => empty_references(),
         },
 
-        SchemaPosition::Model(_, ModelPosition::Field(_, FieldPosition::Attribute(name, _, _)))
-        | SchemaPosition::CompositeType(_, CompositeTypePosition::Field(_, FieldPosition::Attribute(name, _, _))) => {
-            let ds_name = ctx.datasource().map(|ds| ds.name.as_str());
-
-            match ds_name {
-                Some(ds_name) if name.contains(ds_name) => find_where_used_as_top_name(&ctx, ds_name),
-                _ => empty_references(),
-            }
-        }
+        SchemaPosition::Model(
+            model_id,
+            ModelPosition::ModelAttribute(_attr_name, _, AttributePosition::ArgumentValue(_, arg_val)),
+        ) => find_where_used_in_model(&ctx, arg_val.as_str(), model_id, ctx.initiating_file_id),
 
         _ => empty_references(),
     }

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -1,0 +1,190 @@
+use log::*;
+use lsp_types::{Location, ReferenceParams, Url};
+use psl::{
+    error_tolerant_parse_configuration,
+    parser_database::ParserDatabase,
+    schema_ast::ast::{
+        EnumPosition, Field, FieldId, FieldPosition, FieldType, Identifier, ModelPosition, SchemaPosition,
+        SourcePosition, Top, WithIdentifier,
+    },
+    Diagnostics, SourceFile,
+};
+
+use crate::{offsets::position_to_offset, span_to_range, LSPContext};
+
+pub(super) type ReferencesContext<'a> = LSPContext<'a, ReferenceParams>;
+
+pub(crate) fn empty_references() -> Vec<Location> {
+    Vec::new()
+}
+
+pub(crate) fn references(schema_files: Vec<(String, SourceFile)>, params: ReferenceParams) -> Vec<Location> {
+    info!("Finding references");
+
+    let (_, config, _) = error_tolerant_parse_configuration(&schema_files);
+
+    let db = {
+        let mut diag = Diagnostics::new();
+        ParserDatabase::new(&schema_files, &mut diag)
+    };
+
+    let Some(initiating_file_id) = db.file_id(params.text_document_position.text_document.uri.as_str()) else {
+        warn!("Initating file name is not found in the schema");
+        return empty_references();
+    };
+
+    let initiating_doc = db.source(initiating_file_id);
+
+    let position = if let Some(pos) = position_to_offset(&params.text_document_position.position, initiating_doc) {
+        pos
+    } else {
+        warn!("Received a position outside of the document boundaries in ReferenceParams");
+        return empty_references();
+    };
+
+    let target_position = db.ast(initiating_file_id).find_at_position(position);
+
+    let ctx = ReferencesContext {
+        db: &db,
+        config: &config,
+        initiating_file_id,
+        params: &params,
+    };
+
+    get_reference_target(ctx, target_position)
+}
+
+fn get_reference_target(ctx: ReferencesContext<'_>, target: SchemaPosition) -> Vec<Location> {
+    info!("{:?}", target);
+
+    match target {
+        // Block Names
+        SchemaPosition::Model(_, ModelPosition::Name(name)) => find_where_used_as_top_name(&ctx, name)
+            .into_iter()
+            .chain(find_where_used_as_type(ctx, name))
+            .collect(),
+
+        SchemaPosition::Enum(_, EnumPosition::Name(name)) => find_where_used_as_type(ctx, name),
+        SchemaPosition::DataSource(_, SourcePosition::Name(_name)) => empty_references(),
+        // Fields
+        SchemaPosition::Model(_, ModelPosition::Field(_, FieldPosition::Type(r#type))) => {
+            find_where_used_as_top_name(&ctx, r#type)
+                .into_iter()
+                .chain(find_where_used_as_type(ctx, r#type))
+                .collect()
+        }
+
+        _ => empty_references(),
+    }
+}
+
+fn find_where_used_as_type(ctx: ReferencesContext<'_>, name: &str) -> Vec<Location> {
+    info!("Get references for top");
+
+    let references: Vec<Location> = ctx
+        .db
+        .iter_tops()
+        .map(|(file_id, _top_id, top)| match top {
+            Top::Model(model) => {
+                info!("Get references in model");
+                info!("{:?}", file_id);
+
+                let fields = model.iter_fields();
+
+                let identifiers = get_relevent_identifiers(fields, name);
+
+                identifiers_to_locations(identifiers, &ctx)
+            }
+            Top::CompositeType(composite_type) => {
+                info!("Get references in composite type");
+                info!("{:?}", file_id);
+
+                let fields = composite_type.iter_fields();
+                let ids = get_relevent_identifiers(fields, name);
+
+                identifiers_to_locations(ids, &ctx)
+            }
+            Top::Enum(_) | Top::Source(_) | Top::Generator(_) => empty_references(),
+        })
+        .flatten()
+        .collect();
+
+    references
+}
+
+// fn find_where_used_in_relation(ctx: &ReferencesContext<'_>, name: &str) -> Vec<Location> {
+//     empty_references()
+// }
+
+fn find_where_used_as_top_name(ctx: &ReferencesContext<'_>, name: &str) -> Vec<Location> {
+    fn ident_to_location(id: &Identifier, name: &str, ctx: &ReferencesContext<'_>) -> Vec<Location> {
+        if id.name == name {
+            identifiers_to_locations(vec![id], ctx)
+        } else {
+            empty_references()
+        }
+    }
+    let references: Vec<Location> = ctx
+        .db
+        .iter_tops()
+        .map(|(_file_id, _top_id, top)| match top {
+            Top::CompositeType(composite_type) => ident_to_location(composite_type.identifier(), name, ctx),
+
+            Top::Enum(enm) => ident_to_location(enm.identifier(), name, ctx),
+
+            Top::Model(model) => ident_to_location(model.identifier(), name, ctx),
+
+            Top::Source(source) => ident_to_location(source.identifier(), name, ctx),
+
+            Top::Generator(_) => empty_references(),
+        })
+        .flatten()
+        .collect();
+
+    references
+}
+
+fn get_relevent_identifiers<'a, 'b>(
+    fields: impl Iterator<Item = (FieldId, &'a Field)> + std::iter::ExactSizeIterator,
+    name: &str,
+) -> Vec<&'a Identifier> {
+    let filter_map = fields
+        .filter_map(|(_id, field)| {
+            info!("{:?}", field);
+            match &field.field_type {
+                FieldType::Supported(id) => {
+                    if id.name == name {
+                        Some(id)
+                    } else {
+                        None
+                    }
+                }
+                FieldType::Unsupported(_, _) => None,
+            }
+        })
+        .collect::<Vec<&Identifier>>();
+
+    filter_map
+}
+
+fn identifiers_to_locations<'a>(ids: Vec<&'a Identifier>, ctx: &ReferencesContext<'_>) -> Vec<Location> {
+    ids.iter()
+        .filter_map(|identifier| {
+            let file_id = identifier.span.file_id;
+
+            let source = ctx.db.source(file_id);
+            let range = span_to_range(identifier.span, source);
+
+            let file_name = ctx.db.file_name(file_id);
+
+            let uri = if let Ok(uri) = Url::parse(file_name) {
+                uri
+            } else {
+                warn!("Failed to parse file path: {:?}", file_name);
+                return None;
+            };
+
+            Some(Location { uri, range })
+        })
+        .collect()
+}

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -132,16 +132,17 @@ fn find_where_used_in_model(
     let Some(model) = ctx
         .db
         .walk_models()
+        .chain(ctx.db.walk_views())
         .find(|model| model.id.1 == model_id && model.file_id() == file_id)
     else {
-        info!("Couldn't find model");
+        warn!("Could not find model");
         return empty_references();
     };
 
     let identifier = if let Some(field) = model.scalar_fields().find(|field| field.name() == name) {
         field.ast_field().identifier()
     } else {
-        warn!("Couldn't find field with name: `{}`", name);
+        warn!("Could not find field with name: `{}`", name);
         return empty_references();
     };
 
@@ -282,7 +283,7 @@ fn identifiers_to_locations<'a>(ids: Vec<&'a Identifier>, ctx: &ReferencesContex
             let uri = if let Ok(uri) = Url::parse(file_name) {
                 uri
             } else {
-                warn!("Failed to parse file path: {:?}", file_name);
+                warn!("Could not find file at path: {:?}", file_name);
                 return None;
             };
 

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -109,6 +109,17 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
             _ => empty_references(),
         },
 
+        // ? This might make more sense to add as a definition rather than a reference
+        SchemaPosition::Model(_, ModelPosition::Field(_, FieldPosition::Attribute(name, _, _)))
+        | SchemaPosition::CompositeType(_, CompositeTypePosition::Field(_, FieldPosition::Attribute(name, _, _))) => {
+            if let Some(ds) = ctx.datasource() {
+                if name.contains(ds.name.as_str()) {
+                    return find_where_used_as_top_name(&ctx, ds.name.as_str());
+                }
+            }
+            empty_references()
+        }
+
         SchemaPosition::Model(
             model_id,
             ModelPosition::ModelAttribute(_attr_name, _, AttributePosition::ArgumentValue(_, arg_val)),

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -152,7 +152,7 @@ fn find_where_used_in_model(
         return empty_references();
     };
 
-    identifiers_to_locations(vec![identifier], &ctx)
+    identifiers_to_locations(vec![identifier], ctx)
 }
 
 fn find_where_used_for_native_type(ctx: &ReferencesContext<'_>, name: &str) -> Vec<Location> {
@@ -161,10 +161,9 @@ fn find_where_used_for_native_type(ctx: &ReferencesContext<'_>, name: &str) -> V
     let references = ctx
         .db
         .walk_tops()
-        .into_iter()
         .flat_map(|top| match top.ast_top() {
-            Top::CompositeType(composite_type) => find_native_type_locations(&ctx, name, composite_type.iter_fields()),
-            Top::Model(model) => find_native_type_locations(&ctx, name, model.iter_fields()),
+            Top::CompositeType(composite_type) => find_native_type_locations(ctx, name, composite_type.iter_fields()),
+            Top::Model(model) => find_native_type_locations(ctx, name, model.iter_fields()),
 
             Top::Enum(_) | Top::Source(_) | Top::Generator(_) => empty_references(),
         })
@@ -189,11 +188,11 @@ fn find_native_type_locations<'a>(
         })
         .collect();
 
-    identifiers_to_locations(identifiers, &ctx)
+    identifiers_to_locations(identifiers, ctx)
 }
 
 fn extract_ds_from_native_type(attr_name: &str) -> &str {
-    let split = attr_name.split(".").collect::<Vec<&str>>()[0];
+    let split = attr_name.split('.').collect::<Vec<&str>>()[0];
     split
 }
 
@@ -203,7 +202,6 @@ fn find_where_used_as_type(ctx: ReferencesContext<'_>, name: &str) -> Vec<Locati
     let references: Vec<Location> = ctx
         .db
         .walk_tops()
-        .into_iter()
         .flat_map(|top| match top.ast_top() {
             Top::Model(model) => {
                 info!("Get references in model");
@@ -241,7 +239,6 @@ fn find_where_used_as_top_name(ctx: &ReferencesContext<'_>, name: &str) -> Vec<L
     let references: Vec<Location> = ctx
         .db
         .walk_tops()
-        .into_iter()
         .flat_map(|top| match top.ast_top() {
             Top::CompositeType(composite_type) => ident_to_location(composite_type.identifier(), name, ctx),
 
@@ -276,7 +273,7 @@ fn get_relevent_identifiers<'a, 'b>(
         .collect()
 }
 
-fn identifiers_to_locations<'a>(ids: Vec<&'a Identifier>, ctx: &ReferencesContext<'_>) -> Vec<Location> {
+fn identifiers_to_locations(ids: Vec<&Identifier>, ctx: &ReferencesContext<'_>) -> Vec<Location> {
     ids.iter()
         .filter_map(|identifier| {
             let file_id = identifier.span.file_id;

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -81,9 +81,10 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
                 .chain(find_where_used_as_field_type(&ctx, name))
                 .collect()
         }
-        SchemaPosition::DataSource(_, SourcePosition::Name(name)) => {
-            find_where_used_for_native_type(&ctx, name).collect()
-        }
+        SchemaPosition::DataSource(_, SourcePosition::Name(name)) => find_where_used_as_top_name(&ctx, name)
+            .into_iter()
+            .chain(find_where_used_for_native_type(&ctx, name))
+            .collect(),
 
         // Fields
         SchemaPosition::Model(_, ModelPosition::Field(_, FieldPosition::Type(r#type)))
@@ -217,7 +218,7 @@ fn find_where_used_as_top_name<'ast>(ctx: &'ast ReferencesContext<'_>, name: &'a
 }
 
 fn extract_ds_from_native_type(attr_name: &str) -> &str {
-    attr_name.split('.').collect::<Vec<&str>>()[0]
+    attr_name.split('.').next().unwrap_or("")
 }
 
 fn ident_to_location<'ast>(id: &'ast Identifier, ctx: &'ast ReferencesContext<'_>) -> Option<Location> {

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -5,7 +5,7 @@ use lsp_types::*;
 use psl::{
     diagnostics::Span,
     error_tolerant_parse_configuration,
-    parser_database::{ast, ParserDatabase, SourceFile},
+    parser_database::{ast, ParserDatabase, ReferentialAction, SourceFile},
     schema_ast::ast::AttributePosition,
     Diagnostics, PreviewFeature,
 };
@@ -86,7 +86,20 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
         .relation_mode()
         .unwrap_or_else(|| ctx.connector().default_relation_mode());
 
-    match ctx.db.ast(ctx.initiating_file_id).find_at_position(position) {
+    let find_at_position = ctx.db.ast(ctx.initiating_file_id).find_at_position(position);
+    info!("cursor position: {:?}", find_at_position);
+
+    fn push_referential_action(completion_list: &mut CompletionList, referential_action: ReferentialAction) {
+        completion_list.items.push(CompletionItem {
+            label: referential_action.as_str().to_owned(),
+            kind: Some(CompletionItemKind::ENUM),
+            // what is the difference between detail and documentation?
+            detail: Some(referential_action.documentation().to_owned()),
+            ..Default::default()
+        });
+    }
+
+    match find_at_position {
         ast::SchemaPosition::Model(
             _model_id,
             ast::ModelPosition::Field(
@@ -95,13 +108,25 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
             ),
         ) if attr_name == "onDelete" || attr_name == "onUpdate" => {
             for referential_action in ctx.connector().referential_actions(&relation_mode).iter() {
-                completion_list.items.push(CompletionItem {
-                    label: referential_action.as_str().to_owned(),
-                    kind: Some(CompletionItemKind::ENUM),
-                    // what is the difference between detail and documentation?
-                    detail: Some(referential_action.documentation().to_owned()),
-                    ..Default::default()
-                });
+                push_referential_action(completion_list, referential_action);
+            }
+        }
+
+        ast::SchemaPosition::Model(
+            _model_id,
+            ast::ModelPosition::Field(
+                _,
+                ast::FieldPosition::Attribute("relation", _, AttributePosition::ArgumentValue(attr_name, value)),
+            ),
+        ) => {
+            if let Some(attr_name) = attr_name {
+                if attr_name == "onDelete" || attr_name == "onUpdate" {
+                    ctx.connector()
+                        .referential_actions(&relation_mode)
+                        .iter()
+                        .filter(|ref_action| ref_action.to_string().starts_with(&value))
+                        .for_each(|ref_action| push_referential_action(completion_list, ref_action));
+                }
             }
         }
 

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -6,6 +6,7 @@ use psl::{
     diagnostics::Span,
     error_tolerant_parse_configuration,
     parser_database::{ast, ParserDatabase, SourceFile},
+    schema_ast::ast::AttributePosition,
     Diagnostics, PreviewFeature,
 };
 
@@ -88,7 +89,10 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
     match ctx.db.ast(ctx.initiating_file_id).find_at_position(position) {
         ast::SchemaPosition::Model(
             _model_id,
-            ast::ModelPosition::Field(_, ast::FieldPosition::Attribute("relation", _, Some(attr_name))),
+            ast::ModelPosition::Field(
+                _,
+                ast::FieldPosition::Attribute("relation", _, AttributePosition::Argument(attr_name)),
+            ),
         ) if attr_name == "onDelete" || attr_name == "onUpdate" => {
             for referential_action in ctx.connector().referential_actions(&relation_mode).iter() {
                 completion_list.items.push(CompletionItem {

--- a/prisma-fmt/src/text_document_completion.rs
+++ b/prisma-fmt/src/text_document_completion.rs
@@ -87,7 +87,6 @@ fn push_ast_completions(ctx: CompletionContext<'_>, completion_list: &mut Comple
         .unwrap_or_else(|| ctx.connector().default_relation_mode());
 
     let find_at_position = ctx.db.ast(ctx.initiating_file_id).find_at_position(position);
-    info!("cursor position: {:?}", find_at_position);
 
     fn push_referential_action(completion_list: &mut CompletionList, referential_action: ReferentialAction) {
         completion_list.items.push(CompletionItem {

--- a/prisma-fmt/tests/references/mod.rs
+++ b/prisma-fmt/tests/references/mod.rs
@@ -1,0 +1,2 @@
+mod test_api;
+mod tests;

--- a/prisma-fmt/tests/references/scenarios/composite_type_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/composite_type_as_type/a.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+type Address {
+  city     String
+  postCode String
+}

--- a/prisma-fmt/tests/references/scenarios/composite_type_as_type/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/composite_type_as_type/b.prisma
@@ -1,0 +1,5 @@
+model User {
+  id       String @id @map("_id")
+  authorId String
+  address  Add<|>ress
+}

--- a/prisma-fmt/tests/references/scenarios/composite_type_as_type/result.json
+++ b/prisma-fmt/tests/references/scenarios/composite_type_as_type/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 5
+      },
+      "end": {
+        "line": 10,
+        "character": 12
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 11
+      },
+      "end": {
+        "line": 3,
+        "character": 18
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/composite_type_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/composite_type_name/a.prisma
@@ -1,0 +1,14 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+type Add<|>ress {
+city     String
+postCode String
+}

--- a/prisma-fmt/tests/references/scenarios/composite_type_name/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/composite_type_name/b.prisma
@@ -1,0 +1,5 @@
+model User {
+  id       String  @id @map("_id")
+  authorId String
+  address  Address
+}

--- a/prisma-fmt/tests/references/scenarios/composite_type_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/composite_type_name/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 5
+      },
+      "end": {
+        "line": 10,
+        "character": 12
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 11
+      },
+      "end": {
+        "line": 3,
+        "character": 18
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/datasource_as_attribute/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/datasource_as_attribute/a.prisma
@@ -1,0 +1,15 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+enum Pet {
+  Cat
+  Dog
+  Redpanda
+}

--- a/prisma-fmt/tests/references/scenarios/datasource_as_attribute/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/datasource_as_attribute/b.prisma
@@ -1,0 +1,4 @@
+model User {
+  id  String @id @map("_id") @d<|>b.String
+  pet Pet
+}

--- a/prisma-fmt/tests/references/scenarios/datasource_as_attribute/result.json
+++ b/prisma-fmt/tests/references/scenarios/datasource_as_attribute/result.json
@@ -11,5 +11,18 @@
         "character": 13
       }
     }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 30
+      },
+      "end": {
+        "line": 1,
+        "character": 39
+      }
+    }
   }
 ]

--- a/prisma-fmt/tests/references/scenarios/datasource_as_attribute/result.json
+++ b/prisma-fmt/tests/references/scenarios/datasource_as_attribute/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 11
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/datasource_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/datasource_name/a.prisma
@@ -1,0 +1,15 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource d<|>b {
+provider = "mongodb"
+url      = env("DATABASE_URL")
+}
+
+enum Pet {
+  Cat
+  Dog
+  Redpanda
+}

--- a/prisma-fmt/tests/references/scenarios/datasource_name/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/datasource_name/b.prisma
@@ -1,0 +1,4 @@
+model User {
+  id  String @id @map("_id") @db.String
+  pet Pet
+}

--- a/prisma-fmt/tests/references/scenarios/datasource_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/datasource_name/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 1,
+        "character": 30
+      },
+      "end": {
+        "line": 1,
+        "character": 39
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/datasource_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/datasource_name/result.json
@@ -1,5 +1,18 @@
 [
   {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 11
+      },
+      "end": {
+        "line": 5,
+        "character": 13
+      }
+    }
+  },
+  {
     "uri": "file:///path/to/b.prisma",
     "range": {
       "start": {

--- a/prisma-fmt/tests/references/scenarios/enum_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/enum_as_type/a.prisma
@@ -1,0 +1,15 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+enum Pet {
+  Cat
+  Dog
+  Redpanda
+}

--- a/prisma-fmt/tests/references/scenarios/enum_as_type/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/enum_as_type/b.prisma
@@ -1,0 +1,4 @@
+model User {
+  id String @id @map("_id")
+  pet P<|>et
+}

--- a/prisma-fmt/tests/references/scenarios/enum_as_type/result.json
+++ b/prisma-fmt/tests/references/scenarios/enum_as_type/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 5
+      },
+      "end": {
+        "line": 10,
+        "character": 8
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 6
+      },
+      "end": {
+        "line": 2,
+        "character": 9
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/enum_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/enum_name/a.prisma
@@ -1,0 +1,15 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+enum P<|>et {
+Cat
+Dog
+Redpanda
+}

--- a/prisma-fmt/tests/references/scenarios/enum_name/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/enum_name/b.prisma
@@ -1,0 +1,4 @@
+model User {
+  id  String @id @map("_id")
+  pet Pet
+}

--- a/prisma-fmt/tests/references/scenarios/enum_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/enum_name/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 5
+      },
+      "end": {
+        "line": 10,
+        "character": 8
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 6
+      },
+      "end": {
+        "line": 2,
+        "character": 9
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_as_type/a.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model UserTwo {
+  id String @id @map("_id") @db.String
+
+  posts  Post   @relation(fields: [postId], references: [id])
+  postId String
+}

--- a/prisma-fmt/tests/references/scenarios/model_as_type/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_as_type/b.prisma
@@ -1,0 +1,5 @@
+model Post {
+  id       String    @id @map("_id")
+  authorId String
+  UserTwo  User<|>Two[]
+}

--- a/prisma-fmt/tests/references/scenarios/model_as_type/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_as_type/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 6
+      },
+      "end": {
+        "line": 10,
+        "character": 13
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 11
+      },
+      "end": {
+        "line": 3,
+        "character": 18
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_name/a.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+model User<|>Two {
+id String @id @map("_id") @db.String
+
+posts  Post   @relation(fields: [postId], references: [id])
+postId String
+}

--- a/prisma-fmt/tests/references/scenarios/model_name/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_name/b.prisma
@@ -1,0 +1,5 @@
+model Post {
+  id       String    @id @map("_id")
+  authorId String
+  UserTwo  UserTwo[]
+}

--- a/prisma-fmt/tests/references/scenarios/model_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_name/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 6
+      },
+      "end": {
+        "line": 10,
+        "character": 13
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 11
+      },
+      "end": {
+        "line": 3,
+        "character": 18
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_relation_fields/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_fields/a.prisma
@@ -1,0 +1,7 @@
+model Compound {
+    id      String
+    name    String
+    UserTwo UserTwo[]
+
+    @@id([id, name])
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_fields/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_fields/b.prisma
@@ -1,0 +1,7 @@
+model UserTwo {
+    id String @id @map("_id")
+
+    compounds    Compound @relation(fields: [comp<|>oundId, compoundName], references: [id, name])
+    compoundId   String
+    compoundName String
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_fields/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_fields/config.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_fields/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_relation_fields/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 4,
+        "character": 4
+      },
+      "end": {
+        "line": 4,
+        "character": 14
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_relation_references/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_references/a.prisma
@@ -1,0 +1,7 @@
+model Compound {
+    id      String
+    name    String
+    UserTwo UserTwo[]
+
+    @@id([id, name])
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_references/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_references/b.prisma
@@ -1,0 +1,7 @@
+model UserTwo {
+    id String @id @map("_id")
+
+    compounds    Compound @relation(fields: [compoundId, compoundName], references: [id, n<|>ame])
+    compoundId   String
+    compoundName String
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_references/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_references/config.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_references/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_relation_references/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 4
+      },
+      "end": {
+        "line": 2,
+        "character": 8
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_unique_fields/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_unique_fields/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 11,
+        "character": 4
+      },
+      "end": {
+        "line": 11,
+        "character": 8
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_unique_fields/schema.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_unique_fields/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+    provider        = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}
+
+model Compound {
+    id      String
+    name    String
+
+    @@unique([id, n<|>ame])
+}
+

--- a/prisma-fmt/tests/references/scenarios/view_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_as_type/a.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+view UserTwo {
+    id String @id @map("_id") @db.String
+
+    posts  Post   @relation(fields: [postId], references: [id])
+    postId String
+}

--- a/prisma-fmt/tests/references/scenarios/view_as_type/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_as_type/b.prisma
@@ -1,0 +1,5 @@
+model Post {
+  id       String    @id @map("_id")
+  authorId String
+  UserTwo  User<|>Two[]
+}

--- a/prisma-fmt/tests/references/scenarios/view_as_type/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_as_type/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 5
+      },
+      "end": {
+        "line": 10,
+        "character": 12
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 11
+      },
+      "end": {
+        "line": 3,
+        "character": 18
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/view_index_fields/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_index_fields/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 11,
+        "character": 4
+      },
+      "end": {
+        "line": 11,
+        "character": 8
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/view_index_fields/schema.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_index_fields/schema.prisma
@@ -1,0 +1,16 @@
+generator client {
+    provider        = "prisma-client-js"
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}
+
+model Compound {
+    id      String
+    name    String
+
+    @@unique(fields: [id, n<|>ame])
+}
+

--- a/prisma-fmt/tests/references/scenarios/view_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_name/a.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+  provider = "mongodb"
+  url      = env("DATABASE_URL")
+}
+
+view User<|>Two {
+    id String @id @map("_id") @db.String
+
+    posts  Post   @relation(fields: [postId], references: [id])
+    postId String
+}

--- a/prisma-fmt/tests/references/scenarios/view_name/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_name/b.prisma
@@ -1,0 +1,5 @@
+model Post {
+  id       String    @id @map("_id")
+  authorId String
+  UserTwo  UserTwo[]
+}

--- a/prisma-fmt/tests/references/scenarios/view_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_name/result.json
@@ -1,0 +1,28 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 10,
+        "character": 5
+      },
+      "end": {
+        "line": 10,
+        "character": 12
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 3,
+        "character": 11
+      },
+      "end": {
+        "line": 3,
+        "character": 18
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/view_relation_fields/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_fields/a.prisma
@@ -1,0 +1,7 @@
+view Compound {
+    id      String
+    name    String
+    UserTwo UserTwo[]
+
+    @@id([id, name])
+}

--- a/prisma-fmt/tests/references/scenarios/view_relation_fields/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_fields/b.prisma
@@ -1,0 +1,7 @@
+view UserTwo {
+    id String @id @map("_id")
+
+    compounds    Compound @relation(fields: [comp<|>oundId, compoundName], references: [id, name])
+    compoundId   String
+    compoundName String
+}

--- a/prisma-fmt/tests/references/scenarios/view_relation_fields/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_fields/config.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/references/scenarios/view_relation_fields/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_relation_fields/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/b.prisma",
+    "range": {
+      "start": {
+        "line": 4,
+        "character": 4
+      },
+      "end": {
+        "line": 4,
+        "character": 14
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/view_relation_references/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_references/a.prisma
@@ -1,0 +1,7 @@
+view Compound {
+    id      String
+    name    String
+    UserTwo UserTwo[]
+
+    @@id([id, name])
+}

--- a/prisma-fmt/tests/references/scenarios/view_relation_references/b.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_references/b.prisma
@@ -1,0 +1,7 @@
+view UserTwo {
+    id String @id @map("_id")
+
+    compounds    Compound @relation(fields: [compoundId, compoundName], references: [id, n<|>ame])
+    compoundId   String
+    compoundName String
+}

--- a/prisma-fmt/tests/references/scenarios/view_relation_references/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_references/config.prisma
@@ -1,0 +1,9 @@
+generator client {
+    provider        = "prisma-client-js"
+    previewFeatures = ["prismaSchemaFolder", "views"]
+}
+
+datasource db {
+    provider = "postgres"
+    url      = env("DATABASE_URL")
+}

--- a/prisma-fmt/tests/references/scenarios/view_relation_references/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_relation_references/result.json
@@ -1,0 +1,15 @@
+[
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 2,
+        "character": 4
+      },
+      "end": {
+        "line": 2,
+        "character": 8
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/test_api.rs
+++ b/prisma-fmt/tests/references/test_api.rs
@@ -1,0 +1,149 @@
+use crate::helpers::load_schema_files;
+use once_cell::sync::Lazy;
+use std::{fmt::Write as _, io::Write as _};
+
+const CURSOR_MARKER: &str = "<|>";
+const SCENARIOS_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/references/scenarios");
+static UPDATE_EXPECT: Lazy<bool> = Lazy::new(|| std::env::var("UPDATE_EXPECT").is_ok());
+
+pub(crate) fn test_scenario(scenario_name: &str) {
+    let mut path = String::with_capacity(SCENARIOS_PATH.len() + 12);
+
+    let schema_files = {
+        write!(path, "{SCENARIOS_PATH}/{scenario_name}").unwrap();
+        load_schema_files(&path)
+    };
+
+    path.clear();
+    write!(path, "{SCENARIOS_PATH}/{scenario_name}/result.json").unwrap();
+    let expected_result = std::fs::read_to_string(&path).unwrap_or_else(|_| String::new());
+
+    let (initiating_file_uri, cursor_position, schema_files) = take_cursor(schema_files);
+
+    let params = lsp_types::ReferenceParams {
+        text_document_position: lsp_types::TextDocumentPositionParams {
+            text_document: lsp_types::TextDocumentIdentifier {
+                uri: initiating_file_uri.parse().unwrap(),
+            },
+            position: cursor_position,
+        },
+        work_done_progress_params: lsp_types::WorkDoneProgressParams { work_done_token: None },
+        partial_result_params: lsp_types::PartialResultParams {
+            partial_result_token: None,
+        },
+        context: lsp_types::ReferenceContext {
+            include_declaration: true,
+        },
+    };
+
+    let result = prisma_fmt::references(
+        serde_json::to_string_pretty(&schema_files).unwrap(),
+        &serde_json::to_string_pretty(&params).unwrap(),
+    );
+    // Prettify the JSON
+    let result =
+        serde_json::to_string_pretty(&serde_json::from_str::<Vec<lsp_types::Location>>(&result).unwrap()).unwrap();
+
+    if *UPDATE_EXPECT {
+        let mut file = std::fs::File::create(&path).unwrap(); // truncate
+        file.write_all(result.as_bytes()).unwrap();
+    } else if expected_result != result {
+        let chunks = dissimilar::diff(&expected_result, &result);
+        panic!(
+            r#"
+Snapshot comparison failed. Run the test again with UPDATE_EXPECT=1 in the environment to update the snapshot.
+
+===== EXPECTED ====
+{}
+====== FOUND ======
+{}
+======= DIFF ======
+{}
+"#,
+            expected_result,
+            result,
+            format_chunks(chunks),
+        );
+    }
+}
+
+fn format_chunks(chunks: Vec<dissimilar::Chunk>) -> String {
+    let mut buf = String::new();
+    for chunk in chunks {
+        let formatted = match chunk {
+            dissimilar::Chunk::Equal(text) => text.into(),
+            dissimilar::Chunk::Delete(text) => format!("\x1b[41m{text}\x1b[0m"),
+            dissimilar::Chunk::Insert(text) => format!("\x1b[42m{text}\x1b[0m"),
+        };
+        buf.push_str(&formatted);
+    }
+    buf
+}
+
+fn take_cursor(schema_files: Vec<(String, String)>) -> (String, lsp_types::Position, Vec<(String, String)>) {
+    let mut result = Vec::with_capacity(schema_files.len());
+    let mut file_and_pos = None;
+    for (file_name, content) in schema_files {
+        if let Some((pos, without_cursor)) = take_cursor_one(&content) {
+            file_and_pos = Some((file_name.clone(), pos));
+            result.push((file_name, without_cursor));
+        } else {
+            result.push((file_name, content));
+        }
+    }
+
+    let (file_name, position) = file_and_pos.expect("Could not find a cursor in any of the schema files");
+
+    (file_name, position, result)
+}
+
+fn take_cursor_one(schema: &str) -> Option<(lsp_types::Position, String)> {
+    let mut schema_without_cursor = String::with_capacity(schema.len() - 3);
+    let mut cursor_position = lsp_types::Position { character: 0, line: 0 };
+    let mut cursor_found = false;
+    for line in schema.lines() {
+        if !cursor_found {
+            if let Some(pos) = line.find(CURSOR_MARKER) {
+                cursor_position.character = pos as u32;
+                cursor_found = true;
+                schema_without_cursor.push_str(&line[..pos]);
+                schema_without_cursor.push_str(&line[pos + 3..]);
+                schema_without_cursor.push('\n');
+            } else {
+                schema_without_cursor.push_str(line);
+                schema_without_cursor.push('\n');
+                cursor_position.line += 1;
+            }
+        } else {
+            schema_without_cursor.push_str(line);
+            schema_without_cursor.push('\n');
+        }
+    }
+
+    if !cursor_found {
+        return None;
+    }
+    // remove extra newline
+    schema_without_cursor.truncate(schema_without_cursor.len() - 1);
+
+    Some((cursor_position, schema_without_cursor))
+}
+
+#[test]
+fn take_cursor_works() {
+    let schema = r#"
+        model Test {
+            id Int @id @map(<|>)
+        }
+    "#;
+    let expected_schema = r#"
+        model Test {
+            id Int @id @map()
+        }
+    "#;
+
+    let (pos, schema) = take_cursor_one(schema).unwrap();
+    assert_eq!(pos.line, 2);
+    assert_eq!(pos.character, 28);
+    assert_eq!(schema, expected_schema);
+}

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -12,6 +12,8 @@ macro_rules! scenarios {
 }
 
 scenarios! {
+    composite_type_as_type
+    composite_type_name
     enum_as_type
     enum_name
     view_as_type

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -16,6 +16,8 @@ scenarios! {
     composite_type_name
     enum_as_type
     enum_name
+    model_as_type
+    model_name
     view_as_type
     view_name
 }

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -19,6 +19,7 @@ scenarios! {
     model_as_type
     model_name
     model_relation_fields
+    model_relation_references
     view_as_type
     view_name
     datasource_as_attribute

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -12,6 +12,8 @@ macro_rules! scenarios {
 }
 
 scenarios! {
+    enum_as_type
+    enum_name
     view_as_type
     view_name
 }

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -20,7 +20,9 @@ scenarios! {
     model_name
     model_relation_fields
     model_relation_references
+    model_unique_fields
     view_as_type
+    view_index_fields
     view_name
     view_relation_fields
     view_relation_references

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -18,6 +18,7 @@ scenarios! {
     enum_name
     model_as_type
     model_name
+    model_relation_fields
     view_as_type
     view_name
     datasource_as_attribute

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -22,6 +22,8 @@ scenarios! {
     model_relation_references
     view_as_type
     view_name
+    view_relation_fields
+    view_relation_references
     datasource_as_attribute
     datasource_name
 }

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -1,0 +1,17 @@
+use super::test_api::test_scenario;
+
+macro_rules! scenarios {
+    ($($scenario_name:ident)+) => {
+        $(
+            #[test]
+            fn $scenario_name() {
+                test_scenario(stringify!($scenario_name))
+            }
+        )*
+    }
+}
+
+scenarios! {
+    view_as_type
+    view_name
+}

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -20,4 +20,6 @@ scenarios! {
     model_name
     view_as_type
     view_name
+    datasource_as_attribute
+    datasource_name
 }

--- a/prisma-fmt/tests/references_tests.rs
+++ b/prisma-fmt/tests/references_tests.rs
@@ -1,0 +1,2 @@
+mod helpers;
+mod references;

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_in_arg_value/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_in_arg_value/result.json
@@ -1,0 +1,4 @@
+{
+  "isIncomplete": false,
+  "items": []
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_in_arg_value/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_in_arg_value/schema.prisma
@@ -1,0 +1,10 @@
+datasource db {
+    provider = "sqlserver"
+    url      = env("DATABASE_URL")
+}
+
+model User {
+    id String @id
+
+    postId String @unique @default("defaul<|>t_value")
+}

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/result.json
@@ -5,21 +5,6 @@
       "label": "Cascade",
       "kind": 13,
       "detail": "Delete the child records when the parent record is deleted."
-    },
-    {
-      "label": "NoAction",
-      "kind": 13,
-      "detail": "Prevent deleting a parent record as long as it is referenced."
-    },
-    {
-      "label": "SetNull",
-      "kind": 13,
-      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
-    },
-    {
-      "label": "SetDefault",
-      "kind": 13,
-      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress_2/result.json
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress_2/result.json
@@ -2,29 +2,9 @@
   "isIncomplete": false,
   "items": [
     {
-      "label": "Cascade",
-      "kind": 13,
-      "detail": "Delete the child records when the parent record is deleted."
-    },
-    {
       "label": "Restrict",
       "kind": 13,
       "detail": "Prevent deleting a parent record as long as it is referenced."
-    },
-    {
-      "label": "NoAction",
-      "kind": 13,
-      "detail": "Prevent deleting a parent record as long as it is referenced."
-    },
-    {
-      "label": "SetNull",
-      "kind": 13,
-      "detail": "Set the referencing fields to NULL when the referenced record is deleted."
-    },
-    {
-      "label": "SetDefault",
-      "kind": 13,
-      "detail": "Set the referencing field's value to the default when the referenced record is deleted."
     }
   ]
 }

--- a/prisma-fmt/tests/text_document_completion/tests.rs
+++ b/prisma-fmt/tests/text_document_completion/tests.rs
@@ -15,6 +15,7 @@ scenarios! {
     argument_after_trailing_comma
     default_map_end_of_args_list
     default_map_mssql
+    default_map_mssql_in_arg_value
     default_map_mssql_multifile
     empty_schema
     extended_indexes_basic

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -86,7 +86,7 @@ pub fn preview_features() -> String {
 }
 
 /// The API is modelled on an LSP [completion
-/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_completion).
+/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#completion-request-leftwards_arrow_with_hook).
 /// Input and output are both JSON, the request being a `CompletionParams` object and the response
 /// being a `CompletionList` object.
 #[wasm_bindgen]
@@ -96,7 +96,7 @@ pub fn text_document_completion(schema_files: String, params: String) -> String 
 }
 
 /// This API is modelled on an LSP [code action
-/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_codeAction=).
+/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#code-action-request-leftwards_arrow_with_hook).
 /// Input and output are both JSON, the request being a
 /// `CodeActionParams` object and the response being a list of
 /// `CodeActionOrCommand` objects.
@@ -106,8 +106,8 @@ pub fn code_actions(schema: String, params: String) -> String {
     prisma_fmt::code_actions(schema, &params)
 }
 
-/// This API is modelled on an LSP [code action
-/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_codeAction=).
+/// This API is modelled on an LSP [references
+/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#find-references-request-leftwards_arrow_with_hook).
 /// Input and output are both JSON, the request being a
 /// `CodeActionParams` object and the response being a list of
 /// `CodeActionOrCommand` objects.

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -106,6 +106,17 @@ pub fn code_actions(schema: String, params: String) -> String {
     prisma_fmt::code_actions(schema, &params)
 }
 
+/// This API is modelled on an LSP [code action
+/// request](https://github.com/microsoft/language-server-protocol/blob/gh-pages/_specifications/specification-3-16.md#textDocument_codeAction=).
+/// Input and output are both JSON, the request being a
+/// `CodeActionParams` object and the response being a list of
+/// `CodeActionOrCommand` objects.
+#[wasm_bindgen]
+pub fn references(schema: String, params: String) -> String {
+    register_panic_hook();
+    prisma_fmt::references(schema, &params)
+}
+
 /// Trigger a panic inside the wasm module. This is only useful in development for testing panic
 /// handling.
 #[wasm_bindgen]

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -75,7 +75,15 @@ impl crate::ParserDatabase {
             .flat_map(move |(file_id, _, _, ast)| ast.iter_tops().map(move |(top_id, top)| (file_id, top_id, top)))
     }
 
-    /// Intern any top by name.
+    /// Find the datasource by name.
+    pub fn find_source<'db>(&'db self, name: &str) -> Option<(FileId, ast::TopId)> {
+        self.interner
+            .lookup(name)
+            .and_then(|name_id| self.names.datasources.get(&name_id))
+            .map(|(file_id, top_id)| (*file_id, *top_id))
+    }
+
+    /// Find any top by name.
     pub fn find_top<'db>(&'db self, name: &str) -> Option<TopWalker<'db>> {
         self.interner
             .lookup(name)

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -76,7 +76,7 @@ impl crate::ParserDatabase {
     }
 
     /// Find the datasource by name.
-    pub fn find_source<'db>(&'db self, name: &str) -> Option<(FileId, ast::TopId)> {
+    pub fn find_source(&self, name: &str) -> Option<(FileId, ast::TopId)> {
         self.interner
             .lookup(name)
             .and_then(|name_id| self.names.datasources.get(&name_id))

--- a/psl/psl-core/src/builtin_connectors/mssql_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/mssql_datamodel_connector.rs
@@ -262,7 +262,7 @@ impl Connector for MsSqlDatamodelConnector {
     ) {
         if let ast::SchemaPosition::Model(
             _model_id,
-            ast::ModelPosition::Field(_, ast::FieldPosition::Attribute("default", _, None)),
+            ast::ModelPosition::Field(_, ast::FieldPosition::Attribute("default", _, _)),
         ) = position
         {
             completions.items.push(CompletionItem {

--- a/psl/psl-core/src/builtin_connectors/mssql_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/mssql_datamodel_connector.rs
@@ -262,7 +262,10 @@ impl Connector for MsSqlDatamodelConnector {
     ) {
         if let ast::SchemaPosition::Model(
             _model_id,
-            ast::ModelPosition::Field(_, ast::FieldPosition::Attribute("default", _, _)),
+            ast::ModelPosition::Field(
+                _,
+                ast::FieldPosition::Attribute("default", _, ast::AttributePosition::Attribute),
+            ),
         ) = position
         {
             completions.items.push(CompletionItem {

--- a/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
@@ -495,7 +495,7 @@ impl Connector for PostgresDatamodelConnector {
                 ast::ModelPosition::ModelAttribute(
                     "index",
                     attr_id,
-                    ast::AttributePosition::FunctionArgument(field_name, "ops"),
+                    ast::AttributePosition::FunctionArgument(field_name, "ops", _),
                 ),
             ) => {
                 // let's not care about composite field indices yet

--- a/psl/schema-ast/src/ast/argument.rs
+++ b/psl/schema-ast/src/ast/argument.rs
@@ -68,6 +68,13 @@ impl Argument {
     pub fn is_unnamed(&self) -> bool {
         self.name.is_none()
     }
+
+    pub fn name(&self) -> Option<&str> {
+        match &self.name {
+            Some(ident) => Some(ident.name.as_str()),
+            None => None,
+        }
+    }
 }
 
 impl WithSpan for Argument {

--- a/psl/schema-ast/src/ast/field.rs
+++ b/psl/schema-ast/src/ast/field.rs
@@ -158,4 +158,11 @@ impl FieldType {
             FieldType::Supported(_) => None,
         }
     }
+
+    pub fn name(&self) -> &str {
+        match self {
+            FieldType::Supported(supported) => &supported.name,
+            FieldType::Unsupported(name, _) => name,
+        }
+    }
 }

--- a/psl/schema-ast/src/ast/field.rs
+++ b/psl/schema-ast/src/ast/field.rs
@@ -158,11 +158,4 @@ impl FieldType {
             FieldType::Supported(_) => None,
         }
     }
-
-    pub fn name(&self) -> &str {
-        match self {
-            FieldType::Supported(supported) => &supported.name,
-            FieldType::Unsupported(name, _) => name,
-        }
-    }
 }

--- a/psl/schema-ast/src/ast/find_at_position/attribute.rs
+++ b/psl/schema-ast/src/ast/find_at_position/attribute.rs
@@ -11,8 +11,8 @@ pub enum AttributePosition<'ast> {
     Argument(&'ast str),
     /// In an argument's value. (argument name, value)
     ArgumentValue(Option<&'ast str>, String),
-    /// In an function argument. (function name, argument name)
-    FunctionArgument(&'ast str, &'ast str),
+    /// In an function argument. (function name, argument name, argument value)
+    FunctionArgument(&'ast str, &'ast str, String),
 }
 
 impl<'ast> AttributePosition<'ast> {
@@ -45,7 +45,15 @@ impl<'ast> AttributePosition<'ast> {
 
         if let Some(arg) = attr.arguments.iter().find(|arg| arg.span().contains(position)) {
             if let ExpressionPosition::FunctionArgument(fun, name) = ExpressionPosition::new(&arg.value, position) {
-                return Self::FunctionArgument(fun, name);
+                return Self::FunctionArgument(fun, name, arg.value.to_string());
+            }
+
+            if arg.value.is_array() {
+                let arr = arg.value.as_array().unwrap();
+                let expr = arr.0.iter().find(|expr| expr.span().contains(position));
+                if let Some(expr) = expr {
+                    return Self::ArgumentValue(arg.name(), expr.to_string());
+                }
             }
 
             return Self::ArgumentValue(arg.name(), arg.value.to_string());

--- a/psl/schema-ast/src/ast/find_at_position/attribute.rs
+++ b/psl/schema-ast/src/ast/find_at_position/attribute.rs
@@ -9,50 +9,52 @@ pub enum AttributePosition<'ast> {
     Attribute,
     /// In an argument. (argument name)
     Argument(&'ast str),
+    /// In an argument's value. (argument name, value)
+    ArgumentValue(Option<&'ast str>, String),
     /// In an function argument. (function name, argument name)
     FunctionArgument(&'ast str, &'ast str),
 }
 
 impl<'ast> AttributePosition<'ast> {
     pub(crate) fn new(attr: &'ast ast::Attribute, position: usize) -> Self {
-        if attr.span().contains(position) {
-            // We can't go by Span::contains() because we also care about the empty space
-            // between arguments and that's hard to capture in the pest grammar.
-            let mut spans: Vec<(Option<&str>, ast::Span)> = attr
-                .arguments
-                .iter()
-                .map(|arg| (arg.name.as_ref().map(|n| n.name.as_str()), arg.span()))
-                .chain(
-                    attr.arguments
-                        .empty_arguments
-                        .iter()
-                        .map(|arg| (Some(arg.name.name.as_str()), arg.name.span())),
-                )
-                .collect();
+        let mut spans: Vec<(Option<&str>, ast::Span)> = attr
+            .arguments
+            .iter()
+            .map(|arg| (arg.name.as_ref().map(|n| n.name.as_str()), arg.span()))
+            .chain(
+                attr.arguments
+                    .empty_arguments
+                    .iter()
+                    .map(|arg| (Some(arg.name.name.as_str()), arg.name.span())),
+            )
+            .collect();
 
-            spans.sort_by_key(|(_, span)| span.start);
+        spans.sort_by_key(|(_, span)| span.start);
 
-            let mut arg_name = None;
-            for (name, _) in spans.iter().take_while(|(_, span)| span.start < position) {
-                arg_name = Some(*name);
+        let mut arg_name = None;
+        for (name, _) in spans.iter().take_while(|(_, span)| span.start < position) {
+            arg_name = Some(*name);
+        }
+
+        // If the cursor is after a trailing comma, we're not in an argument.
+        if let Some(span) = attr.arguments.trailing_comma {
+            if position > span.start {
+                arg_name = None;
+            }
+        }
+
+        if let Some(arg) = attr.arguments.iter().find(|arg| arg.span().contains(position)) {
+            if let ExpressionPosition::FunctionArgument(fun, name) = ExpressionPosition::new(&arg.value, position) {
+                return Self::FunctionArgument(fun, name);
             }
 
-            // If the cursor is after a trailing comma, we're not in an argument.
-            if let Some(span) = attr.arguments.trailing_comma {
-                if position > span.start {
-                    arg_name = None;
-                }
-            }
+            return Self::ArgumentValue(arg.name(), arg.value.to_string());
 
-            if let Some(arg_name) = arg_name.flatten() {
-                return Self::Argument(arg_name);
-            }
+            // Self::ArgumentValue(arg_name, ())
+        }
 
-            if let Some(arg) = attr.arguments.iter().find(|arg| arg.span().contains(position)) {
-                if let ExpressionPosition::FunctionArgument(fun, name) = ExpressionPosition::new(&arg.value, position) {
-                    return Self::FunctionArgument(fun, name);
-                }
-            }
+        if let Some(arg_name) = arg_name.flatten() {
+            return Self::Argument(arg_name);
         }
 
         Self::Attribute


### PR DESCRIPTION
I left details on testing this locally in the language-tools pr [here](https://github.com/prisma/language-tools/pull/1775)

closes https://github.com/prisma/team-orm/issues/1201

---

https://github.com/prisma/prisma-engines/assets/29753584/ddc7e581-3b64-4e03-844d-80bfa528f056



https://github.com/prisma/prisma-engines/assets/29753584/54cfa638-3f6d-4788-8d87-99afd5076567



closes https://github.com/prisma/team-orm/issues/1196

---

https://github.com/prisma/prisma-engines/assets/29753584/f8c6869e-07e4-4876-8e39-77f92acd9b99

These only apply to models and views. Composite types have uniques, indices, so on defined in their containing model / view.

closes https://github.com/prisma/team-orm/issues/1200