### PR TITLE
feat(prisma-schema-wasm): add get_datamodel method

### DIFF
--- a/prisma-fmt/src/get_datamodel.rs
+++ b/prisma-fmt/src/get_datamodel.rs
@@ -1,0 +1,209 @@
+use serde::Deserialize;
+
+use crate::{schema_file_input::SchemaFileInput, validate};
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+struct GetDatamodelParams {
+    prisma_schema: SchemaFileInput,
+    #[serde(default)]
+    no_color: bool,
+}
+
+pub(crate) fn get_datamodel(params: &str) -> Result<String, String> {
+    let params: GetDatamodelParams =
+        serde_json::from_str(params).map_err(|e| format!("Failed to deserialize GetDatamodelParams: {e}"))?;
+
+    let schema = validate::run(params.prisma_schema, params.no_color)?;
+
+    let datamodel = dmmf::datamodel_from_validated_schema(&schema);
+
+    Ok(serde_json::to_string(&datamodel).unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use expect_test::expect;
+    use indoc::indoc;
+    use serde_json::json;
+
+    #[test]
+    fn sample_schema() {
+        let schema = indoc! {r#"
+            generator js {
+                provider = "prisma-client-js"
+            }
+
+            datasource db {
+                provider = "postgresql"
+                url      = env("DATABASE_URL")
+            }
+
+            model User {
+                id    Int    @id @default(autoincrement())
+                email String @unique
+                posts Post[]
+            }
+
+            model Post {
+                id        Int    @id @default(autoincrement())
+                title     String
+                author    User    @relation(fields: [authorId], references: [id])
+                authorId  Int
+
+                @@index([title], name: "idx_post_on_title")
+            }
+        "#};
+
+        let expected = expect![[r#"
+            {
+              "enums": [],
+              "models": [
+                {
+                  "name": "User",
+                  "dbName": null,
+                  "fields": [
+                    {
+                      "name": "id",
+                      "kind": "scalar",
+                      "isList": false,
+                      "isRequired": true,
+                      "isUnique": false,
+                      "isId": true,
+                      "isReadOnly": false,
+                      "hasDefaultValue": true,
+                      "type": "Int",
+                      "default": {
+                        "name": "autoincrement",
+                        "args": []
+                      },
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    },
+                    {
+                      "name": "email",
+                      "kind": "scalar",
+                      "isList": false,
+                      "isRequired": true,
+                      "isUnique": true,
+                      "isId": false,
+                      "isReadOnly": false,
+                      "hasDefaultValue": false,
+                      "type": "String",
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    },
+                    {
+                      "name": "posts",
+                      "kind": "object",
+                      "isList": true,
+                      "isRequired": true,
+                      "isUnique": false,
+                      "isId": false,
+                      "isReadOnly": false,
+                      "hasDefaultValue": false,
+                      "type": "Post",
+                      "relationName": "PostToUser",
+                      "relationFromFields": [],
+                      "relationToFields": [],
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    }
+                  ],
+                  "primaryKey": null,
+                  "uniqueFields": [],
+                  "uniqueIndexes": [],
+                  "isGenerated": false
+                },
+                {
+                  "name": "Post",
+                  "dbName": null,
+                  "fields": [
+                    {
+                      "name": "id",
+                      "kind": "scalar",
+                      "isList": false,
+                      "isRequired": true,
+                      "isUnique": false,
+                      "isId": true,
+                      "isReadOnly": false,
+                      "hasDefaultValue": true,
+                      "type": "Int",
+                      "default": {
+                        "name": "autoincrement",
+                        "args": []
+                      },
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    },
+                    {
+                      "name": "title",
+                      "kind": "scalar",
+                      "isList": false,
+                      "isRequired": true,
+                      "isUnique": false,
+                      "isId": false,
+                      "isReadOnly": false,
+                      "hasDefaultValue": false,
+                      "type": "String",
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    },
+                    {
+                      "name": "author",
+                      "kind": "object",
+                      "isList": false,
+                      "isRequired": true,
+                      "isUnique": false,
+                      "isId": false,
+                      "isReadOnly": false,
+                      "hasDefaultValue": false,
+                      "type": "User",
+                      "relationName": "PostToUser",
+                      "relationFromFields": [
+                        "authorId"
+                      ],
+                      "relationToFields": [
+                        "id"
+                      ],
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    },
+                    {
+                      "name": "authorId",
+                      "kind": "scalar",
+                      "isList": false,
+                      "isRequired": true,
+                      "isUnique": false,
+                      "isId": false,
+                      "isReadOnly": true,
+                      "hasDefaultValue": false,
+                      "type": "Int",
+                      "isGenerated": false,
+                      "isUpdatedAt": false
+                    }
+                  ],
+                  "primaryKey": null,
+                  "uniqueFields": [],
+                  "uniqueIndexes": [],
+                  "isGenerated": false
+                }
+              ],
+              "types": []
+            }"#]];
+
+        let response = get_datamodel(
+            &json!({
+                "prismaSchema": schema
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let prettified_response =
+            serde_json::to_string_pretty(&serde_json::from_str::<serde_json::Value>(&response).unwrap()).unwrap();
+
+        expected.assert_eq(&prettified_response);
+    }
+}

--- a/prisma-fmt/src/lib.rs
+++ b/prisma-fmt/src/lib.rs
@@ -1,6 +1,7 @@
 mod actions;
 mod code_actions;
 mod get_config;
+mod get_datamodel;
 mod get_dmmf;
 mod lint;
 mod merge_schemas;
@@ -274,4 +275,8 @@ pub fn get_config(get_config_params: String) -> String {
 /// ```
 pub fn get_dmmf(get_dmmf_params: String) -> Result<String, String> {
     get_dmmf::get_dmmf(&get_dmmf_params)
+}
+
+pub fn get_datamodel(get_datamodel_params: String) -> Result<String, String> {
+    get_datamodel::get_datamodel(&get_datamodel_params)
 }

--- a/prisma-schema-wasm/src/lib.rs
+++ b/prisma-schema-wasm/src/lib.rs
@@ -50,6 +50,12 @@ pub fn get_dmmf(params: String) -> Result<String, JsError> {
 }
 
 #[wasm_bindgen]
+pub fn get_datamodel(params: String) -> Result<String, JsError> {
+    register_panic_hook();
+    prisma_fmt::get_datamodel(params).map_err(|e| JsError::new(&e))
+}
+
+#[wasm_bindgen]
 pub fn lint(input: String) -> String {
     register_panic_hook();
     prisma_fmt::lint(input)

--- a/query-engine/dmmf/src/lib.rs
+++ b/query-engine/dmmf/src/lib.rs
@@ -5,7 +5,7 @@ mod serialization_ast;
 mod tests;
 
 use psl::ValidatedSchema;
-pub use serialization_ast::DataModelMetaFormat;
+pub use serialization_ast::{DataModelMetaFormat, Datamodel};
 
 use ast_builders::schema_to_dmmf;
 use schema::QuerySchema;
@@ -35,4 +35,9 @@ pub fn from_precomputed_parts(query_schema: &QuerySchema) -> DataModelMetaFormat
         schema,
         mappings,
     }
+}
+
+#[inline]
+pub fn datamodel_from_validated_schema(schema: &ValidatedSchema) -> Datamodel {
+    schema_to_dmmf(schema)
 }


### PR DESCRIPTION
Add `get_datamodel` method to get just that part of the DMMF without building, serializing, sending across WASM boundary and then deserializing the whole DMMF.

We will also need information about the indexes (currently only unique indexes are included there) and, later, spans of the entities in the schema file.
