### PR TITLE
feat(fmt): find references of field names

### DIFF
--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -210,7 +210,7 @@ fn find_where_used_in_relation_attribute<'a>(
                     .and_then(|arg| {
                         arg.value.as_array().and_then(|arr| {
                             arr.0
-                                .into_iter()
+                                .iter()
                                 .find(|expr| expr.as_constant_value().map_or(false, |cv| cv.0 == name))
                         })
                     })
@@ -232,7 +232,7 @@ fn find_where_used_in_block_attribute<'ast>(
             .arguments
             .iter()
             .find_map(|arg| {
-                arg.value.as_array().map_or(None, |arr| {
+                arg.value.as_array().and_then(|arr| {
                     arr.0
                         .iter()
                         .find(|expr| expr.as_constant_value().map_or(false, |cv| cv.0 == name))
@@ -317,7 +317,7 @@ fn extract_ds_from_native_type(attr_name: &str) -> Option<&str> {
     attr_name.split('.').next()
 }
 
-fn span_to_location<'ast>(span: Span, ctx: &'ast ReferencesContext<'_>) -> Option<Location> {
+fn span_to_location(span: Span, ctx: &ReferencesContext<'_>) -> Option<Location> {
     let file_id = span.file_id;
 
     let source = ctx.db.source(file_id);

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -1,12 +1,12 @@
 use log::*;
 use lsp_types::{Location, ReferenceParams, Url};
 use psl::{
-    diagnostics::FileId,
+    diagnostics::{FileId, Span},
     error_tolerant_parse_configuration,
     parser_database::ParserDatabase,
     schema_ast::ast::{
-        AttributePosition, CompositeTypePosition, EnumPosition, Field, FieldId, FieldPosition, FieldType, Identifier,
-        ModelId, ModelPosition, SchemaPosition, SourcePosition, Top, WithIdentifier, WithName,
+        AttributePosition, CompositeTypePosition, EnumPosition, Field, FieldId, FieldPosition, FieldType, ModelId,
+        ModelPosition, SchemaPosition, SourcePosition, Top, WithAttributes, WithIdentifier, WithName, WithSpan,
     },
     Diagnostics, SourceFile,
 };
@@ -20,10 +20,6 @@ pub(super) type ReferencesContext<'a> = LSPContext<'a, ReferenceParams>;
 
 pub(crate) fn empty_references() -> Vec<Location> {
     Vec::new()
-}
-
-fn empty_identifiers<'ast>() -> impl Iterator<Item = &'ast Identifier> {
-    std::iter::empty()
 }
 
 pub(crate) fn references(schema_files: Vec<(String, SourceFile)>, params: ReferenceParams) -> Vec<Location> {
@@ -61,26 +57,26 @@ pub(crate) fn references(schema_files: Vec<(String, SourceFile)>, params: Refere
 }
 
 fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosition) -> Vec<Location> {
-    let identifiers: Vec<&Identifier> = match target {
+    let spans: Vec<Span> = match target {
         // Blocks
         SchemaPosition::Model(model_id, ModelPosition::Name(name)) => {
             let model = ctx.db.walk((ctx.initiating_file_id, model_id));
 
-            std::iter::once(model.ast_model().identifier())
+            std::iter::once(model.ast_model().identifier().span())
                 .chain(find_where_used_as_field_type(&ctx, name))
                 .collect()
         }
         SchemaPosition::Enum(enum_id, EnumPosition::Name(name)) => {
             let enm = ctx.db.walk((ctx.initiating_file_id, enum_id));
 
-            std::iter::once(enm.ast_enum().identifier())
+            std::iter::once(enm.ast_enum().identifier().span())
                 .chain(find_where_used_as_field_type(&ctx, name))
                 .collect()
         }
         SchemaPosition::CompositeType(composite_id, CompositeTypePosition::Name(name)) => {
             let ct = ctx.db.walk((ctx.initiating_file_id, composite_id));
 
-            std::iter::once(ct.ast_composite_type().identifier())
+            std::iter::once(ct.ast_composite_type().identifier().span())
                 .chain(find_where_used_as_field_type(&ctx, name))
                 .collect()
         }
@@ -98,6 +94,25 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
                 .collect()
         }
 
+        SchemaPosition::Model(model_id, ModelPosition::Field(field_id, FieldPosition::Name(name))) => {
+            let field = ctx.db.walk(((ctx.initiating_file_id, model_id), field_id));
+
+            std::iter::once(field.ast_field().identifier().span())
+                .chain(find_where_used_in_block_attribute(
+                    &ctx,
+                    name,
+                    model_id,
+                    ctx.initiating_file_id,
+                ))
+                .chain(find_where_used_in_relation_attribute(
+                    &ctx,
+                    name,
+                    model_id,
+                    ctx.initiating_file_id,
+                ))
+                .collect()
+        }
+
         // Attributes
         SchemaPosition::Model(
             model_id,
@@ -108,6 +123,12 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
         ) => match arg_name {
             Some("fields") => find_where_used_as_field_name(&ctx, arg_value.as_str(), model_id, ctx.initiating_file_id)
                 .into_iter()
+                .chain(find_where_used_in_block_attribute(
+                    &ctx,
+                    arg_value.as_str(),
+                    model_id,
+                    ctx.initiating_file_id,
+                ))
                 .collect(),
             Some("references") => {
                 let field = &ctx.db.ast(ctx.initiating_file_id)[model_id][field_id];
@@ -120,6 +141,12 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
 
                 find_where_used_as_field_name(&ctx, arg_value.as_str(), ref_model_id.id.1, ref_model_id.id.0)
                     .into_iter()
+                    .chain(find_where_used_in_block_attribute(
+                        &ctx,
+                        arg_value.as_str(),
+                        ref_model_id.id.1,
+                        ref_model_id.id.0,
+                    ))
                     .collect()
             }
             _ => vec![],
@@ -142,46 +169,108 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
             ModelPosition::ModelAttribute(_attr_name, _, AttributePosition::ArgumentValue(_, arg_val)),
         ) => find_where_used_as_field_name(&ctx, arg_val.as_str(), model_id, ctx.initiating_file_id)
             .into_iter()
+            .chain(find_where_used_in_relation_attribute(
+                &ctx,
+                arg_val.as_str(),
+                model_id,
+                ctx.initiating_file_id,
+            ))
+            .chain(find_where_used_in_block_attribute(
+                &ctx,
+                arg_val.as_str(),
+                model_id,
+                ctx.initiating_file_id,
+            ))
             .collect(),
 
         _ => vec![],
     };
 
-    identifiers
-        .iter()
-        .filter_map(|ident| ident_to_location(ident, &ctx))
+    spans
+        .into_iter()
+        .filter_map(|span| span_to_location(span, &ctx))
         .collect()
 }
 
-fn find_where_used_as_field_name<'ast>(
-    ctx: &'ast ReferencesContext<'_>,
+fn find_where_used_in_relation_attribute<'a>(
+    ctx: &'a LSPContext<ReferenceParams>,
+    name: &'a str,
+    model_id: ModelId,
+    file_id: FileId,
+) -> impl Iterator<Item = Span> + 'a {
+    let model = ctx.db.walk((file_id, model_id));
+
+    model.relation_fields().flat_map(move |rf| {
+        rf.relation_attribute()
+            .and_then(|attr| {
+                attr.arguments
+                    .arguments
+                    .iter()
+                    .find(|arg| arg.name().map_or(false, |name| name == "fields") && arg.value.is_array())
+                    .and_then(|arg| {
+                        arg.value.as_array().and_then(|arr| {
+                            arr.0
+                                .into_iter()
+                                .find(|expr| expr.as_constant_value().map_or(false, |cv| cv.0 == name))
+                        })
+                    })
+            })
+            .map(|expr| expr.span())
+    })
+}
+
+fn find_where_used_in_block_attribute<'ast>(
+    ctx: &'ast LSPContext<'ast, ReferenceParams>,
+    name: &'ast str,
+    model_id: ModelId,
+    file_id: FileId,
+) -> impl Iterator<Item = Span> + 'ast {
+    let model = ctx.db.walk((file_id, model_id));
+
+    model.ast_model().attributes().iter().filter_map(move |attr| {
+        attr.arguments
+            .arguments
+            .iter()
+            .find_map(|arg| {
+                arg.value.as_array().map_or(None, |arr| {
+                    arr.0
+                        .iter()
+                        .find(|expr| expr.as_constant_value().map_or(false, |cv| cv.0 == name))
+                })
+            })
+            .map(|arg| arg.span())
+    })
+}
+
+fn find_where_used_as_field_name(
+    ctx: &ReferencesContext<'_>,
     name: &str,
     model_id: ModelId,
     file_id: FileId,
-) -> Option<&'ast Identifier> {
+) -> Option<Span> {
     let model = ctx.db.walk((file_id, model_id));
 
-    match model.scalar_fields().find(|field| field.name() == name) {
-        Some(field) => Some(field.ast_field().identifier()),
-        None => None,
-    }
+    model
+        .scalar_fields()
+        .find(|field| field.name() == name)
+        .map(|field| field.ast_field().identifier().span())
 }
 
 fn find_where_used_for_native_type<'ast>(
     ctx: &ReferencesContext<'ast>,
     name: &'ast str,
-) -> impl Iterator<Item = &'ast Identifier> {
+) -> impl Iterator<Item = Span> + 'ast {
     fn find_native_type_locations<'ast>(
         name: &'ast str,
         fields: impl Iterator<Item = (FieldId, &'ast Field)> + 'ast,
-    ) -> Box<dyn Iterator<Item = &'ast Identifier> + 'ast> {
+    ) -> Box<dyn Iterator<Item = Span> + 'ast> {
         Box::new(fields.filter_map(move |field| {
             field
                 .1
                 .attributes
                 .iter()
                 .find(|attr| extract_ds_from_native_type(attr.name()) == Some(name))
-                .map(|attr| attr.identifier())
+                .map(|attr| attr.identifier().span())
         }))
     }
 
@@ -189,21 +278,18 @@ fn find_where_used_for_native_type<'ast>(
         Top::CompositeType(composite_type) => find_native_type_locations(name, composite_type.iter_fields()),
         Top::Model(model) => find_native_type_locations(name, model.iter_fields()),
 
-        Top::Enum(_) | Top::Source(_) | Top::Generator(_) => Box::new(empty_identifiers()),
+        Top::Enum(_) | Top::Source(_) | Top::Generator(_) => Box::new(std::iter::empty()),
     })
 }
 
 fn find_where_used_as_field_type<'ast>(
     ctx: &'ast ReferencesContext<'_>,
     name: &'ast str,
-) -> impl Iterator<Item = &'ast Identifier> {
-    fn get_relevent_identifiers<'a>(
-        fields: impl Iterator<Item = (FieldId, &'a Field)>,
-        name: &str,
-    ) -> Vec<&'a Identifier> {
+) -> impl Iterator<Item = Span> + 'ast {
+    fn get_relevent_identifiers<'a>(fields: impl Iterator<Item = (FieldId, &'a Field)>, name: &str) -> Vec<Span> {
         fields
             .filter_map(|(_id, field)| match &field.field_type {
-                FieldType::Supported(id) if id.name == name => Some(id),
+                FieldType::Supported(id) if id.name == name => Some(id.span()),
                 _ => None,
             })
             .collect()
@@ -217,25 +303,25 @@ fn find_where_used_as_field_type<'ast>(
     })
 }
 
-fn find_where_used_as_top_name<'ast>(ctx: &'ast ReferencesContext<'_>, name: &'ast str) -> Option<&'ast Identifier> {
-    ctx.db.find_top(name).map(|top| top.ast_top().identifier())
+fn find_where_used_as_top_name<'ast>(ctx: &'ast ReferencesContext<'_>, name: &'ast str) -> Option<Span> {
+    ctx.db.find_top(name).map(|top| top.ast_top().identifier().span())
 }
 
-fn find_where_used_as_ds_name<'ast>(ctx: &'ast ReferencesContext<'_>, name: &'ast str) -> Option<&'ast Identifier> {
+fn find_where_used_as_ds_name<'ast>(ctx: &'ast ReferencesContext<'_>, name: &'ast str) -> Option<Span> {
     ctx.db
         .find_source(name)
-        .map(|source| ctx.db.ast(source.0)[source.1].identifier())
+        .map(|source| ctx.db.ast(source.0)[source.1].identifier().span())
 }
 
 fn extract_ds_from_native_type(attr_name: &str) -> Option<&str> {
     attr_name.split('.').next()
 }
 
-fn ident_to_location<'ast>(id: &'ast Identifier, ctx: &'ast ReferencesContext<'_>) -> Option<Location> {
-    let file_id = id.span.file_id;
+fn span_to_location<'ast>(span: Span, ctx: &'ast ReferencesContext<'_>) -> Option<Location> {
+    let file_id = span.file_id;
 
     let source = ctx.db.source(file_id);
-    let range = span_to_range(id.span, source);
+    let range = span_to_range(span, source);
     let file_name = ctx.db.file_name(file_id);
 
     let uri = if let Ok(uri) = Url::parse(file_name) {

--- a/prisma-fmt/tests/references/scenarios/model_field_name/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_field_name/result.json
@@ -1,0 +1,54 @@
+[
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 4
+      },
+      "end": {
+        "line": 5,
+        "character": 12
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 7,
+        "character": 14
+      },
+      "end": {
+        "line": 7,
+        "character": 22
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 8,
+        "character": 13
+      },
+      "end": {
+        "line": 8,
+        "character": 21
+      }
+    }
+  },
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 4,
+        "character": 41
+      },
+      "end": {
+        "line": 4,
+        "character": 49
+      }
+    }
+  }
+]

--- a/prisma-fmt/tests/references/scenarios/model_field_name/schema.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_field_name/schema.prisma
@@ -1,0 +1,20 @@
+model Post {
+    id        Int     @id @default(autoincrement())
+    content   String?
+    published Boolean @default(false)
+    author    User?   @relation(fields: [authorId], references: [id])
+    a<|>uthorId  Int?
+
+    @@unique([authorId])
+    @@index([authorId])
+}
+
+// Documentation for this model.
+model User {
+    id    Int     @id @default(autoincrement())
+    email String  @unique
+    name  String?
+    posts Post[]
+
+    @@index([id])
+}

--- a/prisma-fmt/tests/references/scenarios/model_relation_references/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_relation_references/result.json
@@ -11,5 +11,18 @@
         "character": 8
       }
     }
+  },
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 14
+      },
+      "end": {
+        "line": 5,
+        "character": 18
+      }
+    }
   }
 ]

--- a/prisma-fmt/tests/references/scenarios/model_unique_fields/result.json
+++ b/prisma-fmt/tests/references/scenarios/model_unique_fields/result.json
@@ -11,5 +11,18 @@
         "character": 8
       }
     }
+  },
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 13,
+        "character": 18
+      },
+      "end": {
+        "line": 13,
+        "character": 22
+      }
+    }
   }
 ]

--- a/prisma-fmt/tests/references/scenarios/view_index_fields/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_index_fields/result.json
@@ -11,5 +11,18 @@
         "character": 8
       }
     }
+  },
+  {
+    "uri": "file:///path/to/schema.prisma",
+    "range": {
+      "start": {
+        "line": 13,
+        "character": 26
+      },
+      "end": {
+        "line": 13,
+        "character": 30
+      }
+    }
   }
 ]

--- a/prisma-fmt/tests/references/scenarios/view_relation_references/result.json
+++ b/prisma-fmt/tests/references/scenarios/view_relation_references/result.json
@@ -11,5 +11,18 @@
         "character": 8
       }
     }
+  },
+  {
+    "uri": "file:///path/to/a.prisma",
+    "range": {
+      "start": {
+        "line": 5,
+        "character": 14
+      },
+      "end": {
+        "line": 5,
+        "character": 18
+      }
+    }
   }
 ]

--- a/prisma-fmt/tests/references/tests.rs
+++ b/prisma-fmt/tests/references/tests.rs
@@ -17,6 +17,7 @@ scenarios! {
     enum_as_type
     enum_name
     model_as_type
+    model_field_name
     model_name
     model_relation_fields
     model_relation_references


### PR DESCRIPTION
collect spans instead of identifiers for locations
add support for finding references of field names in relations and block attributes

related: https://github.com/prisma/team-orm/issues/1200