### PR TITLE
impr(fmt): relation qf

### DIFF
--- a/prisma-fmt/src/code_actions/relations.rs
+++ b/prisma-fmt/src/code_actions/relations.rs
@@ -269,11 +269,11 @@ pub(super) fn add_referencing_side_relation(
     let newline = relation.referenced_model().newline();
 
     let Some((reference_ids, field_ids, fields)) = pk.map(|pk| {
-        let fields = pk.fields();
-        let (names, (field_ids, fields)): (Vec<&str>, (Vec<String>, Vec<String>)) = fields
+        let (names, (field_ids, fields)): (Vec<&str>, (Vec<String>, Vec<String>)) = pk
+            .fields()
             .map(|f| {
                 let field_name = f.name();
-                let field_id = format!("{}{}", relation.referenced_model().name(), field_name);
+                let field_id = format!("{}{}", initiating_field.ast_field().name(), field_name);
                 let field_full = format!("{} {}?", field_id, f.ast_field().field_type.name());
 
                 (field_name, (field_id, field_full))

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute/result.json
@@ -32,7 +32,7 @@
                 "character": 0
               }
             },
-            "newText": " @relation(fields: [Forumid], references: [id])\n"
+            "newText": " @relation(fields: [forumid], references: [id])\n"
           },
           {
             "range": {
@@ -45,7 +45,7 @@
                 "character": 0
               }
             },
-            "newText": "\nForumid Int?\n"
+            "newText": "\nforumid Int?\n"
           }
         ]
       }

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_args/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_args/result.json
@@ -32,7 +32,7 @@
                 "character": 29
               }
             },
-            "newText": "@relation(fields: [Forumid], references: [id])"
+            "newText": "@relation(fields: [forumid], references: [id])"
           },
           {
             "range": {
@@ -45,7 +45,7 @@
                 "character": 0
               }
             },
-            "newText": "\nForumid Int?\n"
+            "newText": "\nforumid Int?\n"
           }
         ]
       }

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_args_fields/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_args_fields/result.json
@@ -32,7 +32,7 @@
                 "character": 51
               }
             },
-            "newText": "@relation(fields: [Postpost_id], references: [post_id])"
+            "newText": "@relation(fields: [postpost_id], references: [post_id])"
           },
           {
             "range": {
@@ -45,7 +45,7 @@
                 "character": 0
               }
             },
-            "newText": "\nPostpost_id Int?\n"
+            "newText": "\npostpost_id Int?\n"
           }
         ]
       }

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_args_self/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_args_self/result.json
@@ -32,7 +32,7 @@
                 "character": 54
               }
             },
-            "newText": "@relation(\"MarriagePartners\", fields: [Userid], references: [id])"
+            "newText": "@relation(\"MarriagePartners\", fields: [wifeid], references: [id])"
           },
           {
             "range": {
@@ -45,7 +45,7 @@
                 "character": 0
               }
             },
-            "newText": "\nUserid Int?\n"
+            "newText": "\nwifeid Int?\n"
           }
         ]
       }
@@ -84,7 +84,7 @@
                 "character": 53
               }
             },
-            "newText": "@relation(\"TeacherStudents\", fields: [Userid], references: [id])"
+            "newText": "@relation(\"TeacherStudents\", fields: [teacherid], references: [id])"
           },
           {
             "range": {
@@ -97,7 +97,7 @@
                 "character": 0
               }
             },
-            "newText": "\nUserid Int?\n"
+            "newText": "\nteacherid Int?\n"
           }
         ]
       }

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_mongodb/result.json
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_mongodb/result.json
@@ -110,7 +110,7 @@
                 "character": 0
               }
             },
-            "newText": " @relation(fields: [Forumid], references: [id])\n"
+            "newText": " @relation(fields: [forumid], references: [id])\n"
           },
           {
             "range": {
@@ -123,7 +123,7 @@
                 "character": 0
               }
             },
-            "newText": "\nForumid Int?\n"
+            "newText": "\nforumid Int?\n"
           }
         ]
       }


### PR DESCRIPTION
Use the relation field name instead of the referenced model name to eliminate collisions (as field names are unique)