### PR TITLE
fix(qe): support MySQL base64 newlines

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -69,7 +69,7 @@ pub fn encode_bytes(bytes: &[u8]) -> String {
     base64::encode(bytes)
 }
 
-pub fn decode_bytes(s: &str) -> PrismaValueResult<Vec<u8>> {
+pub fn decode_bytes(s: impl AsRef<[u8]>) -> PrismaValueResult<Vec<u8>> {
     base64::decode(s).map_err(|_| ConversionFailure::new("base64 encoded bytes", "PrismaValue::Bytes"))
 }
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -37,12 +37,12 @@ mod scalar_relations {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"{ findManyParent { id children { childId string int bInt float bytes bool dt } } }"#),
-          @r###"{"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"string":"abc","int":1,"bInt":"1","float":1.5,"bytes":"AQID","bool":false,"dt":"1900-10-10T01:10:10.001Z"},{"childId":2,"string":"def","int":-4234234,"bInt":"14324324234324","float":-2.54367,"bytes":"FDSF","bool":true,"dt":"1999-12-12T21:12:12.121Z"}]}]}}"###
+          @r###"{"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"string":"abc","int":1,"bInt":"1","float":1.5,"bytes":"VGhpcyBpcyBhIGxhcmdlIGJhc2U2NCBzdHJpbmcgdGhhdCBlbnN1cmVzIHdlIHNhbml0aXplIHRoZSBvdXRwdXQgb2YgTXlTUUwgYmFzZTY0IHN0cmluZy4=","bool":false,"dt":"1900-10-10T01:10:10.001Z"},{"childId":2,"string":"def","int":-4234234,"bInt":"14324324234324","float":-2.54367,"bytes":"FDSF","bool":true,"dt":"1999-12-12T21:12:12.121Z"}]}]}}"###
         );
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"{ findUniqueParent(where: { id: 1 }) { id children { childId string int bInt float bytes bool dt } } }"#),
-          @r###"{"data":{"findUniqueParent":{"id":1,"children":[{"childId":1,"string":"abc","int":1,"bInt":"1","float":1.5,"bytes":"AQID","bool":false,"dt":"1900-10-10T01:10:10.001Z"},{"childId":2,"string":"def","int":-4234234,"bInt":"14324324234324","float":-2.54367,"bytes":"FDSF","bool":true,"dt":"1999-12-12T21:12:12.121Z"}]}}}"###
+          @r###"{"data":{"findUniqueParent":{"id":1,"children":[{"childId":1,"string":"abc","int":1,"bInt":"1","float":1.5,"bytes":"VGhpcyBpcyBhIGxhcmdlIGJhc2U2NCBzdHJpbmcgdGhhdCBlbnN1cmVzIHdlIHNhbml0aXplIHRoZSBvdXRwdXQgb2YgTXlTUUwgYmFzZTY0IHN0cmluZy4=","bool":false,"dt":"1900-10-10T01:10:10.001Z"},{"childId":2,"string":"def","int":-4234234,"bInt":"14324324234324","float":-2.54367,"bytes":"FDSF","bool":true,"dt":"1999-12-12T21:12:12.121Z"}]}}}"###
         );
 
         insta::assert_snapshot!(
@@ -327,7 +327,7 @@ mod scalar_relations {
           int: 1,
           bInt: 1,
           float: 1.5,
-          bytes: "AQID",
+          bytes: "VGhpcyBpcyBhIGxhcmdlIGJhc2U2NCBzdHJpbmcgdGhhdCBlbnN1cmVzIHdlIHNhbml0aXplIHRoZSBvdXRwdXQgb2YgTXlTUUwgYmFzZTY0IHN0cmluZy4=",
           bool: false,
           dt: "1900-10-10T01:10:10.001Z",
       }"#,


### PR DESCRIPTION
## Overview

fixes https://github.com/prisma/prisma/issues/23262

MySQL encodes base64 strings with a newline every 76 characters. Rust's `base64` crate does not support newlines and suggests sanitizing the input before passing it down. This PR sanitizes MySQL's base64 outputs.

Credit to @aqrln for the fast™ sanitization.

**With read loop**
```rust
fn read_loop(s: &str, buf: &mut [u8]) {
    let mut pos = 0;

    for c in s.chars() {
        if pos == buf.len() {
            break;
        }

        if c != '\n' {
            buf[pos] = c as u8;
            pos += 1;
        }
    }
}
```
![image](https://github.com/user-attachments/assets/09120d09-099f-48b5-a8db-b268bf47e6b8)

**Current implementation**
```rust
fn sanitize_base64<'a>(mut s: &str, buf: &'a mut [u8]) -> &'a [u8] {
    let mut pos = 0;

    while !s.is_empty() && pos < buf.len() {
        let nl = s.find('\n').unwrap_or(s.len());
        let len = nl.min(buf.len() - pos);
        buf[pos..pos + len].copy_from_slice(&s.as_bytes()[..len]);
        pos += len;
        s = &s[(nl + 1).min(s.len())..];
    }

    &buf[0..pos]
}
```
![image](https://github.com/user-attachments/assets/0a78a19b-93c3-4acc-8223-075c403063d6)
