### PR TITLE
fix(psl): handle named args in ds url env

### DIFF
--- a/psl/diagnostics/src/error.rs
+++ b/psl/diagnostics/src/error.rs
@@ -29,6 +29,13 @@ impl DatamodelError {
         )
     }
 
+    pub fn new_named_env_val(span: Span) -> Self {
+        Self::new(
+            "The env function expects a singular, unnamed, string argument.".to_owned(),
+            span,
+        )
+    }
+
     pub fn new_argument_not_found_error(argument_name: &str, span: Span) -> DatamodelError {
         Self::new(format!("Argument \"{argument_name}\" is missing."), span)
     }

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -44,6 +44,11 @@ impl DatamodelWarning {
         Self::new(message, span)
     }
 
+    pub fn new_named_env_val(span: Span) -> Self {
+        let message = "The env function doesn't expect named arguments".to_owned();
+        Self::new(message, span)
+    }
+
     pub fn new_field_validation(message: &str, model: &str, field: &str, span: Span) -> DatamodelWarning {
         let msg = format!(
             "Warning validating field `{}` in {} `{}`: {}",

--- a/psl/psl/tests/validation/datasource/url_empty_named_arg.prisma
+++ b/psl/psl/tests/validation/datasource/url_empty_named_arg.prisma
@@ -1,0 +1,11 @@
+datasource testds {
+    provider = "mysql"
+    url      = env(named: )
+}
+
+// [1;91merror[0m: [1mThe env function expects a singular, unnamed, string argument.[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m    provider = "mysql"
+// [1;94m 3 | [0m    url      = [1;91menv(named: )[0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/url_named_arg.prisma
+++ b/psl/psl/tests/validation/datasource/url_named_arg.prisma
@@ -1,0 +1,11 @@
+datasource testds {
+    provider = "mysql"
+    url      = env(named: "DATABASE_URL")
+}
+
+// [1;93mwarning[0m: [1mThe env function doesn't expect named arguments[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m    provider = "mysql"
+// [1;94m 3 | [0m    url      = env([1;93mnamed: "DATABASE_URL"[0m)
+// [1;94m   | [0m


### PR DESCRIPTION
Added new warning for named argument in datasource url env.
We now correctly propagate warnings from the ds url env