### PR TITLE
refactor: expose `ColumnType` to `quaint::ResultSet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,15 +520,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e53693616d3075149f4ead59bdeecd204ac6b8192d8969757601b74bddf00f"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -674,6 +668,16 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "concat-idents"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f76990911f2267d837d9d0ad060aa63aaad170af40904b29461734c339030d4d"
+dependencies = [
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -3595,8 +3599,9 @@ dependencies = [
  "bit-vec",
  "byteorder",
  "bytes",
- "cfg_aliases 0.1.1",
+ "cfg_aliases",
  "chrono",
+ "concat-idents",
  "connection-string",
  "crosstarget-utils",
  "either",
@@ -4261,7 +4266,7 @@ name = "request-handlers"
 version = "0.1.0"
 dependencies = [
  "bigdecimal",
- "cfg_aliases 0.2.0",
+ "cfg_aliases",
  "codspeed-criterion-compat",
  "connection-string",
  "dmmf",
@@ -5428,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "tiberius"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66303a42b7c5daffb95c10cd8f3007a9c29b3e90128cf42b3738f58102aa2516"
+checksum = "091052ba8f20c1e14f85913a5242a663a09d17ff4c0137b9b1f0735cb3c5dabc"
 dependencies = [
  "async-native-tls",
  "async-trait",

--- a/quaint/.envrc
+++ b/quaint/.envrc
@@ -1,7 +1,7 @@
 export TEST_MYSQL="mysql://root:prisma@localhost:3306/prisma"
 export TEST_MYSQL8="mysql://root:prisma@localhost:3307/prisma"
 export TEST_MYSQL_MARIADB="mysql://root:prisma@localhost:3308/prisma"
-export TEST_PSQL="postgres://postgres:prisma@localhost:5432/postgres"
+export TEST_PSQL="postgresql://postgres:prisma@localhost:5432/postgres"
 export TEST_CRDB="postgresql://prisma@127.0.0.1:26259/postgres"
 export TEST_MSSQL="jdbc:sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true"
 if command -v nix-shell &> /dev/null

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -93,6 +93,7 @@ serde = { version = "1.0" }
 sqlformat = { version = "0.2.3", optional = true }
 uuid.workspace = true
 crosstarget-utils = { path = "../libs/crosstarget-utils" }
+concat-idents = "1.1.5"
 
 [dev-dependencies]
 once_cell = "1.3"
@@ -125,12 +126,12 @@ features = ["chrono", "column_decltype"]
 optional = true
 
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies.tiberius]
-version = "0.11.6"
+version = "0.11.8"
 optional = true
 features = ["sql-browser-tokio", "chrono", "bigdecimal"]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.tiberius]
-version = "0.11.2"
+version = "0.11.8"
 optional = true
 default-features = false
 features = [
@@ -183,4 +184,4 @@ features = ["compat"]
 optional = true
 
 [build-dependencies]
-cfg_aliases = "0.1.0"
+cfg_aliases = "0.2.1"

--- a/quaint/src/connector.rs
+++ b/quaint/src/connector.rs
@@ -9,6 +9,7 @@
 //! implement the [Queryable](trait.Queryable.html) trait for generalized
 //! querying interface.
 
+mod column_type;
 mod connection_info;
 
 pub mod external;
@@ -24,6 +25,7 @@ mod transaction;
 mod type_identifier;
 
 pub use self::result_set::*;
+pub use column_type::*;
 pub use connection_info::*;
 
 #[cfg(native)]

--- a/quaint/src/connector/column_type.rs
+++ b/quaint/src/connector/column_type.rs
@@ -1,0 +1,177 @@
+#[cfg(not(target_arch = "wasm32"))]
+use super::TypeIdentifier;
+
+use crate::{Value, ValueType};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColumnType {
+    Int32,
+    Int64,
+    Float,
+    Double,
+    Text,
+    Bytes,
+    Boolean,
+    Char,
+    Numeric,
+    Json,
+    Xml,
+    Uuid,
+    DateTime,
+    Date,
+    Time,
+    Enum,
+
+    Int32Array,
+    Int64Array,
+    FloatArray,
+    DoubleArray,
+    TextArray,
+    CharArray,
+    BytesArray,
+    BooleanArray,
+    NumericArray,
+    JsonArray,
+    XmlArray,
+    UuidArray,
+    DateTimeArray,
+    DateArray,
+    TimeArray,
+
+    Unknown,
+}
+
+impl ColumnType {
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, ColumnType::Unknown)
+    }
+}
+
+impl std::fmt::Display for ColumnType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ColumnType::Int32 => write!(f, "int"),
+            ColumnType::Int64 => write!(f, "bigint"),
+            ColumnType::Float => write!(f, "float"),
+            ColumnType::Double => write!(f, "double"),
+            ColumnType::Text => write!(f, "string"),
+            ColumnType::Enum => write!(f, "enum"),
+            ColumnType::Bytes => write!(f, "bytes"),
+            ColumnType::Boolean => write!(f, "bool"),
+            ColumnType::Char => write!(f, "char"),
+            ColumnType::Numeric => write!(f, "decimal"),
+            ColumnType::Json => write!(f, "json"),
+            ColumnType::Xml => write!(f, "xml"),
+            ColumnType::Uuid => write!(f, "uuid"),
+            ColumnType::DateTime => write!(f, "datetime"),
+            ColumnType::Date => write!(f, "date"),
+            ColumnType::Time => write!(f, "time"),
+            ColumnType::Int32Array => write!(f, "int-array"),
+            ColumnType::Int64Array => write!(f, "bigint-array"),
+            ColumnType::FloatArray => write!(f, "float-array"),
+            ColumnType::DoubleArray => write!(f, "double-array"),
+            ColumnType::TextArray => write!(f, "string-array"),
+            ColumnType::BytesArray => write!(f, "bytes-array"),
+            ColumnType::BooleanArray => write!(f, "bool-array"),
+            ColumnType::CharArray => write!(f, "char-array"),
+            ColumnType::NumericArray => write!(f, "decimal-array"),
+            ColumnType::JsonArray => write!(f, "json-array"),
+            ColumnType::XmlArray => write!(f, "xml-array"),
+            ColumnType::UuidArray => write!(f, "uuid-array"),
+            ColumnType::DateTimeArray => write!(f, "datetime-array"),
+            ColumnType::DateArray => write!(f, "date-array"),
+            ColumnType::TimeArray => write!(f, "time-array"),
+
+            ColumnType::Unknown => write!(f, "unknown"),
+        }
+    }
+}
+
+impl From<&Value<'_>> for ColumnType {
+    fn from(value: &Value<'_>) -> Self {
+        Self::from(&value.typed)
+    }
+}
+
+impl From<&ValueType<'_>> for ColumnType {
+    fn from(value: &ValueType) -> Self {
+        match value {
+            ValueType::Int32(_) => ColumnType::Int32,
+            ValueType::Int64(_) => ColumnType::Int64,
+            ValueType::Float(_) => ColumnType::Float,
+            ValueType::Double(_) => ColumnType::Double,
+            ValueType::Text(_) => ColumnType::Text,
+            ValueType::Enum(_, _) => ColumnType::Enum,
+            ValueType::EnumArray(_, _) => ColumnType::TextArray,
+            ValueType::Bytes(_) => ColumnType::Bytes,
+            ValueType::Boolean(_) => ColumnType::Boolean,
+            ValueType::Char(_) => ColumnType::Char,
+            ValueType::Numeric(_) => ColumnType::Numeric,
+            ValueType::Json(_) => ColumnType::Json,
+            ValueType::Xml(_) => ColumnType::Xml,
+            ValueType::Uuid(_) => ColumnType::Uuid,
+            ValueType::DateTime(_) => ColumnType::DateTime,
+            ValueType::Date(_) => ColumnType::Date,
+            ValueType::Time(_) => ColumnType::Time,
+            ValueType::Array(Some(vals)) if !vals.is_empty() => match &vals[0].typed {
+                ValueType::Int32(_) => ColumnType::Int32Array,
+                ValueType::Int64(_) => ColumnType::Int64Array,
+                ValueType::Float(_) => ColumnType::FloatArray,
+                ValueType::Double(_) => ColumnType::DoubleArray,
+                ValueType::Text(_) => ColumnType::TextArray,
+                ValueType::Enum(_, _) => ColumnType::TextArray,
+                ValueType::Bytes(_) => ColumnType::BytesArray,
+                ValueType::Boolean(_) => ColumnType::BooleanArray,
+                ValueType::Char(_) => ColumnType::CharArray,
+                ValueType::Numeric(_) => ColumnType::NumericArray,
+                ValueType::Json(_) => ColumnType::JsonArray,
+                ValueType::Xml(_) => ColumnType::TextArray,
+                ValueType::Uuid(_) => ColumnType::UuidArray,
+                ValueType::DateTime(_) => ColumnType::DateTimeArray,
+                ValueType::Date(_) => ColumnType::DateArray,
+                ValueType::Time(_) => ColumnType::TimeArray,
+                ValueType::Array(_) => ColumnType::Unknown,
+                ValueType::EnumArray(_, _) => ColumnType::Unknown,
+            },
+            ValueType::Array(_) => ColumnType::Unknown,
+        }
+    }
+}
+
+impl ColumnType {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn from_type_identifier<T>(value: T) -> Self
+    where
+        T: TypeIdentifier,
+    {
+        if value.is_bool() {
+            ColumnType::Boolean
+        } else if value.is_bytes() {
+            ColumnType::Bytes
+        } else if value.is_date() {
+            ColumnType::Date
+        } else if value.is_datetime() {
+            ColumnType::DateTime
+        } else if value.is_time() {
+            ColumnType::Time
+        } else if value.is_double() {
+            ColumnType::Double
+        } else if value.is_float() {
+            ColumnType::Float
+        } else if value.is_int32() {
+            ColumnType::Int32
+        } else if value.is_int64() {
+            ColumnType::Int64
+        } else if value.is_enum() {
+            ColumnType::Enum
+        } else if value.is_json() {
+            ColumnType::Json
+        } else if value.is_real() {
+            ColumnType::Numeric
+        } else if value.is_text() {
+            ColumnType::Text
+        } else {
+            ColumnType::Unknown
+        }
+    }
+}

--- a/quaint/src/connector/mssql/native/column_type.rs
+++ b/quaint/src/connector/mssql/native/column_type.rs
@@ -1,0 +1,43 @@
+use crate::connector::ColumnType;
+use tiberius::{Column, ColumnType as MssqlColumnType};
+
+impl From<&Column> for ColumnType {
+    fn from(value: &Column) -> Self {
+        match value.column_type() {
+            MssqlColumnType::Null => ColumnType::Unknown,
+
+            MssqlColumnType::BigVarChar
+            | MssqlColumnType::BigChar
+            | MssqlColumnType::NVarchar
+            | MssqlColumnType::NChar
+            | MssqlColumnType::Text
+            | MssqlColumnType::NText => ColumnType::Text,
+
+            MssqlColumnType::Xml => ColumnType::Xml,
+
+            MssqlColumnType::Bit | MssqlColumnType::Bitn => ColumnType::Boolean,
+            MssqlColumnType::Int1 | MssqlColumnType::Int2 | MssqlColumnType::Int4 => ColumnType::Int32,
+            MssqlColumnType::Int8 | MssqlColumnType::Intn => ColumnType::Int64,
+
+            MssqlColumnType::Datetime2
+            | MssqlColumnType::Datetime4
+            | MssqlColumnType::Datetime
+            | MssqlColumnType::Datetimen
+            | MssqlColumnType::DatetimeOffsetn => ColumnType::DateTime,
+
+            MssqlColumnType::Float4 => ColumnType::Float,
+            MssqlColumnType::Float8 | MssqlColumnType::Money | MssqlColumnType::Money4 | MssqlColumnType::Floatn => {
+                ColumnType::Double
+            }
+            MssqlColumnType::Guid => ColumnType::Uuid,
+            MssqlColumnType::Decimaln | MssqlColumnType::Numericn => ColumnType::Numeric,
+            MssqlColumnType::Daten => ColumnType::Date,
+            MssqlColumnType::Timen => ColumnType::Time,
+            MssqlColumnType::BigVarBin | MssqlColumnType::BigBinary | MssqlColumnType::Image => ColumnType::Bytes,
+
+            MssqlColumnType::Udt | MssqlColumnType::SSVariant => {
+                unreachable!("UDT and SSVariant types are not supported by Tiberius.")
+            }
+        }
+    }
+}

--- a/quaint/src/connector/mssql/native/conversion.rs
+++ b/quaint/src/connector/mssql/native/conversion.rs
@@ -3,8 +3,7 @@ use crate::ast::{Value, ValueType};
 use bigdecimal::BigDecimal;
 use std::{borrow::Cow, convert::TryFrom};
 
-use tiberius::ToSql;
-use tiberius::{ColumnData, FromSql, IntoSql};
+use tiberius::{ColumnData, FromSql, IntoSql, ToSql};
 
 impl<'a> IntoSql<'a> for &'a Value<'a> {
     fn into_sql(self) -> ColumnData<'a> {

--- a/quaint/src/connector/mysql.rs
+++ b/quaint/src/connector/mysql.rs
@@ -1,6 +1,7 @@
 //! Wasm-compatible definitions for the MySQL connector.
 //! This module is only available with the `mysql` feature.
 mod defaults;
+
 pub(crate) mod error;
 pub(crate) mod url;
 

--- a/quaint/src/connector/mysql/native/column_type.rs
+++ b/quaint/src/connector/mysql/native/column_type.rs
@@ -1,0 +1,8 @@
+use crate::connector::ColumnType;
+use mysql_async::Column as MysqlColumn;
+
+impl From<&MysqlColumn> for ColumnType {
+    fn from(value: &MysqlColumn) -> Self {
+        ColumnType::from_type_identifier(value)
+    }
+}

--- a/quaint/src/connector/mysql/native/mod.rs
+++ b/quaint/src/connector/mysql/native/mod.rs
@@ -1,11 +1,12 @@
 //! Definitions for the MySQL connector.
 //! This module is not compatible with wasm32-* targets.
 //! This module is only available with the `mysql-native` feature.
+mod column_type;
 mod conversion;
 mod error;
 
 pub(crate) use crate::connector::mysql::MysqlUrl;
-use crate::connector::{timeout, IsolationLevel};
+use crate::connector::{timeout, ColumnType, IsolationLevel};
 
 use crate::{
     ast::{Query, Value},
@@ -197,14 +198,39 @@ impl Queryable for Mysql {
             self.prepared(sql, |stmt| async move {
                 let mut conn = self.conn.lock().await;
                 let rows: Vec<my::Row> = conn.exec(&stmt, conversion::conv_params(params)?).await?;
-                let columns = stmt.columns().iter().map(|s| s.name_str().into_owned()).collect();
 
                 let last_id = conn.last_insert_id();
-                let mut result_set = ResultSet::new(columns, Vec::new());
+
+                let mut result_rows = Vec::with_capacity(rows.len());
+                let mut columns: Vec<String> = Vec::new();
+                let mut column_types: Vec<ColumnType> = Vec::new();
+
+                let mut columns_set = false;
 
                 for mut row in rows {
-                    result_set.rows.push(row.take_result_row()?);
+                    let row = row.take_result_row()?;
+
+                    if !columns_set {
+                        for (idx, _) in row.iter().enumerate() {
+                            let maybe_column = stmt.columns().get(idx);
+                            // `mysql_async` does not return columns in `ResultSet` when a call to a stored procedure is done
+                            // See https://github.com/prisma/prisma/issues/6173
+                            let column = maybe_column
+                                .map(|col| col.name_str().into_owned())
+                                .unwrap_or_else(|| format!("f{idx}"));
+                            let column_type = maybe_column.map(ColumnType::from).unwrap_or(ColumnType::Unknown);
+
+                            columns.push(column);
+                            column_types.push(column_type);
+                        }
+
+                        columns_set = true;
+                    }
+
+                    result_rows.push(row);
                 }
+
+                let mut result_set = ResultSet::new(columns, column_types, result_rows);
 
                 if let Some(id) = last_id {
                     result_set.set_last_insert_id(id);

--- a/quaint/src/connector/postgres.rs
+++ b/quaint/src/connector/postgres.rs
@@ -1,6 +1,7 @@
 //! Wasm-compatible definitions for the PostgreSQL connector.
 //! This module is only available with the `postgresql` feature.
 mod defaults;
+
 pub(crate) mod error;
 pub(crate) mod url;
 

--- a/quaint/src/connector/postgres/native/column_type.rs
+++ b/quaint/src/connector/postgres/native/column_type.rs
@@ -1,0 +1,129 @@
+use crate::connector::ColumnType;
+
+use std::borrow::Cow;
+use tokio_postgres::types::{Kind as PostgresKind, Type as PostgresType};
+
+macro_rules! create_pg_mapping {
+  (
+    $($key:ident($typ: ty) => [$($value:ident),+]),* $(,)?
+    $([$pg_only_key:ident => $column_type_mapping:ident]),*
+  ) => {
+      // Generate PGColumnType<Type> enums
+      $(
+          concat_idents::concat_idents!(enum_name = PGColumnType, $key {
+            #[derive(Debug)]
+            #[allow(non_camel_case_types)]
+            #[allow(clippy::upper_case_acronyms)]
+            pub(crate) enum enum_name {
+                $($value,)*
+            }
+        });
+      )*
+
+      // Generate validators
+      $(
+        concat_idents::concat_idents!(struct_name = PGColumnValidator, $key {
+            #[derive(Debug)]
+            #[allow(non_camel_case_types)]
+            pub struct struct_name;
+
+            impl struct_name {
+                #[inline]
+                #[allow(clippy::extra_unused_lifetimes)]
+                pub fn read<'a>(&self, val: $typ) -> $typ {
+                    val
+                }
+            }
+        });
+    )*
+
+      pub(crate) enum PGColumnType {
+        $(
+          $key(
+            concat_idents::concat_idents!(variant = PGColumnType, $key, { variant }),
+            concat_idents::concat_idents!(enum_name = PGColumnValidator, $key, { enum_name })
+          ),
+        )*
+        $($pg_only_key(concat_idents::concat_idents!(enum_name = PGColumnValidator, $column_type_mapping, { enum_name })),)*
+      }
+
+      impl PGColumnType {
+          /// Takes a Postgres type and returns the corresponding ColumnType
+          #[deny(unreachable_patterns)]
+          pub(crate) fn from_pg_type(ty: &PostgresType) -> PGColumnType {
+              match ty {
+                  $(
+                      $(
+                        &PostgresType::$value => PGColumnType::$key(
+                          concat_idents::concat_idents!(variant = PGColumnType, $key, { variant::$value }),
+                          concat_idents::concat_idents!(enum_name = PGColumnValidator, $key, { enum_name }),
+                        ),
+                      )*
+                  )*
+                  ref x => match x.kind() {
+                      PostgresKind::Enum => PGColumnType::Enum(PGColumnValidatorText),
+                      PostgresKind::Array(inner) => match inner.kind() {
+                          PostgresKind::Enum => PGColumnType::EnumArray(PGColumnValidatorTextArray),
+                          _ => PGColumnType::UnknownArray(PGColumnValidatorTextArray),
+                      },
+                      _ => PGColumnType::Unknown(PGColumnValidatorText),
+                  },
+              }
+          }
+      }
+
+      impl From<PGColumnType> for ColumnType {
+          fn from(ty: PGColumnType) -> ColumnType {
+              match ty {
+                  $(
+                      PGColumnType::$key(..) => ColumnType::$key,
+                  )*
+                  $(
+                      PGColumnType::$pg_only_key(..) => ColumnType::$column_type_mapping,
+                  )*
+              }
+          }
+      }
+  };
+}
+
+// Create a mapping between Postgres types and ColumnType and ensures there's a single source of truth.
+// ColumnType(<accepted data>) => [PostgresType(s)...]
+create_pg_mapping! {
+  Boolean(Option<bool>) => [BOOL],
+  Int32(Option<i32>) => [INT2, INT4],
+  Int64(Option<i64>) => [INT8, OID],
+  Float(Option<f32>) => [FLOAT4],
+  Double(Option<f64>) => [FLOAT8],
+  Bytes(Option<Cow<'a, [u8]>>) => [BYTEA],
+  Numeric(Option<bigdecimal::BigDecimal>) => [NUMERIC, MONEY],
+  DateTime(Option<chrono::DateTime<chrono::Utc>>) => [TIMESTAMP, TIMESTAMPTZ],
+  Date(Option<chrono::NaiveDate>) => [DATE],
+  Time(Option<chrono::NaiveTime>) => [TIME, TIMETZ],
+  Text(Option<Cow<'a, str>>) => [INET, CIDR, BIT, VARBIT],
+  Uuid(Option<uuid::Uuid>) => [UUID],
+  Json(Option<serde_json::Value>) => [JSON, JSONB],
+  Xml(Option<Cow<'a, str>>) => [XML],
+  Char(Option<char>) => [CHAR],
+
+  BooleanArray(impl Iterator<Item = Option<bool>>) => [BOOL_ARRAY],
+  Int32Array(impl Iterator<Item = Option<i32>>) => [INT2_ARRAY, INT4_ARRAY],
+  Int64Array(impl Iterator<Item =Option<i64>>) => [INT8_ARRAY, OID_ARRAY],
+  FloatArray(impl Iterator<Item = Option<f32>>) => [FLOAT4_ARRAY],
+  DoubleArray(impl Iterator<Item = Option<f64>>) => [FLOAT8_ARRAY],
+  BytesArray(impl Iterator<Item = Option<Vec<u8>>>) => [BYTEA_ARRAY],
+  NumericArray(impl Iterator<Item = Option<bigdecimal::BigDecimal>>) => [NUMERIC_ARRAY, MONEY_ARRAY],
+  DateTimeArray(impl Iterator<Item = Option<chrono::DateTime<chrono::Utc>>>) => [TIMESTAMP_ARRAY, TIMESTAMPTZ_ARRAY],
+  DateArray(impl Iterator<Item = Option<chrono::NaiveDate>>) => [DATE_ARRAY],
+  TimeArray(impl Iterator<Item = Option<chrono::NaiveTime>>) => [TIME_ARRAY, TIMETZ_ARRAY],
+  TextArray(impl Iterator<Item = Option<Cow<'a, str>>>) => [TEXT_ARRAY, NAME_ARRAY, VARCHAR_ARRAY, INET_ARRAY, CIDR_ARRAY, BIT_ARRAY, VARBIT_ARRAY, XML_ARRAY],
+  UuidArray(impl Iterator<Item = Option<uuid::Uuid>>) => [UUID_ARRAY],
+  JsonArray(impl Iterator<Item = Option<serde_json::Value>>) => [JSON_ARRAY, JSONB_ARRAY],
+
+  // For the cases where the Postgres type is not directly mappable to ColumnType, use the following:
+  // [PGColumnType => ColumnType]
+  [Enum => Text],
+  [EnumArray => TextArray],
+  [UnknownArray => TextArray],
+  [Unknown => Text]
+}

--- a/quaint/src/connector/postgres/native/conversion.rs
+++ b/quaint/src/connector/postgres/native/conversion.rs
@@ -4,7 +4,10 @@ use crate::{
     ast::{Value, ValueType},
     connector::queryable::{GetRow, ToColumnNames},
     error::{Error, ErrorKind},
+    prelude::EnumVariant,
 };
+
+use super::column_type::*;
 
 use bigdecimal::{num_bigint::BigInt, BigDecimal, FromPrimitive, ToPrimitive};
 use bit_vec::BitVec;
@@ -13,7 +16,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 
 pub(crate) use decimal::DecimalWrapper;
 use postgres_types::{FromSql, ToSql, WrongType};
-use std::{convert::TryFrom, error::Error as StdError};
+use std::{borrow::Cow, convert::TryFrom, error::Error as StdError};
 use tokio_postgres::{
     types::{self, IsNull, Kind, Type as PostgresType},
     Row as PostgresRow, Statement as PostgresStatement,
@@ -162,411 +165,528 @@ impl<'a> FromSql<'a> for NaiveMoney {
 impl GetRow for PostgresRow {
     fn get_result_row(&self) -> crate::Result<Vec<Value<'static>>> {
         fn convert(row: &PostgresRow, i: usize) -> crate::Result<Value<'static>> {
-            let result = match *row.columns()[i].type_() {
-                PostgresType::BOOL => ValueType::Boolean(row.try_get(i)?).into_value(),
-                PostgresType::INT2 => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: i16 = val;
-                        Value::int32(val)
-                    }
-                    None => Value::null_int32(),
-                },
-                PostgresType::INT4 => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: i32 = val;
-                        Value::int32(val)
-                    }
-                    None => Value::null_int32(),
-                },
-                PostgresType::INT8 => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: i64 = val;
-                        Value::int64(val)
-                    }
-                    None => Value::null_int64(),
-                },
-                PostgresType::FLOAT4 => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: f32 = val;
-                        Value::float(val)
-                    }
-                    None => Value::null_float(),
-                },
-                PostgresType::FLOAT8 => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: f64 = val;
-                        Value::double(val)
-                    }
-                    None => Value::null_double(),
-                },
-                PostgresType::BYTEA => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: &[u8] = val;
-                        Value::bytes(val.to_owned())
-                    }
-                    None => Value::null_bytes(),
-                },
-                PostgresType::BYTEA_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<Vec<u8>>> = val;
-                        let byteas = val.into_iter().map(|b| ValueType::Bytes(b.map(Into::into)));
+            let pg_ty = row.columns()[i].type_();
+            let column_type = PGColumnType::from_pg_type(pg_ty);
 
-                        Value::array(byteas)
-                    }
-                    None => Value::null_array(),
+            // This convoluted nested enum is macro-generated to ensure we have a single source of truth for
+            // the mapping between Postgres types and ColumnType. The macro is in `./column_type.rs`.
+            // PGColumnValidator<Type> are used to softly ensure that the correct `ValueType` variants are created.
+            // If you ever add a new type or change some mapping, please ensure you pass the data through `v.read()`.
+            let result = match column_type {
+                PGColumnType::Boolean(ty, v) => match ty {
+                    PGColumnTypeBoolean::BOOL => ValueType::Boolean(v.read(row.try_get(i)?)),
                 },
-                PostgresType::NUMERIC => {
-                    let dw: Option<DecimalWrapper> = row.try_get(i)?;
+                PGColumnType::Int32(ty, v) => match ty {
+                    PGColumnTypeInt32::INT2 => {
+                        let val: Option<i16> = row.try_get(i)?;
 
-                    ValueType::Numeric(dw.map(|dw| dw.0)).into_value()
-                }
-                PostgresType::MONEY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: NaiveMoney = val;
-                        Value::numeric(val.0)
+                        ValueType::Int32(v.read(val.map(i32::from)))
                     }
-                    None => Value::null_numeric(),
-                },
-                PostgresType::TIMESTAMP => match row.try_get(i)? {
-                    Some(val) => {
-                        let ts: NaiveDateTime = val;
-                        let dt = DateTime::<Utc>::from_naive_utc_and_offset(ts, Utc);
-                        Value::datetime(dt)
-                    }
-                    None => Value::null_datetime(),
-                },
-                PostgresType::TIMESTAMPTZ => match row.try_get(i)? {
-                    Some(val) => {
-                        let ts: DateTime<Utc> = val;
-                        Value::datetime(ts)
-                    }
-                    None => Value::null_datetime(),
-                },
-                PostgresType::DATE => match row.try_get(i)? {
-                    Some(val) => Value::date(val),
-                    None => Value::null_date(),
-                },
-                PostgresType::TIME => match row.try_get(i)? {
-                    Some(val) => Value::time(val),
-                    None => Value::null_time(),
-                },
-                PostgresType::TIMETZ => match row.try_get(i)? {
-                    Some(val) => {
-                        let time: TimeTz = val;
-                        Value::time(time.0)
-                    }
-                    None => Value::null_time(),
-                },
-                PostgresType::UUID => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Uuid = val;
-                        Value::uuid(val)
-                    }
-                    None => ValueType::Uuid(None).into_value(),
-                },
-                PostgresType::UUID_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<Uuid>> = val;
-                        let val = val.into_iter().map(ValueType::Uuid);
+                    PGColumnTypeInt32::INT4 => {
+                        let val: Option<i32> = row.try_get(i)?;
 
-                        Value::array(val)
+                        ValueType::Int32(v.read(val))
                     }
-                    None => Value::null_array(),
                 },
-                PostgresType::JSON | PostgresType::JSONB => ValueType::Json(row.try_get(i)?).into_value(),
-                PostgresType::INT2_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<i16>> = val;
-                        let ints = val.into_iter().map(|i| ValueType::Int32(i.map(|i| i as i32)));
+                PGColumnType::Int64(ty, v) => match ty {
+                    PGColumnTypeInt64::INT8 => {
+                        let val = v.read(row.try_get(i)?);
 
-                        Value::array(ints)
+                        ValueType::Int64(val)
                     }
-                    None => Value::null_array(),
-                },
-                PostgresType::INT4_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<i32>> = val;
-                        let ints = val.into_iter().map(ValueType::Int32);
+                    PGColumnTypeInt64::OID => {
+                        let val: Option<u32> = row.try_get(i)?;
 
-                        Value::array(ints)
+                        ValueType::Int64(v.read(val.map(i64::from)))
                     }
-                    None => Value::null_array(),
                 },
-                PostgresType::INT8_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<i64>> = val;
-                        let ints = val.into_iter().map(ValueType::Int64);
+                PGColumnType::Float(ty, v) => match ty {
+                    PGColumnTypeFloat::FLOAT4 => ValueType::Float(v.read(row.try_get(i)?)),
+                },
+                PGColumnType::Double(ty, v) => match ty {
+                    PGColumnTypeDouble::FLOAT8 => ValueType::Double(v.read(row.try_get(i)?)),
+                },
+                PGColumnType::Bytes(ty, v) => match ty {
+                    PGColumnTypeBytes::BYTEA => {
+                        let val: Option<&[u8]> = row.try_get(i)?;
+                        let val = val.map(ToOwned::to_owned).map(Cow::Owned);
 
-                        Value::array(ints)
+                        ValueType::Bytes(v.read(val))
                     }
-                    None => Value::null_array(),
                 },
-                PostgresType::FLOAT4_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<f32>> = val;
-                        let floats = val.into_iter().map(ValueType::Float);
+                PGColumnType::Text(ty, v) => match ty {
+                    PGColumnTypeText::INET | PGColumnTypeText::CIDR => {
+                        let val: Option<std::net::IpAddr> = row.try_get(i)?;
+                        let val = val.map(|val| val.to_string()).map(Cow::from);
 
-                        Value::array(floats)
+                        ValueType::Text(v.read(val))
                     }
-                    None => Value::null_array(),
-                },
-                PostgresType::FLOAT8_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<f64>> = val;
-                        let floats = val.into_iter().map(ValueType::Double);
+                    PGColumnTypeText::VARBIT | PGColumnTypeText::BIT => {
+                        let val: Option<BitVec> = row.try_get(i)?;
+                        let val_str = val.map(|val| bits_to_string(&val)).transpose()?.map(Cow::Owned);
 
-                        Value::array(floats)
+                        ValueType::Text(v.read(val_str))
                     }
-                    None => Value::null_array(),
                 },
-                PostgresType::BOOL_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<bool>> = val;
-                        let bools = val.into_iter().map(ValueType::Boolean);
+                PGColumnType::Char(ty, v) => match ty {
+                    PGColumnTypeChar::CHAR => {
+                        let val: Option<i8> = row.try_get(i)?;
+                        let val = val.map(|val| (val as u8) as char);
 
-                        Value::array(bools)
+                        ValueType::Char(v.read(val))
                     }
-                    None => Value::null_array(),
                 },
-                PostgresType::TIMESTAMP_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<NaiveDateTime>> = val;
+                PGColumnType::Numeric(ty, v) => match ty {
+                    PGColumnTypeNumeric::NUMERIC => {
+                        let dw: Option<DecimalWrapper> = row.try_get(i)?;
+                        let val = dw.map(|dw| dw.0);
 
-                        let dates = val.into_iter().map(|dt| {
-                            ValueType::DateTime(dt.map(|dt| DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc)))
-                        });
-
-                        Value::array(dates)
+                        ValueType::Numeric(v.read(val))
                     }
-                    None => Value::null_array(),
-                },
-                PostgresType::NUMERIC_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<DecimalWrapper>> = val;
+                    PGColumnTypeNumeric::MONEY => {
+                        let val: Option<NaiveMoney> = row.try_get(i)?;
 
-                        let decimals = val
-                            .into_iter()
-                            .map(|dec| ValueType::Numeric(dec.map(|dec| dec.0.to_string().parse().unwrap())));
-
-                        Value::array(decimals)
+                        ValueType::Numeric(v.read(val.map(|val| val.0)))
                     }
-                    None => Value::null_array(),
                 },
-                PostgresType::TEXT_ARRAY | PostgresType::NAME_ARRAY | PostgresType::VARCHAR_ARRAY => {
-                    match row.try_get(i)? {
-                        Some(val) => {
-                            let strings: Vec<Option<&str>> = val;
+                PGColumnType::DateTime(ty, v) => match ty {
+                    PGColumnTypeDateTime::TIMESTAMP => {
+                        let ts: Option<NaiveDateTime> = row.try_get(i)?;
+                        let dt = ts.map(|ts| DateTime::<Utc>::from_naive_utc_and_offset(ts, Utc));
 
-                            Value::array(strings.into_iter().map(|s| s.map(|s| s.to_string())))
+                        ValueType::DateTime(v.read(dt))
+                    }
+                    PGColumnTypeDateTime::TIMESTAMPTZ => {
+                        let ts: Option<DateTime<Utc>> = row.try_get(i)?;
+
+                        ValueType::DateTime(v.read(ts))
+                    }
+                },
+                PGColumnType::Date(ty, v) => match ty {
+                    PGColumnTypeDate::DATE => ValueType::Date(v.read(row.try_get(i)?)),
+                },
+                PGColumnType::Time(ty, v) => match ty {
+                    PGColumnTypeTime::TIME => ValueType::Time(v.read(row.try_get(i)?)),
+                    PGColumnTypeTime::TIMETZ => {
+                        let val: Option<TimeTz> = row.try_get(i)?;
+
+                        ValueType::Time(v.read(val.map(|val| val.0)))
+                    }
+                },
+                PGColumnType::Json(ty, v) => match ty {
+                    PGColumnTypeJson::JSON | PGColumnTypeJson::JSONB => ValueType::Json(v.read(row.try_get(i)?)),
+                },
+                PGColumnType::Xml(ty, v) => match ty {
+                    PGColumnTypeXml::XML => {
+                        let val: Option<XmlString> = row.try_get(i)?;
+
+                        ValueType::Xml(v.read(val.map(|val| Cow::Owned(val.0))))
+                    }
+                },
+                PGColumnType::Uuid(ty, v) => match ty {
+                    PGColumnTypeUuid::UUID => ValueType::Uuid(v.read(row.try_get(i)?)),
+                },
+                PGColumnType::Int32Array(ty, v) => match ty {
+                    PGColumnTypeInt32Array::INT2_ARRAY => {
+                        let vals: Option<Vec<Option<i16>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let ints = vals.into_iter().map(|val| val.map(i32::from));
+
+                                ValueType::Array(Some(
+                                    v.read(ints).map(ValueType::Int32).map(ValueType::into_value).collect(),
+                                ))
+                            }
+                            None => ValueType::Array(None),
                         }
-                        None => Value::null_array(),
                     }
-                }
-                PostgresType::MONEY_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<NaiveMoney>> = val;
-                        let nums = val.into_iter().map(|num| ValueType::Numeric(num.map(|num| num.0)));
+                    PGColumnTypeInt32Array::INT4_ARRAY => {
+                        let vals: Option<Vec<Option<i32>>> = row.try_get(i)?;
 
-                        Value::array(nums)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::OID_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<u32>> = val;
-                        let nums = val.into_iter().map(|oid| ValueType::Int64(oid.map(|oid| oid as i64)));
-
-                        Value::array(nums)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::TIMESTAMPTZ_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<DateTime<Utc>>> = val;
-                        let dates = val.into_iter().map(ValueType::DateTime);
-
-                        Value::array(dates)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::DATE_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<chrono::NaiveDate>> = val;
-                        let dates = val.into_iter().map(ValueType::Date);
-
-                        Value::array(dates)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::TIME_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<chrono::NaiveTime>> = val;
-                        let times = val.into_iter().map(ValueType::Time);
-
-                        Value::array(times)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::TIMETZ_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<TimeTz>> = val;
-                        let timetzs = val.into_iter().map(|time| ValueType::Time(time.map(|time| time.0)));
-
-                        Value::array(timetzs)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::JSON_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<serde_json::Value>> = val;
-                        let jsons = val.into_iter().map(ValueType::Json);
-
-                        Value::array(jsons)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::JSONB_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<serde_json::Value>> = val;
-                        let jsons = val.into_iter().map(ValueType::Json);
-
-                        Value::array(jsons)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::OID => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: u32 = val;
-                        Value::int64(val)
-                    }
-                    None => Value::null_int64(),
-                },
-                PostgresType::CHAR => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: i8 = val;
-                        Value::character((val as u8) as char)
-                    }
-                    None => Value::null_character(),
-                },
-                PostgresType::INET | PostgresType::CIDR => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: std::net::IpAddr = val;
-                        Value::text(val.to_string())
-                    }
-                    None => Value::null_text(),
-                },
-                PostgresType::INET_ARRAY | PostgresType::CIDR_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<std::net::IpAddr>> = val;
-                        let addrs = val
-                            .into_iter()
-                            .map(|ip| ValueType::Text(ip.map(|ip| ip.to_string().into())));
-
-                        Value::array(addrs)
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::BIT | PostgresType::VARBIT => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: BitVec = val;
-                        Value::text(bits_to_string(&val)?)
-                    }
-                    None => Value::null_text(),
-                },
-                PostgresType::BIT_ARRAY | PostgresType::VARBIT_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<BitVec>> = val;
-                        val.into_iter()
-                            .map(|bits| match bits {
-                                Some(bits) => bits_to_string(&bits).map(|s| ValueType::Text(Some(s.into()))),
-                                None => Ok(ValueType::Text(None)),
-                            })
-                            .collect::<crate::Result<Vec<_>>>()
-                            .map(Value::array)?
-                    }
-                    None => Value::null_array(),
-                },
-                PostgresType::XML => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: XmlString = val;
-                        Value::xml(val.0)
-                    }
-                    None => Value::null_xml(),
-                },
-                PostgresType::XML_ARRAY => match row.try_get(i)? {
-                    Some(val) => {
-                        let val: Vec<Option<XmlString>> = val;
-                        let xmls = val.into_iter().map(|xml| xml.map(|xml| xml.0));
-
-                        Value::array(xmls)
-                    }
-                    None => Value::null_array(),
-                },
-                ref x => match x.kind() {
-                    Kind::Enum => match row.try_get(i)? {
-                        Some(val) => {
-                            let val: EnumString = val;
-
-                            Value::enum_variant(val.value)
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Int32)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
                         }
-                        None => Value::null_enum(),
-                    },
-                    Kind::Array(inner) => match inner.kind() {
-                        Kind::Enum => match row.try_get(i)? {
-                            Some(val) => {
-                                let val: Vec<Option<EnumString>> = val;
-                                let variants = val
+                    }
+                },
+                PGColumnType::Int64Array(ty, v) => match ty {
+                    PGColumnTypeInt64Array::INT8_ARRAY => {
+                        let vals: Option<Vec<Option<i64>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Int64)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
+                        }
+                    }
+                    PGColumnTypeInt64Array::OID_ARRAY => {
+                        let vals: Option<Vec<Option<u32>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let oids = vals.into_iter().map(|oid| oid.map(i64::from));
+
+                                ValueType::Array(Some(
+                                    v.read(oids).map(ValueType::Int64).map(ValueType::into_value).collect(),
+                                ))
+                            }
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::FloatArray(ty, v) => match ty {
+                    PGColumnTypeFloatArray::FLOAT4_ARRAY => {
+                        let vals: Option<Vec<Option<f32>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Float)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::DoubleArray(ty, v) => match ty {
+                    PGColumnTypeDoubleArray::FLOAT8_ARRAY => {
+                        let vals: Option<Vec<Option<f64>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Double)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::TextArray(ty, v) => match ty {
+                    PGColumnTypeTextArray::TEXT_ARRAY
+                    | PGColumnTypeTextArray::NAME_ARRAY
+                    | PGColumnTypeTextArray::VARCHAR_ARRAY => {
+                        let vals: Option<Vec<Option<&str>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let strings = vals.into_iter().map(|s| s.map(ToOwned::to_owned).map(Cow::Owned));
+
+                                ValueType::Array(Some(
+                                    v.read(strings)
+                                        .map(ValueType::Text)
+                                        .map(ValueType::into_value)
+                                        .collect(),
+                                ))
+                            }
+                            None => ValueType::Array(None),
+                        }
+                    }
+                    PGColumnTypeTextArray::INET_ARRAY | PGColumnTypeTextArray::CIDR_ARRAY => {
+                        let vals: Option<Vec<Option<std::net::IpAddr>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let addrs = vals
                                     .into_iter()
-                                    .map(|x| ValueType::Enum(x.map(|x| x.value.into()), None));
+                                    .map(|ip| ip.as_ref().map(ToString::to_string).map(Cow::Owned));
 
-                                Ok(Value::array(variants))
+                                ValueType::Array(Some(
+                                    v.read(addrs).map(ValueType::Text).map(ValueType::into_value).collect(),
+                                ))
                             }
-                            None => Ok(Value::null_array()),
-                        },
-                        _ => match row.try_get(i) {
-                            Ok(Some(val)) => {
-                                let val: Vec<Option<String>> = val;
-                                let strings = val.into_iter().map(|str| ValueType::Text(str.map(Into::into)));
-
-                                Ok(Value::array(strings))
-                            }
-                            Ok(None) => Ok(Value::null_array()),
-                            Err(err) => {
-                                if err.source().map(|err| err.is::<WrongType>()).unwrap_or(false) {
-                                    let kind = ErrorKind::UnsupportedColumnType {
-                                        column_type: x.to_string(),
-                                    };
-
-                                    return Err(Error::builder(kind).build());
-                                } else {
-                                    Err(err)
-                                }
-                            }
-                        },
-                    }?,
-                    _ => match row.try_get(i) {
-                        Ok(Some(val)) => {
-                            let val: String = val;
-
-                            Ok(Value::text(val))
+                            None => ValueType::Array(None),
                         }
-                        Ok(None) => Ok(Value::from(ValueType::Text(None))),
-                        Err(err) => {
-                            if err.source().map(|err| err.is::<WrongType>()).unwrap_or(false) {
-                                let kind = ErrorKind::UnsupportedColumnType {
-                                    column_type: x.to_string(),
-                                };
+                    }
+                    PGColumnTypeTextArray::BIT_ARRAY | PGColumnTypeTextArray::VARBIT_ARRAY => {
+                        let vals: Option<Vec<Option<BitVec>>> = row.try_get(i)?;
 
-                                return Err(Error::builder(kind).build());
-                            } else {
-                                Err(err)
+                        match vals {
+                            Some(vals) => {
+                                let vals = vals
+                                    .into_iter()
+                                    .map(|bits| bits.map(|bits| bits_to_string(&bits).map(Cow::Owned)).transpose())
+                                    .collect::<crate::Result<Vec<_>>>()?;
+
+                                ValueType::Array(Some(
+                                    v.read(vals.into_iter())
+                                        .map(ValueType::Text)
+                                        .map(ValueType::into_value)
+                                        .collect(),
+                                ))
                             }
+                            None => ValueType::Array(None),
                         }
-                    }?,
+                    }
+                    PGColumnTypeTextArray::XML_ARRAY => {
+                        let vals: Option<Vec<Option<XmlString>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let xmls = vals.into_iter().map(|xml| xml.map(|xml| xml.0).map(Cow::Owned));
+
+                                ValueType::Array(Some(
+                                    v.read(xmls).map(ValueType::Text).map(ValueType::into_value).collect(),
+                                ))
+                            }
+                            None => ValueType::Array(None),
+                        }
+                    }
                 },
+                PGColumnType::BytesArray(ty, v) => match ty {
+                    PGColumnTypeBytesArray::BYTEA_ARRAY => {
+                        let vals: Option<Vec<Option<Vec<u8>>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(|b| b.map(Cow::Owned))
+                                    .map(ValueType::Bytes)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::BooleanArray(ty, v) => match ty {
+                    PGColumnTypeBooleanArray::BOOL_ARRAY => {
+                        let vals: Option<Vec<Option<bool>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Boolean)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::NumericArray(ty, v) => match ty {
+                    PGColumnTypeNumericArray::NUMERIC_ARRAY => {
+                        let vals: Option<Vec<Option<DecimalWrapper>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let decimals = vals.into_iter().map(|dec| dec.map(|dec| dec.0));
+
+                                ValueType::Array(Some(
+                                    v.read(decimals.into_iter())
+                                        .map(ValueType::Numeric)
+                                        .map(ValueType::into_value)
+                                        .collect(),
+                                ))
+                            }
+                            None => ValueType::Array(None),
+                        }
+                    }
+                    PGColumnTypeNumericArray::MONEY_ARRAY => {
+                        let vals: Option<Vec<Option<NaiveMoney>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => {
+                                let nums = vals.into_iter().map(|num| num.map(|num| num.0));
+
+                                ValueType::Array(Some(
+                                    v.read(nums.into_iter())
+                                        .map(ValueType::Numeric)
+                                        .map(ValueType::into_value)
+                                        .collect(),
+                                ))
+                            }
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::JsonArray(ty, v) => match ty {
+                    PGColumnTypeJsonArray::JSON_ARRAY | PGColumnTypeJsonArray::JSONB_ARRAY => {
+                        let vals: Option<Vec<Option<serde_json::Value>>> = row.try_get(i)?;
+
+                        match vals {
+                            Some(vals) => ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Json)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            )),
+                            None => ValueType::Array(None),
+                        }
+                    }
+                },
+                PGColumnType::UuidArray(ty, v) => match ty {
+                    PGColumnTypeUuidArray::UUID_ARRAY => match row.try_get(i)? {
+                        Some(vals) => {
+                            let vals: Vec<Option<Uuid>> = vals;
+
+                            ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Uuid)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    },
+                },
+                PGColumnType::DateTimeArray(ty, v) => match ty {
+                    PGColumnTypeDateTimeArray::TIMESTAMP_ARRAY => match row.try_get(i)? {
+                        Some(vals) => {
+                            let vals: Vec<Option<NaiveDateTime>> = vals;
+                            let dates = vals
+                                .into_iter()
+                                .map(|dt| dt.map(|dt| DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc)));
+
+                            ValueType::Array(Some(
+                                v.read(dates)
+                                    .map(ValueType::DateTime)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    },
+                    PGColumnTypeDateTimeArray::TIMESTAMPTZ_ARRAY => match row.try_get(i)? {
+                        Some(vals) => {
+                            let vals: Vec<Option<DateTime<Utc>>> = vals;
+
+                            ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::DateTime)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    },
+                },
+                PGColumnType::DateArray(ty, v) => match ty {
+                    PGColumnTypeDateArray::DATE_ARRAY => match row.try_get(i)? {
+                        Some(vals) => {
+                            let vals: Vec<Option<chrono::NaiveDate>> = vals;
+
+                            ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Date)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    },
+                },
+                PGColumnType::TimeArray(ty, v) => match ty {
+                    PGColumnTypeTimeArray::TIME_ARRAY => match row.try_get(i)? {
+                        Some(vals) => {
+                            let vals: Vec<Option<chrono::NaiveTime>> = vals;
+
+                            ValueType::Array(Some(
+                                v.read(vals.into_iter())
+                                    .map(ValueType::Time)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    },
+                    PGColumnTypeTimeArray::TIMETZ_ARRAY => match row.try_get(i)? {
+                        Some(val) => {
+                            let val: Vec<Option<TimeTz>> = val;
+                            let timetzs = val.into_iter().map(|time| time.map(|time| time.0));
+
+                            ValueType::Array(Some(
+                                v.read(timetzs.into_iter())
+                                    .map(ValueType::Time)
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    },
+                },
+                PGColumnType::EnumArray(v) => {
+                    let vals: Option<Vec<Option<EnumString>>> = row.try_get(i)?;
+
+                    match vals {
+                        Some(vals) => {
+                            let enums = vals.into_iter().map(|val| val.map(|val| Cow::Owned(val.value)));
+
+                            ValueType::Array(Some(
+                                v.read(enums)
+                                    .map(|variant| ValueType::Enum(variant.map(EnumVariant::new), None))
+                                    .map(ValueType::into_value)
+                                    .collect(),
+                            ))
+                        }
+                        None => ValueType::Array(None),
+                    }
+                }
+                PGColumnType::Enum(v) => {
+                    let val: Option<EnumString> = row.try_get(i)?;
+                    let enum_variant = v.read(val.map(|x| Cow::Owned(x.value)));
+
+                    ValueType::Enum(enum_variant.map(EnumVariant::new), None)
+                }
+                PGColumnType::UnknownArray(v) => match row.try_get(i) {
+                    Ok(Some(vals)) => {
+                        let vals: Vec<Option<String>> = vals;
+                        let strings = vals.into_iter().map(|str| str.map(Cow::Owned));
+
+                        Ok(ValueType::Array(Some(
+                            v.read(strings.into_iter())
+                                .map(ValueType::Text)
+                                .map(ValueType::into_value)
+                                .collect(),
+                        )))
+                    }
+                    Ok(None) => Ok(ValueType::Array(None)),
+                    Err(err) => {
+                        if err.source().map(|err| err.is::<WrongType>()).unwrap_or(false) {
+                            let kind = ErrorKind::UnsupportedColumnType {
+                                column_type: pg_ty.to_string(),
+                            };
+
+                            return Err(Error::builder(kind).build());
+                        } else {
+                            Err(err)
+                        }
+                    }
+                }?,
+                PGColumnType::Unknown(v) => match row.try_get(i) {
+                    Ok(Some(val)) => {
+                        let val: String = val;
+
+                        Ok(ValueType::Text(v.read(Some(Cow::Owned(val)))))
+                    }
+                    Ok(None) => Ok(ValueType::Text(None)),
+                    Err(err) => {
+                        if err.source().map(|err| err.is::<WrongType>()).unwrap_or(false) {
+                            let kind = ErrorKind::UnsupportedColumnType {
+                                column_type: pg_ty.to_string(),
+                            };
+
+                            return Err(Error::builder(kind).build());
+                        } else {
+                            Err(err)
+                        }
+                    }
+                }?,
             };
 
-            Ok(result)
+            Ok(result.into_value())
         }
 
         let num_columns = self.columns().len();

--- a/quaint/src/connector/result_set/result_row.rs
+++ b/quaint/src/connector/result_set/result_row.rs
@@ -1,5 +1,6 @@
 use crate::{
     ast::Value,
+    connector::ColumnType,
     error::{Error, ErrorKind},
 };
 use std::sync::Arc;
@@ -9,6 +10,7 @@ use std::sync::Arc;
 #[derive(Debug, PartialEq)]
 pub struct ResultRow {
     pub(crate) columns: Arc<Vec<String>>,
+    pub(crate) types: Vec<ColumnType>,
     pub(crate) values: Vec<Value<'static>>,
 }
 
@@ -38,6 +40,7 @@ impl IntoIterator for ResultRow {
 #[derive(Debug, PartialEq)]
 pub struct ResultRowRef<'a> {
     pub(crate) columns: Arc<Vec<String>>,
+    pub(crate) types: Vec<ColumnType>,
     pub(crate) values: &'a Vec<Value<'static>>,
 }
 
@@ -70,6 +73,7 @@ impl ResultRow {
         ResultRowRef {
             columns: Arc::clone(&self.columns),
             values: &self.values,
+            types: self.types.clone(),
         }
     }
 

--- a/quaint/src/connector/sqlite.rs
+++ b/quaint/src/connector/sqlite.rs
@@ -1,6 +1,7 @@
 //! Wasm-compatible definitions for the SQLite connector.
 //! This module is only available with the `sqlite` feature.
 mod defaults;
+
 pub(crate) mod error;
 mod ffi;
 pub(crate) mod params;

--- a/quaint/src/connector/sqlite/native/column_type.rs
+++ b/quaint/src/connector/sqlite/native/column_type.rs
@@ -1,0 +1,14 @@
+use rusqlite::Column;
+
+use crate::connector::{ColumnType, TypeIdentifier};
+
+impl From<&Column<'_>> for ColumnType {
+    fn from(value: &Column) -> Self {
+        if value.is_float() {
+            // Sqlite always returns Double for floats
+            ColumnType::Double
+        } else {
+            ColumnType::from_type_identifier(value)
+        }
+    }
+}

--- a/quaint/src/connector/sqlite/native/conversion.rs
+++ b/quaint/src/connector/sqlite/native/conversion.rs
@@ -82,7 +82,6 @@ impl TypeIdentifier for &Column<'_> {
         )
     }
 
-    #[cfg(feature = "mysql")]
     fn is_time(&self) -> bool {
         false
     }
@@ -119,12 +118,10 @@ impl TypeIdentifier for &Column<'_> {
         matches!(self.decl_type(), Some("BOOLEAN") | Some("boolean"))
     }
 
-    #[cfg(feature = "mysql")]
     fn is_json(&self) -> bool {
         false
     }
 
-    #[cfg(feature = "mysql")]
     fn is_enum(&self) -> bool {
         false
     }

--- a/quaint/src/connector/type_identifier.rs
+++ b/quaint/src/connector/type_identifier.rs
@@ -5,15 +5,12 @@ pub(crate) trait TypeIdentifier {
     fn is_int32(&self) -> bool;
     fn is_int64(&self) -> bool;
     fn is_datetime(&self) -> bool;
-    #[cfg(feature = "mysql")]
     fn is_time(&self) -> bool;
     fn is_date(&self) -> bool;
     fn is_text(&self) -> bool;
     fn is_bytes(&self) -> bool;
     fn is_bool(&self) -> bool;
-    #[cfg(feature = "mysql")]
     fn is_json(&self) -> bool;
-    #[cfg(feature = "mysql")]
     fn is_enum(&self) -> bool;
     fn is_null(&self) -> bool;
 }

--- a/quaint/src/prelude.rs
+++ b/quaint/src/prelude.rs
@@ -1,7 +1,7 @@
 //! A "prelude" for users of the `quaint` crate.
 pub use crate::ast::*;
 pub use crate::connector::{
-    ConnectionInfo, DefaultTransaction, ExternalConnectionInfo, Queryable, ResultRow, ResultSet, SqlFamily,
+    ColumnType, ConnectionInfo, DefaultTransaction, ExternalConnectionInfo, Queryable, ResultRow, ResultSet, SqlFamily,
     TransactionCapable,
 };
 pub use crate::{col, val, values};

--- a/quaint/src/tests/types/mssql.rs
+++ b/quaint/src/tests/types/mssql.rs
@@ -2,11 +2,14 @@
 
 mod bigdecimal;
 
-use crate::tests::test_api::*;
+use crate::macros::assert_matching_value_and_column_type;
+use crate::{connector::ColumnType, tests::test_api::*};
+use std::str::FromStr;
 
 test_type!(nvarchar_limited(
     mssql,
     "NVARCHAR(10)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar"),
     Value::text("余"),
@@ -15,6 +18,7 @@ test_type!(nvarchar_limited(
 test_type!(nvarchar_max(
     mssql,
     "NVARCHAR(max)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar"),
     Value::text("余"),
@@ -24,6 +28,7 @@ test_type!(nvarchar_max(
 test_type!(ntext(
     mssql,
     "NTEXT",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar"),
     Value::text("余"),
@@ -32,6 +37,7 @@ test_type!(ntext(
 test_type!(varchar_limited(
     mssql,
     "VARCHAR(10)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar"),
 ));
@@ -39,15 +45,23 @@ test_type!(varchar_limited(
 test_type!(varchar_max(
     mssql,
     "VARCHAR(max)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar"),
 ));
 
-test_type!(text(mssql, "TEXT", Value::null_text(), Value::text("foobar")));
+test_type!(text(
+    mssql,
+    "TEXT",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
 
 test_type!(tinyint(
     mssql,
     "tinyint",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(u8::MIN),
     Value::int32(u8::MAX),
@@ -56,6 +70,7 @@ test_type!(tinyint(
 test_type!(smallint(
     mssql,
     "smallint",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i16::MIN),
     Value::int32(i16::MAX),
@@ -64,6 +79,7 @@ test_type!(smallint(
 test_type!(int(
     mssql,
     "int",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i32::MIN),
     Value::int32(i32::MAX),
@@ -72,27 +88,48 @@ test_type!(int(
 test_type!(bigint(
     mssql,
     "bigint",
+    ColumnType::Int64,
     Value::null_int64(),
     Value::int64(i64::MIN),
     Value::int64(i64::MAX),
 ));
 
-test_type!(float_24(mssql, "float(24)", Value::null_float(), Value::float(1.23456),));
+test_type!(float_24(
+    mssql,
+    "float(24)",
+    ColumnType::Float,
+    Value::null_float(),
+    Value::float(1.23456),
+));
 
-test_type!(real(mssql, "real", Value::null_float(), Value::float(1.123456)));
+test_type!(real(
+    mssql,
+    "real",
+    ColumnType::Float,
+    Value::null_float(),
+    Value::float(1.123456)
+));
 
 test_type!(float_53(
     mssql,
     "float(53)",
+    ColumnType::Double,
     Value::null_double(),
     Value::double(1.1234567891)
 ));
 
-test_type!(money(mssql, "money", Value::null_double(), Value::double(3.14)));
+test_type!(money(
+    mssql,
+    "money",
+    ColumnType::Double,
+    Value::null_double(),
+    Value::double(3.14)
+));
 
 test_type!(smallmoney(
     mssql,
     "smallmoney",
+    ColumnType::Double,
     Value::null_double(),
     Value::double(3.14)
 ));
@@ -100,6 +137,7 @@ test_type!(smallmoney(
 test_type!(boolean(
     mssql,
     "bit",
+    ColumnType::Boolean,
     Value::null_boolean(),
     Value::boolean(true),
     Value::boolean(false),
@@ -108,6 +146,7 @@ test_type!(boolean(
 test_type!(binary(
     mssql,
     "binary(8)",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(b"DEADBEEF".to_vec()),
 ));
@@ -115,6 +154,7 @@ test_type!(binary(
 test_type!(varbinary(
     mssql,
     "varbinary(8)",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(b"DEADBEEF".to_vec()),
 ));
@@ -122,6 +162,7 @@ test_type!(varbinary(
 test_type!(image(
     mssql,
     "image",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(b"DEADBEEF".to_vec()),
 ));
@@ -129,6 +170,7 @@ test_type!(image(
 test_type!(date(
     mssql,
     "date",
+    ColumnType::Date,
     Value::null_date(),
     Value::date(chrono::NaiveDate::from_ymd_opt(2020, 4, 20).unwrap())
 ));
@@ -136,26 +178,67 @@ test_type!(date(
 test_type!(time(
     mssql,
     "time",
+    ColumnType::Time,
     Value::null_time(),
     Value::time(chrono::NaiveTime::from_hms_opt(16, 20, 00).unwrap())
 ));
 
-test_type!(datetime2(mssql, "datetime2", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:00Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(datetime2(
+    mssql,
+    "datetime2",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:00Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
 
-test_type!(datetime(mssql, "datetime", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(datetime(
+    mssql,
+    "datetime",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
 
-test_type!(datetimeoffset(mssql, "datetimeoffset", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(datetimeoffset(
+    mssql,
+    "datetimeoffset",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
 
-test_type!(smalldatetime(mssql, "smalldatetime", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:00Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(smalldatetime(
+    mssql,
+    "smalldatetime",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:00Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
+
+test_type!(uuid(
+    mssql,
+    "uniqueidentifier",
+    ColumnType::Uuid,
+    Value::null_uuid(),
+    Value::uuid(uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap())
+));
+
+test_type!(xml(
+    mssql,
+    "xml",
+    ColumnType::Xml,
+    Value::null_xml(),
+    Value::xml("<foo>bar</foo>"),
+));

--- a/quaint/src/tests/types/mssql/bigdecimal.rs
+++ b/quaint/src/tests/types/mssql/bigdecimal.rs
@@ -1,10 +1,12 @@
 use super::*;
-use crate::bigdecimal::BigDecimal;
+use crate::macros::assert_matching_value_and_column_type;
+use crate::{bigdecimal::BigDecimal, connector::ColumnType};
 use std::str::FromStr;
 
 test_type!(numeric(
     mssql,
     "numeric(10,2)",
+    ColumnType::Numeric,
     Value::null_numeric(),
     Value::numeric(BigDecimal::from_str("3.14")?)
 ));
@@ -12,6 +14,7 @@ test_type!(numeric(
 test_type!(numeric_10_2(
     mssql,
     "numeric(10,2)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3950.123456")?),
         Value::numeric(BigDecimal::from_str("3950.12")?)
@@ -21,6 +24,7 @@ test_type!(numeric_10_2(
 test_type!(numeric_35_6(
     mssql,
     "numeric(35, 6)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3950")?),
         Value::numeric(BigDecimal::from_str("3950.000000")?)
@@ -102,6 +106,7 @@ test_type!(numeric_35_6(
 test_type!(numeric_35_2(
     mssql,
     "numeric(35, 2)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3950.123456")?),
         Value::numeric(BigDecimal::from_str("3950.12")?)
@@ -115,18 +120,21 @@ test_type!(numeric_35_2(
 test_type!(numeric_4_0(
     mssql,
     "numeric(4, 0)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str("3950")?)
 ));
 
 test_type!(numeric_35_0(
     mssql,
     "numeric(35, 0)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str("79228162514264337593543950335")?),
 ));
 
 test_type!(numeric_35_1(
     mssql,
     "numeric(35, 1)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("79228162514264337593543950335")?),
         Value::numeric(BigDecimal::from_str("79228162514264337593543950335.0")?)
@@ -141,12 +149,14 @@ test_type!(numeric_35_1(
 test_type!(numeric_38_6(
     mssql,
     "numeric(38, 6)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str("9343234567898765456789043634999.345678")?),
 ));
 
 test_type!(money(
     mssql,
     "money",
+    ColumnType::Double,
     (Value::null_numeric(), Value::null_double()),
     (Value::numeric(BigDecimal::from_str("3.14")?), Value::double(3.14))
 ));
@@ -154,6 +164,7 @@ test_type!(money(
 test_type!(smallmoney(
     mssql,
     "smallmoney",
+    ColumnType::Double,
     (Value::null_numeric(), Value::null_double()),
     (Value::numeric(BigDecimal::from_str("3.14")?), Value::double(3.14))
 ));
@@ -161,6 +172,7 @@ test_type!(smallmoney(
 test_type!(float_24(
     mssql,
     "float(24)",
+    ColumnType::Float,
     (Value::null_numeric(), Value::null_float()),
     (
         Value::numeric(BigDecimal::from_str("1.123456")?),
@@ -171,6 +183,7 @@ test_type!(float_24(
 test_type!(real(
     mssql,
     "real",
+    ColumnType::Float,
     (Value::null_numeric(), Value::null_float()),
     (
         Value::numeric(BigDecimal::from_str("1.123456")?),
@@ -181,6 +194,7 @@ test_type!(real(
 test_type!(float_53(
     mssql,
     "float(53)",
+    ColumnType::Double,
     (Value::null_numeric(), Value::null_double()),
     (
         Value::numeric(BigDecimal::from_str("1.123456789012345")?),

--- a/quaint/src/tests/types/mysql.rs
+++ b/quaint/src/tests/types/mysql.rs
@@ -1,14 +1,15 @@
 #![allow(clippy::approx_constant)]
 
-use crate::tests::test_api::*;
-
 use std::str::FromStr;
 
 use crate::bigdecimal::BigDecimal;
+use crate::macros::assert_matching_value_and_column_type;
+use crate::{connector::ColumnType, tests::test_api::*};
 
 test_type!(tinyint(
     mysql,
     "tinyint(4)",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i8::MIN),
     Value::int32(i8::MAX)
@@ -17,6 +18,7 @@ test_type!(tinyint(
 test_type!(tinyint1(
     mysql,
     "tinyint(1)",
+    ColumnType::Int32,
     Value::int32(-1),
     Value::int32(1),
     Value::int32(0)
@@ -25,6 +27,7 @@ test_type!(tinyint1(
 test_type!(tinyint_unsigned(
     mysql,
     "tinyint(4) unsigned",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(0),
     Value::int32(255)
@@ -33,6 +36,7 @@ test_type!(tinyint_unsigned(
 test_type!(year(
     mysql,
     "year",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(1984),
     Value::int32(2049)
@@ -41,6 +45,7 @@ test_type!(year(
 test_type!(smallint(
     mysql,
     "smallint",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i16::MIN),
     Value::int32(i16::MAX)
@@ -49,6 +54,7 @@ test_type!(smallint(
 test_type!(smallint_unsigned(
     mysql,
     "smallint unsigned",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(0),
     Value::int32(65535)
@@ -57,6 +63,7 @@ test_type!(smallint_unsigned(
 test_type!(mediumint(
     mysql,
     "mediumint",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(-8388608),
     Value::int32(8388607)
@@ -65,6 +72,7 @@ test_type!(mediumint(
 test_type!(mediumint_unsigned(
     mysql,
     "mediumint unsigned",
+    ColumnType::Int64,
     Value::null_int64(),
     Value::int64(0),
     Value::int64(16777215)
@@ -73,6 +81,7 @@ test_type!(mediumint_unsigned(
 test_type!(int(
     mysql,
     "int",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i32::MIN),
     Value::int32(i32::MAX)
@@ -81,6 +90,7 @@ test_type!(int(
 test_type!(int_unsigned(
     mysql,
     "int unsigned",
+    ColumnType::Int64,
     Value::null_int64(),
     Value::int64(0),
     Value::int64(2173158296i64),
@@ -90,6 +100,7 @@ test_type!(int_unsigned(
 test_type!(int_unsigned_not_null(
     mysql,
     "int unsigned not null",
+    ColumnType::Int64,
     Value::int64(0),
     Value::int64(2173158296i64),
     Value::int64(4294967295i64)
@@ -98,6 +109,7 @@ test_type!(int_unsigned_not_null(
 test_type!(bigint(
     mysql,
     "bigint",
+    ColumnType::Int64,
     Value::null_int64(),
     Value::int64(i64::MIN),
     Value::int64(i64::MAX)
@@ -106,6 +118,7 @@ test_type!(bigint(
 test_type!(decimal(
     mysql,
     "decimal(10,2)",
+    ColumnType::Numeric,
     Value::null_numeric(),
     Value::numeric(bigdecimal::BigDecimal::from_str("3.14").unwrap())
 ));
@@ -114,6 +127,7 @@ test_type!(decimal(
 test_type!(decimal_65_6(
     mysql,
     "decimal(65, 6)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str(
         "93431006223456789876545678909876545678903434334567834369999.345678"
     )?),
@@ -122,6 +136,7 @@ test_type!(decimal_65_6(
 test_type!(float_decimal(
     mysql,
     "float",
+    ColumnType::Float,
     (Value::null_numeric(), Value::null_float()),
     (
         Value::numeric(bigdecimal::BigDecimal::from_str("3.14").unwrap()),
@@ -132,6 +147,7 @@ test_type!(float_decimal(
 test_type!(double_decimal(
     mysql,
     "double",
+    ColumnType::Double,
     (Value::null_numeric(), Value::null_double()),
     (
         Value::numeric(bigdecimal::BigDecimal::from_str("3.14").unwrap()),
@@ -142,6 +158,7 @@ test_type!(double_decimal(
 test_type!(bit1(
     mysql,
     "bit(1)",
+    ColumnType::Boolean,
     (Value::null_bytes(), Value::null_boolean()),
     (Value::int32(0), Value::boolean(false)),
     (Value::int32(1), Value::boolean(true)),
@@ -150,28 +167,77 @@ test_type!(bit1(
 test_type!(bit64(
     mysql,
     "bit(64)",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(vec![0, 0, 0, 0, 0, 6, 107, 58])
 ));
 
-test_type!(char(mysql, "char(255)", Value::null_text(), Value::text("foobar")));
-test_type!(float(mysql, "float", Value::null_float(), Value::float(1.12345),));
-test_type!(double(mysql, "double", Value::null_double(), Value::double(1.12314124)));
-test_type!(varchar(
+test_type!(char(
     mysql,
-    "varchar(255)",
+    "char(255)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar")
 ));
-test_type!(tinytext(mysql, "tinytext", Value::null_text(), Value::text("foobar")));
-test_type!(text(mysql, "text", Value::null_text(), Value::text("foobar")));
-test_type!(longtext(mysql, "longtext", Value::null_text(), Value::text("foobar")));
-test_type!(binary(mysql, "binary(5)", Value::bytes(vec![1, 2, 3, 0, 0])));
-test_type!(varbinary(mysql, "varbinary(255)", Value::bytes(vec![1, 2, 3])));
+test_type!(float(
+    mysql,
+    "float",
+    ColumnType::Float,
+    Value::null_float(),
+    Value::float(1.12345),
+));
+test_type!(double(
+    mysql,
+    "double",
+    ColumnType::Double,
+    Value::null_double(),
+    Value::double(1.12314124)
+));
+test_type!(varchar(
+    mysql,
+    "varchar(255)",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
+test_type!(tinytext(
+    mysql,
+    "tinytext",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
+test_type!(text(
+    mysql,
+    "text",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
+test_type!(longtext(
+    mysql,
+    "longtext",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
+test_type!(binary(
+    mysql,
+    "binary(5)",
+    ColumnType::Bytes,
+    Value::bytes(vec![1, 2, 3, 0, 0])
+));
+test_type!(varbinary(
+    mysql,
+    "varbinary(255)",
+    ColumnType::Bytes,
+    Value::bytes(vec![1, 2, 3])
+));
 
 test_type!(mediumtext(
     mysql,
     "mediumtext",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar")
 ));
@@ -179,6 +245,7 @@ test_type!(mediumtext(
 test_type!(tinyblob(
     mysql,
     "tinyblob",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(vec![1, 2, 3])
 ));
@@ -186,6 +253,7 @@ test_type!(tinyblob(
 test_type!(mediumblob(
     mysql,
     "mediumblob",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(vec![1, 2, 3])
 ));
@@ -193,15 +261,23 @@ test_type!(mediumblob(
 test_type!(longblob(
     mysql,
     "longblob",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(vec![1, 2, 3])
 ));
 
-test_type!(blob(mysql, "blob", Value::null_bytes(), Value::bytes(vec![1, 2, 3])));
+test_type!(blob(
+    mysql,
+    "blob",
+    ColumnType::Bytes,
+    Value::null_bytes(),
+    Value::bytes(vec![1, 2, 3])
+));
 
 test_type!(enum(
     mysql,
     "enum('pollicle_dogs','jellicle_cats')",
+    ColumnType::Enum,
     Value::null_enum(),
     Value::enum_variant("jellicle_cats"),
     Value::enum_variant("pollicle_dogs")
@@ -210,28 +286,50 @@ test_type!(enum(
 test_type!(json(
     mysql,
     "json",
+    ColumnType::Json,
     Value::null_json(),
     Value::json(serde_json::json!({"this": "is", "a": "json", "number": 2}))
 ));
 
-test_type!(date(mysql, "date", Value::null_date(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-04-20T00:00:00Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(date(
+    mysql,
+    "date",
+    ColumnType::Date,
+    (Value::null_date(), Value::null_date()),
+    (
+        Value::date(chrono::NaiveDate::from_ymd_opt(2020, 4, 20).unwrap()),
+        Value::date(chrono::NaiveDate::from_ymd_opt(2020, 4, 20).unwrap())
+    ),
+    (
+        Value::datetime(
+            chrono::DateTime::parse_from_rfc3339("2020-04-20T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc)
+        ),
+        Value::date(chrono::NaiveDate::from_ymd_opt(2020, 4, 20).unwrap())
+    )
+));
 
 test_type!(time(
     mysql,
     "time",
+    ColumnType::Time,
     Value::null_time(),
     Value::time(chrono::NaiveTime::from_hms_opt(16, 20, 00).unwrap())
 ));
 
-test_type!(datetime(mysql, "datetime", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(datetime(
+    mysql,
+    "datetime",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
 
-test_type!(timestamp(mysql, "timestamp", {
+test_type!(timestamp(mysql, "timestamp", ColumnType::DateTime, {
     let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
     Value::datetime(dt.with_timezone(&chrono::Utc))
 }));

--- a/quaint/src/tests/types/postgres.rs
+++ b/quaint/src/tests/types/postgres.rs
@@ -1,11 +1,13 @@
 mod bigdecimal;
 
-use crate::tests::test_api::*;
+use crate::macros::assert_matching_value_and_column_type;
+use crate::{connector::ColumnType, tests::test_api::*};
 use std::str::FromStr;
 
 test_type!(boolean(
     postgresql,
     "boolean",
+    ColumnType::Boolean,
     Value::null_boolean(),
     Value::boolean(true),
     Value::boolean(false),
@@ -14,6 +16,7 @@ test_type!(boolean(
 test_type!(boolean_array(
     postgresql,
     "boolean[]",
+    ColumnType::BooleanArray,
     Value::null_array(),
     Value::array(vec![
         Value::boolean(true),
@@ -26,6 +29,7 @@ test_type!(boolean_array(
 test_type!(int2(
     postgresql,
     "int2",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i16::MIN),
     Value::int32(i16::MAX),
@@ -34,6 +38,7 @@ test_type!(int2(
 test_type!(int2_with_int64(
     postgresql,
     "int2",
+    ColumnType::Int32,
     (Value::null_int64(), Value::null_int32()),
     (Value::int64(i16::MIN), Value::int32(i16::MIN)),
     (Value::int64(i16::MAX), Value::int32(i16::MAX))
@@ -42,6 +47,7 @@ test_type!(int2_with_int64(
 test_type!(int2_array(
     postgresql,
     "int2[]",
+    ColumnType::Int32Array,
     Value::null_array(),
     Value::array(vec![
         Value::int32(1),
@@ -54,6 +60,7 @@ test_type!(int2_array(
 test_type!(int2_array_with_i64(
     postgresql,
     "int2[]",
+    ColumnType::Int32Array,
     (
         Value::array(vec![
             Value::int64(i16::MIN),
@@ -71,6 +78,7 @@ test_type!(int2_array_with_i64(
 test_type!(int4(
     postgresql,
     "int4",
+    ColumnType::Int32,
     Value::null_int32(),
     Value::int32(i32::MIN),
     Value::int32(i32::MAX),
@@ -79,6 +87,7 @@ test_type!(int4(
 test_type!(int4_with_i64(
     postgresql,
     "int4",
+    ColumnType::Int32,
     (Value::null_int64(), Value::null_int32()),
     (Value::int64(i32::MIN), Value::int32(i32::MIN)),
     (Value::int64(i32::MAX), Value::int32(i32::MAX))
@@ -87,6 +96,7 @@ test_type!(int4_with_i64(
 test_type!(int4_array(
     postgresql,
     "int4[]",
+    ColumnType::Int32Array,
     Value::null_array(),
     Value::array(vec![
         Value::int32(i32::MIN),
@@ -98,6 +108,7 @@ test_type!(int4_array(
 test_type!(int4_array_with_i64(
     postgresql,
     "int4[]",
+    ColumnType::Int32Array,
     (
         Value::array(vec![
             Value::int64(i32::MIN),
@@ -115,6 +126,7 @@ test_type!(int4_array_with_i64(
 test_type!(int8(
     postgresql,
     "int8",
+    ColumnType::Int64,
     Value::null_int64(),
     Value::int64(i64::MIN),
     Value::int64(i64::MAX),
@@ -123,6 +135,7 @@ test_type!(int8(
 test_type!(int8_array(
     postgresql,
     "int8[]",
+    ColumnType::Int64Array,
     Value::null_array(),
     Value::array(vec![
         Value::int64(1),
@@ -132,11 +145,18 @@ test_type!(int8_array(
     ]),
 ));
 
-test_type!(float4(postgresql, "float4", Value::null_float(), Value::float(1.234)));
+test_type!(float4(
+    postgresql,
+    "float4",
+    ColumnType::Float,
+    Value::null_float(),
+    Value::float(1.234)
+));
 
 test_type!(float4_array(
     postgresql,
     "float4[]",
+    ColumnType::FloatArray,
     Value::null_array(),
     Value::array(vec![Value::float(1.1234), Value::float(4.321), Value::null_float()])
 ));
@@ -144,6 +164,7 @@ test_type!(float4_array(
 test_type!(float8(
     postgresql,
     "float8",
+    ColumnType::Double,
     Value::null_double(),
     Value::double(1.12345764),
 ));
@@ -151,6 +172,7 @@ test_type!(float8(
 test_type!(float8_array(
     postgresql,
     "float8[]",
+    ColumnType::DoubleArray,
     Value::null_array(),
     Value::array(vec![Value::double(1.1234), Value::double(4.321), Value::null_double()])
 ));
@@ -160,6 +182,7 @@ test_type!(float8_array(
 test_type!(oid_with_i32(
     postgresql,
     "oid",
+    ColumnType::Int64,
     (Value::null_int32(), Value::null_int64()),
     (Value::int32(i32::MAX), Value::int64(i32::MAX)),
     (Value::int32(u32::MIN as i32), Value::int64(u32::MIN)),
@@ -168,6 +191,7 @@ test_type!(oid_with_i32(
 test_type!(oid_with_i64(
     postgresql,
     "oid",
+    ColumnType::Int64,
     Value::null_int64(),
     Value::int64(u32::MAX),
     Value::int64(u32::MIN),
@@ -176,6 +200,7 @@ test_type!(oid_with_i64(
 test_type!(oid_array(
     postgresql,
     "oid[]",
+    ColumnType::Int64Array,
     Value::null_array(),
     Value::array(vec![
         Value::int64(1),
@@ -188,6 +213,7 @@ test_type!(oid_array(
 test_type!(serial2(
     postgresql,
     "serial2",
+    ColumnType::Int32,
     Value::int32(i16::MIN),
     Value::int32(i16::MAX),
 ));
@@ -195,6 +221,7 @@ test_type!(serial2(
 test_type!(serial4(
     postgresql,
     "serial4",
+    ColumnType::Int32,
     Value::int32(i32::MIN),
     Value::int32(i32::MAX),
 ));
@@ -202,15 +229,23 @@ test_type!(serial4(
 test_type!(serial8(
     postgresql,
     "serial8",
+    ColumnType::Int64,
     Value::int64(i64::MIN),
     Value::int64(i64::MAX),
 ));
 
-test_type!(char(postgresql, "char(6)", Value::null_text(), Value::text("foobar")));
+test_type!(char(
+    postgresql,
+    "char(6)",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
 
 test_type!(char_array(
     postgresql,
     "char(6)[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![Value::text("foobar"), Value::text("omgwtf"), Value::null_text()])
 ));
@@ -218,6 +253,7 @@ test_type!(char_array(
 test_type!(varchar(
     postgresql,
     "varchar(255)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("foobar")
 ));
@@ -225,24 +261,39 @@ test_type!(varchar(
 test_type!(varchar_array(
     postgresql,
     "varchar(255)[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![Value::text("foobar"), Value::text("omgwtf"), Value::null_text()])
 ));
 
-test_type!(text(postgresql, "text", Value::null_text(), Value::text("foobar")));
+test_type!(text(
+    postgresql,
+    "text",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("foobar")
+));
 
 test_type!(text_array(
     postgresql,
     "text[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![Value::text("foobar"), Value::text("omgwtf"), Value::null_text()])
 ));
 
-test_type!(bit(postgresql, "bit(4)", Value::null_text(), Value::text("1001")));
+test_type!(bit(
+    postgresql,
+    "bit(4)",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("1001")
+));
 
 test_type!(bit_array(
     postgresql,
     "bit(4)[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![Value::text("1001"), Value::text("0110"), Value::null_text()])
 ));
@@ -250,6 +301,7 @@ test_type!(bit_array(
 test_type!(varbit(
     postgresql,
     "varbit(20)",
+    ColumnType::Text,
     Value::null_text(),
     Value::text("001010101")
 ));
@@ -257,6 +309,7 @@ test_type!(varbit(
 test_type!(varbit_array(
     postgresql,
     "varbit(20)[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![
         Value::text("001010101"),
@@ -265,11 +318,18 @@ test_type!(varbit_array(
     ])
 ));
 
-test_type!(inet(postgresql, "inet", Value::null_text(), Value::text("127.0.0.1")));
+test_type!(inet(
+    postgresql,
+    "inet",
+    ColumnType::Text,
+    Value::null_text(),
+    Value::text("127.0.0.1")
+));
 
 test_type!(inet_array(
     postgresql,
     "inet[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![
         Value::text("127.0.0.1"),
@@ -281,6 +341,7 @@ test_type!(inet_array(
 test_type!(json(
     postgresql,
     "json",
+    ColumnType::Json,
     Value::null_json(),
     Value::json(serde_json::json!({"foo": "bar"}))
 ));
@@ -288,6 +349,7 @@ test_type!(json(
 test_type!(json_array(
     postgresql,
     "json[]",
+    ColumnType::JsonArray,
     Value::null_array(),
     Value::array(vec![
         Value::json(serde_json::json!({"foo": "bar"})),
@@ -299,6 +361,7 @@ test_type!(json_array(
 test_type!(jsonb(
     postgresql,
     "jsonb",
+    ColumnType::Json,
     Value::null_json(),
     Value::json(serde_json::json!({"foo": "bar"}))
 ));
@@ -306,6 +369,7 @@ test_type!(jsonb(
 test_type!(jsonb_array(
     postgresql,
     "jsonb[]",
+    ColumnType::JsonArray,
     Value::null_array(),
     Value::array(vec![
         Value::json(serde_json::json!({"foo": "bar"})),
@@ -314,11 +378,18 @@ test_type!(jsonb_array(
     ])
 ));
 
-test_type!(xml(postgresql, "xml", Value::null_xml(), Value::xml("<test>1</test>",)));
+test_type!(xml(
+    postgresql,
+    "xml",
+    ColumnType::Xml,
+    Value::null_xml(),
+    Value::xml("<test>1</test>",)
+));
 
 test_type!(xml_array(
     postgresql,
     "xml[]",
+    ColumnType::TextArray,
     Value::null_array(),
     Value::array(vec![
         Value::text("<test>1</test>"),
@@ -330,6 +401,7 @@ test_type!(xml_array(
 test_type!(uuid(
     postgresql,
     "uuid",
+    ColumnType::Uuid,
     Value::null_uuid(),
     Value::uuid(uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap())
 ));
@@ -337,6 +409,7 @@ test_type!(uuid(
 test_type!(uuid_array(
     postgresql,
     "uuid[]",
+    ColumnType::UuidArray,
     Value::null_array(),
     Value::array(vec![
         Value::uuid(uuid::Uuid::from_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap()),
@@ -347,6 +420,7 @@ test_type!(uuid_array(
 test_type!(date(
     postgresql,
     "date",
+    ColumnType::Date,
     Value::null_date(),
     Value::date(chrono::NaiveDate::from_ymd_opt(2020, 4, 20).unwrap())
 ));
@@ -354,6 +428,7 @@ test_type!(date(
 test_type!(date_array(
     postgresql,
     "date[]",
+    ColumnType::DateArray,
     Value::null_array(),
     Value::array(vec![
         Value::date(chrono::NaiveDate::from_ymd_opt(2020, 4, 20).unwrap()),
@@ -364,6 +439,7 @@ test_type!(date_array(
 test_type!(time(
     postgresql,
     "time",
+    ColumnType::Time,
     Value::null_time(),
     Value::time(chrono::NaiveTime::from_hms_opt(16, 20, 00).unwrap())
 ));
@@ -371,6 +447,7 @@ test_type!(time(
 test_type!(time_array(
     postgresql,
     "time[]",
+    ColumnType::TimeArray,
     Value::null_array(),
     Value::array(vec![
         Value::time(chrono::NaiveTime::from_hms_opt(16, 20, 00).unwrap()),
@@ -378,37 +455,62 @@ test_type!(time_array(
     ])
 ));
 
-test_type!(timestamp(postgresql, "timestamp", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(timestamp(
+    postgresql,
+    "timestamp",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
 
-test_type!(timestamp_array(postgresql, "timestamp[]", Value::null_array(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+test_type!(timestamp_array(
+    postgresql,
+    "timestamp[]",
+    ColumnType::DateTimeArray,
+    Value::null_array(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
 
-    Value::array(vec![
-        Value::datetime(dt.with_timezone(&chrono::Utc)),
-        Value::null_datetime(),
-    ])
-}));
+        Value::array(vec![
+            Value::datetime(dt.with_timezone(&chrono::Utc)),
+            Value::null_datetime(),
+        ])
+    }
+));
 
-test_type!(timestamptz(postgresql, "timestamptz", Value::null_datetime(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
-    Value::datetime(dt.with_timezone(&chrono::Utc))
-}));
+test_type!(timestamptz(
+    postgresql,
+    "timestamptz",
+    ColumnType::DateTime,
+    Value::null_datetime(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+        Value::datetime(dt.with_timezone(&chrono::Utc))
+    }
+));
 
-test_type!(timestamptz_array(postgresql, "timestamptz[]", Value::null_array(), {
-    let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
+test_type!(timestamptz_array(
+    postgresql,
+    "timestamptz[]",
+    ColumnType::DateTimeArray,
+    Value::null_array(),
+    {
+        let dt = chrono::DateTime::parse_from_rfc3339("2020-02-27T19:10:22Z").unwrap();
 
-    Value::array(vec![
-        Value::datetime(dt.with_timezone(&chrono::Utc)),
-        Value::null_datetime(),
-    ])
-}));
+        Value::array(vec![
+            Value::datetime(dt.with_timezone(&chrono::Utc)),
+            Value::null_datetime(),
+        ])
+    }
+));
 
 test_type!(bytea(
     postgresql,
     "bytea",
+    ColumnType::Bytes,
     Value::null_bytes(),
     Value::bytes(b"DEADBEEF".to_vec())
 ));
@@ -416,6 +518,7 @@ test_type!(bytea(
 test_type!(bytea_array(
     postgresql,
     "bytea[]",
+    ColumnType::BytesArray,
     Value::null_array(),
     Value::array(vec![
         Value::bytes(b"DEADBEEF".to_vec()),

--- a/quaint/src/tests/types/postgres/bigdecimal.rs
+++ b/quaint/src/tests/types/postgres/bigdecimal.rs
@@ -1,9 +1,11 @@
 use super::*;
 use crate::bigdecimal::BigDecimal;
+use crate::macros::assert_matching_value_and_column_type;
 
 test_type!(decimal(
     postgresql,
     "decimal(10,2)",
+    ColumnType::Numeric,
     Value::null_numeric(),
     Value::numeric(BigDecimal::from_str("3.14")?)
 ));
@@ -11,6 +13,7 @@ test_type!(decimal(
 test_type!(decimal_10_2(
     postgresql,
     "decimal(10, 2)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3950.123456")?),
         Value::numeric(BigDecimal::from_str("3950.12")?)
@@ -20,6 +23,7 @@ test_type!(decimal_10_2(
 test_type!(decimal_35_6(
     postgresql,
     "decimal(35, 6)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3950")?),
         Value::numeric(BigDecimal::from_str("3950.000000")?)
@@ -101,6 +105,7 @@ test_type!(decimal_35_6(
 test_type!(decimal_35_2(
     postgresql,
     "decimal(35, 2)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3950.123456")?),
         Value::numeric(BigDecimal::from_str("3950.12")?)
@@ -114,12 +119,14 @@ test_type!(decimal_35_2(
 test_type!(decimal_4_0(
     postgresql,
     "decimal(4, 0)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str("3950")?)
 ));
 
 test_type!(decimal_65_30(
     postgresql,
     "decimal(65, 30)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("1.2")?),
         Value::numeric(BigDecimal::from_str("1.2000000000000000000000000000")?)
@@ -133,6 +140,7 @@ test_type!(decimal_65_30(
 test_type!(decimal_65_34(
     postgresql,
     "decimal(65, 34)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("3.1415926535897932384626433832795028")?),
         Value::numeric(BigDecimal::from_str("3.1415926535897932384626433832795028")?)
@@ -150,12 +158,14 @@ test_type!(decimal_65_34(
 test_type!(decimal_35_0(
     postgresql,
     "decimal(35, 0)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str("79228162514264337593543950335")?),
 ));
 
 test_type!(decimal_35_1(
     postgresql,
     "decimal(35, 1)",
+    ColumnType::Numeric,
     (
         Value::numeric(BigDecimal::from_str("79228162514264337593543950335")?),
         Value::numeric(BigDecimal::from_str("79228162514264337593543950335.0")?)
@@ -169,6 +179,7 @@ test_type!(decimal_35_1(
 test_type!(decimal_128_6(
     postgresql,
     "decimal(128, 6)",
+    ColumnType::Numeric,
     Value::numeric(BigDecimal::from_str(
         "93431006223456789876545678909876545678903434369343100622345678987654567890987654567890343436999999100622345678343699999910.345678"
     )?),
@@ -177,6 +188,7 @@ test_type!(decimal_128_6(
 test_type!(decimal_array(
     postgresql,
     "decimal(10,2)[]",
+    ColumnType::NumericArray,
     Value::null_array(),
     Value::array(vec![BigDecimal::from_str("3.14")?, BigDecimal::from_str("5.12")?])
 ));
@@ -184,6 +196,7 @@ test_type!(decimal_array(
 test_type!(money(
     postgresql,
     "money",
+    ColumnType::Numeric,
     Value::null_numeric(),
     Value::numeric(BigDecimal::from_str("1.12")?)
 ));
@@ -191,6 +204,7 @@ test_type!(money(
 test_type!(money_array(
     postgresql,
     "money[]",
+    ColumnType::NumericArray,
     Value::null_array(),
     Value::array(vec![BigDecimal::from_str("1.12")?, BigDecimal::from_str("1.12")?])
 ));
@@ -198,6 +212,7 @@ test_type!(money_array(
 test_type!(float4(
     postgresql,
     "float4",
+    ColumnType::Float,
     (Value::null_numeric(), Value::null_float()),
     (
         Value::numeric(BigDecimal::from_str("1.123456")?),
@@ -208,6 +223,7 @@ test_type!(float4(
 test_type!(float8(
     postgresql,
     "float8",
+    ColumnType::Double,
     (Value::null_numeric(), Value::null_double()),
     (
         Value::numeric(BigDecimal::from_str("1.123456")?),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_6173.rs
@@ -19,13 +19,13 @@ mod query_raw {
         let res = run_query_json!(
             &runner,
             r#"
-                mutation {
-                    queryRaw(
-                        query: "BEGIN NOT ATOMIC\n INSERT INTO Test VALUES(FLOOR(RAND()*1000));\n SELECT * FROM Test;\n END",
-                        parameters: "[]"
-                    )
-                }
-                "#
+              mutation {
+                  queryRaw(
+                      query: "BEGIN NOT ATOMIC\n INSERT INTO Test VALUES(FLOOR(RAND()*1000));\n SELECT * FROM Test;\n END",
+                      parameters: "[]"
+                  )
+              }
+            "#
         );
         // fmt_execute_raw cannot run this query, doing it directly instead
         insta::assert_json_snapshot!(res,
@@ -46,6 +46,36 @@ mod query_raw {
                   "<rand_int>"
                 ]
               ]
+            }
+          }
+        }
+        "###);
+
+        Ok(())
+    }
+
+    #[connector_test(only(MySQL("mariadb")))]
+    async fn mysql_call_2(runner: Runner) -> TestResult<()> {
+        let res = run_query_json!(
+            &runner,
+            r#"
+              mutation {
+                  queryRaw(
+                      query: "BEGIN NOT ATOMIC\n INSERT INTO Test VALUES(FLOOR(RAND()*1000));\n SELECT * FROM Test WHERE 1=0;\n END",
+                      parameters: "[]"
+                  )
+              }
+            "#
+        );
+
+        insta::assert_json_snapshot!(res,
+          @r###"
+        {
+          "data": {
+            "queryRaw": {
+              "columns": [],
+              "types": [],
+              "rows": []
             }
           }
         }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/transactional_batch.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/batching/transactional_batch.rs
@@ -176,7 +176,7 @@ mod transactional {
         let batch_results = runner.batch(queries, true, None).await?;
         insta::assert_snapshot!(
             batch_results.to_string(),
-            @r###"{"batchResult":[{"data":{"createOneModelB":{"id":1}}},{"data":{"executeRaw":1}},{"data":{"queryRaw":{"columns":["id"],"types":[],"rows":[]}}}]}"###
+            @r###"{"batchResult":[{"data":{"createOneModelB":{"id":1}}},{"data":{"executeRaw":1}},{"data":{"queryRaw":{"columns":["id"],"types":["int"],"rows":[]}}}]}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/scalar_list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/scalar_list.rs
@@ -254,12 +254,12 @@ mod scalar_list {
               "types": [
                 "int",
                 "string-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array"
+                "int-array",
+                "bigint-array",
+                "double-array",
+                "bytes-array",
+                "bool-array",
+                "datetime-array"
               ],
               "rows": [
                 [
@@ -332,13 +332,13 @@ mod scalar_list {
               ],
               "types": [
                 "int",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array",
-                "unknown-array"
+                "string-array",
+                "int-array",
+                "bigint-array",
+                "double-array",
+                "bytes-array",
+                "bool-array",
+                "datetime-array"
               ],
               "rows": [
                 [

--- a/query-engine/driver-adapters/src/conversion/js_to_quaint.rs
+++ b/query-engine/driver-adapters/src/conversion/js_to_quaint.rs
@@ -5,7 +5,7 @@ pub use crate::types::{ColumnType, JSResultSet};
 use quaint::bigdecimal::BigDecimal;
 use quaint::chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use quaint::{
-    connector::ResultSet as QuaintResultSet,
+    connector::{ColumnType as QuaintColumnType, ResultSet as QuaintResultSet},
     error::{Error as QuaintError, ErrorKind},
     Value as QuaintValue,
 };
@@ -22,6 +22,7 @@ impl TryFrom<JSResultSet> for QuaintResultSet {
         } = js_result_set;
 
         let mut quaint_rows = Vec::with_capacity(rows.len());
+        let quaint_column_types = column_types.iter().map(QuaintColumnType::from).collect::<Vec<_>>();
 
         for row in rows {
             let mut quaint_row = Vec::with_capacity(column_types.len());
@@ -37,7 +38,7 @@ impl TryFrom<JSResultSet> for QuaintResultSet {
         }
 
         let last_insert_id = last_insert_id.and_then(|id| id.parse::<u64>().ok());
-        let mut quaint_result_set = QuaintResultSet::new(column_names, quaint_rows);
+        let mut quaint_result_set = QuaintResultSet::new(column_names, quaint_column_types, quaint_rows);
 
         // Not a fan of this (extracting the `Some` value from an `Option` and pass it to a method that creates a new `Some` value),
         // but that's Quaint's ResultSet API and that's how the MySQL connector does it.

--- a/query-engine/driver-adapters/src/types.rs
+++ b/query-engine/driver-adapters/src/types.rs
@@ -149,6 +149,7 @@ macro_rules! js_column_type {
     };
 }
 
+// JsColumnType(discriminant) => quaint::ColumnType
 js_column_type! {
     /// [PLANETSCALE_TYPE] (MYSQL_TYPE) -> [TypeScript example]
     /// The following PlanetScale type IDs are mapped into Int32:

--- a/query-engine/request-handlers/Cargo.toml
+++ b/query-engine/request-handlers/Cargo.toml
@@ -75,7 +75,7 @@ all = [
 graphql-protocol = ["query-core/graphql-protocol", "dep:graphql-parser"]
 
 [build-dependencies]
-cfg_aliases = "0.2.0"
+cfg_aliases = "0.2.1"
 
 [[bench]]
 name = "query_planning_bench"

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connection.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connection.rs
@@ -2,7 +2,7 @@
 
 pub(crate) use quaint::connector::rusqlite;
 
-use quaint::connector::{GetRow, ToColumnNames};
+use quaint::connector::{ColumnType, GetRow, ToColumnNames};
 use schema_connector::{ConnectorError, ConnectorResult};
 use sql_schema_describer::{sqlite as describer, DescriberErrorKind, SqlSchema};
 use std::sync::Mutex;
@@ -56,6 +56,7 @@ impl Connection {
         let conn = self.0.lock().unwrap();
         let mut stmt = conn.prepare_cached(sql).map_err(convert_error)?;
 
+        let column_types = stmt.columns().iter().map(ColumnType::from).collect::<Vec<_>>();
         let mut rows = stmt
             .query(rusqlite::params_from_iter(params.iter()))
             .map_err(convert_error)?;
@@ -65,7 +66,11 @@ impl Connection {
             converted_rows.push(row.get_result_row().unwrap());
         }
 
-        Ok(quaint::prelude::ResultSet::new(column_names, converted_rows))
+        Ok(quaint::prelude::ResultSet::new(
+            column_names,
+            column_types,
+            converted_rows,
+        ))
     }
 }
 


### PR DESCRIPTION
## Overview

closes https://github.com/prisma/team-orm/issues/1245

This PR adds a new `types` fields to `quaint::ResultSet`. It is a preparatory PR for the TypedSQL initiative. It helps to have a single abstraction that's used both for `TypedSQL` and `queryRaw` in general. This ensures we're always in sync between the types sent to the client at compile-time and those sent back at runtime.

For Postgres specifically, this PR adds a macro that helps keep the `ColumnType` and the actual `Value` we return at runtime in sync.