### PR TITLE
fix: make batching keys unique

### DIFF
--- a/query-engine/core/src/query_document/mod.rs
+++ b/query-engine/core/src/query_document/mod.rs
@@ -32,6 +32,7 @@ use crate::{
     query_ast::{QueryOption, QueryOptions},
     query_graph_builder::resolve_compound_field,
 };
+use itertools::Itertools;
 use query_structure::Model;
 use schema::{constants::*, QuerySchema};
 use std::collections::HashMap;
@@ -293,6 +294,7 @@ impl CompactedDocument {
                     _ => vec![key.to_owned()],
                 })
             })
+            .unique()
             .collect();
 
         Self {


### PR DESCRIPTION
## Overview

Tiny follow-up PR to https://github.com/prisma/prisma-engines/pull/4911.

Since we're now taking into account field names from all queries, it's better to dedup them to ensure the callers don't have to deal with duplicates.