### PR TITLE
ci: fix cargo-codspeed installation

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install cargo-codspeed
-        run: cargo install cargo-codspeed
+        run: cargo install --locked cargo-codspeed
 
       - name: "Build the benchmark targets: schema"
         run: cargo codspeed build -p schema --features all_connectors


### PR DESCRIPTION
Take `Cargo.lock` of `cargo-codspeed` into account when installing it to prevent the compilation errors (e.g. https://github.com/prisma/prisma-engines/actions/runs/10252506779/job/28363037904).
