### PR TITLE
fix(typedsql): mysql should work with @param notations

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/lib.rs
@@ -23,7 +23,7 @@ use migration_pair::MigrationPair;
 use psl::{datamodel_connector::NativeTypeInstance, parser_database::ScalarType, ValidatedSchema};
 use quaint::connector::DescribedQuery;
 use schema_connector::{migrations_directory::MigrationDirectory, *};
-use sql_doc_parser::parse_sql_doc;
+use sql_doc_parser::{parse_sql_doc, sanitize_sql};
 use sql_migration::{DropUserDefinedType, DropView, SqlMigration, SqlMigrationStep};
 use sql_schema_describer as sql;
 use std::{future, sync::Arc};
@@ -366,7 +366,7 @@ impl SchemaConnector for SqlSchemaConnector {
                 parameters,
                 columns,
                 enum_names,
-            } = self.flavour.describe_query(&input.source).await?;
+            } = self.flavour.describe_query(&sanitize_sql(&input.source)).await?;
             let enum_names = enum_names.unwrap_or_default();
             let sql_source = input.source.clone();
             let parsed_doc = parse_sql_doc(&sql_source, enum_names.as_slice())?;

--- a/schema-engine/connectors/sql-schema-connector/src/sql_doc_parser.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_doc_parser.rs
@@ -353,7 +353,6 @@ pub(crate) fn sanitize_sql(sql: &str) -> String {
     sql.lines()
         .map(|line| line.trim())
         .filter(|line| !line.starts_with("--"))
-        .collect::<Vec<&str>>()
         .join("\n")
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_doc_parser.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_doc_parser.rs
@@ -1118,7 +1118,7 @@ SELECT enum FROM "test_introspect_sql"."model" WHERE id = $1;"#,
     }
 
     #[test]
-    fn sanitize_sql_test() {
+    fn sanitize_sql_test_1() {
         use expect_test::expect;
 
         let sql = r#"

--- a/schema-engine/connectors/sql-schema-connector/src/sql_doc_parser.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_doc_parser.rs
@@ -347,6 +347,16 @@ pub(crate) fn parse_sql_doc<'a>(sql: &'a str, enum_names: &'a [String]) -> Conne
     Ok(parsed_sql)
 }
 
+/// Mysql-async poorly parses the sql input to support named parameters, which conflicts with our own syntax for overriding query parameters type and nullability.
+/// This function removes all single-line comments from the sql input to avoid conflicts.
+pub(crate) fn sanitize_sql(sql: &str) -> String {
+    sql.lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.starts_with("--"))
+        .collect::<Vec<&str>>()
+        .join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1106,5 +1116,30 @@ SELECT enum FROM "test_introspect_sql"."model" WHERE id = $1;"#,
         "#]];
 
         expected.assert_debug_eq(&res);
+    }
+
+    #[test]
+    fn sanitize_sql_test() {
+        use expect_test::expect;
+
+        let sql = r#"
+            -- @description This query returns a user by it's id
+            -- @param {Int} $1:userId valid user identifier
+            -- @param {String} $2:parentId valid parent identifier
+            SELECT enum
+                FROM 
+                        "test_introspect_sql"."model" WHERE id =
+                    $1;
+        "#;
+
+        let expected = expect![[r#"
+
+            SELECT enum
+            FROM
+            "test_introspect_sql"."model" WHERE id =
+            $1;
+        "#]];
+
+        expected.assert_eq(&sanitize_sql(sql));
     }
 }


### PR DESCRIPTION
## Overview

mysql-async, the driver, supports named parameters by parsing queries.

Unfortunately, it poorly parses queries and treats `:alias` in SQL comments as actual named parameters, leading to errors about mixed and positional parameters when `-- @param $1:alias` is present. This PR strips out all single-line comments before sending it to quaint.
