### PR TITLE
fix(ci): add sanity check to build.rs scripts, fixed "detected dubious ownership in repository" errors on `git`

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -69,6 +69,7 @@ jobs:
           (
             github.event.pull_request.author_association == 'OWNER' ||
             github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'CONTRIBUTOR' ||
             github.event.pull_request.author_association == 'COLLABORATOR'
           )
         run: |

--- a/query-engine/query-engine-node-api/build.rs
+++ b/query-engine/query-engine-node-api/build.rs
@@ -4,6 +4,16 @@ use std::process::Command;
 
 fn store_git_commit_hash() {
     let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
+
+    // Sanity check on the output.
+    if !output.status.success() {
+        panic!(
+            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
+            String::from_utf8(output.stderr).unwrap_or_default(),
+            String::from_utf8(output.stdout).unwrap_or_default(),
+        );
+    }
+
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }

--- a/query-engine/query-engine/build.rs
+++ b/query-engine/query-engine/build.rs
@@ -2,6 +2,16 @@ use std::process::Command;
 
 fn store_git_commit_hash() {
     let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
+
+    // Sanity check on the output.
+    if !output.status.success() {
+        panic!(
+            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
+            String::from_utf8(output.stderr).unwrap_or_default(),
+            String::from_utf8(output.stdout).unwrap_or_default(),
+        );
+    }
+
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }

--- a/schema-engine/cli/build.rs
+++ b/schema-engine/cli/build.rs
@@ -2,6 +2,16 @@ use std::process::Command;
 
 fn store_git_commit_hash() {
     let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
+
+    // Sanity check on the output.
+    if !output.status.success() {
+        panic!(
+            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
+            String::from_utf8(output.stderr).unwrap_or_default(),
+            String::from_utf8(output.stdout).unwrap_or_default(),
+        );
+    }
+
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }


### PR DESCRIPTION
This PR checks that `git rev-parse HEAD`, the CLI command used at compilation time to store the hash in the Query Engine and Schema Engine, exits successfully.

It also complements https://github.com/prisma/prisma-engines/pull/4947 by running `git config --global --add safe.directory /root/build` when cross-building via `prismagraphql/build:*`. This avoids "fatal: detected dubious ownership in repository at /root/build" errors in Linux Musl ARM64 and Linux Static ARM64 architectures.

This was introduced after third-party clients notified us that `./query-engine --version` no longer displayed the version hash in Linux Alpine.

Fixes: https://github.com/prisma/prisma/issues/25020
Fixes: https://github.com/prisma/prisma/issues/24971