### PR TITLE
fix: make it possible to build the engines without `.git` directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "build-utils"
+version = "0.1.0"
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3544,6 +3548,7 @@ dependencies = [
 name = "prisma-fmt"
 version = "0.1.0"
 dependencies = [
+ "build-utils",
  "colored",
  "dissimilar",
  "dmmf",
@@ -3913,6 +3918,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.13.1",
+ "build-utils",
  "connection-string",
  "enumflags2",
  "graphql-parser",
@@ -3947,6 +3953,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "build-utils",
  "cbindgen",
  "chrono",
  "connection-string",
@@ -4025,6 +4032,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "build-utils",
  "connection-string",
  "driver-adapters",
  "futures",
@@ -4087,6 +4095,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "build-utils",
  "connection-string",
  "driver-adapters",
  "futures",
@@ -4795,6 +4804,7 @@ version = "0.1.0"
 dependencies = [
  "backtrace",
  "base64 0.13.1",
+ "build-utils",
  "connection-string",
  "expect-test",
  "indoc 2.0.3",
@@ -5570,6 +5580,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "build-utils",
  "colored",
  "dmmf",
  "enumflags2",

--- a/libs/build-utils/Cargo.toml
+++ b/libs/build-utils/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "build-utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/libs/build-utils/src/lib.rs
+++ b/libs/build-utils/src/lib.rs
@@ -1,0 +1,23 @@
+use std::process::Command;
+
+/// Store the current git commit hash in the `GIT_HASH` variable in rustc env.
+/// If the `GIT_HASH` environment variable is already set, this function does nothing.
+pub fn store_git_commit_hash_in_env() {
+    if std::env::var("GIT_HASH").is_ok() {
+        return;
+    }
+
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
+
+    // Sanity check on the output.
+    if !output.status.success() {
+        panic!(
+            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
+            String::from_utf8(output.stderr).unwrap_or_default(),
+            String::from_utf8(output.stdout).unwrap_or_default(),
+        );
+    }
+
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}

--- a/libs/test-cli/Cargo.toml
+++ b/libs/test-cli/Cargo.toml
@@ -18,3 +18,6 @@ tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-error = "0.2"
 async-trait.workspace = true
+
+[build-dependencies]
+build-utils.path = "../build-utils"

--- a/libs/test-cli/build.rs
+++ b/libs/test-cli/build.rs
@@ -1,7 +1,3 @@
-use std::process::Command;
-
 fn main() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
+    build_utils::store_git_commit_hash_in_env();
 }

--- a/nix/publish-engine-size.nix
+++ b/nix/publish-engine-size.nix
@@ -22,11 +22,14 @@ let
   craneLib = (flakeInputs.crane.mkLib pkgs).overrideToolchain rustToolchain;
   deps = craneLib.vendorCargoDeps { inherit src; };
   libSuffix = stdenv.hostPlatform.extensions.sharedLibrary;
+  fakeGitHash = "0000000000000000000000000000000000000000";
 in
 {
   packages.prisma-engines = stdenv.mkDerivation {
     name = "prisma-engines";
     inherit src;
+
+    GIT_HASH = "${fakeGitHash}";
 
     buildInputs = [ pkgs.openssl.out ];
     nativeBuildInputs = with pkgs; [
@@ -68,6 +71,8 @@ in
       inherit src;
       inherit (self'.packages.prisma-engines) buildInputs nativeBuildInputs configurePhase dontStrip;
 
+      GIT_HASH = "${fakeGitHash}";
+
       buildPhase = "cargo build --profile=${profile} --bin=test-cli";
 
       installPhase = ''
@@ -84,6 +89,8 @@ in
       name = "query-engine-bin";
       inherit src;
       inherit (self'.packages.prisma-engines) buildInputs nativeBuildInputs configurePhase dontStrip;
+
+      GIT_HASH = "${fakeGitHash}";
 
       buildPhase = "cargo build --profile=${profile} --bin=query-engine";
 
@@ -104,6 +111,8 @@ in
       name = "query-engine-bin-and-lib";
       inherit src;
       inherit (self'.packages.prisma-engines) buildInputs nativeBuildInputs configurePhase dontStrip;
+
+      GIT_HASH = "${fakeGitHash}";
 
       buildPhase = ''
         cargo build --profile=${profile} --bin=query-engine
@@ -133,6 +142,8 @@ in
       name = "query-engine-wasm-gz";
       inherit src;
       buildInputs = with pkgs; [ iconv ];
+
+      GIT_HASH = "${fakeGitHash}";
 
       buildPhase = ''
       export HOME=$(mktemp -dt wasm-engine-home-XXXX)

--- a/prisma-fmt/Cargo.toml
+++ b/prisma-fmt/Cargo.toml
@@ -22,6 +22,9 @@ dissimilar = "1.0.3"
 once_cell = "1.9.0"
 expect-test = "1"
 
+[build-dependencies]
+build-utils.path = "../libs/build-utils"
+
 [features]
 # sigh please don't ask :(
 vendored-openssl = []

--- a/prisma-fmt/build.rs
+++ b/prisma-fmt/build.rs
@@ -1,11 +1,3 @@
-use std::process::Command;
-
-fn store_git_commit_hash() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-}
-
 fn main() {
-    store_git_commit_hash();
+    build_utils::store_git_commit_hash_in_env();
 }

--- a/query-engine/query-engine-c-abi/Cargo.toml
+++ b/query-engine/query-engine-c-abi/Cargo.toml
@@ -46,3 +46,4 @@ once_cell = "1.19.0"
 
 [build-dependencies]
 cbindgen = "0.24.0"
+build-utils.path = "../../libs/build-utils"

--- a/query-engine/query-engine-c-abi/build.rs
+++ b/query-engine/query-engine-c-abi/build.rs
@@ -1,13 +1,4 @@
-extern crate cbindgen;
-
 use std::env;
-use std::process::Command;
-
-fn store_git_commit_hash() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-}
 
 fn generate_c_headers() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
@@ -28,6 +19,6 @@ fn main() {
     // Tell Cargo that if the given file changes, to rerun this build script.
     println!("cargo:rerun-if-changed=src/engine.rs");
     // println!("✅ Running build.rs");
-    store_git_commit_hash();
+    build_utils::store_git_commit_hash_in_env();
     generate_c_headers();
 }

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -56,3 +56,4 @@ query-engine-metrics = { path = "../metrics" }
 
 [build-dependencies]
 napi-build = "1"
+build-utils.path = "../../libs/build-utils"

--- a/query-engine/query-engine-node-api/build.rs
+++ b/query-engine/query-engine-node-api/build.rs
@@ -1,24 +1,4 @@
-extern crate napi_build;
-
-use std::process::Command;
-
-fn store_git_commit_hash() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-
-    // Sanity check on the output.
-    if !output.status.success() {
-        panic!(
-            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
-            String::from_utf8(output.stderr).unwrap_or_default(),
-            String::from_utf8(output.stdout).unwrap_or_default(),
-        );
-    }
-
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-}
-
 fn main() {
-    store_git_commit_hash();
+    build_utils::store_git_commit_hash_in_env();
     napi_build::setup()
 }

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -66,6 +66,9 @@ tracing-futures = "0.2"
 tracing-opentelemetry = "0.17.3"
 opentelemetry = { version = "0.17" }
 
+[build-dependencies]
+build-utils.path = "../../libs/build-utils"
+
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false # use wasm-opt explicitly in `./build.sh`
 

--- a/query-engine/query-engine-wasm/build.rs
+++ b/query-engine/query-engine-wasm/build.rs
@@ -1,11 +1,3 @@
-use std::process::Command;
-
-fn store_git_commit_hash() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-}
-
 fn main() {
-    store_git_commit_hash();
+    build_utils::store_git_commit_hash_in_env();
 }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -40,3 +40,6 @@ user-facing-errors = { path = "../../libs/user-facing-errors" }
 serial_test = "*"
 quaint.workspace = true
 indoc.workspace = true
+
+[build-dependencies]
+build-utils.path = "../../libs/build-utils"

--- a/query-engine/query-engine/build.rs
+++ b/query-engine/query-engine/build.rs
@@ -1,21 +1,3 @@
-use std::process::Command;
-
-fn store_git_commit_hash() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-
-    // Sanity check on the output.
-    if !output.status.success() {
-        panic!(
-            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
-            String::from_utf8(output.stderr).unwrap_or_default(),
-            String::from_utf8(output.stdout).unwrap_or_default(),
-        );
-    }
-
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-}
-
 fn main() {
-    store_git_commit_hash();
+    build_utils::store_git_commit_hash_in_env();
 }

--- a/schema-engine/cli/Cargo.toml
+++ b/schema-engine/cli/Cargo.toml
@@ -36,6 +36,9 @@ connection-string.workspace = true
 expect-test = "1.4.0"
 quaint = { workspace = true, features = ["all-native"] }
 
+[build-dependencies]
+build-utils.path = "../../libs/build-utils"
+
 [[bin]]
 name = "schema-engine"
 path = "src/main.rs"

--- a/schema-engine/cli/build.rs
+++ b/schema-engine/cli/build.rs
@@ -1,21 +1,3 @@
-use std::process::Command;
-
-fn store_git_commit_hash() {
-    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
-
-    // Sanity check on the output.
-    if !output.status.success() {
-        panic!(
-            "Failed to get git commit hash.\nstderr: \n{}\nstdout {}\n",
-            String::from_utf8(output.stderr).unwrap_or_default(),
-            String::from_utf8(output.stdout).unwrap_or_default(),
-        );
-    }
-
-    let git_hash = String::from_utf8(output.stdout).unwrap();
-    println!("cargo:rustc-env=GIT_HASH={git_hash}");
-}
-
 fn main() {
-    store_git_commit_hash();
+    build_utils::store_git_commit_hash_in_env();
 }


### PR DESCRIPTION
Follow-up to https://github.com/prisma/prisma-engines/pull/4986.

* Change the `build.rs` scripts to pass through the `GIT_HASH` environment variable if it's already set.
* Set dummmy `GIT_HASH` value in the Nix packages used in the engines size dashboard.
* Consistently use the new logic everywhere.

Fixes: https://github.com/prisma/prisma-engines/issues/4991
Closes: https://github.com/prisma/team-orm/issues/1261
