### PR TITLE
Revert "chore(deps): bump openssl from 0.10.60 to 0.10.66"

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -53,7 +53,7 @@ jobs:
           echo "Repository Owner: $${{ github.repository_owner }}"
           echo "Pull Request Author: ${{ github.actor }}"
           echo "Pull Request Author Association: ${{ github.event.pull_request.author_association }}"
-          echo "Commit message:${{ steps.commit-msg.outputs.commit-msg }}"
+          # echo "Commit message:${{ steps.commit-msg.outputs.commit-msg }}"
           echo "Commit message contains [integration]: ${{ contains(steps.commit-msg.outputs.commit-msg, '[integration]') }}"
 
       - name: 'Check if commit message conatains `[integration]` and the PR author has permissions to trigger the workflow'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,9 +3067,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "79a4c6c3a2b158f7f8f2a2fc5a969fa3a068df6fc9dbb4a43845436e3af7c800"
 dependencies = [
  "bitflags 2.4.0",
  "cfg-if",
@@ -3099,18 +3099,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.1+3.3.1"
+version = "300.1.6+3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
Reverts prisma/prisma-engines#4965 to fix the https://github.com/prisma/prisma/issues/25101 regression, according to https://github.com/prisma/prisma/issues/25101#issuecomment-2322916479 and https://github.com/prisma/prisma/issues/25101#issuecomment-2322925536.

TODO, post patch release:
- [ ] write an ecosystem tests that reflects that user's scenario, with Ubuntu 22.04 defaulting on OpenSSL 1.1.x.