### PR TITLE
chore(ci): temporarily move to Ubuntu 20.04 to circumvent cache issues in `main`

### DIFF
--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -49,7 +49,9 @@ jobs:
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
       PRISMA_RELATION_LOAD_STRATEGY: ${{ matrix.relation_load_strategy }}
 
-    runs-on: "ubuntu-${{ inputs.ubuntu }}"
+    runs-on: "ubuntu-20.04"
+    # TODO: Replace with the following once `prisma@5.20.0` is released.
+    # runs-on: "ubuntu-${{ inputs.ubuntu }}"
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -105,7 +105,9 @@ jobs:
             is_vitess: true
             single_threaded: true
 
-    runs-on: "ubuntu-${{ matrix.database.ubuntu || 'latest' }}"
+    runs-on: "ubuntu-20.04"
+    # TODO: Replace with the following once `prisma@5.20.0` is released.
+    # runs-on: "ubuntu-${{ matrix.database.ubuntu || 'latest' }}"
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1


### PR DESCRIPTION
Workaround for [problem disclosed on Slack](https://prisma-company.slack.com/archives/C058VM009HT/p1727166601365529?thread_ts=1727122263.236439&cid=C058VM009HT) about Rust caches in `main`.

This is to avoid failures like: https://github.com/prisma/prisma-engines/actions/runs/10999639780/job/30540401825.