### PR TITLE
fix(mongodb-query-connector): add missing span for aggregate

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
@@ -3,6 +3,7 @@ use crate::{constants::*, output_meta, query_builder::MongoReadQueryBuilder, val
 use connector_interface::*;
 use mongodb::{bson::Document, ClientSession, Database};
 use query_structure::{prelude::*, Filter, QueryArguments};
+use tracing::{info_span, Instrument};
 
 pub async fn aggregate<'conn>(
     database: &Database,
@@ -16,11 +17,17 @@ pub async fn aggregate<'conn>(
     let is_group_by = !group_by.is_empty();
     let coll = database.collection(model.db_name());
 
+    let span = info_span!(
+        "prisma:engine:db_query",
+        user_facing = true,
+        "db.statement" = &format_args!("db.{}.aggregate(*)", coll.name())
+    );
+
     let query = MongoReadQueryBuilder::from_args(query_arguments)?
         .with_groupings(group_by, &selections, having)?
         .build()?;
 
-    let docs = query.execute(coll, session).await?;
+    let docs = query.execute(coll, session).instrument(span).await?;
 
     if is_group_by && docs.is_empty() {
         Ok(vec![])


### PR DESCRIPTION
Add the missing `prisma:engine:db_query` span for aggregate operation in MongoDB.

Fixes: https://github.com/prisma/prisma/issues/24494
Refs: https://github.com/prisma/prisma/pull/25385

/integration