### PR TITLE
feat(mongodb-query-connector): add full queries to the spans

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -18,6 +18,7 @@ use query_engine_metrics::{
     PRISMA_DATASOURCE_QUERIES_TOTAL,
 };
 use query_structure::*;
+use std::sync::Arc;
 use std::time::Instant;
 use tracing::{debug, info_span};
 use tracing_futures::Instrument;
@@ -63,12 +64,12 @@ where
     // TODO: build the string lazily in the Display impl so it doesn't have to be built if neither
     // logs nor traces are enabled. This is tricky because whatever we store in the span has to be
     // 'static, and all `QueryString` implementations aren't, so this requires some refactoring.
-    let query_string = builder.build();
+    let query_string: Arc<str> = builder.build().into();
 
     let span = info_span!(
         "prisma:engine:db_query",
         user_facing = true,
-        "db.statement" = %query_string.clone()
+        "db.statement" = %Arc::clone(&query_string)
     );
 
     let start = Instant::now();

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -66,7 +66,6 @@ where
     histogram!(PRISMA_DATASOURCE_QUERIES_DURATION_HISTOGRAM_MS, elapsed);
     increment_counter!(PRISMA_DATASOURCE_QUERIES_TOTAL);
 
-    // TODO: emit tracing event only when "debug" level query logs are enabled.
     // TODO prisma/team-orm#136: fix log subscription.
     let query_string = builder.build();
     // NOTE: `params` is a part of the interface for query logs.

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -69,8 +69,7 @@ where
     // TODO prisma/team-orm#136: fix log subscription.
     let query_string = builder.build();
     // NOTE: `params` is a part of the interface for query logs.
-    let params: Vec<i32> = vec![];
-    debug!(target: "mongodb_query_connector::query", item_type = "query", is_query = true, query = %query_string, params = ?params, duration_ms = elapsed);
+    debug!(target: "mongodb_query_connector::query", item_type = "query", is_query = true, query = %query_string, params = "[]", duration_ms = elapsed);
 
     res
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -68,7 +68,7 @@ where
     let span = info_span!(
         "prisma:engine:db_query",
         user_facing = true,
-        "db.statement" = query_string.clone()
+        "db.statement" = %query_string.clone()
     );
 
     let start = Instant::now();
@@ -80,7 +80,7 @@ where
 
     // TODO prisma/team-orm#136: fix log subscription.
     // NOTE: `params` is a part of the interface for query logs.
-    debug!(target: "mongodb_query_connector::query", item_type = "query", is_query = true, query = query_string, params = "[]", duration_ms = elapsed);
+    debug!(target: "mongodb_query_connector::query", item_type = "query", is_query = true, query = %query_string, params = %"[]", duration_ms = elapsed);
 
     res
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -80,7 +80,7 @@ where
 
     // TODO prisma/team-orm#136: fix log subscription.
     // NOTE: `params` is a part of the interface for query logs.
-    debug!(target: "mongodb_query_connector::query", item_type = "query", is_query = true, query = %query_string, params = "[]", duration_ms = elapsed);
+    debug!(target: "mongodb_query_connector::query", item_type = "query", is_query = true, query = query_string, params = "[]", duration_ms = elapsed);
 
     res
 }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/read.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/read.rs
@@ -6,7 +6,6 @@ use crate::{
 use mongodb::{bson::doc, options::FindOptions, ClientSession, Database};
 use query_structure::*;
 use std::future::IntoFuture;
-use tracing::{info_span, Instrument};
 
 /// Finds a single record. Joins are not required at the moment because the selector is always a unique one.
 pub async fn get_single_record<'conn>(
@@ -18,12 +17,6 @@ pub async fn get_single_record<'conn>(
 ) -> crate::Result<Option<SingleRecord>> {
     let coll = database.collection(model.db_name());
 
-    let span = info_span!(
-        "prisma:engine:db_query",
-        user_facing = true,
-        "db.statement" = &format_args!("db.{}.findOne(*)", coll.name())
-    );
-
     let meta_mapping = output_meta::from_selected_fields(selected_fields);
     let query_arguments: QueryArguments = (model.clone(), filter.clone()).into();
     let query = MongoReadQueryBuilder::from_args(query_arguments)?
@@ -31,7 +24,7 @@ pub async fn get_single_record<'conn>(
         .with_virtual_fields(selected_fields.virtuals())?
         .build()?;
 
-    let docs = query.execute(coll, session).instrument(span).await?;
+    let docs = query.execute(coll, session).await?;
 
     if docs.is_empty() {
         Ok(None)
@@ -60,12 +53,6 @@ pub async fn get_many_records<'conn>(
 ) -> crate::Result<ManyRecords> {
     let coll = database.collection(model.db_name());
 
-    let span = info_span!(
-        "prisma:engine:db_query",
-        user_facing = true,
-        "db.statement" = &format_args!("db.{}.findMany(*)", coll.name())
-    );
-
     let reverse_order = query_arguments.take.map(|t| t < 0).unwrap_or(false);
     let field_names: Vec<_> = selected_fields.db_names().collect();
 
@@ -81,7 +68,7 @@ pub async fn get_many_records<'conn>(
         .with_virtual_fields(selected_fields.virtuals())?
         .build()?;
 
-    let docs = query.execute(coll, session).instrument(span).await?;
+    let docs = query.execute(coll, session).await?;
     for doc in docs {
         let record = document_to_record(doc, &field_names, &meta_mapping)?;
         records.push(record)


### PR DESCRIPTION
Add full queries to the `prisma:engine:db_queries` spans in MongoDB.

Closes: https://github.com/prisma/prisma/issues/24463

/integration
