### PR TITLE
fix(query-engine-wasm): reduce size of `postgres` Query Engine after regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
 name = "crosstarget-utils"
 version = "0.1.0"
 dependencies = [
+ "enumflags2",
  "futures",
  "js-sys",
  "pin-project",
@@ -3832,6 +3833,7 @@ dependencies = [
  "connection-string",
  "crosstarget-utils",
  "either",
+ "enumflags2",
  "expect-test",
  "futures",
  "getrandom 0.2.11",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,7 @@ dependencies = [
  "futures",
  "js-sys",
  "pin-project",
+ "regex",
  "tokio",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
 name = "crosstarget-utils"
 version = "0.1.0"
 dependencies = [
+ "derive_more",
  "enumflags2",
  "futures",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tokio = { version = "1", features = [
   "time",
 ] }
 chrono = { version = "0.4.38", features = ["serde"] }
+derive_more = "0.99.17"
 user-facing-errors = { path = "./libs/user-facing-errors" }
 uuid = { version = "1", features = ["serde", "v4", "v7", "js"] }
 indoc = "2.0.1"

--- a/libs/crosstarget-utils/Cargo.toml
+++ b/libs/crosstarget-utils/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 futures = "0.3"
+enumflags2.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys.workspace = true

--- a/libs/crosstarget-utils/Cargo.toml
+++ b/libs/crosstarget-utils/Cargo.toml
@@ -17,3 +17,4 @@ pin-project = "1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio.workspace = true
+regex.workspace = true

--- a/libs/crosstarget-utils/Cargo.toml
+++ b/libs/crosstarget-utils/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-futures = "0.3"
+derive_more.workspace = true
 enumflags2.workspace = true
+futures = "0.3"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys.workspace = true

--- a/libs/crosstarget-utils/src/common.rs
+++ b/libs/crosstarget-utils/src/common.rs
@@ -21,3 +21,24 @@ impl Display for TimeoutError {
 }
 
 impl std::error::Error for TimeoutError {}
+
+#[derive(Debug)]
+pub struct RegExpError {
+    pub message: String,
+}
+
+#[derive(PartialEq)]
+pub enum RegExpFlags {
+    IgnoreCase,
+    Multiline,
+}
+
+impl From<RegExpFlags> for String {
+    fn from(flags: RegExpFlags) -> Self {
+        match flags {
+            RegExpFlags::IgnoreCase => "i",
+            RegExpFlags::Multiline => "m",
+        }
+        .to_string()
+    }
+}

--- a/libs/crosstarget-utils/src/common.rs
+++ b/libs/crosstarget-utils/src/common.rs
@@ -27,18 +27,28 @@ pub struct RegExpError {
     pub message: String,
 }
 
-#[derive(PartialEq)]
-pub enum RegExpFlags {
-    IgnoreCase,
-    Multiline,
+impl Display for RegExpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Regular expression error: {}", self.message)
+    }
 }
 
-impl From<RegExpFlags> for String {
-    fn from(flags: RegExpFlags) -> Self {
-        match flags {
-            RegExpFlags::IgnoreCase => "i",
-            RegExpFlags::Multiline => "m",
+impl std::error::Error for RegExpError {}
+
+/// Test-relevant connector capabilities.
+#[enumflags2::bitflags]
+#[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(u8)]
+pub enum RegExpFlags {
+    IgnoreCase = 0b0001,
+    Multiline = 0b0010,
+}
+
+impl RegExpFlags {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::IgnoreCase => "i",
+            Self::Multiline => "m",
         }
-        .to_string()
     }
 }

--- a/libs/crosstarget-utils/src/common/mod.rs
+++ b/libs/crosstarget-utils/src/common/mod.rs
@@ -1,0 +1,3 @@
+pub mod regex;
+pub mod spawn;
+pub mod timeout;

--- a/libs/crosstarget-utils/src/common/regex.rs
+++ b/libs/crosstarget-utils/src/common/regex.rs
@@ -13,7 +13,7 @@ impl Display for RegExpError {
 
 impl std::error::Error for RegExpError {}
 
-/// Test-relevant connector capabilities.
+/// Flag modifiers for regular expressions.
 #[enumflags2::bitflags]
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]

--- a/libs/crosstarget-utils/src/common/regex.rs
+++ b/libs/crosstarget-utils/src/common/regex.rs
@@ -1,28 +1,6 @@
 use std::fmt::Display;
 
 #[derive(Debug)]
-pub struct SpawnError;
-
-impl Display for SpawnError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Failed to spawn a future")
-    }
-}
-
-impl std::error::Error for SpawnError {}
-
-#[derive(Debug)]
-pub struct TimeoutError;
-
-impl Display for TimeoutError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Operation timed out")
-    }
-}
-
-impl std::error::Error for TimeoutError {}
-
-#[derive(Debug)]
 pub struct RegExpError {
     pub message: String,
 }
@@ -51,4 +29,14 @@ impl RegExpFlags {
             Self::Multiline => "m",
         }
     }
+}
+
+pub trait RegExpCompat {
+    /// Searches for the first match of this regex in the haystack given, and if found,
+    /// returns not only the overall match but also the matches of each capture group in the regex.
+    /// If no match is found, then None is returned.
+    fn captures(&self, message: &str) -> Option<Vec<String>>;
+
+    /// Tests if the regex matches the input string.
+    fn test(&self, message: &str) -> bool;
 }

--- a/libs/crosstarget-utils/src/common/regex.rs
+++ b/libs/crosstarget-utils/src/common/regex.rs
@@ -1,14 +1,9 @@
-use std::fmt::Display;
+use derive_more::Display;
 
-#[derive(Debug)]
+#[derive(Debug, Display)]
+#[display("Regular expression error: {message}")]
 pub struct RegExpError {
     pub message: String,
-}
-
-impl Display for RegExpError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Regular expression error: {}", self.message)
-    }
 }
 
 impl std::error::Error for RegExpError {}

--- a/libs/crosstarget-utils/src/common/regex.rs
+++ b/libs/crosstarget-utils/src/common/regex.rs
@@ -1,7 +1,7 @@
 use derive_more::Display;
 
 #[derive(Debug, Display)]
-#[display("Regular expression error: {message}")]
+#[display(fmt = "Regular expression error: {message}")]
 pub struct RegExpError {
     pub message: String,
 }

--- a/libs/crosstarget-utils/src/common/spawn.rs
+++ b/libs/crosstarget-utils/src/common/spawn.rs
@@ -1,0 +1,12 @@
+use std::fmt::Display;
+
+#[derive(Debug)]
+pub struct SpawnError;
+
+impl Display for SpawnError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Failed to spawn a future")
+    }
+}
+
+impl std::error::Error for SpawnError {}

--- a/libs/crosstarget-utils/src/common/spawn.rs
+++ b/libs/crosstarget-utils/src/common/spawn.rs
@@ -1,12 +1,8 @@
-use std::fmt::Display;
+use derive_more::Display;
 
-#[derive(Debug)]
+#[derive(Debug, Display)]
+#[display(fmt = "Failed to spawn a future")]
+
 pub struct SpawnError;
-
-impl Display for SpawnError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Failed to spawn a future")
-    }
-}
 
 impl std::error::Error for SpawnError {}

--- a/libs/crosstarget-utils/src/common/timeout.rs
+++ b/libs/crosstarget-utils/src/common/timeout.rs
@@ -1,0 +1,12 @@
+use std::fmt::Display;
+
+#[derive(Debug)]
+pub struct TimeoutError;
+
+impl Display for TimeoutError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Operation timed out")
+    }
+}
+
+impl std::error::Error for TimeoutError {}

--- a/libs/crosstarget-utils/src/common/timeout.rs
+++ b/libs/crosstarget-utils/src/common/timeout.rs
@@ -1,12 +1,7 @@
-use std::fmt::Display;
+use derive_more::Display;
 
-#[derive(Debug)]
+#[derive(Debug, Display)]
+#[display(fmt = "Operation timed out")]
 pub struct TimeoutError;
-
-impl Display for TimeoutError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Operation timed out")
-    }
-}
 
 impl std::error::Error for TimeoutError {}

--- a/libs/crosstarget-utils/src/lib.rs
+++ b/libs/crosstarget-utils/src/lib.rs
@@ -9,4 +9,5 @@ mod native;
 #[cfg(not(target_arch = "wasm32"))]
 pub use crate::native::*;
 
-pub use common::SpawnError;
+pub use crate::common::regex::RegExpCompat;
+pub use crate::common::spawn::SpawnError;

--- a/libs/crosstarget-utils/src/native/mod.rs
+++ b/libs/crosstarget-utils/src/native/mod.rs
@@ -1,3 +1,4 @@
+pub mod regex;
 pub mod spawn;
 pub mod task;
 pub mod time;

--- a/libs/crosstarget-utils/src/native/regex.rs
+++ b/libs/crosstarget-utils/src/native/regex.rs
@@ -1,3 +1,4 @@
+use enumflags2::BitFlags;
 use regex::{Regex as NativeRegex, RegexBuilder};
 
 use crate::common::{RegExpError, RegExpFlags};
@@ -7,14 +8,14 @@ pub struct RegExp {
 }
 
 impl RegExp {
-    pub fn new(pattern: &str, flags: Vec<RegExpFlags>) -> Result<Self, RegExpError> {
+    pub fn new(pattern: &str, flags: BitFlags<RegExpFlags>) -> Result<Self, RegExpError> {
         let mut builder = RegexBuilder::new(pattern);
 
-        if flags.contains(&RegExpFlags::Multiline) {
+        if flags.contains(RegExpFlags::Multiline) {
             builder.multi_line(true);
         }
 
-        if flags.contains(&RegExpFlags::IgnoreCase) {
+        if flags.contains(RegExpFlags::IgnoreCase) {
             builder.case_insensitive(true);
         }
 
@@ -30,7 +31,7 @@ impl RegExp {
         self.inner.captures(message).map(|captures| {
             captures
                 .iter()
-                .flat_map(|capture| capture.map(|cap| cap.as_str().to_string()))
+                .flat_map(|capture| capture.map(|cap| cap.as_str().to_owned()))
                 .collect()
         })
     }

--- a/libs/crosstarget-utils/src/native/regex.rs
+++ b/libs/crosstarget-utils/src/native/regex.rs
@@ -1,7 +1,7 @@
 use enumflags2::BitFlags;
 use regex::{Regex as NativeRegex, RegexBuilder};
 
-use crate::common::{RegExpError, RegExpFlags};
+use crate::common::regex::{RegExpCompat, RegExpError, RegExpFlags};
 
 pub struct RegExp {
     inner: NativeRegex,
@@ -23,11 +23,10 @@ impl RegExp {
 
         Ok(Self { inner })
     }
+}
 
-    /// Searches for the first match of this regex in the haystack given, and if found,
-    /// returns not only the overall match but also the matches of each capture group in the regex.
-    /// If no match is found, then None is returned.
-    pub fn captures(&self, message: &str) -> Option<Vec<String>> {
+impl RegExpCompat for RegExp {
+    fn captures(&self, message: &str) -> Option<Vec<String>> {
         self.inner.captures(message).map(|captures| {
             captures
                 .iter()
@@ -36,8 +35,7 @@ impl RegExp {
         })
     }
 
-    /// Tests if the regex matches the input string.
-    pub fn test(&self, message: &str) -> bool {
+    fn test(&self, message: &str) -> bool {
         self.inner.is_match(message)
     }
 }

--- a/libs/crosstarget-utils/src/native/regex.rs
+++ b/libs/crosstarget-utils/src/native/regex.rs
@@ -1,0 +1,44 @@
+use regex::{Regex as NativeRegex, RegexBuilder};
+
+use crate::common::{RegExpError, RegExpFlags};
+
+pub struct RegExp {
+    inner: NativeRegex,
+}
+
+impl RegExp {
+    pub fn new(pattern: &str, flags: Vec<RegExpFlags>) -> Result<Self, RegExpError> {
+        let mut builder = RegexBuilder::new(pattern);
+
+        if flags.contains(&RegExpFlags::Multiline) {
+            builder.multi_line(true);
+        }
+
+        if flags.contains(&RegExpFlags::IgnoreCase) {
+            builder.case_insensitive(true);
+        }
+
+        let inner = builder.build().map_err(|e| RegExpError { message: e.to_string() })?;
+
+        Ok(Self { inner })
+    }
+
+    /// Searches for the first match of this regex in the haystack given, and if found,
+    /// returns not only the overall match but also the matches of each capture group in the regex.
+    /// If no match is found, then None is returned.
+    pub fn captures(&self, message: &str) -> Option<Vec<String>> {
+        self.inner.captures(message).map(|captures| {
+            captures
+                .iter()
+                .map(|capture| capture.and_then(|cap| Some(cap.as_str().to_string())))
+                .filter(|capture| capture.is_some())
+                .map(|capture| capture.unwrap())
+                .collect()
+        })
+    }
+
+    /// Tests if the regex matches the input string.
+    pub fn test(&self, message: &str) -> bool {
+        self.inner.is_match(message)
+    }
+}

--- a/libs/crosstarget-utils/src/native/regex.rs
+++ b/libs/crosstarget-utils/src/native/regex.rs
@@ -30,9 +30,7 @@ impl RegExp {
         self.inner.captures(message).map(|captures| {
             captures
                 .iter()
-                .map(|capture| capture.and_then(|cap| Some(cap.as_str().to_string())))
-                .filter(|capture| capture.is_some())
-                .map(|capture| capture.unwrap())
+                .flat_map(|capture| capture.map(|cap| cap.as_str().to_string()))
                 .collect()
         })
     }

--- a/libs/crosstarget-utils/src/native/spawn.rs
+++ b/libs/crosstarget-utils/src/native/spawn.rs
@@ -1,7 +1,7 @@
 use futures::TryFutureExt;
 use std::future::Future;
 
-use crate::common::SpawnError;
+use crate::common::spawn::SpawnError;
 
 pub fn spawn_if_possible<F>(future: F) -> impl Future<Output = Result<F::Output, SpawnError>>
 where

--- a/libs/crosstarget-utils/src/native/time.rs
+++ b/libs/crosstarget-utils/src/native/time.rs
@@ -3,7 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::common::TimeoutError;
+use crate::common::timeout::TimeoutError;
 
 pub struct ElapsedTimeCounter {
     instant: Instant,

--- a/libs/crosstarget-utils/src/wasm/mod.rs
+++ b/libs/crosstarget-utils/src/wasm/mod.rs
@@ -1,3 +1,4 @@
+pub mod regex;
 pub mod spawn;
 pub mod task;
 pub mod time;

--- a/libs/crosstarget-utils/src/wasm/regex.rs
+++ b/libs/crosstarget-utils/src/wasm/regex.rs
@@ -1,7 +1,7 @@
 use enumflags2::BitFlags;
 use js_sys::RegExp as JSRegExp;
 
-use crate::common::{RegExpError, RegExpFlags};
+use crate::common::regex::{RegExpCompat, RegExpError, RegExpFlags};
 
 pub struct RegExp {
     inner: JSRegExp,
@@ -18,11 +18,10 @@ impl RegExp {
             inner: JSRegExp::new(pattern, &flags),
         })
     }
+}
 
-    /// Searches for the first match of this regex in the haystack given, and if found,
-    /// returns not only the overall match but also the matches of each capture group in the regex.
-    /// If no match is found, then None is returned.
-    pub fn captures(&self, message: &str) -> Option<Vec<String>> {
+impl RegExpCompat for RegExp {
+    fn captures(&self, message: &str) -> Option<Vec<String>> {
         let matches = self.inner.exec(message);
         matches.map(|matches| {
             let mut captures = Vec::new();
@@ -38,8 +37,7 @@ impl RegExp {
         })
     }
 
-    /// Tests if the regex matches the input string.
-    pub fn test(&self, input: &str) -> bool {
+    fn test(&self, input: &str) -> bool {
         self.inner.test(input)
     }
 }

--- a/libs/crosstarget-utils/src/wasm/regex.rs
+++ b/libs/crosstarget-utils/src/wasm/regex.rs
@@ -24,17 +24,14 @@ impl RegExpCompat for RegExp {
     fn captures(&self, message: &str) -> Option<Vec<String>> {
         let matches = self.inner.exec(message);
         matches.map(|matches| {
-            let mut captures = Vec::new();
+            let mut captures: Vec<String> = Vec::new();
             for i in 0..matches.length() {
                 let match_value = matches.get(i);
 
                 // We keep the same number of captures as the number of groups in the regex pattern,
                 // but we guarantee that the captures are always strings.
-                if match_value.is_string() {
-                    captures.push(match_value.as_string().unwrap());
-                } else {
-                    captures.push(String::new());
-                }
+                let capture: String = match_value.try_into().ok().unwrap_or_default();
+                captures.push(capture);
             }
             captures
         })

--- a/libs/crosstarget-utils/src/wasm/regex.rs
+++ b/libs/crosstarget-utils/src/wasm/regex.rs
@@ -22,18 +22,13 @@ impl RegExp {
 
 impl RegExpCompat for RegExp {
     fn captures(&self, message: &str) -> Option<Vec<String>> {
-        let matches = self.inner.exec(message);
-        matches.map(|matches| {
-            let mut captures: Vec<String> = Vec::new();
-            for i in 0..matches.length() {
-                let match_value = matches.get(i);
-
-                // We keep the same number of captures as the number of groups in the regex pattern,
-                // but we guarantee that the captures are always strings.
-                let capture: String = match_value.try_into().ok().unwrap_or_default();
-                captures.push(capture);
-            }
-            captures
+        self.inner.exec(message).map(|matches| {
+            // We keep the same number of captures as the number of groups in the regex pattern,
+            // but we guarantee that the captures are always strings.
+            matches
+                .iter()
+                .map(|match_value| match_value.try_into().ok().unwrap_or_default())
+                .collect()
         })
     }
 

--- a/libs/crosstarget-utils/src/wasm/regex.rs
+++ b/libs/crosstarget-utils/src/wasm/regex.rs
@@ -23,12 +23,12 @@ impl RegExp {
     /// If no match is found, then None is returned.
     pub fn captures(&self, message: &str) -> Option<Vec<String>> {
         let matches = self.inner.exec(message);
-        matches.and_then(|matches| {
+        matches.map(|matches| {
             let mut captures = Vec::new();
             for i in 0..matches.length() {
                 captures.push(matches.get(i).as_string().unwrap());
             }
-            Some(captures)
+            captures
         })
     }
 

--- a/libs/crosstarget-utils/src/wasm/regex.rs
+++ b/libs/crosstarget-utils/src/wasm/regex.rs
@@ -28,9 +28,12 @@ impl RegExpCompat for RegExp {
             for i in 0..matches.length() {
                 let match_value = matches.get(i);
 
-                // `match_value` may be `undefined`.
+                // We keep the same number of captures as the number of groups in the regex pattern,
+                // but we guarantee that the captures are always strings.
                 if match_value.is_string() {
                     captures.push(match_value.as_string().unwrap());
+                } else {
+                    captures.push(String::new());
                 }
             }
             captures

--- a/libs/crosstarget-utils/src/wasm/regex.rs
+++ b/libs/crosstarget-utils/src/wasm/regex.rs
@@ -1,0 +1,39 @@
+use js_sys::RegExp as JSRegExp;
+
+use crate::common::{RegExpError, RegExpFlags};
+
+pub struct RegExp {
+    inner: JSRegExp,
+}
+
+impl RegExp {
+    pub fn new(pattern: &str, flags: Vec<RegExpFlags>) -> Result<Self, RegExpError> {
+        let mut flags_as_str: String = flags.into_iter().map(|flag| String::from(flag)).collect();
+
+        // Global flag is implied in `regex::Regex`, so we match that behavior for consistency.
+        flags_as_str.push('g');
+
+        Ok(Self {
+            inner: JSRegExp::new(pattern, &flags_as_str),
+        })
+    }
+
+    /// Searches for the first match of this regex in the haystack given, and if found,
+    /// returns not only the overall match but also the matches of each capture group in the regex.
+    /// If no match is found, then None is returned.
+    pub fn captures(&self, message: &str) -> Option<Vec<String>> {
+        let matches = self.inner.exec(message);
+        matches.and_then(|matches| {
+            let mut captures = Vec::new();
+            for i in 0..matches.length() {
+                captures.push(matches.get(i).as_string().unwrap());
+            }
+            Some(captures)
+        })
+    }
+
+    /// Tests if the regex matches the input string.
+    pub fn test(&self, input: &str) -> bool {
+        self.inner.test(input)
+    }
+}

--- a/libs/crosstarget-utils/src/wasm/spawn.rs
+++ b/libs/crosstarget-utils/src/wasm/spawn.rs
@@ -4,7 +4,7 @@ use futures::TryFutureExt;
 use tokio::sync::oneshot;
 use wasm_bindgen_futures::spawn_local;
 
-use crate::common::SpawnError;
+use crate::common::spawn::SpawnError;
 
 pub fn spawn_if_possible<F>(future: F) -> impl Future<Output = Result<F::Output, SpawnError>>
 where

--- a/libs/crosstarget-utils/src/wasm/time.rs
+++ b/libs/crosstarget-utils/src/wasm/time.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::common::TimeoutError;
+use crate::common::timeout::TimeoutError;
 
 #[wasm_bindgen]
 extern "C" {

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -82,6 +82,7 @@ url.workspace = true
 hex = "0.4"
 itertools.workspace = true
 regex.workspace = true
+enumflags2.workspace = true
 
 either = { version = "1.6" }
 base64 = { version = "0.12.3" }

--- a/quaint/src/connector/postgres/error.rs
+++ b/quaint/src/connector/postgres/error.rs
@@ -1,4 +1,4 @@
-use regex::Regex;
+use crosstarget_utils::regex::RegExp;
 use std::fmt::{Display, Formatter};
 
 use crate::error::{DatabaseConstraint, Error, ErrorKind, Name};
@@ -30,9 +30,8 @@ impl Display for PostgresError {
 }
 
 fn extract_fk_constraint_name(message: &str) -> Option<String> {
-    let re = Regex::new(r#"foreign key constraint "([^"]+)""#).unwrap();
-    re.captures(message)
-        .and_then(|caps| caps.get(1).map(|m| m.as_str().to_string()))
+    let re = RegExp::new(r#"foreign key constraint "([^"]+)""#, vec![]).unwrap();
+    re.captures(message).and_then(|caps| caps.get(1).cloned())
 }
 
 impl From<PostgresError> for Error {

--- a/quaint/src/connector/postgres/error.rs
+++ b/quaint/src/connector/postgres/error.rs
@@ -1,4 +1,5 @@
 use crosstarget_utils::regex::RegExp;
+use enumflags2::BitFlags;
 use std::fmt::{Display, Formatter};
 
 use crate::error::{DatabaseConstraint, Error, ErrorKind, Name};
@@ -30,7 +31,7 @@ impl Display for PostgresError {
 }
 
 fn extract_fk_constraint_name(message: &str) -> Option<String> {
-    let re = RegExp::new(r#"foreign key constraint "([^"]+)""#, vec![]).unwrap();
+    let re = RegExp::new(r#"foreign key constraint "([^"]+)""#, BitFlags::empty()).unwrap();
     re.captures(message).and_then(|caps| caps.get(1).cloned())
 }
 

--- a/quaint/src/connector/postgres/error.rs
+++ b/quaint/src/connector/postgres/error.rs
@@ -1,4 +1,4 @@
-use crosstarget_utils::regex::RegExp;
+use crosstarget_utils::{regex::RegExp, RegExpCompat};
 use enumflags2::BitFlags;
 use std::fmt::{Display, Formatter};
 

--- a/query-engine/connectors/mongodb-query-connector/Cargo.toml
+++ b/query-engine/connectors/mongodb-query-connector/Cargo.toml
@@ -22,7 +22,7 @@ uuid.workspace = true
 indexmap.workspace = true
 query-engine-metrics = { path = "../../metrics" }
 cuid = { git = "https://github.com/prisma/cuid-rust", branch = "wasm32-support" }
-derive_more = "0.99.17"
+derive_more.workspace = true
 
 [dependencies.query-structure]
 path = "../../query-structure"


### PR DESCRIPTION
This PR fixes a size regression introduced in https://github.com/prisma/prisma-engines/pull/5002.
The `regex` crate is too large, and caused a 236.376KiB gzip size increment for the `postgres` Query Engine.
The fix was using `js_sys::RegExp` on Wasm targets.

Closes: https://github.com/prisma/prisma-engines/issues/5008.