### PR TITLE
feat(telemetry): add dynamic "db.system" attribute to OTEL spans

### DIFF
--- a/quaint/src/connector/metrics.rs
+++ b/quaint/src/connector/metrics.rs
@@ -4,12 +4,18 @@ use crate::ast::{Params, Value};
 use crosstarget_utils::time::ElapsedTimeCounter;
 use std::future::Future;
 
-pub async fn query<'a, F, T, U>(tag: &'static str, query: &'a str, params: &'a [Value<'_>], f: F) -> crate::Result<T>
+pub async fn query<'a, F, T, U>(
+    tag: &'static str,
+    system_name: &'static str,
+    query: &'a str,
+    params: &'a [Value<'_>],
+    f: F,
+) -> crate::Result<T>
 where
     F: FnOnce() -> U + 'a,
     U: Future<Output = crate::Result<T>>,
 {
-    let span = info_span!("quaint:query", "db.statement" = %query);
+    let span = info_span!("quaint:query", "db.system" = %system_name, "db.statement" = %query);
     do_query(tag, query, params, f).instrument(span).await
 }
 

--- a/quaint/src/connector/mssql/native/mod.rs
+++ b/quaint/src/connector/mssql/native/mod.rs
@@ -30,6 +30,7 @@ use tokio_util::compat::{Compat, TokioAsyncWriteCompatExt};
 pub use tiberius;
 
 static SQL_SERVER_DEFAULT_ISOLATION: IsolationLevel = IsolationLevel::ReadCommitted;
+const SYSTEM_NAME: &str = "mssql";
 
 #[async_trait]
 impl TransactionCapable for Mssql {
@@ -60,6 +61,7 @@ pub struct Mssql {
     url: MssqlUrl,
     socket_timeout: Option<Duration>,
     is_healthy: AtomicBool,
+    system_name: &'static str,
 }
 
 impl Mssql {
@@ -91,6 +93,7 @@ impl Mssql {
             url,
             socket_timeout,
             is_healthy: AtomicBool::new(true),
+            system_name: SYSTEM_NAME,
         };
 
         if let Some(isolation) = this.url.transaction_isolation_level() {
@@ -130,7 +133,7 @@ impl Queryable for Mssql {
     }
 
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        metrics::query("mssql.query_raw", sql, params, move || async move {
+        metrics::query("mssql.query_raw", self.system_name, sql, params, move || async move {
             let mut client = self.client.lock().await;
 
             let mut query = tiberius::Query::new(sql);
@@ -193,7 +196,7 @@ impl Queryable for Mssql {
     }
 
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        metrics::query("mssql.execute_raw", sql, params, move || async move {
+        metrics::query("mssql.execute_raw", self.system_name, sql, params, move || async move {
             let mut query = tiberius::Query::new(sql);
 
             for param in params {
@@ -213,7 +216,7 @@ impl Queryable for Mssql {
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {
-        metrics::query("mssql.raw_cmd", cmd, &[], move || async move {
+        metrics::query("mssql.raw_cmd", self.system_name, cmd, &[], move || async move {
             let mut client = self.client.lock().await;
             self.perform_io(client.simple_query(cmd)).await?.into_results().await?;
             Ok(())

--- a/quaint/src/connector/mysql/native/mod.rs
+++ b/quaint/src/connector/mysql/native/mod.rs
@@ -68,6 +68,8 @@ impl MysqlUrl {
     }
 }
 
+const SYSTEM_NAME: &'static str = "mysql";
+
 /// A connector interface for the MySQL database.
 #[derive(Debug)]
 pub struct Mysql {
@@ -76,6 +78,7 @@ pub struct Mysql {
     socket_timeout: Option<Duration>,
     is_healthy: AtomicBool,
     statement_cache: Mutex<LruCache<String, my::Statement>>,
+    system_name: &'static str,
 }
 
 impl Mysql {
@@ -89,6 +92,7 @@ impl Mysql {
             statement_cache: Mutex::new(url.cache()),
             url,
             is_healthy: AtomicBool::new(true),
+            system_name: SYSTEM_NAME,
         })
     }
 
@@ -195,7 +199,7 @@ impl Queryable for Mysql {
     }
 
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
-        metrics::query("mysql.query_raw", sql, params, move || async move {
+        metrics::query("mysql.query_raw", self.system_name, sql, params, move || async move {
             self.prepared(sql, |stmt| async move {
                 let mut conn = self.conn.lock().await;
                 let rows: Vec<my::Row> = conn.exec(&stmt, conversion::conv_params(params)?).await?;
@@ -280,7 +284,7 @@ impl Queryable for Mysql {
     }
 
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
-        metrics::query("mysql.execute_raw", sql, params, move || async move {
+        metrics::query("mysql.execute_raw", self.system_name, sql, params, move || async move {
             self.prepared(sql, |stmt| async move {
                 let mut conn = self.conn.lock().await;
                 conn.exec_drop(stmt, conversion::conv_params(params)?).await?;
@@ -297,7 +301,7 @@ impl Queryable for Mysql {
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {
-        metrics::query("mysql.raw_cmd", cmd, &[], move || async move {
+        metrics::query("mysql.raw_cmd", self.system_name, cmd, &[], move || async move {
             self.perform_io(|| async move {
                 let mut conn = self.conn.lock().await;
                 let mut result = cmd.run(&mut *conn).await?;

--- a/quaint/src/connector/postgres/native/mod.rs
+++ b/quaint/src/connector/postgres/native/mod.rs
@@ -55,6 +55,9 @@ impl Debug for PostgresClient {
     }
 }
 
+const SYSTEM_NAME_POSTGRESQL: &str = "postgresql";
+const SYSTEM_NAME_COCKROACHDB: &str = "cockroachdb";
+
 /// A connector interface for the PostgreSQL database.
 #[derive(Debug)]
 pub struct PostgreSql {
@@ -65,6 +68,7 @@ pub struct PostgreSql {
     is_healthy: AtomicBool,
     is_cockroachdb: bool,
     is_materialize: bool,
+    system_name: &'static str,
 }
 
 /// Key uniquely representing an SQL statement in the prepared statements cache.
@@ -285,6 +289,12 @@ impl PostgreSql {
             }
         }
 
+        let system_name = if is_cockroachdb {
+            SYSTEM_NAME_COCKROACHDB
+        } else {
+            SYSTEM_NAME_POSTGRESQL
+        };
+
         Ok(Self {
             client: PostgresClient(client),
             socket_timeout: url.query_params.socket_timeout,
@@ -293,6 +303,7 @@ impl PostgreSql {
             is_healthy: AtomicBool::new(true),
             is_cockroachdb,
             is_materialize,
+            system_name,
         })
     }
 
@@ -308,6 +319,7 @@ impl PostgreSql {
             is_healthy: AtomicBool::new(true),
             is_cockroachdb: false,
             is_materialize: false,
+            system_name: SYSTEM_NAME_POSTGRESQL,
         })
     }
 
@@ -539,72 +551,84 @@ impl Queryable for PostgreSql {
     async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
         self.check_bind_variables_len(params)?;
 
-        metrics::query("postgres.query_raw", sql, params, move || async move {
-            let stmt = self.fetch_cached(sql, &[]).await?;
+        metrics::query(
+            "postgres.query_raw",
+            self.system_name,
+            sql,
+            params,
+            move || async move {
+                let stmt = self.fetch_cached(sql, &[]).await?;
 
-            if stmt.params().len() != params.len() {
-                let kind = ErrorKind::IncorrectNumberOfParameters {
-                    expected: stmt.params().len(),
-                    actual: params.len(),
-                };
+                if stmt.params().len() != params.len() {
+                    let kind = ErrorKind::IncorrectNumberOfParameters {
+                        expected: stmt.params().len(),
+                        actual: params.len(),
+                    };
 
-                return Err(Error::builder(kind).build());
-            }
+                    return Err(Error::builder(kind).build());
+                }
 
-            let rows = self
-                .perform_io(self.client.0.query(&stmt, conversion::conv_params(params).as_slice()))
-                .await?;
+                let rows = self
+                    .perform_io(self.client.0.query(&stmt, conversion::conv_params(params).as_slice()))
+                    .await?;
 
-            let col_types = stmt
-                .columns()
-                .iter()
-                .map(|c| PGColumnType::from_pg_type(c.type_()))
-                .map(ColumnType::from)
-                .collect::<Vec<_>>();
-            let mut result = ResultSet::new(stmt.to_column_names(), col_types, Vec::new());
+                let col_types = stmt
+                    .columns()
+                    .iter()
+                    .map(|c| PGColumnType::from_pg_type(c.type_()))
+                    .map(ColumnType::from)
+                    .collect::<Vec<_>>();
+                let mut result = ResultSet::new(stmt.to_column_names(), col_types, Vec::new());
 
-            for row in rows {
-                result.rows.push(row.get_result_row()?);
-            }
+                for row in rows {
+                    result.rows.push(row.get_result_row()?);
+                }
 
-            Ok(result)
-        })
+                Ok(result)
+            },
+        )
         .await
     }
 
     async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<ResultSet> {
         self.check_bind_variables_len(params)?;
 
-        metrics::query("postgres.query_raw", sql, params, move || async move {
-            let stmt = self.fetch_cached(sql, params).await?;
+        metrics::query(
+            "postgres.query_raw",
+            self.system_name,
+            sql,
+            params,
+            move || async move {
+                let stmt = self.fetch_cached(sql, params).await?;
 
-            if stmt.params().len() != params.len() {
-                let kind = ErrorKind::IncorrectNumberOfParameters {
-                    expected: stmt.params().len(),
-                    actual: params.len(),
-                };
+                if stmt.params().len() != params.len() {
+                    let kind = ErrorKind::IncorrectNumberOfParameters {
+                        expected: stmt.params().len(),
+                        actual: params.len(),
+                    };
 
-                return Err(Error::builder(kind).build());
-            }
+                    return Err(Error::builder(kind).build());
+                }
 
-            let col_types = stmt
-                .columns()
-                .iter()
-                .map(|c| PGColumnType::from_pg_type(c.type_()))
-                .map(ColumnType::from)
-                .collect::<Vec<_>>();
-            let rows = self
-                .perform_io(self.client.0.query(&stmt, conversion::conv_params(params).as_slice()))
-                .await?;
+                let col_types = stmt
+                    .columns()
+                    .iter()
+                    .map(|c| PGColumnType::from_pg_type(c.type_()))
+                    .map(ColumnType::from)
+                    .collect::<Vec<_>>();
+                let rows = self
+                    .perform_io(self.client.0.query(&stmt, conversion::conv_params(params).as_slice()))
+                    .await?;
 
-            let mut result = ResultSet::new(stmt.to_column_names(), col_types, Vec::new());
+                let mut result = ResultSet::new(stmt.to_column_names(), col_types, Vec::new());
 
-            for row in rows {
-                result.rows.push(row.get_result_row()?);
-            }
+                for row in rows {
+                    result.rows.push(row.get_result_row()?);
+                }
 
-            Ok(result)
-        })
+                Ok(result)
+            },
+        )
         .await
     }
 
@@ -692,53 +716,65 @@ impl Queryable for PostgreSql {
     async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
         self.check_bind_variables_len(params)?;
 
-        metrics::query("postgres.execute_raw", sql, params, move || async move {
-            let stmt = self.fetch_cached(sql, &[]).await?;
+        metrics::query(
+            "postgres.execute_raw",
+            self.system_name,
+            sql,
+            params,
+            move || async move {
+                let stmt = self.fetch_cached(sql, &[]).await?;
 
-            if stmt.params().len() != params.len() {
-                let kind = ErrorKind::IncorrectNumberOfParameters {
-                    expected: stmt.params().len(),
-                    actual: params.len(),
-                };
+                if stmt.params().len() != params.len() {
+                    let kind = ErrorKind::IncorrectNumberOfParameters {
+                        expected: stmt.params().len(),
+                        actual: params.len(),
+                    };
 
-                return Err(Error::builder(kind).build());
-            }
+                    return Err(Error::builder(kind).build());
+                }
 
-            let changes = self
-                .perform_io(self.client.0.execute(&stmt, conversion::conv_params(params).as_slice()))
-                .await?;
+                let changes = self
+                    .perform_io(self.client.0.execute(&stmt, conversion::conv_params(params).as_slice()))
+                    .await?;
 
-            Ok(changes)
-        })
+                Ok(changes)
+            },
+        )
         .await
     }
 
     async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> crate::Result<u64> {
         self.check_bind_variables_len(params)?;
 
-        metrics::query("postgres.execute_raw", sql, params, move || async move {
-            let stmt = self.fetch_cached(sql, params).await?;
+        metrics::query(
+            "postgres.execute_raw",
+            self.system_name,
+            sql,
+            params,
+            move || async move {
+                let stmt = self.fetch_cached(sql, params).await?;
 
-            if stmt.params().len() != params.len() {
-                let kind = ErrorKind::IncorrectNumberOfParameters {
-                    expected: stmt.params().len(),
-                    actual: params.len(),
-                };
+                if stmt.params().len() != params.len() {
+                    let kind = ErrorKind::IncorrectNumberOfParameters {
+                        expected: stmt.params().len(),
+                        actual: params.len(),
+                    };
 
-                return Err(Error::builder(kind).build());
-            }
+                    return Err(Error::builder(kind).build());
+                }
 
-            let changes = self
-                .perform_io(self.client.0.execute(&stmt, conversion::conv_params(params).as_slice()))
-                .await?;
+                let changes = self
+                    .perform_io(self.client.0.execute(&stmt, conversion::conv_params(params).as_slice()))
+                    .await?;
 
-            Ok(changes)
-        })
+                Ok(changes)
+            },
+        )
         .await
     }
 
     async fn raw_cmd(&self, cmd: &str) -> crate::Result<()> {
-        metrics::query("postgres.raw_cmd", cmd, &[], move || async move {
+        metrics::query("postgres.raw_cmd", self.system_name, cmd, &[], move || async move {
             self.perform_io(self.client.0.simple_query(cmd)).await?;
             Ok(())
         })

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/mod.rs
@@ -23,6 +23,8 @@ use std::time::Instant;
 use tracing::{debug, info_span};
 use tracing_futures::Instrument;
 
+const SYSTEM_NAME: &'static str = "mongodb";
+
 /// Transforms a document to a `Record`, fields ordered as defined in `fields`.
 fn document_to_record(mut doc: Document, fields: &[String], meta_mapping: &OutputMetaMapping) -> crate::Result<Record> {
     let mut values: Vec<PrismaValue> = Vec::with_capacity(fields.len());
@@ -69,6 +71,7 @@ where
     let span = info_span!(
         "prisma:engine:db_query",
         user_facing = true,
+        "db.system" = SYSTEM_NAME,
         "db.statement" = %Arc::clone(&query_string)
     );
 

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -12,6 +12,15 @@ pub trait Connector {
     /// Returns the name of the connector.
     fn name(&self) -> &'static str;
 
+    /// The database system name, as per the OTEL spec.
+    /// In most cases, this is the same as the connector's name.
+    /// Reference:
+    /// - https://opentelemetry.io/docs/specs/semconv/database/sql/
+    /// - https://opentelemetry.io/docs/specs/semconv/database/mongodb/
+    fn system_name(&self) -> &'static str {
+        self.name()
+    }
+
     /// Returns whether a connector should retry an entire transaction when that transaction failed during its execution
     /// because of a transient transaction error. Note: This is specific to MongoDB for now.
     fn should_retry_on_transient_error(&self) -> bool;

--- a/query-engine/connectors/sql-query-connector/src/database/native/postgresql.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/native/postgresql.rs
@@ -13,6 +13,7 @@ pub struct PostgreSql {
     pool: Quaint,
     connection_info: ConnectionInfo,
     features: psl::PreviewFeatures,
+    flavour: PostgresFlavour,
 }
 
 impl PostgreSql {
@@ -60,6 +61,7 @@ impl FromSource for PostgreSql {
             pool,
             connection_info,
             features,
+            flavour,
         })
     }
 }
@@ -77,6 +79,13 @@ impl Connector for PostgreSql {
 
     fn name(&self) -> &'static str {
         "postgres"
+    }
+
+    fn system_name(&self) -> &'static str {
+        match self.flavour {
+            PostgresFlavour::Postgres | PostgresFlavour::Unknown => "postgresql",
+            PostgresFlavour::Cockroach => "cockroachdb",
+        }
     }
 
     fn should_retry_on_transient_error(&self) -> bool {

--- a/query-engine/core/src/executor/execute_operation.rs
+++ b/query-engine/core/src/executor/execute_operation.rs
@@ -87,7 +87,9 @@ pub async fn execute_single_self_contained<C: Connector + Send + Sync>(
     let conn_span = info_span!(
         "prisma:engine:connection",
         user_facing = true,
-        "db.type" = connector.name()
+        // TODO: consider removing `db.type`
+        "db.type" = connector.name(),
+        "db.system" = connector.system_name(),
     );
     let conn = connector.get_connection().instrument(conn_span).await?;
 
@@ -120,7 +122,7 @@ pub async fn execute_many_self_contained<C: Connector + Send + Sync>(
         let conn_span = info_span!(
             "prisma:engine:connection",
             user_facing = true,
-            "db.type" = connector.name(),
+            "db.system" = connector.system_name(),
         );
         let conn = connector.get_connection().instrument(conn_span).await?;
 

--- a/query-engine/core/src/telemetry/models.rs
+++ b/query-engine/core/src/telemetry/models.rs
@@ -7,7 +7,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-const ACCEPT_ATTRIBUTES: &[&str] = &["db.statement", "itx_id", "db.type"];
+const ACCEPT_ATTRIBUTES: &[&str] = &["db.system", "db.statement", "itx_id", "db.type"];
 
 #[derive(Serialize, Debug, Clone, PartialEq, Eq)]
 pub struct TraceSpan {

--- a/query-engine/driver-adapters/src/transaction.rs
+++ b/query-engine/driver-adapters/src/transaction.rs
@@ -99,7 +99,14 @@ impl JsTransaction {
 
     pub async fn raw_phantom_cmd(&self, cmd: &str) -> quaint::Result<()> {
         let params = &[];
-        quaint::connector::metrics::query("js.raw_phantom_cmd", cmd, params, move || async move { Ok(()) }).await
+        quaint::connector::metrics::query(
+            "js.raw_phantom_cmd",
+            self.inner.system_name,
+            cmd,
+            params,
+            move || async move { Ok(()) },
+        )
+        .await
     }
 }
 


### PR DESCRIPTION
This PR closes https://github.com/prisma/prisma/issues/21472.
It applies the `db.system` attribute to `metrics` spans accoding to https://opentelemetry.io/docs/specs/semconv/database/database-spans/.

Here's the breakdown of how `db.system` is set for each connector:

- `provider = "postgres"` → `db.system = "postgresql"
- `provider = "cockroachdb" → `db.system = "cockroachdb"
- `provider = "mysql" → `db.system = "mysql"
  - Note: we don't set `db.system = "mariadb"` at this moment.
- provider = "sqlite" → `db.system = "sqlite"
- provider = "sqlserver" → `db.system = "mssql"
- provider = "mongodb" → `db.system = "mongodb"

Closes [OTEL-237](https://linear.app/prisma-company/issue/ORM-237/otel-spec-conformance-and-compatibility-with-different-collectors).