### PR TITLE
fix(schema-engine): Ensure WS migrations can use shadow database

### DIFF
--- a/quaint/src/connector/postgres/native/websocket.rs
+++ b/quaint/src/connector/postgres/native/websocket.rs
@@ -23,12 +23,16 @@ const CONNECTION_PARAMS_HEADER: &str = "Prisma-Connection-Parameters";
 const HOST_HEADER: &str = "Prisma-Db-Host";
 
 pub(crate) async fn connect_via_websocket(url: PostgresWebSocketUrl) -> crate::Result<Client> {
+    let db_name = url.overriden_db_name().map(ToOwned::to_owned);
     let (ws_stream, response) = connect_async(url).await?;
 
     let connection_params = require_header_value(response.headers(), CONNECTION_PARAMS_HEADER)?;
     let db_host = require_header_value(response.headers(), HOST_HEADER)?;
 
-    let config = Config::from_str(connection_params)?;
+    let mut config = Config::from_str(connection_params)?;
+    if let Some(db_name) = db_name {
+       config.dbname(&db_name);
+    }
     let ws_byte_stream = WsStream::new(ws_stream);
 
     let tls = TlsConnector::new(native_tls::TlsConnector::new()?, db_host);

--- a/quaint/src/connector/postgres/url.rs
+++ b/quaint/src/connector/postgres/url.rs
@@ -81,7 +81,7 @@ impl PostgresUrl {
     pub fn dbname(&self) -> &str {
         match self {
             Self::Native(url) => url.dbname(),
-            Self::WebSocket(_) => "postgres",
+            Self::WebSocket(url) => url.dbname(),
         }
     }
 
@@ -493,15 +493,28 @@ pub(crate) struct PostgresUrlQueryParams {
 pub struct PostgresWebSocketUrl {
     pub(crate) url: Url,
     pub(crate) api_key: String,
+    pub(crate) db_name: Option<String>,
 }
 
 impl PostgresWebSocketUrl {
     pub fn new(url: Url, api_key: String) -> Self {
-        Self { url, api_key }
+        Self { url, api_key, db_name: None }
+    }
+
+    pub fn override_db_name(&mut self, name: String) {
+        self.db_name = Some(name)
     }
 
     pub fn api_key(&self) -> &str {
         &self.api_key
+    }
+
+    pub fn dbname(&self) -> &str {
+        self.overriden_db_name().unwrap_or("postgres")
+    }
+
+    pub fn overriden_db_name(&self) -> Option<&str> {
+        self.db_name.as_ref().map(|s| s.as_str())
     }
 
     pub fn host(&self) -> &str {


### PR DESCRIPTION
Previousy, when creating shadow DB connection over websocket, we
connected to the same DB which broke in every `migrate` case except the
one that starts with clean migration history.

This PR ensures it works normally. Implementation is quite cursed
though: for WS we now allow to override db name via `dbname` query
string parameter. If set, we ignore `dbname` that we got from migration
server and use provided DB with the same username and password. Shadow
DB then uses this query string parameter to specify the url.

Close ORM-325
