### PR TITLE
chore: update toolchain and fix lint errors

### DIFF
--- a/.github/workflows/include/rust-wasm-setup/action.yml
+++ b/.github/workflows/include/rust-wasm-setup/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: |
         cargo binstall -y \
-            wasm-bindgen-cli@0.2.92 \
+            wasm-bindgen-cli@0.2.93 \
             wasm-opt@0.116.0
 
     - name: Install bc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6460,19 +6460,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -6497,9 +6498,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6507,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6520,9 +6521,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-logger"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ serde_repr = { version = "0.1.17" }
 serde-wasm-bindgen = { version = "0.5" }
 tracing = { version = "0.1" }
 tsify = { version = "0.4.5" }
-wasm-bindgen = { version = "0.2.92" }
+wasm-bindgen = { version = "0.2.93" }
 wasm-bindgen-futures = { version = "0.4" }
 wasm-rs-dbg = { version = "0.1.2", default-features = false, features = ["console-error"] }
 wasm-bindgen-test = { version = "0.3.0" }

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,12 @@
 {
   "nodes": {
     "crane": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
       "locked": {
-        "lastModified": 1722960479,
-        "narHash": "sha256-NhCkJJQhD5GUib8zN9JrmYGMwt4lCRp6ZVNzIiYCl0Y=",
+        "lastModified": 1728776144,
+        "narHash": "sha256-fROVjMcKRoGHofDm8dY3uDUtCMwUICh/KjBFQnuBzfg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "4c6c77920b8d44cd6660c1621dea6b3fc4b4c4f4",
+        "rev": "f876e3d905b922502f031aeec1a84490122254b7",
         "type": "github"
       },
       "original": {
@@ -27,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -62,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722813957,
-        "narHash": "sha256-IAoYyYnED7P8zrBFMnmp7ydaJfwTnwcnqxUElC1I26Y=",
+        "lastModified": 1728888510,
+        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cb9a96f23c491c081b38eab96d22fa958043c9fa",
+        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
         "type": "github"
       },
       "original": {
@@ -92,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1723170066,
-        "narHash": "sha256-SFkQfOA+8AIYJsPlQtxNP+z5jRLfz91z/aOrV94pPmw=",
+        "lastModified": 1729045942,
+        "narHash": "sha256-HjmK0x5Zm2TK2vFpC7XBM2e3EDNVnAIuEoU2FkeN8xw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fecfe4d7c96fea2982c7907997b387a6b52c1093",
+        "rev": "9de3cea452d2401d6f93c06ad985178a4e11d1fc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729045942,
-        "narHash": "sha256-HjmK0x5Zm2TK2vFpC7XBM2e3EDNVnAIuEoU2FkeN8xw=",
+        "lastModified": 1729184663,
+        "narHash": "sha256-uNyi5vQrzaLkt4jj6ZEOs4+4UqOAwP6jFG2s7LIDwIk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9de3cea452d2401d6f93c06ad985178a4e11d1fc",
+        "rev": "16fb78d443c1970dda9a0bbb93070c9d8598a925",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,6 @@
 {
   inputs = {
-    crane = {
-      url = "github:ipetkov/crane";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    crane.url = "github:ipetkov/crane";
     flake-parts = {
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -119,9 +119,9 @@ impl Error {
         }
     }
 
-    /// Construct a new UnknownError from a `PanicInfo` in a panic hook. `UnknownError`s created
-    /// with this constructor will have a proper, useful backtrace.
-    pub fn new_in_panic_hook(panic_info: &std::panic::PanicInfo<'_>) -> Self {
+    /// Construct a new UnknownError from a [`PanicHookInfo`] in a panic hook. [`UnknownError`]s
+    /// created with this constructor will have a proper, useful backtrace.
+    pub fn new_in_panic_hook(panic_info: &std::panic::PanicHookInfo<'_>) -> Self {
         let message = panic_info
             .payload()
             .downcast_ref::<&str>()

--- a/libs/user-facing-errors/src/schema_engine.rs
+++ b/libs/user-facing-errors/src/schema_engine.rs
@@ -15,25 +15,29 @@ pub struct DatabaseCreationFailed {
     code = "P3001",
     message = "Migration possible with destructive changes and possible data loss: {destructive_details}"
 )]
+#[allow(dead_code)]
 pub struct DestructiveMigrationDetected {
     pub destructive_details: String,
 }
 
+/// No longer used.
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P3002",
     message = "The attempted migration was rolled back: {database_error}"
 )]
+#[allow(dead_code)]
 struct MigrationRollback {
     pub database_error: String,
 }
 
-// No longer used.
+/// No longer used.
 #[derive(Debug, SimpleUserFacingError)]
 #[user_facing(
     code = "P3003",
     message = "The format of migrations changed, the saved migrations are no longer valid. To solve this problem, please follow the steps at: https://pris.ly/d/migrate"
 )]
+#[allow(dead_code)]
 pub struct DatabaseMigrationFormatChanged;
 
 #[derive(Debug, UserFacingError, Serialize)]

--- a/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
@@ -65,14 +65,11 @@ fn parse_configuration(datamodel: &str) -> ConnectorResult<(Datasource, String, 
 /// (rather than just the Schema Engine), this function will call [`ExternalInitializer::init_with_migration`].
 /// Otherwise, it will call [`ExternalInitializer::init`], and then proceed with the standard
 /// setup based on the Schema Engine.
-pub async fn setup_external<'a, EI>(
+pub async fn setup_external<'a>(
     driver_adapter: DriverAdapter,
-    initializer: EI,
+    initializer: impl ExternalInitializer<'a>,
     db_schemas: &[&str],
-) -> ConnectorResult<InitResult>
-where
-    EI: ExternalInitializer<'a> + ?Sized,
-{
+) -> ConnectorResult<InitResult> {
     let prisma_schema = initializer.datamodel();
     let (source, url, _preview_features) = parse_configuration(prisma_schema)?;
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
@@ -108,7 +108,7 @@ fn to_aggregation_rows(
 
                     for field in fields {
                         let meta = selection_meta.get(field.db_name()).unwrap();
-                        let bson = doc.remove(&format!("count_{}", field.db_name())).unwrap();
+                        let bson = doc.remove(format!("count_{}", field.db_name())).unwrap();
                         let field_val = value_from_bson(bson, meta)?;
 
                         row.push(AggregationResult::Count(Some(field.clone()), field_val));
@@ -117,7 +117,7 @@ fn to_aggregation_rows(
                 AggregationSelection::Average(fields) => {
                     for field in fields {
                         let meta = selection_meta.get(field.db_name()).unwrap();
-                        let bson = doc.remove(&format!("avg_{}", field.db_name())).unwrap();
+                        let bson = doc.remove(format!("avg_{}", field.db_name())).unwrap();
                         let field_val = value_from_bson(bson, meta)?;
 
                         row.push(AggregationResult::Average(field.clone(), field_val));
@@ -126,7 +126,7 @@ fn to_aggregation_rows(
                 AggregationSelection::Sum(fields) => {
                     for field in fields {
                         let meta = selection_meta.get(field.db_name()).unwrap();
-                        let bson = doc.remove(&format!("sum_{}", field.db_name())).unwrap();
+                        let bson = doc.remove(format!("sum_{}", field.db_name())).unwrap();
                         let field_val = value_from_bson(bson, meta)?;
 
                         row.push(AggregationResult::Sum(field.clone(), field_val));
@@ -135,7 +135,7 @@ fn to_aggregation_rows(
                 AggregationSelection::Min(fields) => {
                     for field in fields {
                         let meta = selection_meta.get(field.db_name()).unwrap();
-                        let bson = doc.remove(&format!("min_{}", field.db_name())).unwrap();
+                        let bson = doc.remove(format!("min_{}", field.db_name())).unwrap();
                         let field_val = value_from_bson(bson, meta)?;
 
                         row.push(AggregationResult::Min(field.clone(), field_val));
@@ -144,7 +144,7 @@ fn to_aggregation_rows(
                 AggregationSelection::Max(fields) => {
                     for field in fields {
                         let meta = selection_meta.get(field.db_name()).unwrap();
-                        let bson = doc.remove(&format!("max_{}", field.db_name())).unwrap();
+                        let bson = doc.remove(format!("max_{}", field.db_name())).unwrap();
                         let field_val = value_from_bson(bson, meta)?;
 
                         row.push(AggregationResult::Max(field.clone(), field_val));

--- a/query-engine/query-engine-wasm/rust-toolchain.toml
+++ b/query-engine/query-engine-wasm/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2024-05-25"
+channel = "nightly-2024-09-01"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     "wasm32-unknown-unknown",

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -227,10 +227,7 @@ async fn metrics_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
     // block and buffer request until the request has completed
     let full_body = hyper::body::to_bytes(body_start).await?;
 
-    let global_labels: HashMap<String, String> = match serde_json::from_slice(full_body.as_ref()) {
-        Ok(map) => map,
-        Err(_e) => HashMap::new(),
-    };
+    let global_labels: HashMap<String, String> = serde_json::from_slice(full_body.as_ref()).unwrap_or_default();
 
     let response = if requested_json {
         let metrics = cx.metrics.to_json(global_labels);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.80.1"
+channel = "1.81.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.

--- a/schema-engine/sql-migration-tests/src/assertions.rs
+++ b/schema-engine/sql-migration-tests/src/assertions.rs
@@ -191,13 +191,11 @@ impl SchemaAssertion {
     }
 
     fn print_context(&self) {
-        match &self.context {
-            Some(context) => println!("Test failure with context <{}>", context.red()),
-            None => {}
+        if let Some(context) = &self.context {
+            println!("Test failure with context <{}>", context.red())
         }
-        match &self.description {
-            Some(description) => println!("{}: {}", "Description".bold(), description.italic()),
-            None => {}
+        if let Some(description) = &self.description {
+            println!("{}: {}", "Description".bold(), description.italic())
         }
     }
 
@@ -325,13 +323,11 @@ pub struct TableAssertion<'a> {
 
 impl<'a> TableAssertion<'a> {
     fn print_context(&self) {
-        match &self.context {
-            Some(context) => println!("Test failure with context <{}>", context.red()),
-            None => {}
+        if let Some(context) = &self.context {
+            println!("Test failure with context <{}>", context.red())
         }
-        match &self.description {
-            Some(description) => println!("{}: {}", "Description".bold(), description.italic()),
-            None => {}
+        if let Some(description) = &self.description {
+            println!("{}: {}", "Description".bold(), description.italic())
         }
     }
 

--- a/schema-engine/sql-migration-tests/src/commands/schema_push.rs
+++ b/schema-engine/sql-migration-tests/src/commands/schema_push.rs
@@ -102,13 +102,11 @@ impl SchemaPushAssertion {
     }
 
     pub fn print_context(&self) {
-        match &self.context {
-            Some(context) => println!("Test failure with context <{}>", context.red()),
-            None => {}
+        if let Some(context) = &self.context {
+            println!("Test failure with context <{}>", context.red())
         }
-        match &self.description {
-            Some(description) => println!("{}: {}", "Description".bold(), description.italic()),
-            None => {}
+        if let Some(description) = &self.description {
+            println!("{}: {}", "Description".bold(), description.italic())
         }
     }
 

--- a/schema-engine/sql-migration-tests/tests/migrations/mssql.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/mssql.rs
@@ -158,7 +158,7 @@ fn mssql_apply_migrations_error_output(api: TestApi) {
         .split_terminator("   0: ")
         .next()
         .unwrap()
-        .trim_end_matches(|c| c == '\n' || c == ' ');
+        .trim_end_matches(['\n', ' ']);
 
     expectation.assert_eq(first_segment)
 }


### PR DESCRIPTION
- Update Nix flake
- Update Rust to 1.82.0
- Fix compiler warning for unused errors on Rust 1.81 (we keep those on purpose for documentation purposes)
- Fix deprecation warning on Rust 1.82
- Fix clippy warnings
- Update wasm-bindgen to match the version in Nix
- Update WASM toolchain to nightly-2024-09-01 (corresponds to Rust 1.82.0)