### PR TITLE
fix(schema): fix type clash for generated relation filter

### DIFF
--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -606,7 +606,7 @@ mod tests {
                           "isNullable": false,
                           "inputTypes": [
                             {
-                              "type": "BRelationFilter",
+                              "type": "BScalarRelationFilter",
                               "namespace": "prisma",
                               "location": "inputObjectTypes",
                               "isList": false
@@ -764,7 +764,7 @@ mod tests {
                           "isNullable": false,
                           "inputTypes": [
                             {
-                              "type": "BRelationFilter",
+                              "type": "BScalarRelationFilter",
                               "namespace": "prisma",
                               "location": "inputObjectTypes",
                               "isList": false
@@ -1037,7 +1037,7 @@ mod tests {
                           "isNullable": true,
                           "inputTypes": [
                             {
-                              "type": "ANullableRelationFilter",
+                              "type": "ANullableScalarRelationFilter",
                               "namespace": "prisma",
                               "location": "inputObjectTypes",
                               "isList": false
@@ -1174,7 +1174,7 @@ mod tests {
                           "isNullable": true,
                           "inputTypes": [
                             {
-                              "type": "ANullableRelationFilter",
+                              "type": "ANullableScalarRelationFilter",
                               "namespace": "prisma",
                               "location": "inputObjectTypes",
                               "isList": false
@@ -2037,7 +2037,7 @@ mod tests {
                       ]
                     },
                     {
-                      "name": "BRelationFilter",
+                      "name": "BScalarRelationFilter",
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2436,7 +2436,7 @@ mod tests {
                       ]
                     },
                     {
-                      "name": "ANullableRelationFilter",
+                      "name": "ANullableScalarRelationFilter",
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null

--- a/query-engine/schema/src/identifier_type.rs
+++ b/query-engine/schema/src/identifier_type.rs
@@ -186,7 +186,12 @@ impl std::fmt::Display for IdentifierType {
             IdentifierType::ToOneRelationFilterInput(related_model, arity) => {
                 let nullable = if arity.is_optional() { "Nullable" } else { "" };
 
-                write!(f, "{}{}RelationFilter", capitalize(related_model.name()), nullable)
+                write!(
+                    f,
+                    "{}{}ScalarRelationFilter",
+                    capitalize(related_model.name()),
+                    nullable
+                )
             }
             IdentifierType::ToOneCompositeFilterInput(ct, arity) => {
                 let nullable = if arity.is_optional() { "Nullable" } else { "" };

--- a/query-engine/schema/test-schemas/odoo.prisma
+++ b/query-engine/schema/test-schemas/odoo.prisma
@@ -1,5 +1,5 @@
 datasource db {
-  provider = "postgresql"
+  provider = "postgres"
   url      = env("DB_URL")
 }
 


### PR DESCRIPTION
**BREAKING**

Fixes https://github.com/prisma/prisma/issues/15718, closes [ORM-306](https://linear.app/prisma-company/issue/ORM-306/type-clash-in-generated-relation-filter-when-naming-models-something).
This is for Prisma 6. We're merging this to `integration/next` until we're ready for rebasing that branch into `main`.

/integration
