### PR TITLE
postgres: switch to query_typed api to avoid prepared statement overhead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,7 +3417,7 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#c62b9928d402685e152161907e8480603c29ef65"
+source = "git+https://github.com/tmm1/rust-postgres?branch=execute-typed#6debe5b6ba7f1e3904eb58f87a829b18e1735003"
 dependencies = [
  "native-tls",
  "tokio",
@@ -3428,7 +3428,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.7"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#c62b9928d402685e152161907e8480603c29ef65"
+source = "git+https://github.com/tmm1/rust-postgres?branch=execute-typed#6debe5b6ba7f1e3904eb58f87a829b18e1735003"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -3445,7 +3445,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.8"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#c62b9928d402685e152161907e8480603c29ef65"
+source = "git+https://github.com/tmm1/rust-postgres?branch=execute-typed#6debe5b6ba7f1e3904eb58f87a829b18e1735003"
 dependencies = [
  "bit-vec",
  "bytes",
@@ -5764,7 +5764,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.12"
-source = "git+https://github.com/prisma/rust-postgres?branch=pgbouncer-mode#c62b9928d402685e152161907e8480603c29ef65"
+source = "git+https://github.com/tmm1/rust-postgres?branch=execute-typed#6debe5b6ba7f1e3904eb58f87a829b18e1735003"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -168,8 +168,8 @@ features = [
   "with-serde_json-1",
   "with-bit-vec-0_6",
 ]
-git = "https://github.com/prisma/rust-postgres"
-branch = "pgbouncer-mode"
+git = "https://github.com/tmm1/rust-postgres"
+branch = "execute-typed"
 optional = true
 
 [dependencies.postgres-types]
@@ -179,13 +179,13 @@ features = [
   "with-serde_json-1",
   "with-bit-vec-0_6",
 ]
-git = "https://github.com/prisma/rust-postgres"
-branch = "pgbouncer-mode"
+git = "https://github.com/tmm1/rust-postgres"
+branch = "execute-typed"
 optional = true
 
 [dependencies.postgres-native-tls]
-git = "https://github.com/prisma/rust-postgres"
-branch = "pgbouncer-mode"
+git = "https://github.com/tmm1/rust-postgres"
+branch = "execute-typed"
 optional = true
 
 [dependencies.tokio]

--- a/quaint/src/connector/postgres/native/mod.rs
+++ b/quaint/src/connector/postgres/native/mod.rs
@@ -729,15 +729,8 @@ impl Queryable for PostgreSql {
                     .collect();
 
                 let changes = self
-                    .perform_io(self.client.0.query_typed_raw::<&(dyn ToSql + Sync), _>(
-                        sql,
-                        params_with_types.as_slice().iter()
-                            .map(|(v, t)| (*v, t.clone()))
-                            .collect::<Vec<_>>()
-                    ))
-                    .await?
-                    .rows_affected()
-                    .unwrap_or(0);
+                    .perform_io(self.client.0.execute_typed(sql, params_with_types.as_slice()))
+                    .await?;
 
                 Ok(changes)
             },
@@ -763,15 +756,8 @@ impl Queryable for PostgreSql {
                     .collect();
 
                 let changes = self
-                    .perform_io(self.client.0.query_typed_raw::<&(dyn ToSql + Sync), _>(
-                        sql,
-                        params_with_types.as_slice().iter()
-                            .map(|(v, t)| (*v, t.clone()))
-                            .collect::<Vec<_>>()
-                    ))
-                    .await?
-                    .rows_affected()
-                    .unwrap_or(0);
+                    .perform_io(self.client.0.execute_typed(sql, params_with_types.as_slice()))
+                    .await?;
 
                 Ok(changes)
             },


### PR DESCRIPTION
implements the new `query_typed` api from https://github.com/sfackler/rust-postgres/pull/1147

this will remove extra round-trips to the database to create prepared statements.

these roundtrips are especially apparent when statement caching is unavailable, such as when using pgbouncer.

statement cache was also ineffective when using traceparent tracing, because sql comments are part of the statement cache key.

follow up to #5027

fixes #5025 #5017

cc @aqrln 
