### PR TITLE
chore(driver-adapters): update napi to 2.16.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2794,9 +2794,9 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.15.1"
+version = "2.16.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43792514b0c95c5beec42996da0c1b39265b02b75c97baa82d163d3ef55cbfa7"
+checksum = "214f07a80874bb96a8433b3cdfc84980d56c7b02e1a0d7ba4ba0db5cef785e2b"
 dependencies = [
  "bitflags 2.4.0",
  "ctor",
@@ -2816,9 +2816,9 @@ checksum = "ebd4419172727423cf30351406c54f6cc1b354a2cfb4f1dba3e6cd07f6d5522b"
 
 [[package]]
 name = "napi-derive"
-version = "2.15.0"
+version = "2.16.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7622f0dbe0968af2dacdd64870eee6dee94f93c989c841f1ad8f300cf1abd514"
+checksum = "17435f7a00bfdab20b0c27d9c56f58f6499e418252253081bfff448099da31d1"
 dependencies = [
  "cfg-if",
  "convert_case 0.6.0",
@@ -2830,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.59"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec514d65fce18a959be55e7f683ac89c6cb850fb59b09e25ab777fd5a4a8d9e"
+checksum = "967c485e00f0bf3b1bdbe510a38a4606919cf1d34d9a37ad41f25a81aa077abe"
 dependencies = [
  "convert_case 0.6.0",
  "once_cell",
@@ -2845,9 +2845,9 @@ dependencies = [
 
 [[package]]
 name = "napi-sys"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2503fa6af34dc83fb74888df8b22afe933b58d37daf7d80424b1c60c68196b8b"
+checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
 dependencies = [
  "libloading 0.8.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,12 +58,12 @@ indoc = "2.0.1"
 indexmap = { version = "2.2.2", features = ["serde"] }
 itertools = "0.12"
 connection-string = "0.2"
-napi = { version = "2.15.1", default-features = false, features = [
+napi = { version = "2.16.13", default-features = false, features = [
   "napi8",
   "tokio_rt",
   "serde-json",
 ] }
-napi-derive = "2.15.0"
+napi-derive = "2.16.12"
 js-sys = { version = "0.3" }
 pin-project = "1"
 rand = { version = "0.8" }

--- a/query-engine/driver-adapters/src/lib.rs
+++ b/query-engine/driver-adapters/src/lib.rs
@@ -117,14 +117,14 @@ mod arch {
 
     pub(crate) fn get_named_property<T>(object: &::napi::JsObject, name: &str) -> JsResult<T>
     where
-        T: ::napi::bindgen_prelude::FromNapiValue,
+        T: ::napi::bindgen_prelude::FromNapiValue + ::napi::bindgen_prelude::ValidateNapiValue,
     {
         object.get_named_property(name)
     }
 
     pub(crate) fn get_optional_named_property<T>(object: &::napi::JsObject, name: &str) -> JsResult<Option<T>>
     where
-        T: ::napi::bindgen_prelude::FromNapiValue,
+        T: ::napi::bindgen_prelude::FromNapiValue + ::napi::bindgen_prelude::ValidateNapiValue,
     {
         if has_named_property(object, name)? {
             Ok(Some(get_named_property(object, name)?))

--- a/query-engine/driver-adapters/src/napi/adapter_method.rs
+++ b/query-engine/driver-adapters/src/napi/adapter_method.rs
@@ -79,3 +79,24 @@ where
         Self::from_threadsafe_function(threadsafe_fn, env)
     }
 }
+
+impl<ArgType, ReturnType> ValidateNapiValue for AdapterMethod<ArgType, ReturnType>
+where
+    ArgType: ToNapiValue + 'static,
+    ReturnType: FromNapiValue + 'static,
+{
+}
+
+impl<ArgType, ReturnType> TypeName for AdapterMethod<ArgType, ReturnType>
+where
+    ArgType: ToNapiValue + 'static,
+    ReturnType: FromNapiValue + 'static,
+{
+    fn type_name() -> &'static str {
+        "AdapterMethod"
+    }
+
+    fn value_type() -> ValueType {
+        ValueType::Function
+    }
+}

--- a/query-engine/driver-adapters/src/napi/result.rs
+++ b/query-engine/driver-adapters/src/napi/result.rs
@@ -1,11 +1,26 @@
 use crate::error::DriverAdapterError;
-use napi::{bindgen_prelude::FromNapiValue, Env, JsUnknown, NapiValue};
+use napi::{
+    bindgen_prelude::{FromNapiValue, TypeName, ValidateNapiValue},
+    Env, JsUnknown, NapiValue,
+};
 
 impl FromNapiValue for DriverAdapterError {
     unsafe fn from_napi_value(napi_env: napi::sys::napi_env, napi_val: napi::sys::napi_value) -> napi::Result<Self> {
         let env = Env::from_raw(napi_env);
         let value = JsUnknown::from_raw(napi_env, napi_val)?;
         env.from_js_value(value)
+    }
+}
+
+impl ValidateNapiValue for DriverAdapterError {}
+
+impl TypeName for DriverAdapterError {
+    fn type_name() -> &'static str {
+        "DriverAdapterError"
+    }
+
+    fn value_type() -> napi::ValueType {
+        napi::ValueType::Object
     }
 }
 


### PR DESCRIPTION
Updating `napi` to `2.16.13` will result in solving a recurrent `driverAdapter` bug that currently occurs for Postgres drivers:
> FATAL ERROR: threadsafe_function.rs:749 Failed to convert return value in ThreadsafeFunction callback into Rust value: GenericFailure, Failed to send return value to tokio sender

Context:
- [Github Actions](https://github.com/prisma/prisma/actions/runs/11666264046/job/32481604180?pr=25285#step:5:41)
- https://github.com/napi-rs/napi-rs/pull/1970