### PR TITLE
fix(nix): make engines buildable on darwin

### DIFF
--- a/nix/publish-engine-size.nix
+++ b/nix/publish-engine-size.nix
@@ -41,6 +41,7 @@ in
     ] ++ lib.optionals stdenv.isDarwin [
       perl # required to build openssl
       darwin.apple_sdk.frameworks.Security
+      darwin.apple_sdk.frameworks.SystemConfiguration
       iconv
     ];
 


### PR DESCRIPTION
After some recent dependency changes, building with Nix on Darwin also
requires having `SystemConfiguration.framework`.
