### PR TITLE
fix: temporarily rename `prisma:engine:query` back to `prisma:engine`

### DIFF
--- a/query-engine/query-engine-c-abi/src/engine.rs
+++ b/query-engine/query-engine-c-abi/src/engine.rs
@@ -296,7 +296,7 @@ impl QueryEngine {
 
             let query = RequestBody::try_from_str(&body, engine.engine_protocol())?;
 
-            let span = tracing::info_span!("prisma:engine:query", user_facing = true);
+            let span = tracing::info_span!("prisma:engine", user_facing = true);
             let parent_context = telemetry::helpers::restore_remote_context_from_json_str(&trace);
             let traceparent = TraceParent::from_remote_context(&parent_context);
             span.set_parent(parent_context);

--- a/query-engine/query-engine-node-api/src/engine.rs
+++ b/query-engine/query-engine-node-api/src/engine.rs
@@ -313,7 +313,7 @@ impl QueryEngine {
 
             let query = RequestBody::try_from_str(&body, engine.engine_protocol())?;
 
-            let span = tracing::info_span!("prisma:engine:query", user_facing = true);
+            let span = tracing::info_span!("prisma:engine", user_facing = true);
             let parent_context = telemetry::helpers::restore_remote_context_from_json_str(&trace);
             let traceparent = TraceParent::from_remote_context(&parent_context);
             span.set_parent(parent_context);

--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -193,7 +193,7 @@ impl QueryEngine {
             let query = RequestBody::try_from_str(&body, engine.engine_protocol())?;
 
             async move {
-                let span = tracing::info_span!("prisma:engine:query", user_facing = true);
+                let span = tracing::info_span!("prisma:engine", user_facing = true);
                 let parent_context = telemetry::helpers::restore_remote_context_from_json_str(&trace);
                 let traceparent = TraceParent::from_remote_context(&parent_context);
                 span.set_parent(parent_context);

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -113,7 +113,7 @@ async fn request_handler(cx: Arc<PrismaContext>, req: Request<Body>) -> Result<R
     let headers = req.headers();
     let tx_id = try_get_transaction_id(headers);
     let (span, traceparent, ref capturer) =
-        setup_telemetry(info_span!("prisma:engine:query", user_facing = true), headers).await;
+        setup_telemetry(info_span!("prisma:engine", user_facing = true), headers).await;
 
     let query_timeout = query_timeout(headers);
 


### PR DESCRIPTION
This will be reverted in Prisma 6.
