### PR TITLE
feat: add schema to dmmf

### DIFF
--- a/prisma-fmt/src/get_datamodel.rs
+++ b/prisma-fmt/src/get_datamodel.rs
@@ -63,6 +63,7 @@ mod tests {
                 {
                   "name": "User",
                   "dbName": null,
+                  "schema": null,
                   "fields": [
                     {
                       "name": "id",
@@ -122,6 +123,7 @@ mod tests {
                 {
                   "name": "Post",
                   "dbName": null,
+                  "schema": null,
                   "fields": [
                     {
                       "name": "id",

--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -373,6 +373,7 @@ mod tests {
                   {
                     "name": "A",
                     "dbName": null,
+                    "schema": null,
                     "fields": [
                       {
                         "name": "id",
@@ -432,6 +433,7 @@ mod tests {
                   {
                     "name": "B",
                     "dbName": null,
+                    "schema": null,
                     "fields": [
                       {
                         "name": "id",

--- a/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
+++ b/query-engine/dmmf/src/ast_builders/datamodel_ast_builder.rs
@@ -66,6 +66,7 @@ fn composite_type_to_dmmf(ct: walkers::CompositeTypeWalker<'_>) -> Model {
     Model {
         name: ct.name().to_owned(),
         db_name: None,
+        schema: None,
         fields: ct
             .fields()
             .filter(|field| !matches!(field.r#type(), ScalarFieldType::Unsupported(_)))
@@ -130,6 +131,7 @@ fn model_to_dmmf(model: walkers::ModelWalker<'_>) -> Model {
     Model {
         name: model.name().to_owned(),
         db_name: model.mapped_name().map(ToOwned::to_owned),
+        schema: model.schema().map(|(s, _)| s.to_owned()),
         fields: model
             .fields()
             .filter(|field| !should_skip_model_field(field))

--- a/query-engine/dmmf/src/serialization_ast/datamodel_ast.rs
+++ b/query-engine/dmmf/src/serialization_ast/datamodel_ast.rs
@@ -64,6 +64,8 @@ pub struct Function {
 pub struct Model {
     pub name: String,
     pub db_name: Option<String>,
+    pub schema: Option<String>,
+
     pub fields: Vec<Field>,
     pub primary_key: Option<PrimaryKey>,
     pub unique_fields: Vec<Vec<String>>,

--- a/query-engine/dmmf/test_files/functions.json
+++ b/query-engine/dmmf/test_files/functions.json
@@ -4,6 +4,7 @@
     {
       "name": "User",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",

--- a/query-engine/dmmf/test_files/general.json
+++ b/query-engine/dmmf/test_files/general.json
@@ -23,6 +23,7 @@
     {
       "name": "User",
       "dbName": "user",
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -124,6 +125,7 @@
     {
       "name": "Profile",
       "dbName": "profile",
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -197,6 +199,7 @@
     {
       "name": "Post",
       "dbName": "post",
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -352,6 +355,7 @@
     {
       "name": "Category",
       "dbName": "category",
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -421,6 +425,7 @@
     {
       "name": "PostToCategory",
       "dbName": "post_to_category",
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -544,6 +549,7 @@
     {
       "name": "A",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -603,6 +609,7 @@
     {
       "name": "B",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -644,6 +651,7 @@
     {
       "name": "NamedCompounds",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "a",
@@ -729,6 +737,7 @@
     {
       "name": "MappedSingles",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "a",

--- a/query-engine/dmmf/test_files/ignore.json
+++ b/query-engine/dmmf/test_files/ignore.json
@@ -4,6 +4,7 @@
     {
       "name": "User",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",

--- a/query-engine/dmmf/test_files/indexes_mongodb.json
+++ b/query-engine/dmmf/test_files/indexes_mongodb.json
@@ -4,6 +4,7 @@
     {
       "name": "Post",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -76,6 +77,7 @@
     {
       "name": "Comment",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "userId",

--- a/query-engine/dmmf/test_files/indexes_mysql.json
+++ b/query-engine/dmmf/test_files/indexes_mysql.json
@@ -4,6 +4,7 @@
     {
       "name": "Post",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "title",

--- a/query-engine/dmmf/test_files/indexes_postgres.json
+++ b/query-engine/dmmf/test_files/indexes_postgres.json
@@ -4,6 +4,7 @@
     {
       "name": "Example",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",

--- a/query-engine/dmmf/test_files/indexes_sqlserver.json
+++ b/query-engine/dmmf/test_files/indexes_sqlserver.json
@@ -4,6 +4,7 @@
     {
       "name": "Example",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -42,6 +43,7 @@
     {
       "name": "Post",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "title",

--- a/query-engine/dmmf/test_files/schemas.json
+++ b/query-engine/dmmf/test_files/schemas.json
@@ -1,0 +1,78 @@
+{
+  "enums": [],
+  "models": [
+    {
+      "name": "A",
+      "dbName": null,
+      "schema": "public",
+      "fields": [
+        {
+          "name": "id",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": true,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "Int",
+          "nativeType": null,
+          "isGenerated": false,
+          "isUpdatedAt": false
+        }
+      ],
+      "primaryKey": null,
+      "uniqueFields": [],
+      "uniqueIndexes": [],
+      "isGenerated": false
+    },
+    {
+      "name": "B",
+      "dbName": null,
+      "schema": "test",
+      "fields": [
+        {
+          "name": "id",
+          "kind": "scalar",
+          "isList": false,
+          "isRequired": true,
+          "isUnique": false,
+          "isId": true,
+          "isReadOnly": false,
+          "hasDefaultValue": false,
+          "type": "Int",
+          "nativeType": null,
+          "isGenerated": false,
+          "isUpdatedAt": false
+        }
+      ],
+      "primaryKey": null,
+      "uniqueFields": [],
+      "uniqueIndexes": [],
+      "isGenerated": false
+    }
+  ],
+  "types": [],
+  "indexes": [
+    {
+      "model": "A",
+      "type": "id",
+      "isDefinedOnField": true,
+      "fields": [
+        {
+          "name": "id"
+        }
+      ]
+    },
+    {
+      "model": "B",
+      "type": "id",
+      "isDefinedOnField": true,
+      "fields": [
+        {
+          "name": "id"
+        }
+      ]
+    }
+  ]
+}

--- a/query-engine/dmmf/test_files/schemas.prisma
+++ b/query-engine/dmmf/test_files/schemas.prisma
@@ -1,0 +1,22 @@
+datasource pg {
+  provider = "postgresql"
+  url      = "postgresql://"
+  schemas  = ["public", "test"]
+}
+
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["multiSchema"]
+}
+
+model A {
+  id Int @id
+
+  @@schema("public")
+}
+
+model B {
+  id Int @id
+
+  @@schema("test")
+}

--- a/query-engine/dmmf/test_files/source_with_comments.json
+++ b/query-engine/dmmf/test_files/source_with_comments.json
@@ -4,6 +4,7 @@
     {
       "name": "Author",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",

--- a/query-engine/dmmf/test_files/source_with_generator.json
+++ b/query-engine/dmmf/test_files/source_with_generator.json
@@ -4,6 +4,7 @@
     {
       "name": "Author",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",

--- a/query-engine/dmmf/test_files/views.json
+++ b/query-engine/dmmf/test_files/views.json
@@ -4,6 +4,7 @@
     {
       "name": "User",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -73,6 +74,7 @@
     {
       "name": "Profile",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -146,6 +148,7 @@
     {
       "name": "UserInfo",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",

--- a/query-engine/dmmf/test_files/without_relation_name.json
+++ b/query-engine/dmmf/test_files/without_relation_name.json
@@ -4,6 +4,7 @@
     {
       "name": "User",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",
@@ -45,6 +46,7 @@
     {
       "name": "Post",
       "dbName": null,
+      "schema": null,
       "fields": [
         {
           "name": "id",


### PR DESCRIPTION
Add `schema: string | null` property to each `model` entry in the DMMF for use in client generators, Studio or other DMMF consumers.