### PR TITLE
chore!: bump minimal supported Node-API version to 9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ indexmap = { version = "2.2.2", features = ["serde"] }
 itertools = "0.12"
 connection-string = "0.2"
 napi = { version = "2.16.13", default-features = false, features = [
-  "napi8",
+  "napi9",
   "tokio_rt",
   "serde-json",
 ] }


### PR DESCRIPTION
With Node.js 16 support being dropped in Prisma 6, we now raise the
minimal supported Node-API version from 8 to 9 (which corresponds to
v18.17.0+, 20.3.0+, 21.0.0 and all later versions, see [1]).

[1]: https://nodejs.org/api/n-api.html#node-api-version-matrix

Ref: https://github.com/prisma/prisma/pull/25609
Ref: https://github.com/prisma/team-orm/issues/1340
