### PR TITLE
ci: fix build-engines.yml workflow failing on most pull requests

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -50,10 +50,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         run: |
           echo "Pull Request: ${{ github.event.pull_request.number }}"
-          echo "Repository Owner: $${{ github.repository_owner }}"
+          echo "Repository Owner: ${{ github.repository_owner }}"
           echo "Pull Request Author: ${{ github.actor }}"
           echo "Pull Request Author Association: ${{ github.event.pull_request.author_association }}"
-          # echo "Commit message:${{ steps.commit-msg.outputs.commit-msg }}"
+          cat <<END_OF_COMMIT_MESSAGE
+          Commit message:
+          ${{ steps.commit-msg.outputs.commit-msg }}
+          END_OF_COMMIT_MESSAGE
           echo "Commit message contains [integration]: ${{ contains(steps.commit-msg.outputs.commit-msg, '[integration]') }}"
 
       - name: 'Check if commit message conatains `[integration]` and the PR author has permissions to trigger the workflow'


### PR DESCRIPTION
Fix the "Build Engines" workflow failing whenever the commit message
contains multiple lines.

The offending line was previously commented out in [#4995] instead of
fixing or just removing it, working around some errors, but since the
problem was that the commit message here is not a bash variable but a GH
Actions template variable that becomes literal text in the rendered bash
script, commenting it out didn't do much for multi-line messages, as
only the first line would be commented.

Additionally, a "Repository Owner" line above had a bug with double
dollar sign, making the value of `${{ github.repository_owner }}` a name
of a non-existent bash variable.

[#4995]: https://github.com/prisma/prisma-engines/pull/4995
