### PR TITLE
fix(qe): fix broken shebang in query-engine-wasm/build.sh

### DIFF
--- a/query-engine/query-engine-wasm/build.sh
+++ b/query-engine/query-engine-wasm/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Call this script as `./build.sh <npm_version>`
 set -euo pipefail
 


### PR DESCRIPTION
`#!/bin/bash` is non-portable and only works on some systems that have bash in that location, which is not actually standard or necessarily expected.

The only two absolute paths one can rely on in portable scripts are `#!/bin/sh` (which is a POSIX standard) and `#!/usr/bin/env` (which is not technically mandated by a formal standard but is de-facto implemented on all Unix systems).

None of my systems have a usable bash installation in `/bin/bash`.

My Linux system only has bash in `/run/current-system/sw/bin/bash`, so the script fails with `./build.sh: cannot execute: required file not found`.

My macOS system has an ancient version of bash shipped with the system installed as `/bin/bash` (which Apple last updated in 2007 — 17 years ago — and will never ever update anymore for license reasons since bash 4+ switched to GPLv3; it's likely to be removed in future macOS versions though as macOS has long replaced bash with zsh as its shell of choice), and in some ways it's worse than not having any since modern bash scripts that assume bash 4 or 5 often fail or produce incorrect results with it. This specific script accidentally happens to work anyway, but the correct bash installation to use on this system is still `/opt/homebrew/bin/bash`.

Anything other than `/bin/sh` (be it `bash` or `python` or `node`) can only be dispatched via `/usr/bin/env` if a script is intended to be used on more than one machine because it's not possible to predict where the interpreter is going to be at.
