### PR TITLE
feat(schema-engine): prepare skeleton for implicit many-to-many table logical replication on Postgres

### DIFF
--- a/libs/test-setup/src/capabilities.rs
+++ b/libs/test-setup/src/capabilities.rs
@@ -3,8 +3,9 @@
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u8)]
 pub enum Capabilities {
-    ScalarLists = 0b0001,
-    Enums = 0b0010,
-    Json = 0b0100,
-    CreateDatabase = 0b1000,
+    ScalarLists = 1,
+    Enums = 1 << 1,
+    Json = 1 << 2,
+    CreateDatabase = 1 << 3,
+    LogicalReplication = 1 << 4,
 }

--- a/schema-engine/connectors/sql-schema-connector/src/apply_migration.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/apply_migration.rs
@@ -145,6 +145,12 @@ fn render_raw_sql(
             renderer.render_drop_table(table.namespace(), table.name())
         }
         SqlMigrationStep::RedefineIndex { index } => renderer.render_drop_and_recreate_index(schemas.walk(*index)),
+        SqlMigrationStep::ImplicitManyToManyRefinement { index, table_id } => {
+            vec![renderer.refine_implicit_many_to_many_table(
+                schemas.next.walk(*table_id).name(),
+                schemas.next.walk(*index).name(),
+            )]
+        }
         SqlMigrationStep::AddForeignKey { foreign_key_id } => {
             let foreign_key = schemas.next.walk(*foreign_key_id);
             vec![renderer.render_add_foreign_key(foreign_key)]

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connection.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connection.rs
@@ -83,6 +83,9 @@ impl Connection {
         namespaces: Option<Namespaces>,
     ) -> ConnectorResult<SqlSchema> {
         use sql_schema_describer::{postgres as describer, DescriberErrorKind, SqlSchemaDescriberBackend};
+
+        // TODO: `sql_schema_connector::flavour::postgres::Circumstances` and `sql_schema_describer::Circumstances` are identitcal.
+        // What follows is a redundant and confusing mapping.
         let mut describer_circumstances: BitFlags<describer::Circumstances> = Default::default();
 
         if circumstances.contains(super::Circumstances::IsCockroachDb) {
@@ -95,6 +98,10 @@ impl Connection {
 
         if circumstances.contains(super::Circumstances::CanPartitionTables) {
             describer_circumstances |= describer::Circumstances::CanPartitionTables;
+        }
+
+        if circumstances.contains(super::Circumstances::CanReplicateLogically) {
+            describer_circumstances |= describer::Circumstances::CanReplicateLogically;
         }
 
         let namespaces_vec = Namespaces::to_vec(namespaces, String::from(params.url.schema()));

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer.rs
@@ -70,6 +70,10 @@ pub(crate) trait SqlRenderer {
         unreachable!("unreachable render_drop_and_recreate_index")
     }
 
+    fn refine_implicit_many_to_many_table(&self, _table_name: &str, _index_name: &str) -> String {
+        unreachable!("unreachable refine_implicit_many_to_many_table")
+    }
+
     /// Render a `DropEnum` step.
     fn render_drop_enum(&self, dropped_enum: EnumWalker<'_>) -> Vec<String>;
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -53,6 +53,14 @@ pub(crate) trait SqlSchemaDifferFlavour {
     /// Push AlterExtension steps.
     fn push_extension_steps(&self, _steps: &mut Vec<SqlMigrationStep>, _db: &DifferDatabase<'_>) {}
 
+    /// Push implicit many-to-many relation refinement steps.
+    fn push_implicit_many_to_many_refinement_steps(
+        &self,
+        _steps: &mut Vec<SqlMigrationStep>,
+        _db: &DifferDatabase<'_>,
+    ) {
+    }
+
     /// Define database-specific extension modules.
     fn define_extensions(&self, _db: &mut DifferDatabase<'_>) {}
 
@@ -106,6 +114,11 @@ pub(crate) trait SqlSchemaDifferFlavour {
     /// is dropped.
     fn should_drop_foreign_keys_from_dropped_tables(&self) -> bool {
         true
+    }
+
+    /// Whether the implicit many-to-many tables should be refined with further steps.
+    fn should_refine_implicit_many_to_many_tables(&self) -> bool {
+        false
     }
 
     /// Whether to skip diffing JSON defaults.

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/postgres.rs
@@ -36,6 +36,10 @@ static POSTGIS_TABLES_OR_VIEWS: Lazy<RegexSet> = Lazy::new(|| {
 static EXTENSION_VIEWS: Lazy<RegexSet> = Lazy::new(|| RegexSet::new(["(?i)^pg_buffercache$"]).unwrap());
 
 impl SqlSchemaDifferFlavour for PostgresFlavour {
+    fn should_refine_implicit_many_to_many_tables(&self) -> bool {
+        self.can_replicate_logically()
+    }
+
     fn can_alter_primary_keys(&self) -> bool {
         self.is_cockroachdb()
     }
@@ -95,6 +99,30 @@ impl SqlSchemaDifferFlavour for PostgresFlavour {
         for enm in db.dropped_enums() {
             steps.push(SqlMigrationStep::DropEnum(enm.id))
         }
+    }
+
+    fn push_implicit_many_to_many_refinement_steps(&self, steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {
+        // This stuff should only be applied if something changed in the schema.
+
+        // if self.is_cockroachdb() {
+        //     return;
+        // }
+
+        // let implicit_many_to_many_tables = db.table_pairs().map(|differ| differ.tables).filter_map(|table| {
+        //     if table.next.is_implicit_m2m() {
+        //         Some(table)
+        //     } else {
+        //         None
+        //     }
+        // });
+
+        // for table in implicit_many_to_many_tables {
+        //     let index = table.next.indexes().find(|idx| idx.is_unique()).unwrap().id;
+        //     let table_id = table.next.id;
+
+        //     println!("  steps++");
+        //     steps.push(SqlMigrationStep::ImplicitManyToManyRefinement { index, table_id });
+        // }
     }
 
     fn push_alter_sequence_steps(&self, steps: &mut Vec<SqlMigrationStep>, db: &DifferDatabase<'_>) {

--- a/schema-engine/sql-migration-tests/tests/migrations/relations.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/relations.rs
@@ -968,6 +968,7 @@ fn adding_mutual_references_on_existing_tables_works(api: TestApi) {
     };
 }
 
+// TODO: fails on Postgres
 #[test_connector]
 fn migrations_with_many_to_many_related_models_must_not_recreate_indexes(api: TestApi) {
     // test case for https://github.com/prisma/lift/issues/148

--- a/schema-engine/sql-migration-tests/tests/schema_push/mod.rs
+++ b/schema-engine/sql-migration-tests/tests/schema_push/mod.rs
@@ -370,6 +370,7 @@ fn duplicate_constraint_names_across_models_work_on_mysql(api: TestApi) {
     api.schema_push_w_datasource(plain_dm).send().assert_green();
 }
 
+// TODO: fails on Postgres
 #[test_connector(tags(Postgres))]
 fn implicit_relations_indices_are_not_renamed_unnecessarily(api: TestApi) {
     let dm = api.datamodel_with_provider(

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -109,6 +109,7 @@ pub enum Circumstances {
     Cockroach,
     CockroachWithPostgresNativeTypes, // TODO: this is a temporary workaround
     CanPartitionTables,
+    CanReplicateLogically,
 }
 
 pub struct SqlSchemaDescriber<'a> {

--- a/schema-engine/sql-schema-describer/src/walkers/table.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/table.rs
@@ -95,6 +95,15 @@ impl<'a> TableWalker<'a> {
         self.primary_key_columns().map(|cols| cols.len()).unwrap_or(0)
     }
 
+    /// Is the table an implicit many-to-many relation?
+    pub fn is_implicit_m2m(self) -> bool {
+        if self.columns().count() != 2 {
+            return false;
+        }
+
+        self.column("A").is_some() && self.column("B").is_some()
+    }
+
     /// Is the table a partition table?
     pub fn is_partition(self) -> bool {
         self.table().properties.contains(TableProperties::IsPartition)


### PR DESCRIPTION
**DRAFT, expect failures and incomplete code**

This PR:
- closes https://github.com/prisma/prisma/issues/25196
- closes [ORM-386](https://linear.app/prisma-company/issue/ORM-386/migrate-enable-support-for-logical-replication-on-implicit-m2m-tables)