### PR TITLE
feat(psl): GA `fullTextSearch` for `mysql`, introduce `nativeFullTextSearchPostgres` for `postgres`

### DIFF
--- a/libs/user-facing-errors/src/query_engine/mod.rs
+++ b/libs/user-facing-errors/src/query_engine/mod.rs
@@ -282,9 +282,9 @@ pub struct QueryParameterLimitExceeded {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P2030",
-    message = "Cannot find a fulltext index to use for the search, try adding a @@fulltext([Fields...]) to your schema"
+    message = "Cannot find a fulltext index to use for the native search, try adding a @@fulltext([Fields...]) to your schema"
 )]
-pub struct MissingFullTextSearchIndex {}
+pub struct MissingNativeFullTextSearchIndex {}
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -4,6 +4,7 @@ use crate::{
 };
 use colored::{ColoredString, Colorize};
 use indoc::indoc;
+use std::fmt::Display;
 
 /// A non-fatal warning emitted by the schema parser.
 /// For fancy printing, please use the `pretty_print_error` function.
@@ -20,10 +21,35 @@ impl DatamodelWarning {
         DatamodelWarning { message, span }
     }
 
-    pub fn new_feature_deprecated(feature: &str, span: Span) -> DatamodelWarning {
+    pub fn new_preview_feature_deprecated(feature: &str, span: Span) -> DatamodelWarning {
         let message = format!(
             "Preview feature \"{feature}\" is deprecated. The functionality can be used without specifying it as a preview feature."
         );
+        Self::new(message, span)
+    }
+
+    pub fn new_preview_feature_renamed(
+        deprecated_feature: &str,
+        renamed_feature: impl Display,
+        prisly_link_endpoint: &str,
+        span: Span,
+    ) -> DatamodelWarning {
+        let message = format!(
+                "Preview feature \"{deprecated_feature}\" has been renamed as \"{renamed_feature}\". Learn more at https://pris.ly/d/{prisly_link_endpoint}."
+            );
+        Self::new(message, span)
+    }
+
+    pub fn new_preview_feature_renamed_for_provider(
+        provider: &'static str,
+        deprecated_feature: &str,
+        renamed_feature: impl Display,
+        prisly_link_endpoint: &str,
+        span: Span,
+    ) -> DatamodelWarning {
+        let message = format!(
+                "On `provider = \"{provider}\"`, preview feature \"{deprecated_feature}\" has been renamed as \"{renamed_feature}\". Learn more at https://pris.ly/d/{prisly_link_endpoint}."
+            );
         Self::new(message, span)
     }
 

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -41,7 +41,7 @@ impl DatamodelWarning {
     }
 
     pub fn new_preview_feature_renamed_for_provider(
-        provider: &'static str,
+        provider: &str,
         deprecated_feature: &str,
         renamed_feature: impl Display,
         prisly_link_endpoint: &str,

--- a/psl/diagnostics/src/warning.rs
+++ b/psl/diagnostics/src/warning.rs
@@ -35,7 +35,7 @@ impl DatamodelWarning {
         span: Span,
     ) -> DatamodelWarning {
         let message = format!(
-                "Preview feature \"{deprecated_feature}\" has been renamed as \"{renamed_feature}\". Learn more at https://pris.ly/d/{prisly_link_endpoint}."
+                "Preview feature \"{deprecated_feature}\" has been renamed to \"{renamed_feature}\". Learn more at https://pris.ly/d/{prisly_link_endpoint}."
             );
         Self::new(message, span)
     }
@@ -48,7 +48,7 @@ impl DatamodelWarning {
         span: Span,
     ) -> DatamodelWarning {
         let message = format!(
-                "On `provider = \"{provider}\"`, preview feature \"{deprecated_feature}\" has been renamed as \"{renamed_feature}\". Learn more at https://pris.ly/d/{prisly_link_endpoint}."
+                "On `provider = \"{provider}\"`, preview feature \"{deprecated_feature}\" has been renamed to \"{renamed_feature}\". Learn more at https://pris.ly/d/{prisly_link_endpoint}."
             );
         Self::new(message, span)
     }

--- a/psl/psl-core/src/builtin_connectors/mysql_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/mysql_datamodel_connector.rs
@@ -47,8 +47,8 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     AdvancedJsonNullability |
     IndexColumnLengthPrefixing |
     FullTextIndex |
-    FullTextSearch |
-    FullTextSearchWithIndex |
+    NativeFullTextSearch |
+    NativeFullTextSearchWithIndex |
     MultipleFullTextAttributesPerModel |
     ImplicitManyToManyRelation |
     DecimalType |

--- a/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
@@ -266,6 +266,11 @@ impl Connector for PostgresDatamodelConnector {
         CAPABILITIES
     }
 
+    /// The connector-specific name of the `fullTextSearch` preview feature.
+    fn native_full_text_search_preview_feature(&self) -> Option<PreviewFeature> {
+        Some(PreviewFeature::NativeFullTextSearchPostgres)
+    }
+
     /// The maximum length of postgres identifiers, in bytes.
     ///
     /// Reference: <https://www.postgresql.org/docs/12/limits.html>

--- a/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
@@ -39,8 +39,8 @@ pub const CAPABILITIES: ConnectorCapabilities = enumflags2::make_bitflags!(Conne
     CreateSkipDuplicates |
     Enums |
     EnumArrayPush |
-    FullTextSearch |
-    FullTextSearchWithoutIndex |
+    NativeFullTextSearch |
+    NativeFullTextSearchWithoutIndex |
     InsensitiveFilters |
     Json |
     JsonFiltering |

--- a/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
+++ b/psl/psl-core/src/builtin_connectors/postgres_datamodel_connector.rs
@@ -268,7 +268,7 @@ impl Connector for PostgresDatamodelConnector {
 
     /// The connector-specific name of the `fullTextSearch` preview feature.
     fn native_full_text_search_preview_feature(&self) -> Option<PreviewFeature> {
-        Some(PreviewFeature::NativeFullTextSearchPostgres)
+        Some(PreviewFeature::FullTextSearchPostgres)
     }
 
     /// The maximum length of postgres identifiers, in bytes.

--- a/psl/psl-core/src/common.rs
+++ b/psl/psl-core/src/common.rs
@@ -2,4 +2,5 @@
 
 mod preview_features;
 
-pub use self::preview_features::{FeatureMap, PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES};
+pub(crate) use self::preview_features::RenamedFeature;
+pub use self::preview_features::{FeatureMapWithProvider, PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES};

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -269,7 +269,7 @@ impl<'a> FeatureMapWithProvider<'a> {
         provider_specific.or_else(|| {
             self.feature_map
                 .renamed
-                .get(&RenamedFeatureKey::<'a> {
+                .get(&RenamedFeatureKey {
                     from: flag,
                     provider: None,
                 })

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -53,6 +53,7 @@ features!(
     FilterJson,
     FullTextIndex,
     FullTextSearch,
+    NativeFullTextSearchPostgres,
     GroupBy,
     ImprovedQueryRaw,
     InteractiveTransactions,
@@ -90,7 +91,6 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
     active: enumflags2::make_bitflags!(PreviewFeature::{
         Deno
          | DriverAdapters
-         | FullTextSearch
          | Metrics
          | MultiSchema
          | NativeDistinct
@@ -117,6 +117,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | FilteredRelationCount
         | FilterJson
         | FullTextIndex
+        | FullTextSearch
         | GroupBy
         | ImprovedQueryRaw
         | InteractiveTransactions
@@ -136,7 +137,7 @@ pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
         | TransactionApi
         | UncheckedScalarInputs
     }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative | TypedSql}),
+    hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative | TypedSql | NativeFullTextSearchPostgres}),
 };
 
 #[derive(Debug)]

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -182,7 +182,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                     },
                     RenamedFeatureValue {
                         to: PreviewFeature::FullTextSearchPostgres,
-                        prisly_link_endpoint: "native-fts-postgres",
+                        prisly_link_endpoint: "fts-postgres",
                     },
                 ),
             ]),

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -116,7 +116,7 @@ pub(crate) enum RenamedFeature {
 }
 
 #[derive(Debug, Clone)]
-pub struct FeatureMap {
+struct FeatureMap {
     /// Valid, visible features.
     active: PreviewFeatures,
 

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -252,7 +252,7 @@ impl FeatureMapWithProvider {
     }
 
     /// Was the given preview feature deprecated and renamed?
-    pub(crate) fn is_renamed<'f>(&self, flag: PreviewFeature) -> Option<RenamedFeature> {
+    pub(crate) fn is_renamed(&self, flag: PreviewFeature) -> Option<RenamedFeature> {
         // Check for a renamed feature specific to the provider. This is only possible if a provider is not None.
         let provider_specific = self.provider.and_then(|provider| {
             self.feature_map
@@ -261,7 +261,7 @@ impl FeatureMapWithProvider {
                     from: flag,
                     provider: Some(provider),
                 })
-                .map(|renamed| RenamedFeature::ForProvider((provider, renamed.clone())))
+                .map(|renamed| RenamedFeature::ForProvider((provider, *renamed)))
         });
 
         // Fallback to provider-independent renamed feature
@@ -272,7 +272,7 @@ impl FeatureMapWithProvider {
                     from: flag,
                     provider: None,
                 })
-                .map(|renamed| RenamedFeature::AllProviders(renamed.clone()))
+                .map(|renamed| RenamedFeature::AllProviders(*renamed))
         })
     }
 }

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -55,7 +55,7 @@ features!(
     FilterJson,
     FullTextIndex,
     FullTextSearch,
-    NativeFullTextSearchPostgres,
+    FullTextSearchPostgres,
     GroupBy,
     ImprovedQueryRaw,
     InteractiveTransactions,
@@ -169,7 +169,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                 (
                     "postgresql",
                     enumflags2::make_bitflags!(PreviewFeature::{
-                        NativeFullTextSearchPostgres
+                        FullTextSearchPostgres
                     }),
                 ),
             ]),
@@ -181,7 +181,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                         provider: Some("postgresql"),
                     },
                     RenamedFeatureValue {
-                        to: PreviewFeature::NativeFullTextSearchPostgres,
+                        to: PreviewFeature::FullTextSearchPostgres,
                         prisly_link_endpoint: "native-fts-postgres",
                     },
                 ),

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -1,5 +1,7 @@
 use serde::{Serialize, Serializer};
+use std::collections::BTreeMap;
 use std::fmt;
+use std::sync::LazyLock;
 
 /// A set of preview features.
 pub type PreviewFeatures = enumflags2::BitFlags<PreviewFeature>;
@@ -8,7 +10,7 @@ macro_rules! features {
     ($( $variant:ident $(,)? ),*) => {
         #[enumflags2::bitflags]
         #[repr(u64)]
-        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
         pub enum PreviewFeature {
             $( $variant,)*
         }
@@ -86,88 +88,192 @@ features!(
     StrictUndefinedChecks
 );
 
-/// Generator preview features (alphabetically sorted)
-pub const ALL_PREVIEW_FEATURES: FeatureMap = FeatureMap {
-    active: enumflags2::make_bitflags!(PreviewFeature::{
-        Deno
-         | DriverAdapters
-         | Metrics
-         | MultiSchema
-         | NativeDistinct
-         | PostgresqlExtensions
-         | Tracing
-         | Views
-         | RelationJoins
-         | OmitApi
-         | PrismaSchemaFolder
-         | StrictUndefinedChecks
-    }),
-    deprecated: enumflags2::make_bitflags!(PreviewFeature::{
-        AtomicNumberOperations
-        | AggregateApi
-        | ClientExtensions
-        | Cockroachdb
-        | ConnectOrCreate
-        | CreateMany
-        | DataProxy
-        | Distinct
-        | ExtendedIndexes
-        | ExtendedWhereUnique
-        | FieldReference
-        | FilteredRelationCount
-        | FilterJson
-        | FullTextIndex
-        | FullTextSearch
-        | GroupBy
-        | ImprovedQueryRaw
-        | InteractiveTransactions
-        | JsonProtocol
-        | MicrosoftSqlServer
-        | Middlewares
-        | MongoDb
-        | NamedConstraints
-        | NApi
-        | NativeTypes
-        | OrderByAggregateGroup
-        | OrderByNulls
-        | OrderByRelation
-        | ReferentialActions
-        | ReferentialIntegrity
-        | SelectRelationCount
-        | TransactionApi
-        | UncheckedScalarInputs
-    }),
-    hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative | TypedSql | NativeFullTextSearchPostgres}),
-};
+#[derive(Copy, Clone, Debug, PartialOrd, Ord, PartialEq, Eq)]
+struct RenamedFeatureKey {
+    /// The old, deprecated preview feature that was renamed.
+    pub from: PreviewFeature,
 
-#[derive(Debug)]
+    /// The provider that the feature was renamed for.
+    pub provider: Option<&'static str>,
+}
+
+#[derive(Debug, Copy, Clone)]
+pub(crate) struct RenamedFeatureValue {
+    /// The new preview feature.
+    pub to: PreviewFeature,
+
+    /// The Pris.ly link endpoint for the feature, i.e., what comes after `https://pris.ly/d/`.
+    pub prisly_link_endpoint: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum RenamedFeature {
+    /// The preview feature was renamed for a specific provider.
+    ForProvider((&'static str, RenamedFeatureValue)),
+
+    /// The preview feature was renamed for all providers.
+    AllProviders(RenamedFeatureValue),
+}
+
+#[derive(Debug, Clone)]
 pub struct FeatureMap {
     /// Valid, visible features.
     active: PreviewFeatures,
 
+    /// Valid, but connector-specific features that are only visible on matching provider key.
+    native: BTreeMap<&'static str, PreviewFeatures>,
+
     /// Deprecated features.
     deprecated: PreviewFeatures,
+
+    /// History of renamed deprecated features.
+    renamed: BTreeMap<RenamedFeatureKey, RenamedFeatureValue>,
 
     /// Hidden preview features are valid features, but are not propagated into the tooling
     /// (as autocomplete or similar) or into error messages (eg. showing a list of valid features).
     hidden: PreviewFeatures,
 }
 
-impl FeatureMap {
-    pub const fn active_features(&self) -> PreviewFeatures {
-        self.active
+#[derive(Debug, Clone)]
+pub struct FeatureMapWithProvider {
+    provider: Option<&'static str>,
+    feature_map: FeatureMap,
+}
+
+/// The default feature map with an unknown provider.
+/// This is used for convenience in `prisma/language-tools`, which needs the list of all available preview features
+/// before a provider is necessarily known.
+pub static ALL_PREVIEW_FEATURES: LazyLock<FeatureMapWithProvider> = LazyLock::new(|| FeatureMapWithProvider::new(None));
+
+impl FeatureMapWithProvider {
+    pub fn new(connector_provider: Option<&'static str>) -> FeatureMapWithProvider {
+        // Generator preview features (alphabetically sorted)
+        let feature_map: FeatureMap = FeatureMap {
+            active: enumflags2::make_bitflags!(PreviewFeature::{
+                Deno
+                 | DriverAdapters
+                 | Metrics
+                 | MultiSchema
+                 | NativeDistinct
+                 | OmitApi
+                 | PostgresqlExtensions
+                 | PrismaSchemaFolder
+                 | RelationJoins
+                 | StrictUndefinedChecks
+                 | Tracing
+                 | Views
+            }),
+            native: BTreeMap::from([
+                #[cfg(feature = "postgresql")]
+                (
+                    "postgresql",
+                    enumflags2::make_bitflags!(PreviewFeature::{
+                        NativeFullTextSearchPostgres
+                    }),
+                ),
+            ]),
+            renamed: BTreeMap::from([
+                #[cfg(feature = "postgresql")]
+                (
+                    RenamedFeatureKey {
+                        from: PreviewFeature::FullTextSearch,
+                        provider: Some("postgresql"),
+                    },
+                    RenamedFeatureValue {
+                        to: PreviewFeature::NativeFullTextSearchPostgres,
+                        prisly_link_endpoint: "native-fts-postgres",
+                    },
+                ),
+            ]),
+            deprecated: enumflags2::make_bitflags!(PreviewFeature::{
+                AtomicNumberOperations
+                | AggregateApi
+                | ClientExtensions
+                | Cockroachdb
+                | ConnectOrCreate
+                | CreateMany
+                | DataProxy
+                | Distinct
+                | ExtendedIndexes
+                | ExtendedWhereUnique
+                | FieldReference
+                | FilteredRelationCount
+                | FilterJson
+                | FullTextIndex
+                | FullTextSearch
+                | GroupBy
+                | ImprovedQueryRaw
+                | InteractiveTransactions
+                | JsonProtocol
+                | MicrosoftSqlServer
+                | Middlewares
+                | MongoDb
+                | NamedConstraints
+                | NApi
+                | NativeTypes
+                | OrderByAggregateGroup
+                | OrderByNulls
+                | OrderByRelation
+                | ReferentialActions
+                | ReferentialIntegrity
+                | SelectRelationCount
+                | TransactionApi
+                | UncheckedScalarInputs
+            }),
+            hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative | TypedSql}),
+        };
+
+        Self {
+            provider: connector_provider,
+            feature_map,
+        }
+    }
+
+    pub fn native_features(&self) -> PreviewFeatures {
+        self.provider
+            .and_then(|provider| self.feature_map.native.get(provider).copied())
+            .unwrap_or_default()
+    }
+
+    pub fn active_features(&self) -> PreviewFeatures {
+        self.feature_map.active | self.native_features()
     }
 
     pub const fn hidden_features(&self) -> PreviewFeatures {
-        self.hidden
+        self.feature_map.hidden
     }
 
     pub(crate) fn is_valid(&self, flag: PreviewFeature) -> bool {
-        (self.active | self.hidden).contains(flag)
+        (self.active_features() | self.feature_map.hidden).contains(flag)
     }
 
     pub(crate) fn is_deprecated(&self, flag: PreviewFeature) -> bool {
-        self.deprecated.contains(flag)
+        self.feature_map.deprecated.contains(flag)
+    }
+
+    /// Was the given preview feature deprecated and renamed?
+    pub(crate) fn is_renamed<'f>(&self, flag: PreviewFeature) -> Option<RenamedFeature> {
+        // Check for a renamed feature specific to the provider. This is only possible if a provider is not None.
+        let provider_specific = self.provider.and_then(|provider| {
+            self.feature_map
+                .renamed
+                .get(&RenamedFeatureKey {
+                    from: flag,
+                    provider: Some(provider),
+                })
+                .map(|renamed| RenamedFeature::ForProvider((provider, renamed.clone())))
+        });
+
+        // Fallback to provider-independent renamed feature
+        provider_specific.or_else(|| {
+            self.feature_map
+                .renamed
+                .get(&RenamedFeatureKey {
+                    from: flag,
+                    provider: None,
+                })
+                .map(|renamed| RenamedFeature::AllProviders(renamed.clone()))
+        })
     }
 }
 

--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -59,6 +59,11 @@ pub trait Connector: Send + Sync {
     /// The static list of capabilities for the connector.
     fn capabilities(&self) -> ConnectorCapabilities;
 
+    /// The connector-specific name of the `fullTextSearch` preview feature.
+    fn native_full_text_search_preview_feature(&self) -> Option<PreviewFeature> {
+        None
+    }
+
     /// The maximum length of constraint names in bytes. Connectors without a
     /// limit should return usize::MAX.
     fn max_identifier_length(&self) -> usize;

--- a/psl/psl-core/src/datamodel_connector/capabilities.rs
+++ b/psl/psl-core/src/datamodel_connector/capabilities.rs
@@ -87,9 +87,9 @@ capabilities!(
     AnyId, // Any (or combination of) uniques and not only id fields can constitute an id for a model.
     SqlQueryRaw,
     MongoDbQueryRaw,
-    FullTextSearch,
-    FullTextSearchWithoutIndex,
-    FullTextSearchWithIndex,
+    NativeFullTextSearch,
+    NativeFullTextSearchWithoutIndex,
+    NativeFullTextSearchWithIndex,
     AdvancedJsonNullability,    // Connector distinguishes between their null type and JSON null.
     UndefinedType,              // Connector distinguishes `null` and `undefined`
     DecimalType,                // Connector supports Prisma Decimal type.

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -176,7 +176,7 @@ fn validate_configuration(
     // We need to know the active provider to determine which features are active.
     // This was originally introduced because the `fullTextSearch` preview feature will hit GA stage
     // one connector at a time (Prisma 6 GAs it for MySQL, other connectors may follow in future releases).
-    let feature_map_with_provider: FeatureMapWithProvider = datasources
+    let feature_map_with_provider: FeatureMapWithProvider<'_> = datasources
         .first()
         .map(|ds| Some(ds.active_provider))
         .map(FeatureMapWithProvider::new)

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -179,7 +179,7 @@ fn validate_configuration(
     let feature_map_with_provider: FeatureMapWithProvider = datasources
         .first()
         .map(|ds| Some(ds.active_provider))
-        .map(|provider| FeatureMapWithProvider::new(provider))
+        .map(FeatureMapWithProvider::new)
         .unwrap_or_else(|| (*ALL_PREVIEW_FEATURES).clone());
 
     let generators = generator_loader::load_generators_from_ast(schema_ast, diagnostics, &feature_map_with_provider);

--- a/psl/psl-core/src/lib.rs
+++ b/psl/psl-core/src/lib.rs
@@ -18,7 +18,7 @@ mod validate;
 use std::sync::Arc;
 
 pub use crate::{
-    common::{PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES},
+    common::{FeatureMapWithProvider, PreviewFeature, PreviewFeatures, ALL_PREVIEW_FEATURES},
     configuration::{
         Configuration, Datasource, DatasourceConnectorData, Generator, GeneratorConfigValue, StringFromEnvVar,
     },
@@ -171,8 +171,18 @@ fn validate_configuration(
     diagnostics: &mut Diagnostics,
     connectors: ConnectorRegistry<'_>,
 ) -> Configuration {
-    let generators = generator_loader::load_generators_from_ast(schema_ast, diagnostics);
     let datasources = datasource_loader::load_datasources_from_ast(schema_ast, diagnostics, connectors);
+
+    // We need to know the active provider to determine which features are active.
+    // This was originally introduced because the `fullTextSearch` preview feature will hit GA stage
+    // one connector at a time (Prisma 6 GAs it for MySQL, other connectors may follow in future releases).
+    let feature_map_with_provider: FeatureMapWithProvider = datasources
+        .first()
+        .map(|ds| Some(ds.active_provider))
+        .map(|provider| FeatureMapWithProvider::new(provider))
+        .unwrap_or_else(|| (*ALL_PREVIEW_FEATURES).clone());
+
+    let generators = generator_loader::load_generators_from_ast(schema_ast, diagnostics, &feature_map_with_provider);
 
     Configuration::new(generators, datasources, diagnostics.warnings().to_owned())
 }

--- a/psl/psl-core/src/validate/generator_loader.rs
+++ b/psl/psl-core/src/validate/generator_loader.rs
@@ -25,7 +25,7 @@ const FIRST_CLASS_PROPERTIES: &[&str] = &[PROVIDER_KEY, OUTPUT_KEY, BINARY_TARGE
 pub(crate) fn load_generators_from_ast(
     ast_schema: &ast::SchemaAst,
     diagnostics: &mut Diagnostics,
-    feature_map_with_provider: &FeatureMapWithProvider,
+    feature_map_with_provider: &FeatureMapWithProvider<'_>,
 ) -> Vec<Generator> {
     let mut generators: Vec<Generator> = Vec::new();
 
@@ -41,7 +41,7 @@ pub(crate) fn load_generators_from_ast(
 fn lift_generator(
     ast_generator: &ast::GeneratorConfig,
     diagnostics: &mut Diagnostics,
-    feature_map_with_provider: &FeatureMapWithProvider,
+    feature_map_with_provider: &FeatureMapWithProvider<'_>,
 ) -> Option<Generator> {
     let generator_name = ast_generator.name.name.as_str();
     let args: HashMap<_, &Expression> = ast_generator
@@ -140,7 +140,7 @@ fn lift_generator(
 
 fn parse_and_validate_preview_features(
     preview_features: Vec<&str>,
-    feature_map_with_provider: &FeatureMapWithProvider,
+    feature_map_with_provider: &FeatureMapWithProvider<'_>,
     span: ast::Span,
     diagnostics: &mut Diagnostics,
 ) -> BitFlags<PreviewFeature> {

--- a/psl/psl-core/src/validate/generator_loader.rs
+++ b/psl/psl-core/src/validate/generator_loader.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::WithSpan,
-    common::{FeatureMap, PreviewFeature, ALL_PREVIEW_FEATURES},
+    common::{FeatureMapWithProvider, PreviewFeature, RenamedFeature},
     configuration::{Generator, GeneratorConfigValue, StringFromEnvVar},
     diagnostics::*,
 };
@@ -22,11 +22,15 @@ const ENGINE_TYPE_KEY: &str = "engineType";
 const FIRST_CLASS_PROPERTIES: &[&str] = &[PROVIDER_KEY, OUTPUT_KEY, BINARY_TARGETS_KEY, PREVIEW_FEATURES_KEY];
 
 /// Load and validate Generators defined in an AST.
-pub(crate) fn load_generators_from_ast(ast_schema: &ast::SchemaAst, diagnostics: &mut Diagnostics) -> Vec<Generator> {
+pub(crate) fn load_generators_from_ast(
+    ast_schema: &ast::SchemaAst,
+    diagnostics: &mut Diagnostics,
+    feature_map_with_provider: &FeatureMapWithProvider,
+) -> Vec<Generator> {
     let mut generators: Vec<Generator> = Vec::new();
 
     for gen in ast_schema.generators() {
-        if let Some(generator) = lift_generator(gen, diagnostics) {
+        if let Some(generator) = lift_generator(gen, diagnostics, feature_map_with_provider) {
             generators.push(generator);
         }
     }
@@ -34,7 +38,11 @@ pub(crate) fn load_generators_from_ast(ast_schema: &ast::SchemaAst, diagnostics:
     generators
 }
 
-fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagnostics) -> Option<Generator> {
+fn lift_generator(
+    ast_generator: &ast::GeneratorConfig,
+    diagnostics: &mut Diagnostics,
+    feature_map_with_provider: &FeatureMapWithProvider,
+) -> Option<Generator> {
     let generator_name = ast_generator.name.name.as_str();
     let args: HashMap<_, &Expression> = ast_generator
         .properties
@@ -54,6 +62,7 @@ fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagno
         })
         .collect::<Option<HashMap<_, _>>>()?;
 
+    // E.g., "library"
     if let Some(expr) = args.get(ENGINE_TYPE_KEY) {
         if !expr.is_string() {
             diagnostics.push_error(DatamodelError::new_type_mismatch_error(
@@ -65,6 +74,7 @@ fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagno
         }
     }
 
+    // E.g., "prisma-client-js"
     let provider = match args.get(PROVIDER_KEY) {
         Some(val) => StringFromEnvVar::coerce(val, diagnostics)?,
         None => {
@@ -92,7 +102,7 @@ fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagno
     let preview_features = args
         .get(PREVIEW_FEATURES_KEY)
         .and_then(|v| coerce_array(v, &coerce::string, diagnostics).map(|arr| (arr, v.span())))
-        .map(|(arr, span)| parse_and_validate_preview_features(arr, &ALL_PREVIEW_FEATURES, span, diagnostics));
+        .map(|(arr, span)| parse_and_validate_preview_features(arr, feature_map_with_provider, span, diagnostics));
 
     for prop in &ast_generator.properties {
         let is_first_class_prop = FIRST_CLASS_PROPERTIES.iter().any(|k| *k == prop.name());
@@ -130,7 +140,7 @@ fn lift_generator(ast_generator: &ast::GeneratorConfig, diagnostics: &mut Diagno
 
 fn parse_and_validate_preview_features(
     preview_features: Vec<&str>,
-    feature_map: &FeatureMap,
+    feature_map_with_provider: &FeatureMapWithProvider,
     span: ast::Span,
     diagnostics: &mut Diagnostics,
 ) -> BitFlags<PreviewFeature> {
@@ -139,15 +149,44 @@ fn parse_and_validate_preview_features(
     for feature_str in preview_features {
         let feature_opt = PreviewFeature::parse_opt(feature_str);
         match feature_opt {
-            Some(feature) if feature_map.is_deprecated(feature) => {
-                features |= feature;
-                diagnostics.push_warning(DatamodelWarning::new_feature_deprecated(feature_str, span));
+            Some(feature) if feature_map_with_provider.is_deprecated(feature) => {
+                match feature_map_with_provider.is_renamed(feature) {
+                    Some(RenamedFeature::AllProviders(renamed_feature)) => {
+                        features |= renamed_feature.to;
+
+                        diagnostics.push_warning(DatamodelWarning::new_preview_feature_renamed(
+                            feature_str,
+                            renamed_feature.to,
+                            renamed_feature.prisly_link_endpoint,
+                            span,
+                        ));
+                    }
+                    Some(RenamedFeature::ForProvider((provider, renamed_feature))) => {
+                        features |= renamed_feature.to;
+
+                        diagnostics.push_warning(DatamodelWarning::new_preview_feature_renamed_for_provider(
+                            provider,
+                            feature_str,
+                            renamed_feature.to,
+                            renamed_feature.prisly_link_endpoint,
+                            span,
+                        ));
+                    }
+                    None => {
+                        features |= feature;
+                        diagnostics.push_warning(DatamodelWarning::new_preview_feature_deprecated(feature_str, span));
+                    }
+                }
             }
 
-            Some(feature) if !feature_map.is_valid(feature) => {
+            Some(feature) if !feature_map_with_provider.is_valid(feature) => {
                 diagnostics.push_error(DatamodelError::new_preview_feature_not_known_error(
                     feature_str,
-                    feature_map.active_features().iter().map(|pf| pf.to_string()).join(", "),
+                    feature_map_with_provider
+                        .active_features()
+                        .iter()
+                        .map(|pf| pf.to_string())
+                        .join(", "),
                     span,
                 ))
             }
@@ -156,7 +195,11 @@ fn parse_and_validate_preview_features(
 
             None => diagnostics.push_error(DatamodelError::new_preview_feature_not_known_error(
                 feature_str,
-                feature_map.active_features().iter().map(|pf| pf.to_string()).join(", "),
+                feature_map_with_provider
+                    .active_features()
+                    .iter()
+                    .map(|pf| pf.to_string())
+                    .join(", "),
                 span,
             )),
         }

--- a/psl/psl/src/lib.rs
+++ b/psl/psl/src/lib.rs
@@ -22,6 +22,7 @@ pub use psl_core::{
     ConnectorRegistry,
     Datasource,
     DatasourceConnectorData,
+    FeatureMapWithProvider,
     Generator,
     GeneratorConfigValue,
     PreviewFeature,

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -256,7 +256,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, fullTextSearch, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi, strictUndefinedChecks[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi, strictUndefinedChecks[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/config/nice_warnings.rs
+++ b/psl/psl/tests/config/nice_warnings.rs
@@ -12,7 +12,7 @@ fn nice_warning_for_deprecated_generator_preview_feature() {
 
     let res = psl::parse_configuration(schema).unwrap();
 
-    res.warnings.assert_is(DatamodelWarning::new_feature_deprecated(
+    res.warnings.assert_is(DatamodelWarning::new_preview_feature_deprecated(
         "middlewares",
         Span::new(88, 103, psl_core::parser_database::FileId::ZERO),
     ));

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["nativeFullTextSearchPostgres"]
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+  @@fulltext([content, title])
+}
+// [1;91merror[0m: [1mThe preview feature "nativeFullTextSearchPostgres" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi, strictUndefinedChecks[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m  provider        = "prisma-client-js"
+// [1;94m 3 | [0m  previewFeatures = [1;91m["nativeFullTextSearchPostgres"][0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["nativeFullTextSearchPostgres"]
+  previewFeatures = ["fullTextSearchPostgres"]
 }
 
 datasource db {
@@ -14,9 +14,9 @@ model Blog {
   title   String
   @@fulltext([content, title])
 }
-// [1;91merror[0m: [1mThe preview feature "nativeFullTextSearchPostgres" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi, strictUndefinedChecks[0m
+// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, tracing, views, relationJoins, prismaSchemaFolder, omitApi, strictUndefinedChecks[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"
-// [1;94m 3 | [0m  previewFeatures = [1;91m["nativeFullTextSearchPostgres"][0m
+// [1;94m 3 | [0m  previewFeatures = [1;91m["fullTextSearchPostgres"][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgres.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["nativeFullTextSearchPostgres"]
+}
+
+datasource db {
+  provider = "postgres"
+  url      = env("DATABASE_URL")
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+  @@index([content, title])
+}

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgres.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["nativeFullTextSearchPostgres"]
+  previewFeatures = ["fullTextSearchPostgres"]
 }
 
 datasource db {

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgresql.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
-  previewFeatures = ["nativeFullTextSearchPostgres"]
+  previewFeatures = ["fullTextSearchPostgres"]
 }
 
 datasource db {

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgresql.prisma
@@ -1,0 +1,16 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["nativeFullTextSearchPostgres"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+  @@index([content, title])
+}

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/mysql.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch"]
+}
+
+datasource db {
+  provider = "mysql"
+  url      = env("DATABASE_URL")
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+  @@fulltext([content, title])
+}
+// [1;93mwarning[0m: [1mPreview feature "fullTextSearch" is deprecated. The functionality can be used without specifying it as a preview feature.[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m  provider        = "prisma-client-js"
+// [1;94m 3 | [0m  previewFeatures = [1;93m["fullTextSearch"][0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@index([content, title])
 }
-// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "nativeFullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@index([content, title])
 }
-// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@index([content, title])
 }
-// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.[0m
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed to "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch"]
+}
+
+datasource db {
+  provider = "postgres"
+  url      = env("DATABASE_URL")
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+  @@index([content, title])
+}
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "nativeFullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m  provider        = "prisma-client-js"
+// [1;94m 3 | [0m  previewFeatures = [1;93m["fullTextSearch"][0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@index([content, title])
 }
-// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "nativeFullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@index([content, title])
 }
-// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
@@ -1,0 +1,22 @@
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["fullTextSearch"]
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Blog {
+  id      Int    @unique
+  content String
+  title   String
+  @@index([content, title])
+}
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "nativeFullTextSearchPostgres". Learn more at https://pris.ly/d/native-fts-postgres.[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m  provider        = "prisma-client-js"
+// [1;94m 3 | [0m  previewFeatures = [1;93m["fullTextSearch"][0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@index([content, title])
 }
-// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed as "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.[0m
+// [1;93mwarning[0m: [1mOn `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed to "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/chunking.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/chunking.rs
@@ -216,7 +216,7 @@ mod chunking {
         Ok(())
     }
 
-    #[connector_test(capabilities(FullTextSearchWithoutIndex), exclude(MongoDb))]
+    #[connector_test(capabilities(NativeFullTextSearchWithoutIndex), exclude(MongoDb))]
     async fn order_by_relevance_should_fail(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/search_filter.rs
@@ -130,7 +130,7 @@ async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
     Ok(())
 }
 
-#[test_suite(schema(schema), capabilities(FullTextSearchWithoutIndex))]
+#[test_suite(schema(schema), capabilities(NativeFullTextSearchWithoutIndex))]
 mod search_filter_without_index {
     use indoc::indoc;
 
@@ -178,7 +178,7 @@ mod search_filter_without_index {
     }
 }
 
-#[test_suite(schema(schema), capabilities(FullTextSearchWithIndex))]
+#[test_suite(schema(schema), capabilities(NativeFullTextSearchWithIndex))]
 mod search_filter_with_index {
     use indoc::indoc;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_relevance.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/order_and_pagination/order_by_relevance.rs
@@ -490,7 +490,7 @@ async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
     Ok(())
 }
 
-#[test_suite(schema(schema), capabilities(FullTextSearchWithoutIndex))]
+#[test_suite(schema(schema), capabilities(NativeFullTextSearchWithoutIndex))]
 mod order_by_relevance_without_index {
     use indoc::indoc;
 
@@ -572,7 +572,7 @@ mod order_by_relevance_without_index {
     }
 }
 
-#[test_suite(schema(schema), capabilities(FullTextSearchWithIndex))]
+#[test_suite(schema(schema), capabilities(NativeFullTextSearchWithIndex))]
 mod order_by_relevance_with_index {
     use indoc::indoc;
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/postgres.rs
@@ -16,7 +16,7 @@ impl ConnectorTagInterface for PostgresConnectorTag {
     }
 
     fn datamodel_provider(&self) -> &'static str {
-        "postgres"
+        "postgresql"
     }
 
     fn datamodel_renderer(&self) -> Box<dyn DatamodelRenderer> {

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -89,7 +89,7 @@ impl ConnectorError {
                 },
             )),
 
-            ErrorKind::NativeMissingFullTextSearchIndex => Some(KnownError::new(
+            ErrorKind::MissingNativeFullTextSearchIndex => Some(KnownError::new(
                 user_facing_errors::query_engine::MissingNativeFullTextSearchIndex {},
             )),
             ErrorKind::TransactionAborted { message } => Some(KnownError::new(
@@ -271,7 +271,7 @@ pub enum ErrorKind {
     QueryParameterLimitExceeded(String),
 
     #[error("Cannot find a fulltext index to use for the native search")]
-    NativeMissingFullTextSearchIndex,
+    MissingNativeFullTextSearchIndex,
 
     #[error("Replica Set required for Transactions")]
     MongoReplicaSetRequired,

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -89,8 +89,8 @@ impl ConnectorError {
                 },
             )),
 
-            ErrorKind::MissingFullTextSearchIndex => Some(KnownError::new(
-                user_facing_errors::query_engine::MissingFullTextSearchIndex {},
+            ErrorKind::NativeMissingFullTextSearchIndex => Some(KnownError::new(
+                user_facing_errors::query_engine::MissingNativeFullTextSearchIndex {},
             )),
             ErrorKind::TransactionAborted { message } => Some(KnownError::new(
                 user_facing_errors::query_engine::InteractiveTransactionError { error: message.clone() },
@@ -270,8 +270,8 @@ pub enum ErrorKind {
     #[error("The query parameter limit supported by your database is exceeded: {0}.")]
     QueryParameterLimitExceeded(String),
 
-    #[error("Cannot find a fulltext index to use for the search")]
-    MissingFullTextSearchIndex,
+    #[error("Cannot find a fulltext index to use for the native search")]
+    NativeMissingFullTextSearchIndex,
 
     #[error("Replica Set required for Transactions")]
     MongoReplicaSetRequired,

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -290,7 +290,9 @@ impl SqlError {
             SqlError::QueryParameterLimitExceeded(e) => {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
-            SqlError::MissingFullTextSearchIndex => ConnectorError::from_kind(ErrorKind::MissingFullTextSearchIndex),
+            SqlError::MissingFullTextSearchIndex => {
+                ConnectorError::from_kind(ErrorKind::NativeMissingFullTextSearchIndex)
+            }
             SqlError::InvalidIsolationLevel(msg) => ConnectorError::from_kind(ErrorKind::InternalConversionError(msg)),
             SqlError::ExternalError(error_id) => ConnectorError::from_kind(ErrorKind::ExternalError(error_id)),
             SqlError::TooManyConnections(e) => ConnectorError::from_kind(ErrorKind::TooManyConnections(e)),

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -291,7 +291,7 @@ impl SqlError {
                 ConnectorError::from_kind(ErrorKind::QueryParameterLimitExceeded(e))
             }
             SqlError::MissingFullTextSearchIndex => {
-                ConnectorError::from_kind(ErrorKind::NativeMissingFullTextSearchIndex)
+                ConnectorError::from_kind(ErrorKind::MissingNativeFullTextSearchIndex)
             }
             SqlError::InvalidIsolationLevel(msg) => ConnectorError::from_kind(ErrorKind::InternalConversionError(msg)),
             SqlError::ExternalError(error_id) => ConnectorError::from_kind(ErrorKind::ExternalError(error_id)),

--- a/query-engine/connectors/sql-query-connector/src/filter/visitor.rs
+++ b/query-engine/connectors/sql-query-connector/src/filter/visitor.rs
@@ -355,7 +355,7 @@ impl FilterVisitorExt for FilterVisitor {
     fn visit_scalar_filter(&mut self, filter: ScalarFilter, ctx: &Context<'_>) -> ConditionTree<'static> {
         match filter.condition {
             ScalarCondition::Search(_, _) | ScalarCondition::NotSearch(_, _) => {
-                reachable_only_with_capability!(ConnectorCapability::FullTextSearch);
+                reachable_only_with_capability!(ConnectorCapability::NativeFullTextSearch);
                 let mut projections = match filter.condition.clone() {
                     ScalarCondition::Search(_, proj) => proj,
                     ScalarCondition::NotSearch(_, proj) => proj,
@@ -958,7 +958,7 @@ fn default_scalar_filter(
             comparable.not_equals(Expression::from(field_ref.aliased_col(alias, ctx)).all())
         }
         ScalarCondition::Search(value, _) => {
-            reachable_only_with_capability!(ConnectorCapability::FullTextSearch);
+            reachable_only_with_capability!(ConnectorCapability::NativeFullTextSearch);
             let query: String = value
                 .into_value()
                 .unwrap()
@@ -968,7 +968,7 @@ fn default_scalar_filter(
             comparable.matches(query)
         }
         ScalarCondition::NotSearch(value, _) => {
-            reachable_only_with_capability!(ConnectorCapability::FullTextSearch);
+            reachable_only_with_capability!(ConnectorCapability::NativeFullTextSearch);
             let query: String = value
                 .into_value()
                 .unwrap()
@@ -1140,7 +1140,7 @@ fn insensitive_scalar_filter(
             comparable.compare_raw("NOT ILIKE", Expression::from(field_ref.aliased_col(alias, ctx)).all())
         }
         ScalarCondition::Search(value, _) => {
-            reachable_only_with_capability!(ConnectorCapability::FullTextSearch);
+            reachable_only_with_capability!(ConnectorCapability::NativeFullTextSearch);
             let query: String = value
                 .into_value()
                 .unwrap()
@@ -1150,7 +1150,7 @@ fn insensitive_scalar_filter(
             comparable.matches(query)
         }
         ScalarCondition::NotSearch(value, _) => {
-            reachable_only_with_capability!(ConnectorCapability::FullTextSearch);
+            reachable_only_with_capability!(ConnectorCapability::NativeFullTextSearch);
             let query: String = value
                 .into_value()
                 .unwrap()

--- a/query-engine/connectors/sql-query-connector/src/ordering.rs
+++ b/query-engine/connectors/sql-query-connector/src/ordering.rs
@@ -49,7 +49,7 @@ impl OrderByBuilder {
                 }
                 OrderBy::ToManyAggregation(order_by) => self.build_order_aggr_rel(order_by, needs_reversed_order, ctx),
                 OrderBy::Relevance(order_by) => {
-                    reachable_only_with_capability!(ConnectorCapability::FullTextSearch);
+                    reachable_only_with_capability!(ConnectorCapability::NativeFullTextSearch);
                     self.build_order_relevance(order_by, needs_reversed_order, ctx)
                 }
             })

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -105,8 +105,11 @@ impl QuerySchema {
     }
 
     pub(crate) fn can_full_text_search(&self) -> bool {
-        // TODO: add connector-specific `self.has_native_feature(ConnectorCapability::NativeFullTextSearch)` in conjunction with the next bool.
-        self.has_capability(ConnectorCapability::NativeFullTextSearch)
+        self.connector
+            .native_full_text_search_preview_feature()
+            .map(|feature| self.has_feature(feature))
+            .unwrap_or(true)
+            && self.has_capability(ConnectorCapability::NativeFullTextSearch)
     }
 
     /// Returns whether the loaded connector supports the join strategy.

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -105,7 +105,8 @@ impl QuerySchema {
     }
 
     pub(crate) fn can_full_text_search(&self) -> bool {
-        self.has_feature(PreviewFeature::FullTextSearch) && self.has_capability(ConnectorCapability::FullTextSearch)
+        // TODO: add connector-specific `self.has_native_feature(ConnectorCapability::NativeFullTextSearch)` in conjunction with the next bool.
+        self.has_capability(ConnectorCapability::NativeFullTextSearch)
     }
 
     /// Returns whether the loaded connector supports the join strategy.

--- a/schema-engine/connectors/mongodb-schema-connector/tests/introspection/test_api/mod.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/introspection/test_api/mod.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use mongodb::Database;
 use mongodb_schema_connector::MongoDbSchemaConnector;
 use once_cell::sync::Lazy;
-use psl::PreviewFeature;
+use psl::{FeatureMapWithProvider, PreviewFeature};
 use schema_connector::{
     CompositeTypeDepth, ConnectorParams, IntrospectionContext, IntrospectionResult, SchemaConnector,
 };
@@ -177,7 +177,9 @@ where
     F: FnOnce(Database) -> U,
     U: Future<Output = mongodb::error::Result<()>>,
 {
-    let enabled_preview_features = BitFlags::all();
+    let feature_map_with_provider = FeatureMapWithProvider::new(Some("mongodb"));
+    let enabled_preview_features = feature_map_with_provider.active_features();
+
     introspect_features(composite_type_depth, enabled_preview_features, init_database)
 }
 


### PR DESCRIPTION
This PR:
- Closes https://github.com/prisma/team-orm/issues/1327
- Deprecates https://github.com/prisma/prisma-engines/pull/5031
- GAs `fullTextSearch` on `mysql`
- Introduces `fullTextSearchPostgres` for `postgres`, which replaces `fullTextSearch`
- Adapts existing tests, and introduces new ones

---

This is the first time we GA a preview feature for a a subset of every Prisma-supported connector, while also renaming a preview feature for a specific connector:
- we're only GA-ing `fullTextSearch` for `provider = "mysql"`, but `psl_core::common::preview_features::FeatureMap` has no knowledge of which Prisma database provider is currently selected by the user
- we're renaming `fullTextSearch` as `nativeFullTextSearchPostgres` for `provider = "postgresql"` only

Hence, I've introduced `psl_core::common::preview_features::FeatureMapWithProvider::<'a>`, which, given a `provider`, exposes the same functionality as the old `FeatureMap`, but allows for escape hatches when `provider = "mysql"`. `FeatureMap` is now a private struct.

I've added a default implementation of `FeatureMapWithProvider` as a convenience for https://github.com/prisma/language-tools, which is selected when the `datasource` block doesn't yet have a valid `provider` value.

The `FeatureMap` struct now has two new fields:
- `native: BTreeMap<&'static str, PreviewFeatures>`, which lists the valid connector-specific features. It's a map from database provider to the set of native preview features.
- `renamed: BTreeMap<RenamedFeatureKey, RenamedFeatureValue>`, which keeps track of the renamed deprecated issues. It's a map from a deprecated preview feature and an optional database provider to the new, active preview feature, along with information useful for diagnostic messages. 

Both map entries are feature-gated at compile-time. Since `BTreeMap` insertion isn't `const`-initialisable, I had to move the `FeatureMap` instantiation into `FeatureMapWithProvider::new`, while also introducing `std::sync::LazyLock` for `ALL_PREVIEW_FEATURES`, the default `FeatureMapWithProvider` value.

---

- When on `provider = "mysql"`, writing `previewFeatures = ["fullTextSearch"]` in `schema.prisma` now results in the following validation warning:
  ```
  Preview feature "fullTextSearch" is deprecated. The functionality can be used without specifying it as a preview feature.
  ```
- When on `provider = "postgres"` / `provider = "postgresql"`, writing `previewFeatures = ["fullTextSearch"]` in `schema.prisma` now results in the following validation warning:
  ```
  On `provider = "postgresql"`, preview feature "fullTextSearch" has been renamed to "fullTextSearchPostgres". Learn more at https://pris.ly/d/fts-postgres.
  ```
- When on `provider = "postgres"` / `provider = "postgresql"`, writing `previewFeatures = ["fullTextSearchPostgres"]` in `schema.prisma` is now valid.