### PR TITLE
fix: respect isolation level parameter and defaults

### DIFF
--- a/.github/workflows/test-quaint.yml
+++ b/.github/workflows/test-quaint.yml
@@ -22,7 +22,7 @@ jobs:
       TEST_MYSQL8: "mysql://root:prisma@localhost:3307/prisma"
       TEST_MYSQL_MARIADB: "mysql://root:prisma@localhost:3308/prisma"
       TEST_PSQL: "postgres://postgres:prisma@localhost:5432/postgres"
-      TEST_MSSQL: "jdbc:sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true"
+      TEST_MSSQL: "jdbc:sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;isolationLevel=READ UNCOMMITTED"
       TEST_CRDB: "postgresql://prisma@127.0.0.1:26259/postgres"
 
     steps:

--- a/quaint/src/connector/queryable.rs
+++ b/quaint/src/connector/queryable.rs
@@ -112,7 +112,12 @@ pub trait TransactionCapable: Queryable {
     ) -> crate::Result<Box<dyn Transaction + 'a>>;
 }
 
-#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
+#[cfg(any(
+    feature = "sqlite-native",
+    feature = "mssql-native",
+    feature = "postgresql-native",
+    feature = "mysql-native"
+))]
 macro_rules! impl_default_TransactionCapable {
     ($t:ty) => {
         #[async_trait]
@@ -131,5 +136,10 @@ macro_rules! impl_default_TransactionCapable {
     };
 }
 
-#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
+#[cfg(any(
+    feature = "sqlite-native",
+    feature = "mssql-native",
+    feature = "postgresql-native",
+    feature = "mysql-native"
+))]
 pub(crate) use impl_default_TransactionCapable;

--- a/quaint/src/connector/queryable.rs
+++ b/quaint/src/connector/queryable.rs
@@ -112,6 +112,7 @@ pub trait TransactionCapable: Queryable {
     ) -> crate::Result<Box<dyn Transaction + 'a>>;
 }
 
+#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
 macro_rules! impl_default_TransactionCapable {
     ($t:ty) => {
         #[async_trait]
@@ -130,4 +131,5 @@ macro_rules! impl_default_TransactionCapable {
     };
 }
 
+#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
 pub(crate) use impl_default_TransactionCapable;

--- a/quaint/src/connector/transaction.rs
+++ b/quaint/src/connector/transaction.rs
@@ -21,7 +21,12 @@ pub trait Transaction: Queryable {
     fn as_queryable(&self) -> &dyn Queryable;
 }
 
-#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
+#[cfg(any(
+    feature = "sqlite-native",
+    feature = "mssql-native",
+    feature = "postgresql-native",
+    feature = "mysql-native"
+))]
 pub(crate) struct TransactionOptions {
     /// The isolation level to use.
     pub(crate) isolation_level: Option<IsolationLevel>,
@@ -30,7 +35,12 @@ pub(crate) struct TransactionOptions {
     pub(crate) isolation_first: bool,
 }
 
-#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
+#[cfg(any(
+    feature = "sqlite-native",
+    feature = "mssql-native",
+    feature = "postgresql-native",
+    feature = "mysql-native"
+))]
 impl TransactionOptions {
     pub fn new(isolation_level: Option<IsolationLevel>, isolation_first: bool) -> Self {
         Self {
@@ -51,7 +61,12 @@ pub struct DefaultTransaction<'a> {
 }
 
 impl<'a> DefaultTransaction<'a> {
-    #[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
+    #[cfg(any(
+        feature = "sqlite-native",
+        feature = "mssql-native",
+        feature = "postgresql-native",
+        feature = "mysql-native"
+    ))]
     pub(crate) async fn new(
         inner: &'a dyn Queryable,
         begin_stmt: &str,

--- a/quaint/src/connector/transaction.rs
+++ b/quaint/src/connector/transaction.rs
@@ -21,6 +21,7 @@ pub trait Transaction: Queryable {
     fn as_queryable(&self) -> &dyn Queryable;
 }
 
+#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
 pub(crate) struct TransactionOptions {
     /// The isolation level to use.
     pub(crate) isolation_level: Option<IsolationLevel>,
@@ -28,6 +29,17 @@ pub(crate) struct TransactionOptions {
     /// Whether or not to put the isolation level `SET` before or after the `BEGIN`.
     pub(crate) isolation_first: bool,
 }
+
+#[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
+impl TransactionOptions {
+    pub fn new(isolation_level: Option<IsolationLevel>, isolation_first: bool) -> Self {
+        Self {
+            isolation_level,
+            isolation_first,
+        }
+    }
+}
+
 
 /// A default representation of an SQL database transaction. If not commited, a
 /// transaction will be rolled back by default when dropped.
@@ -40,6 +52,7 @@ pub struct DefaultTransaction<'a> {
 }
 
 impl<'a> DefaultTransaction<'a> {
+    #[cfg(any(feature = "mssql-native", feature = "postgresql-native", feature = "mysql-native"))]
     pub(crate) async fn new(
         inner: &'a dyn Queryable,
         begin_stmt: &str,
@@ -193,14 +206,6 @@ impl FromStr for IsolationLevel {
                 let kind = ErrorKind::conversion(format!("Invalid isolation level `{s}`"));
                 Err(Error::builder(kind).build())
             }
-        }
-    }
-}
-impl TransactionOptions {
-    pub fn new(isolation_level: Option<IsolationLevel>, isolation_first: bool) -> Self {
-        Self {
-            isolation_level,
-            isolation_first,
         }
     }
 }

--- a/quaint/src/connector/transaction.rs
+++ b/quaint/src/connector/transaction.rs
@@ -40,7 +40,6 @@ impl TransactionOptions {
     }
 }
 
-
 /// A default representation of an SQL database transaction. If not commited, a
 /// transaction will be rolled back by default when dropped.
 ///

--- a/quaint/src/tests/query.rs
+++ b/quaint/src/tests/query.rs
@@ -121,24 +121,30 @@ async fn mssql_transaction_isolation_level(api: &mut dyn TestApi) -> crate::Resu
 
     let conn_a = api.conn();
     // Start a transaction with the default isolation level, which in tests is
-    // set to READ UNCOMMITED via the DB url and insert a row, but do not commit the transaction
+    // set to READ UNCOMMITED via the DB url and insert a row, but do not commit the transaction.
     let tx_a = conn_a.start_transaction(None).await?;
     let insert = Insert::single_into(&table).value("value", 3).value("id", 4);
     let rows_affected = tx_a.execute(insert.into()).await?;
     assert_eq!(1, rows_affected);
 
-    let conn_b = api.create_additional_connection().await?;
-    // Start a transaction that explicitly sets the isolation level to "SNAPSHOT" and query the table
-    // expecting to see the old state.
-    let tx_b = conn_b.start_transaction(Some(IsolationLevel::Snapshot)).await?;
-    let res = tx_b.query(Select::from_table(&table).into()).await?;
-    assert_eq!(0, res.len());
+    // We want to verify that pooled connection behaves the same way, so we test both cases.
+    let pool = api.create_pool()?;
+    for conn_b in [
+        Box::new(pool.check_out().await?) as Box<dyn TransactionCapable>,
+        Box::new(api.create_additional_connection().await?),
+    ] {
+        // Start a transaction that explicitly sets the isolation level to SNAPSHOT and query the table
+        // expecting to see the old state.
+        let tx_b = conn_b.start_transaction(Some(IsolationLevel::Snapshot)).await?;
+        let res = tx_b.query(Select::from_table(&table).into()).await?;
+        assert_eq!(0, res.len());
 
-    // Start a transaction without an explicit isolation level, it should be run with the default
-    // again, which is set to READ UNCOMMITED here.
-    let tx_c = conn_b.start_transaction(None).await?;
-    let res = tx_c.query(Select::from_table(&table).into()).await?;
-    assert_eq!(1, res.len());
+        // Start a transaction without an explicit isolation level, it should be run with the default
+        // again, which is set to READ UNCOMMITED here.
+        let tx_c = conn_b.start_transaction(None).await?;
+        let res = tx_c.query(Select::from_table(&table).into()).await?;
+        assert_eq!(1, res.len());
+    }
 
     Ok(())
 }

--- a/quaint/src/tests/test_api.rs
+++ b/quaint/src/tests/test_api.rs
@@ -35,5 +35,6 @@ pub trait TestApi {
     fn autogen_id(&self, name: &str) -> String;
     fn conn(&self) -> &crate::single::Quaint;
     async fn create_additional_connection(&self) -> crate::Result<crate::single::Quaint>;
+    fn create_pool(&self) -> crate::Result<crate::pooled::Quaint>;
     fn get_name(&mut self) -> String;
 }

--- a/quaint/src/tests/test_api/mssql.rs
+++ b/quaint/src/tests/test_api/mssql.rs
@@ -21,6 +21,10 @@ impl<'a> MsSql<'a> {
         let names = Generator::default();
         let conn = Quaint::new(&CONN_STR).await?;
 
+        // snapshot isolation enables us to test isolation levels easily
+        conn.raw_cmd(&format!("ALTER DATABASE tempdb SET ALLOW_SNAPSHOT_ISOLATION ON",))
+            .await?;
+
         Ok(Self { names, conn })
     }
 }

--- a/quaint/src/tests/test_api/mssql.rs
+++ b/quaint/src/tests/test_api/mssql.rs
@@ -22,7 +22,7 @@ impl<'a> MsSql<'a> {
         let conn = Quaint::new(&CONN_STR).await?;
 
         // snapshot isolation enables us to test isolation levels easily
-        conn.raw_cmd(&format!("ALTER DATABASE tempdb SET ALLOW_SNAPSHOT_ISOLATION ON",))
+        conn.raw_cmd("ALTER DATABASE tempdb SET ALLOW_SNAPSHOT_ISOLATION ON")
             .await?;
 
         Ok(Self { names, conn })
@@ -78,6 +78,10 @@ impl<'a> TestApi for MsSql<'a> {
 
     async fn create_additional_connection(&self) -> crate::Result<Quaint> {
         Quaint::new(&CONN_STR).await
+    }
+
+    fn create_pool(&self) -> crate::Result<crate::pooled::Quaint> {
+        Ok(crate::pooled::Quaint::builder(&CONN_STR)?.build())
     }
 
     fn render_create_table(&mut self, table_name: &str, columns: &str) -> (String, String) {

--- a/quaint/src/tests/test_api/mysql.rs
+++ b/quaint/src/tests/test_api/mysql.rs
@@ -129,6 +129,10 @@ impl<'a> TestApi for MySql<'a> {
         Quaint::new(&self.conn_str).await
     }
 
+    fn create_pool(&self) -> crate::Result<crate::pooled::Quaint> {
+        Ok(crate::pooled::Quaint::builder(&CONN_STR)?.build())
+    }
+
     fn unique_constraint(&mut self, column: &str) -> String {
         format!("UNIQUE({column})")
     }

--- a/quaint/src/tests/test_api/postgres.rs
+++ b/quaint/src/tests/test_api/postgres.rs
@@ -87,6 +87,10 @@ impl<'a> TestApi for PostgreSql<'a> {
         Quaint::new(&CONN_STR).await
     }
 
+    fn create_pool(&self) -> crate::Result<crate::pooled::Quaint> {
+        Ok(crate::pooled::Quaint::builder(&CONN_STR)?.build())
+    }
+
     fn unique_constraint(&mut self, column: &str) -> String {
         format!("UNIQUE({column})")
     }

--- a/quaint/src/tests/test_api/sqlite.rs
+++ b/quaint/src/tests/test_api/sqlite.rs
@@ -84,7 +84,7 @@ impl<'a> TestApi for Sqlite<'a> {
     }
 
     fn create_pool(&self) -> crate::Result<crate::pooled::Quaint> {
-        Ok(crate::pooled::Quaint::builder(&CONN_STR)?.build())
+        Ok(crate::pooled::Quaint::builder(CONN_STR)?.build())
     }
 
     fn unique_constraint(&mut self, column: &str) -> String {

--- a/quaint/src/tests/test_api/sqlite.rs
+++ b/quaint/src/tests/test_api/sqlite.rs
@@ -83,6 +83,10 @@ impl<'a> TestApi for Sqlite<'a> {
         Quaint::new(CONN_STR).await
     }
 
+    fn create_pool(&self) -> crate::Result<crate::pooled::Quaint> {
+        Ok(crate::pooled::Quaint::builder(&CONN_STR)?.build())
+    }
+
     fn unique_constraint(&mut self, column: &str) -> String {
         format!("UNIQUE({column})")
     }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -32,7 +32,7 @@ mod metrics {
 
         match runner.connector_version() {
             Sqlite(_) => assert_eq!(total_queries, 2),
-            SqlServer(_) => assert_eq!(total_queries, 10),
+            SqlServer(_) => assert_eq!(total_queries, 12),
             MongoDb(_) => assert_eq!(total_queries, 5),
             CockroachDb(_) => assert_eq!(total_queries, 2),
             MySql(_) => assert_eq!(total_queries, 9),


### PR DESCRIPTION
Fixes a few things:
- `start_transaction` was not being dispatched correctly in a few places because `Quaint` had an `impl` that was bypassing the impl of the inner type
- I rewrote the `mssql_transaction_isolation_level` test to capture that the isolation level parameter is respected and that isolation level changes do not linger for more than 1 transaction when left unspecified