### PR TITLE
feat(psl): add "async", "await", "using" to the list of reserved words

### DIFF
--- a/psl/parser-database/src/names/reserved_model_names.rs
+++ b/psl/parser-database/src/names/reserved_model_names.rs
@@ -44,6 +44,8 @@ pub(crate) fn validate_enum_name(ast_enum: &ast::Enum, diagnostics: &mut Diagnos
 const RESERVED_NAMES: &[&str] = &[
     "PrismaClient",
     // JavaScript keywords
+    "async",
+    "await",
     "break",
     "case",
     "catch",
@@ -83,6 +85,7 @@ const RESERVED_NAMES: &[&str] = &[
     "true",
     "try",
     "typeof",
+    "using",
     "var",
     "void",
     "while",


### PR DESCRIPTION
This PR:
- contributes to https://github.com/prisma/team-orm/issues/1384
- adds `async`, `await`, and `using` to the list of reserved words. This means that Prisma `models` cannot be named as such.

---

TODO(jkomyno): follow-up by adding the same words to the denylist in prisma/prisma.