### PR TITLE
chore: update rust to 1.83.0

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -35,7 +35,7 @@ jobs:
       # it is a shortcut for `--lib --bins --tests --benches --examples`.
       - run: |
           cargo clippy --workspace --all-features --all-targets
-          cargo clippy --all-features --all-targets -p query-engine-wasm --target wasm32-unknown-unknown
+          cargo clippy --all-features --all-targets -p query-engine-wasm -p prisma-schema-build --target wasm32-unknown-unknown
 
   rustfmt:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,9 @@ build-schema-wasm:
 
 # Emulate pedantic CI compilation.
 pedantic:
-	RUSTFLAGS="-D warnings" cargo fmt -- --check && RUSTFLAGS="-D warnings" cargo clippy --all-targets
+	RUSTFLAGS="-D warnings" cargo fmt -- --check
+	RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets
+	RUSTFLAGS="-D warnings" cargo clippy --all-features --all-targets -p query-engine-wasm -p prisma-schema-build --target wasm32-unknown-unknown
 
 release:
 	cargo build --release
@@ -391,7 +393,7 @@ test-driver-adapter-planetscale-wasm: test-planetscale-wasm
 # Local dev commands #
 ######################
 
-measure-qe-wasm: build-qe-wasm-gz	
+measure-qe-wasm: build-qe-wasm-gz
 	@cd query-engine/query-engine-wasm/pkg; \
 	for provider in postgresql mysql sqlite; do \
 		echo "$${provider}_size=$$(cat $$provider/query_engine_bg.wasm | wc -c | tr -d ' ')" >> $(ENGINE_SIZE_OUTPUT); \

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1728776144,
-        "narHash": "sha256-fROVjMcKRoGHofDm8dY3uDUtCMwUICh/KjBFQnuBzfg=",
+        "lastModified": 1732906089,
+        "narHash": "sha256-NvYSSiKsC0rqn9yY0a9zglLXrFp92EwKhTFZC38voCQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "f876e3d905b922502f031aeec1a84490122254b7",
+        "rev": "9ed3180f45c2d1499e5af98c4ab7ffee8e886f5f",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727826117,
-        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "lastModified": 1730504689,
+        "narHash": "sha256-hgmguH29K2fvs9szpq2r3pz2/8cJd2LPS+b4tfNFCwE=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "rev": "506278e768c2a08bec68eb62932193e341f55c90",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728888510,
-        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
+        "lastModified": 1732758367,
+        "narHash": "sha256-RzaI1RO0UXqLjydtz3GAXSTzHkpb/lLD1JD8a0W4Wpo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+        "rev": "fa42b5a5f401aab8a32bd33c9a4de0738180dc59",
         "type": "github"
       },
       "original": {
@@ -87,11 +87,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729184663,
-        "narHash": "sha256-uNyi5vQrzaLkt4jj6ZEOs4+4UqOAwP6jFG2s7LIDwIk=",
+        "lastModified": 1732933841,
+        "narHash": "sha256-dge02pUSe2QeC/B3PriA0R8eAX+EU3aDoXj9FcS3XDw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "16fb78d443c1970dda9a0bbb93070c9d8598a925",
+        "rev": "c65e91d4a33abc3bc4a892d3c5b5b378bad64ea1",
         "type": "github"
       },
       "original": {

--- a/libs/crosstarget-utils/src/common/spawn.rs
+++ b/libs/crosstarget-utils/src/common/spawn.rs
@@ -2,7 +2,6 @@ use derive_more::Display;
 
 #[derive(Debug, Display)]
 #[display(fmt = "Failed to spawn a future")]
-
 pub struct SpawnError;
 
 impl std::error::Error for SpawnError {}

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -199,7 +199,7 @@ where
 
 struct BigDecimalVisitor;
 
-impl<'de> serde::de::Visitor<'de> for BigDecimalVisitor {
+impl serde::de::Visitor<'_> for BigDecimalVisitor {
     type Value = BigDecimal;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/libs/sql-ddl/src/mysql.rs
+++ b/libs/sql-ddl/src/mysql.rs
@@ -81,7 +81,7 @@ pub struct ForeignKey<'a> {
     pub on_update: Option<ForeignKeyAction>,
 }
 
-impl<'a> Display for ForeignKey<'a> {
+impl Display for ForeignKey<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(constraint_name) = &self.constraint_name {
             write!(f, "CONSTRAINT `{constraint_name}` ")?;

--- a/libs/sql-ddl/src/postgres.rs
+++ b/libs/sql-ddl/src/postgres.rs
@@ -324,7 +324,7 @@ pub struct CreateEnum<'a> {
     pub variants: Vec<Cow<'a, str>>,
 }
 
-impl<'a> Display for CreateEnum<'a> {
+impl Display for CreateEnum<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "CREATE TYPE {enum_name} AS ENUM (", enum_name = self.enum_name)?;
         self.variants.iter().map(|s| StrLit(s)).join(", ", f)?;
@@ -349,7 +349,7 @@ pub struct CreateIndex<'a> {
     pub using: Option<IndexAlgorithm>,
 }
 
-impl<'a> Display for CreateIndex<'a> {
+impl Display for CreateIndex<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let using = match self.using {
             Some(IndexAlgorithm::Hash) => " USING HASH ",

--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -221,7 +221,7 @@ pub struct DatasourceBlock<'a> {
     preview_features: &'static [&'static str],
 }
 
-impl<'a> DatasourceBlock<'a> {
+impl DatasourceBlock<'_> {
     pub fn url(&self) -> &str {
         self.url
     }

--- a/libs/user-facing-errors/src/query_engine/mod.rs
+++ b/libs/user-facing-errors/src/query_engine/mod.rs
@@ -298,7 +298,6 @@ pub struct MongoReplicaSetRequired {}
     code = "P2032",
     message = "Error converting field \"{field}\" of expected non-nullable type \"{expected_type}\", found incompatible value of \"{found}\"."
 )]
-
 pub struct MissingFieldsInModel {
     pub field: String,
     pub expected_type: String,
@@ -307,7 +306,6 @@ pub struct MissingFieldsInModel {
 
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(code = "P2033", message = "{details}")]
-
 pub struct ValueFitError {
     pub details: String,
 }

--- a/prisma-fmt/src/code_actions.rs
+++ b/prisma-fmt/src/code_actions.rs
@@ -23,7 +23,7 @@ use crate::LSPContext;
 
 pub(super) type CodeActionsContext<'a> = LSPContext<'a, CodeActionParams>;
 
-impl<'a> CodeActionsContext<'a> {
+impl CodeActionsContext<'_> {
     pub(super) fn diagnostics(&self) -> &[Diagnostic] {
         &self.params.context.diagnostics
     }

--- a/prisma-fmt/src/hover.rs
+++ b/prisma-fmt/src/hover.rs
@@ -17,7 +17,7 @@ use crate::{offsets::position_to_offset, LSPContext};
 
 pub(super) type HoverContext<'a> = LSPContext<'a, HoverParams>;
 
-impl<'a> HoverContext<'a> {
+impl HoverContext<'_> {
     pub(super) fn position(&self) -> Option<usize> {
         let pos = self.params.text_document_position_params.position;
         let initiating_doc = self.initiating_file_source();

--- a/psl/parser-database/src/types/index_fields.rs
+++ b/psl/parser-database/src/types/index_fields.rs
@@ -5,7 +5,7 @@ pub(crate) enum OperatorClass<'a> {
     Raw(&'a str),
 }
 
-impl<'a> From<crate::OperatorClass> for OperatorClass<'a> {
+impl From<crate::OperatorClass> for OperatorClass<'_> {
     fn from(inner: crate::OperatorClass) -> Self {
         Self::Constant(inner)
     }

--- a/psl/parser-database/src/walkers.rs
+++ b/psl/parser-database/src/walkers.rs
@@ -47,7 +47,7 @@ impl<'db, I> Walker<'db, I> {
     }
 }
 
-impl<'db, I> PartialEq for Walker<'db, I>
+impl<I> PartialEq for Walker<'_, I>
 where
     I: PartialEq,
 {

--- a/psl/parser-database/src/walkers/relation_field.rs
+++ b/psl/parser-database/src/walkers/relation_field.rs
@@ -177,7 +177,7 @@ pub enum RelationName<'db> {
     Generated(String),
 }
 
-impl<'db> PartialEq for RelationName<'db> {
+impl PartialEq for RelationName<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Explicit(l0), Self::Explicit(r0)) => l0 == r0,
@@ -188,9 +188,9 @@ impl<'db> PartialEq for RelationName<'db> {
     }
 }
 
-impl<'db> Eq for RelationName<'db> {}
+impl Eq for RelationName<'_> {}
 
-impl<'db> Ord for RelationName<'db> {
+impl Ord for RelationName<'_> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self, other) {
             (Self::Explicit(l0), Self::Explicit(r0)) => l0.cmp(r0),
@@ -201,13 +201,13 @@ impl<'db> Ord for RelationName<'db> {
     }
 }
 
-impl<'db> PartialOrd for RelationName<'db> {
+impl PartialOrd for RelationName<'_> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl<'db> std::hash::Hash for RelationName<'db> {
+impl std::hash::Hash for RelationName<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {
             RelationName::Explicit(s) => s.hash(state),
@@ -216,7 +216,7 @@ impl<'db> std::hash::Hash for RelationName<'db> {
     }
 }
 
-impl<'db> RelationName<'db> {
+impl RelationName<'_> {
     pub(crate) fn generated(model_a: &str, model_b: &str) -> Self {
         if model_a < model_b {
             Self::Generated(format!("{model_a}To{model_b}"))
@@ -226,7 +226,7 @@ impl<'db> RelationName<'db> {
     }
 }
 
-impl<'db> fmt::Display for RelationName<'db> {
+impl fmt::Display for RelationName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             RelationName::Explicit(s) => f.write_str(s),
@@ -235,7 +235,7 @@ impl<'db> fmt::Display for RelationName<'db> {
     }
 }
 
-impl<'db> AsRef<str> for RelationName<'db> {
+impl AsRef<str> for RelationName<'_> {
     fn as_ref(&self) -> &str {
         match self {
             RelationName::Explicit(s) => s,

--- a/psl/parser-database/src/walkers/scalar_field.rs
+++ b/psl/parser-database/src/walkers/scalar_field.rs
@@ -165,7 +165,7 @@ impl<'db> ScalarFieldWalker<'db> {
     }
 }
 
-impl<'db> fmt::Display for ScalarFieldWalker<'db> {
+impl fmt::Display for ScalarFieldWalker<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name())
     }

--- a/psl/psl-core/src/datamodel_connector/constraint_names.rs
+++ b/psl/psl-core/src/datamodel_connector/constraint_names.rs
@@ -30,7 +30,6 @@ impl ConstraintNames {
     /// excl for an Exclusion constraint
     /// seq for sequences
     ///
-
     pub fn primary_key_name(table_name: &str, connector: &dyn Connector) -> String {
         let suffix = "_pkey";
         let limit = connector.max_identifier_length();

--- a/psl/psl-core/src/reformat.rs
+++ b/psl/psl-core/src/reformat.rs
@@ -69,7 +69,7 @@ struct MagicReformatCtx<'a> {
     db: &'a ParserDatabase,
 }
 
-impl<'a> MagicReformatCtx<'a> {
+impl MagicReformatCtx<'_> {
     fn add_missing_bit(&mut self, file_id: FileId, bit: MissingBit) {
         self.missing_bits_map.entry(file_id).or_default().push(bit);
     }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/composite_types.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/composite_types.rs
@@ -142,7 +142,7 @@ impl<'db> CompositeTypePath<'db> {
     }
 }
 
-impl<'db> fmt::Display for CompositeTypePath<'db> {
+impl fmt::Display for CompositeTypePath<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut traversed = vec![self.current];
         let mut this = self;

--- a/psl/psl-core/src/validate/validation_pipeline/validations/constraint_namespace.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/constraint_namespace.rs
@@ -221,7 +221,7 @@ impl<'db> ConstraintName<'db> {
     }
 }
 
-impl<'db> AsRef<str> for ConstraintName<'db> {
+impl AsRef<str> for ConstraintName<'_> {
     fn as_ref(&self) -> &str {
         match self {
             ConstraintName::Index(x) => x,
@@ -232,7 +232,7 @@ impl<'db> AsRef<str> for ConstraintName<'db> {
     }
 }
 
-impl<'db> Deref for ConstraintName<'db> {
+impl Deref for ConstraintName<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/models.rs
@@ -221,12 +221,12 @@ pub(crate) fn primary_key_connector_specific(model: ModelWalker<'_>, ctx: &mut C
     }
 
     if primary_key.fields().len() > 1 && !ctx.has_capability(ConnectorCapability::CompoundIds) {
-        return ctx.push_error(DatamodelError::new_model_validation_error(
+        ctx.push_error(DatamodelError::new_model_validation_error(
             "The current connector does not support compound ids.",
             container_type,
             model.name(),
             primary_key.ast_attribute().span,
-        ));
+        ))
     }
 }
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relation_fields.rs
@@ -25,7 +25,7 @@ impl<'db> Fields<'db> {
     }
 }
 
-impl<'db> fmt::Display for Fields<'db> {
+impl fmt::Display for Fields<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut fields = self
             .fields

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/visited_relation.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/visited_relation.rs
@@ -40,7 +40,7 @@ impl<'db> VisitedRelation<'db> {
     }
 }
 
-impl<'db> fmt::Display for VisitedRelation<'db> {
+impl fmt::Display for VisitedRelation<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut traversed = self.iter().map(|relation| {
             format!(

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -151,7 +151,7 @@ impl<'a> DatamodelAssert<'a> for psl::ValidatedSchema {
     }
 }
 
-impl<'a> RelationFieldAssert for walkers::RelationFieldWalker<'a> {
+impl RelationFieldAssert for walkers::RelationFieldWalker<'_> {
     #[track_caller]
     fn assert_relation_to(&self, model_id: ModelId) -> &Self {
         assert!(self.references_model(model_id));
@@ -263,7 +263,7 @@ impl<'a> ModelAssert<'a> for walkers::ModelWalker<'a> {
     }
 }
 
-impl<'a> ScalarFieldAssert for walkers::ScalarFieldWalker<'a> {
+impl ScalarFieldAssert for walkers::ScalarFieldWalker<'_> {
     #[track_caller]
     fn assert_ignored(&self, ignored: bool) -> &Self {
         assert_eq!(self.is_ignored(), ignored);
@@ -374,7 +374,7 @@ impl<'a> ScalarFieldAssert for walkers::ScalarFieldWalker<'a> {
     }
 }
 
-impl<'a> DefaultValueAssert for walkers::DefaultValueWalker<'a> {
+impl DefaultValueAssert for walkers::DefaultValueWalker<'_> {
     #[track_caller]
     fn assert_autoincrement(&self) -> &Self {
         self.value().assert_autoincrement();
@@ -466,7 +466,7 @@ impl<'a> DefaultValueAssert for walkers::DefaultValueWalker<'a> {
     }
 }
 
-impl<'a> IndexAssert for walkers::IndexWalker<'a> {
+impl IndexAssert for walkers::IndexWalker<'_> {
     #[track_caller]
     fn assert_field(&self, name: &str) -> walkers::ScalarFieldAttributeWalker<'_> {
         self.scalar_field_attributes()
@@ -504,7 +504,7 @@ impl<'a> IndexAssert for walkers::IndexWalker<'a> {
     }
 }
 
-impl<'a> IndexFieldAssert for walkers::ScalarFieldAttributeWalker<'a> {
+impl IndexFieldAssert for walkers::ScalarFieldAttributeWalker<'_> {
     #[track_caller]
     fn assert_descending(&self) -> &Self {
         assert_eq!(Some(SortOrder::Desc), self.sort_order());
@@ -539,7 +539,7 @@ impl<'a> TypeAssert<'a> for walkers::CompositeTypeWalker<'a> {
     }
 }
 
-impl<'a> CompositeFieldAssert for walkers::CompositeTypeFieldWalker<'a> {
+impl CompositeFieldAssert for walkers::CompositeTypeFieldWalker<'_> {
     #[track_caller]
     fn assert_scalar_type(&self, t: ScalarType) -> &Self {
         assert_eq!(Some(t), self.scalar_type());
@@ -701,7 +701,7 @@ impl DefaultValueAssert for ast::Expression {
     }
 }
 
-impl<'a> IndexAssert for walkers::PrimaryKeyWalker<'a> {
+impl IndexAssert for walkers::PrimaryKeyWalker<'_> {
     #[track_caller]
     fn assert_field(&self, name: &str) -> walkers::ScalarFieldAttributeWalker<'_> {
         self.scalar_field_attributes()

--- a/psl/schema-ast/src/renderer.rs
+++ b/psl/schema-ast/src/renderer.rs
@@ -50,7 +50,7 @@ impl LineWriteable for Renderer {
     }
 }
 
-impl<'a> LineWriteable for &'a mut String {
+impl LineWriteable for &mut String {
     fn write(&mut self, param: &str) {
         self.push_str(param);
     }

--- a/quaint/src/ast/column.rs
+++ b/quaint/src/ast/column.rs
@@ -51,7 +51,7 @@ pub enum DefaultValue<'a> {
     Generated,
 }
 
-impl<'a> Default for DefaultValue<'a> {
+impl Default for DefaultValue<'_> {
     fn default() -> Self {
         Self::Generated
     }
@@ -66,7 +66,7 @@ where
     }
 }
 
-impl<'a> PartialEq for Column<'a> {
+impl PartialEq for Column<'_> {
     fn eq(&self, other: &Column) -> bool {
         self.name == other.name && self.table == other.table
     }
@@ -209,7 +209,7 @@ impl<'a, 'b> From<&'a &'b str> for Column<'b> {
     }
 }
 
-impl<'a> From<String> for Column<'a> {
+impl From<String> for Column<'_> {
     fn from(s: String) -> Self {
         Column {
             name: s.into(),

--- a/quaint/src/ast/compare.rs
+++ b/quaint/src/ast/compare.rs
@@ -73,6 +73,7 @@ impl<'a> From<Column<'a>> for JsonType<'a> {
     }
 }
 
+#[cfg_attr(not(feature = "mssql"), allow(clippy::needless_lifetimes))]
 impl<'a> Compare<'a> {
     /// Finds a possible `(a,y) IN (SELECT x,z FROM B)`, takes the select out and
     /// converts the comparison into `a IN (SELECT x FROM cte_n where z = y)`.
@@ -740,7 +741,7 @@ pub trait Comparable<'a> {
     ///
     /// assert_eq!(params, vec![Value::from("chicken")]);
     ///
-    /// # Ok(())    
+    /// # Ok(())
     /// # }
     /// ```
     fn matches<T>(self, query: T) -> Compare<'a>
@@ -763,7 +764,7 @@ pub trait Comparable<'a> {
     ///
     /// assert_eq!(params, vec![Value::from("chicken")]);
     ///
-    /// # Ok(())    
+    /// # Ok(())
     /// # }
     /// ```
     fn not_matches<T>(self, query: T) -> Compare<'a>

--- a/quaint/src/ast/enums.rs
+++ b/quaint/src/ast/enums.rs
@@ -29,13 +29,13 @@ impl<'a> EnumVariant<'a> {
     }
 }
 
-impl<'a> AsRef<str> for EnumVariant<'a> {
+impl AsRef<str> for EnumVariant<'_> {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }
 }
 
-impl<'a> std::ops::Deref for EnumVariant<'a> {
+impl std::ops::Deref for EnumVariant<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -43,7 +43,7 @@ impl<'a> std::ops::Deref for EnumVariant<'a> {
     }
 }
 
-impl<'a> fmt::Display for EnumVariant<'a> {
+impl fmt::Display for EnumVariant<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_ref())
     }
@@ -55,7 +55,7 @@ impl<'a> From<Cow<'a, str>> for EnumVariant<'a> {
     }
 }
 
-impl<'a> From<String> for EnumVariant<'a> {
+impl From<String> for EnumVariant<'_> {
     fn from(value: String) -> Self {
         Self(value.into())
     }

--- a/quaint/src/ast/expression.rs
+++ b/quaint/src/ast/expression.rs
@@ -58,7 +58,6 @@ impl<'a> Expression<'a> {
     }
 
     #[allow(dead_code)]
-
     pub(crate) fn is_json_value(&self) -> bool {
         match &self.kind {
             ExpressionKind::Parameterized(Value {
@@ -72,7 +71,6 @@ impl<'a> Expression<'a> {
     }
 
     #[allow(dead_code)]
-
     pub(crate) fn into_json_value(self) -> Option<serde_json::Value> {
         match self.kind {
             ExpressionKind::Parameterized(Value {
@@ -223,7 +221,7 @@ pub enum ExpressionKind<'a> {
     Default,
 }
 
-impl<'a> ExpressionKind<'a> {
+impl ExpressionKind<'_> {
     pub(crate) fn is_xml_value(&self) -> bool {
         match self {
             Self::Parameterized(Value {

--- a/quaint/src/ast/function.rs
+++ b/quaint/src/ast/function.rs
@@ -50,7 +50,7 @@ pub struct Function<'a> {
     pub(crate) alias: Option<Cow<'a, str>>,
 }
 
-impl<'a> Function<'a> {
+impl Function<'_> {
     pub fn returns_json(&self) -> bool {
         matches!(
             self.typ_,

--- a/quaint/src/ast/function/uuid.rs
+++ b/quaint/src/ast/function/uuid.rs
@@ -5,7 +5,7 @@ use crate::ast::Expression;
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
 /// # fn main() -> Result<(), quaint::error::Error> {
-
+///
 /// let query = Select::default().value(uuid_to_bin());
 /// let (sql, _) = Mysql::build(query)?;
 ///
@@ -47,7 +47,7 @@ pub fn uuid_to_bin_swapped() -> Expression<'static> {
 /// ```rust
 /// # use quaint::{ast::*, visitor::{Visitor, Mysql}};
 /// # fn main() -> Result<(), quaint::error::Error> {
-
+///
 /// let query = Select::default().value(native_uuid());
 /// let (sql, _) = Mysql::build(query)?;
 ///

--- a/quaint/src/ast/over.rs
+++ b/quaint/src/ast/over.rs
@@ -8,7 +8,7 @@ pub struct Over<'a> {
     pub(crate) partitioning: Vec<Column<'a>>,
 }
 
-impl<'a> Over<'a> {
+impl Over<'_> {
     pub fn is_empty(&self) -> bool {
         self.ordering.is_empty() && self.partitioning.is_empty()
     }

--- a/quaint/src/ast/query.rs
+++ b/quaint/src/ast/query.rs
@@ -24,7 +24,7 @@ where
     }
 }
 
-impl<'a> Query<'a> {
+impl Query<'_> {
     pub fn is_select(&self) -> bool {
         matches!(self, Query::Select(_))
     }

--- a/quaint/src/ast/query.rs
+++ b/quaint/src/ast/query.rs
@@ -53,6 +53,7 @@ pub enum SelectQuery<'a> {
     Union(Box<Union<'a>>),
 }
 
+#[cfg_attr(not(feature = "mssql"), allow(clippy::needless_lifetimes))]
 impl<'a> SelectQuery<'a> {
     /// Finds all named values or columns from the selection.
     pub fn named_selection(&self) -> Vec<String> {

--- a/quaint/src/ast/table.rs
+++ b/quaint/src/ast/table.rs
@@ -33,7 +33,7 @@ pub struct Table<'a> {
     pub(crate) index_definitions: Vec<IndexDefinition<'a>>,
 }
 
-impl<'a> PartialEq for Table<'a> {
+impl PartialEq for Table<'_> {
     fn eq(&self, other: &Table) -> bool {
         self.typ == other.typ && self.database == other.database
     }
@@ -419,7 +419,7 @@ impl<'a> From<(&'a String, &'a String)> for Table<'a> {
     }
 }
 
-impl<'a> From<String> for Table<'a> {
+impl From<String> for Table<'_> {
     fn from(s: String) -> Self {
         Table {
             typ: TableType::Table(s.into()),

--- a/quaint/src/ast/values.rs
+++ b/quaint/src/ast/values.rs
@@ -41,7 +41,7 @@ pub struct NativeColumnType<'a> {
     pub length: Option<TypeDataLength>,
 }
 
-impl<'a> std::ops::Deref for NativeColumnType<'a> {
+impl std::ops::Deref for NativeColumnType<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -75,7 +75,7 @@ pub struct Value<'a> {
 
 impl<'a> Value<'a> {
     /// Returns the native column type of the value, if any, in the form
-    /// of an UPCASE string. ex: "VARCHAR, BYTEA, DATE, TIMEZ"  
+    /// of an UPCASE string. ex: "VARCHAR, BYTEA, DATE, TIMEZ"
     pub fn native_column_type_name(&'a self) -> Option<&'a str> {
         self.native_column_type.as_deref()
     }
@@ -312,21 +312,18 @@ impl<'a> Value<'a> {
     }
 
     /// `true` if the `Value` is a numeric value or can be converted to one.
-
     pub fn is_numeric(&self) -> bool {
         self.typed.is_numeric()
     }
 
     /// Returns a bigdecimal, if the value is a numeric, float or double value,
     /// otherwise `None`.
-
     pub fn into_numeric(self) -> Option<BigDecimal> {
         self.typed.into_numeric()
     }
 
     /// Returns a reference to a bigdecimal, if the value is a numeric.
     /// Otherwise `None`.
-
     pub fn as_numeric(&self) -> Option<&BigDecimal> {
         self.typed.as_numeric()
     }
@@ -490,7 +487,7 @@ impl<'a> Value<'a> {
     }
 }
 
-impl<'a> Display for Value<'a> {
+impl Display for Value<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.typed.fmt(f)
     }
@@ -560,7 +557,7 @@ pub enum ValueType<'a> {
 
 pub(crate) struct Params<'a>(pub(crate) &'a [Value<'a>]);
 
-impl<'a> Display for Params<'a> {
+impl Display for Params<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let len = self.0.len();
 
@@ -576,7 +573,7 @@ impl<'a> Display for Params<'a> {
     }
 }
 
-impl<'a> fmt::Display for ValueType<'a> {
+impl fmt::Display for ValueType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let res = match self {
             ValueType::Int32(val) => val.map(|v| write!(f, "{v}")),
@@ -711,7 +708,6 @@ impl<'a> ValueType<'a> {
     }
 
     /// Creates a new decimal value.
-
     pub(crate) fn numeric(value: BigDecimal) -> Self {
         Self::Numeric(Some(value))
     }
@@ -979,14 +975,12 @@ impl<'a> ValueType<'a> {
     }
 
     /// `true` if the `Value` is a numeric value or can be converted to one.
-
     pub(crate) fn is_numeric(&self) -> bool {
         matches!(self, Self::Numeric(_) | Self::Float(_) | Self::Double(_))
     }
 
     /// Returns a bigdecimal, if the value is a numeric, float or double value,
     /// otherwise `None`.
-
     pub(crate) fn into_numeric(self) -> Option<BigDecimal> {
         match self {
             Self::Numeric(d) => d,
@@ -998,7 +992,6 @@ impl<'a> ValueType<'a> {
 
     /// Returns a reference to a bigdecimal, if the value is a numeric.
     /// Otherwise `None`.
-
     pub(crate) fn as_numeric(&self) -> Option<&BigDecimal> {
         match self {
             Self::Numeric(d) => d.as_ref(),

--- a/quaint/src/connector/postgres/native/conversion.rs
+++ b/quaint/src/connector/postgres/native/conversion.rs
@@ -707,7 +707,7 @@ impl ToColumnNames for PostgresStatement {
 }
 
 // TODO: consider porting this logic to Driver Adapters as well
-impl<'a> ToSql for Value<'a> {
+impl ToSql for Value<'_> {
     fn to_sql(
         &self,
         ty: &PostgresType,

--- a/quaint/src/connector/postgres/native/conversion/decimal.rs
+++ b/quaint/src/connector/postgres/native/conversion/decimal.rs
@@ -142,7 +142,7 @@ fn to_postgres(decimal: &BigDecimal) -> crate::Result<PostgresDecimal<Vec<i16>>>
     })
 }
 
-impl<'a> FromSql<'a> for DecimalWrapper {
+impl FromSql<'_> for DecimalWrapper {
     // Decimals are represented as follows:
     // Header:
     //  u16 numGroups

--- a/quaint/src/connector/sqlite/native/conversion.rs
+++ b/quaint/src/connector/sqlite/native/conversion.rs
@@ -130,7 +130,7 @@ impl TypeIdentifier for &Column<'_> {
     }
 }
 
-impl<'a> GetRow for SqliteRow<'a> {
+impl GetRow for SqliteRow<'_> {
     fn get_result_row(&self) -> crate::Result<Vec<Value<'static>>> {
         let statement = self.as_ref();
         let mut row = Vec::with_capacity(statement.columns().len());
@@ -233,7 +233,7 @@ impl<'a> GetRow for SqliteRow<'a> {
     }
 }
 
-impl<'a> ToColumnNames for SqliteRows<'a> {
+impl ToColumnNames for SqliteRows<'_> {
     fn to_column_names(&self) -> Vec<String> {
         match self.as_ref() {
             Some(statement) => statement.column_names().into_iter().map(|c| c.into()).collect(),
@@ -242,7 +242,7 @@ impl<'a> ToColumnNames for SqliteRows<'a> {
     }
 }
 
-impl<'a> ToSql for Value<'a> {
+impl ToSql for Value<'_> {
     fn to_sql(&self) -> Result<ToSqlOutput, RusqlError> {
         let value = match &self.typed {
             ValueType::Int32(integer) => integer.map(ToSqlOutput::from),

--- a/quaint/src/connector/transaction.rs
+++ b/quaint/src/connector/transaction.rs
@@ -98,7 +98,7 @@ impl<'a> DefaultTransaction<'a> {
 }
 
 #[async_trait]
-impl<'a> Transaction for DefaultTransaction<'a> {
+impl Transaction for DefaultTransaction<'_> {
     /// Commit the changes to the database and consume the transaction.
     async fn commit(&self) -> crate::Result<()> {
         self.gauge.decrement();
@@ -121,7 +121,7 @@ impl<'a> Transaction for DefaultTransaction<'a> {
 }
 
 #[async_trait]
-impl<'a> Queryable for DefaultTransaction<'a> {
+impl Queryable for DefaultTransaction<'_> {
     async fn query(&self, q: Query<'_>) -> crate::Result<ResultSet> {
         self.inner.query(q).await
     }

--- a/quaint/src/connector/transaction.rs
+++ b/quaint/src/connector/transaction.rs
@@ -60,6 +60,15 @@ pub struct DefaultTransaction<'a> {
     gauge: GaugeGuard,
 }
 
+#[cfg_attr(
+    not(any(
+        feature = "sqlite-native",
+        feature = "mssql-native",
+        feature = "postgresql-native",
+        feature = "mysql-native"
+    )),
+    allow(clippy::needless_lifetimes)
+)]
 impl<'a> DefaultTransaction<'a> {
     #[cfg(any(
         feature = "sqlite-native",

--- a/quaint/src/tests/test_api/mssql.rs
+++ b/quaint/src/tests/test_api/mssql.rs
@@ -30,7 +30,7 @@ impl<'a> MsSql<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> TestApi for MsSql<'a> {
+impl TestApi for MsSql<'_> {
     fn system(&self) -> &'static str {
         "mssql"
     }

--- a/quaint/src/tests/test_api/mysql.rs
+++ b/quaint/src/tests/test_api/mysql.rs
@@ -58,7 +58,7 @@ impl<'a> MySql<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> TestApi for MySql<'a> {
+impl TestApi for MySql<'_> {
     fn system(&self) -> &'static str {
         "mysql"
     }

--- a/quaint/src/tests/test_api/postgres.rs
+++ b/quaint/src/tests/test_api/postgres.rs
@@ -27,7 +27,7 @@ impl<'a> PostgreSql<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> TestApi for PostgreSql<'a> {
+impl TestApi for PostgreSql<'_> {
     fn system(&self) -> &'static str {
         "postgres"
     }

--- a/quaint/src/tests/test_api/sqlite.rs
+++ b/quaint/src/tests/test_api/sqlite.rs
@@ -23,7 +23,7 @@ impl<'a> Sqlite<'a> {
 }
 
 #[async_trait::async_trait]
-impl<'a> TestApi for Sqlite<'a> {
+impl TestApi for Sqlite<'_> {
     fn system(&self) -> &'static str {
         "sqlite"
     }

--- a/query-engine/black-box-tests/tests/helpers/mod.rs
+++ b/query-engine/black-box-tests/tests/helpers/mod.rs
@@ -9,7 +9,7 @@ where
     struct Cleaner<'a> {
         p: &'a mut std::process::Child,
     }
-    impl<'a> Drop for Cleaner<'a> {
+    impl Drop for Cleaner<'_> {
         fn drop(&mut self) {
             self.p.kill().expect("Failed to kill process");
         }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/references.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/schema_gen/references.rs
@@ -14,7 +14,7 @@ pub enum RelationReference<'a> {
     NoRef,
 }
 
-impl<'a> RelationReference<'a> {
+impl RelationReference<'_> {
     pub fn render(&self) -> String {
         match self {
             RelationReference::SimpleChildId(rf) => self.render_simple_child_id(rf),

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -17,7 +17,7 @@ pub struct MongoDbTransaction<'conn> {
     gauge: GaugeGuard,
 }
 
-impl<'conn> ConnectionLike for MongoDbTransaction<'conn> {}
+impl ConnectionLike for MongoDbTransaction<'_> {}
 
 impl<'conn> MongoDbTransaction<'conn> {
     pub(crate) async fn new(
@@ -43,7 +43,7 @@ impl<'conn> MongoDbTransaction<'conn> {
 }
 
 #[async_trait]
-impl<'conn> Transaction for MongoDbTransaction<'conn> {
+impl Transaction for MongoDbTransaction<'_> {
     async fn commit(&mut self) -> connector_interface::Result<()> {
         self.gauge.decrement();
 
@@ -76,7 +76,7 @@ impl<'conn> Transaction for MongoDbTransaction<'conn> {
 }
 
 #[async_trait]
-impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
+impl WriteOperations for MongoDbTransaction<'_> {
     async fn create_record(
         &mut self,
         model: &Model,
@@ -277,7 +277,7 @@ impl<'conn> WriteOperations for MongoDbTransaction<'conn> {
 }
 
 #[async_trait]
-impl<'conn> ReadOperations for MongoDbTransaction<'conn> {
+impl ReadOperations for MongoDbTransaction<'_> {
     async fn get_single_record(
         &mut self,
         model: &Model,

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -34,10 +34,10 @@ impl<'tx> SqlConnectorTransaction<'tx> {
     }
 }
 
-impl<'tx> ConnectionLike for SqlConnectorTransaction<'tx> {}
+impl ConnectionLike for SqlConnectorTransaction<'_> {}
 
 #[async_trait]
-impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
+impl Transaction for SqlConnectorTransaction<'_> {
     async fn commit(&mut self) -> connector::Result<()> {
         catch(&self.connection_info, async {
             self.inner.commit().await.map_err(SqlError::from)
@@ -67,7 +67,7 @@ impl<'tx> Transaction for SqlConnectorTransaction<'tx> {
 }
 
 #[async_trait]
-impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
+impl ReadOperations for SqlConnectorTransaction<'_> {
     async fn get_single_record(
         &mut self,
         model: &Model,
@@ -154,7 +154,7 @@ impl<'tx> ReadOperations for SqlConnectorTransaction<'tx> {
 }
 
 #[async_trait]
-impl<'tx> WriteOperations for SqlConnectorTransaction<'tx> {
+impl WriteOperations for SqlConnectorTransaction<'_> {
     async fn create_record(
         &mut self,
         model: &Model,

--- a/query-engine/connectors/sql-query-connector/src/ser_raw.rs
+++ b/query-engine/connectors/sql-query-connector/src/ser_raw.rs
@@ -32,7 +32,7 @@ impl serde::Serialize for SerializedResultSet {
 #[derive(Debug)]
 struct SerializedColumns<'a>(&'a ResultSet);
 
-impl<'a> Serialize for SerializedColumns<'a> {
+impl Serialize for SerializedColumns<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -46,7 +46,7 @@ impl<'a> Serialize for SerializedColumns<'a> {
 #[derive(Debug)]
 struct SerializedTypes<'a>(&'a ResultSet);
 
-impl<'a> SerializedTypes<'a> {
+impl SerializedTypes<'_> {
     fn infer_unknown_column_types(&self) -> Vec<ColumnType> {
         let rows = self.0;
 
@@ -104,7 +104,7 @@ impl Serialize for SerializedTypes<'_> {
 #[derive(Debug)]
 struct SerializedRows<'a>(&'a ResultSet);
 
-impl<'a> Serialize for SerializedRows<'a> {
+impl Serialize for SerializedRows<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -140,7 +140,7 @@ impl Serialize for SerializedRow<'_> {
 
 struct SerializedValue<'a>(&'a Value<'a>);
 
-impl<'a> Serialize for SerializedValue<'a> {
+impl Serialize for SerializedValue<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -153,7 +153,7 @@ pub(crate) struct QueryInterpreter<'conn> {
     log: Vec<String>,
 }
 
-impl<'conn> fmt::Debug for QueryInterpreter<'conn> {
+impl fmt::Debug for QueryInterpreter<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("QueryInterpreter").finish()
     }

--- a/query-engine/core/src/query_document/parse_ast.rs
+++ b/query-engine/core/src/query_document/parse_ast.rs
@@ -67,7 +67,7 @@ impl<'a> Deref for ParsedInputMap<'a> {
     }
 }
 
-impl<'a> DerefMut for ParsedInputMap<'a> {
+impl DerefMut for ParsedInputMap<'_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.map
     }

--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -121,10 +121,10 @@ impl QueryDocumentParser {
         )
         .and_then(move |arguments| {
             if !selection.nested_selections().is_empty() && schema_field.field_type().is_scalar() {
-                return Err(ValidationError::selection_set_on_scalar(
+                Err(ValidationError::selection_set_on_scalar(
                     selection.name().to_string(),
                     selection_path.segments(),
-                ));
+                ))
             } else {
                 // If the output type of the field is an object type of any form, validate the sub selection as well.
                 let nested_fields = schema_field.field_type().as_object_type().map(|obj| {

--- a/query-engine/core/src/response_ir/internal.rs
+++ b/query-engine/core/src/response_ir/internal.rs
@@ -312,7 +312,7 @@ enum SerializedFieldWithRelations<'a, 'b> {
     VirtualsGroup(&'a str, Vec<&'a VirtualSelection>),
 }
 
-impl<'a, 'b> SerializedFieldWithRelations<'a, 'b> {
+impl SerializedFieldWithRelations<'_, '_> {
     fn name(&self) -> &str {
         match self {
             Self::Model(f, _) => f.name(),

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/enum_renderer.rs
@@ -11,7 +11,7 @@ pub struct DmmfEnumRenderer {
     enum_type: EnumType,
 }
 
-impl<'a> Renderer<'a> for DmmfEnumRenderer {
+impl Renderer<'_> for DmmfEnumRenderer {
     fn render(&self, ctx: &mut RenderContext) {
         let ident = self.enum_type.identifier();
         if ctx.already_rendered(ident) {

--- a/query-engine/query-engine-c-abi/src/logger.rs
+++ b/query-engine/query-engine-c-abi/src/logger.rs
@@ -70,7 +70,7 @@ pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, Value>,
 }
 
-impl<'a> JsonVisitor<'a> {
+impl JsonVisitor<'_> {
     pub fn new(level: &Level, target: &str) -> Self {
         let mut values = BTreeMap::new();
         values.insert("level", serde_json::Value::from(level.to_string()));
@@ -82,7 +82,7 @@ impl<'a> JsonVisitor<'a> {
     }
 }
 
-impl<'a> Visit for JsonVisitor<'a> {
+impl Visit for JsonVisitor<'_> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         match field.name() {
             name if name.starts_with("r#") => {
@@ -112,7 +112,7 @@ impl<'a> Visit for JsonVisitor<'a> {
     }
 }
 
-impl<'a> Display for JsonVisitor<'a> {
+impl Display for JsonVisitor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&serde_json::to_string(&self.values).unwrap())
     }

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -95,7 +95,7 @@ pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, Value>,
 }
 
-impl<'a> JsonVisitor<'a> {
+impl JsonVisitor<'_> {
     pub fn new(level: &Level, target: &str) -> Self {
         let mut values = BTreeMap::new();
         values.insert("level", serde_json::Value::from(level.to_string()));
@@ -107,7 +107,7 @@ impl<'a> JsonVisitor<'a> {
     }
 }
 
-impl<'a> Visit for JsonVisitor<'a> {
+impl Visit for JsonVisitor<'_> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         match field.name() {
             name if name.starts_with("r#") => {
@@ -137,7 +137,7 @@ impl<'a> Visit for JsonVisitor<'a> {
     }
 }
 
-impl<'a> Display for JsonVisitor<'a> {
+impl Display for JsonVisitor<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&serde_json::to_string(&self.values).unwrap())
     }

--- a/query-engine/query-engine-wasm/src/wasm/logger.rs
+++ b/query-engine/query-engine-wasm/src/wasm/logger.rs
@@ -60,7 +60,7 @@ pub struct JsonVisitor<'a> {
     values: BTreeMap<&'a str, Value>,
 }
 
-impl<'a> JsonVisitor<'a> {
+impl JsonVisitor<'_> {
     pub fn new(level: &Level, target: &str) -> Self {
         let mut values = BTreeMap::new();
         values.insert("level", serde_json::Value::from(level.to_string()));
@@ -72,7 +72,7 @@ impl<'a> JsonVisitor<'a> {
     }
 }
 
-impl<'a> Visit for JsonVisitor<'a> {
+impl Visit for JsonVisitor<'_> {
     fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
         match field.name() {
             name if name.starts_with("r#") => {
@@ -102,7 +102,7 @@ impl<'a> Visit for JsonVisitor<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for JsonVisitor<'a> {
+impl std::fmt::Display for JsonVisitor<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&serde_json::to_string(&self.values).unwrap())
     }

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -358,7 +358,7 @@ fn handle_debug_headers(req: &Request<Body>) -> Response<Body> {
 
 struct HeaderExtractor<'a>(&'a HeaderMap);
 
-impl<'a> Extractor for HeaderExtractor<'a> {
+impl Extractor for HeaderExtractor<'_> {
     fn get(&self, key: &str) -> Option<&str> {
         self.0.get(key).and_then(|hv| hv.to_str().ok())
     }

--- a/query-engine/request-handlers/src/handler.rs
+++ b/query-engine/request-handlers/src/handler.rs
@@ -23,7 +23,7 @@ pub struct RequestHandler<'a> {
     engine_protocol: EngineProtocol,
 }
 
-impl<'a> fmt::Debug for RequestHandler<'a> {
+impl fmt::Debug for RequestHandler<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("RequestHandler").finish()
     }

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/field_renderer.rs
@@ -6,7 +6,7 @@ pub(crate) enum GqlFieldRenderer<'a> {
     Output(OutputField<'a>),
 }
 
-impl<'a> Renderer for GqlFieldRenderer<'a> {
+impl Renderer for GqlFieldRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
             GqlFieldRenderer::Input(input) => self.render_input_field(input, ctx),

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/mod.rs
@@ -15,7 +15,7 @@ struct GqlSchemaRenderer<'a> {
     query_schema: &'a QuerySchema,
 }
 
-impl<'a> Renderer for GqlSchemaRenderer<'a> {
+impl Renderer for GqlSchemaRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         let _ = self.query_schema.query().as_renderer().render(ctx);
         self.query_schema.mutation().as_renderer().render(ctx)
@@ -101,7 +101,7 @@ enum GqlRenderer<'a> {
     Enum(GqlEnumRenderer),
 }
 
-impl<'a> Renderer for GqlRenderer<'a> {
+impl Renderer for GqlRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
             GqlRenderer::Schema(s) => s.render(ctx),

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/object_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/object_renderer.rs
@@ -6,7 +6,7 @@ pub enum GqlObjectRenderer<'a> {
     Output(ObjectType<'a>),
 }
 
-impl<'a> Renderer for GqlObjectRenderer<'a> {
+impl Renderer for GqlObjectRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match &self {
             GqlObjectRenderer::Input(input) => self.render_input_object(input, ctx),

--- a/query-engine/request-handlers/src/protocols/graphql/schema_renderer/type_renderer.rs
+++ b/query-engine/request-handlers/src/protocols/graphql/schema_renderer/type_renderer.rs
@@ -6,7 +6,7 @@ pub enum GqlTypeRenderer<'a> {
     Output(OutputType<'a>),
 }
 
-impl<'a> Renderer for GqlTypeRenderer<'a> {
+impl Renderer for GqlTypeRenderer<'_> {
     fn render(&self, ctx: &mut RenderContext) -> String {
         match self {
             GqlTypeRenderer::Input(i) => self.render_input_type(i, ctx),

--- a/query-engine/request-handlers/src/response.rs
+++ b/query-engine/request-handlers/src/response.rs
@@ -136,7 +136,6 @@ impl From<ResponseData> for GQLResponse {
 }
 
 /// GQLBatchResponse converters
-
 impl GQLBatchResponse {
     pub fn insert_responses(&mut self, responses: Vec<GQLResponse>) {
         responses.into_iter().for_each(|response| {

--- a/query-engine/schema/src/build/utils.rs
+++ b/query-engine/schema/src/build/utils.rs
@@ -66,7 +66,7 @@ pub(crate) fn simple_input_field<'a>(
     name: impl Into<std::borrow::Cow<'a, str>>,
     field_type: InputType<'a>,
     default_value: Option<DefaultKind>,
-) -> InputField<'_> {
+) -> InputField<'a> {
     input_field(name, vec![field_type], default_value)
 }
 

--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -195,7 +195,7 @@ pub enum InputType<'a> {
     Object(InputObjectType<'a>),
 }
 
-impl<'a> PartialEq for InputType<'a> {
+impl PartialEq for InputType<'_> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (InputType::Scalar(st), InputType::Scalar(ost)) => st.eq(ost),
@@ -207,7 +207,7 @@ impl<'a> PartialEq for InputType<'a> {
     }
 }
 
-impl<'a> Debug for InputType<'a> {
+impl Debug for InputType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Object(obj) => write!(f, "Object({obj:?})"),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.83.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.
@@ -18,5 +18,5 @@ targets = [
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-gnu",
     "aarch64-unknown-linux-musl",
-    "aarch64-apple-darwin"
+    "aarch64-apple-darwin",
 ]

--- a/schema-engine/connectors/sql-schema-connector/src/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour.rs
@@ -258,7 +258,7 @@ pub(crate) trait SqlFlavour:
         &'a mut self,
         sql: &'a str,
         params: &'a [quaint::prelude::Value<'a>],
-    ) -> BoxFuture<'_, ConnectorResult<quaint::prelude::ResultSet>>;
+    ) -> BoxFuture<'a, ConnectorResult<quaint::prelude::ResultSet>>;
 
     fn raw_cmd<'a>(&'a mut self, sql: &'a str) -> BoxFuture<'a, ConnectorResult<()>>;
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
@@ -347,7 +347,7 @@ impl SqlFlavour for SqliteFlavour {
         migrations: &'a [MigrationDirectory],
         _shadow_database_connection_string: Option<String>,
         _namespaces: Option<Namespaces>,
-    ) -> BoxFuture<'_, ConnectorResult<SqlSchema>> {
+    ) -> BoxFuture<'a, ConnectorResult<SqlSchema>> {
         Box::pin(async move {
             tracing::debug!("Applying migrations to temporary in-memory SQLite database.");
             let mut shadow_db_conn = Connection::new_in_memory();

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/mssql_renderer/alter_table.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/mssql_renderer/alter_table.rs
@@ -51,7 +51,7 @@ struct AlterTableConstructor<'a> {
     column_mods: Vec<String>,
 }
 
-impl<'a> AlterTableConstructor<'a> {
+impl AlterTableConstructor<'_> {
     fn into_statements(mut self) -> Vec<String> {
         for change in self.changes {
             match change {

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/table.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/table.rs
@@ -12,7 +12,7 @@ pub(crate) struct TableDiffer<'a, 'b> {
     pub(crate) db: &'b DifferDatabase<'a>,
 }
 
-impl<'schema, 'b> TableDiffer<'schema, 'b> {
+impl<'schema> TableDiffer<'schema, '_> {
     pub(crate) fn column_pairs(&self) -> impl Iterator<Item = MigrationPair<TableColumnWalker<'schema>>> + '_ {
         self.db
             .column_pairs(self.tables.map(|t| t.id))

--- a/schema-engine/datamodel-renderer/src/configuration.rs
+++ b/schema-engine/datamodel-renderer/src/configuration.rs
@@ -61,7 +61,7 @@ impl<'a> Configuration<'a> {
     }
 }
 
-impl<'a> fmt::Display for Configuration<'a> {
+impl fmt::Display for Configuration<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for (_, generators) in self.generators.iter() {
             for generator in generators {

--- a/schema-engine/datamodel-renderer/src/configuration/datasource.rs
+++ b/schema-engine/datamodel-renderer/src/configuration/datasource.rs
@@ -137,7 +137,7 @@ impl<'a> Datasource<'a> {
     }
 }
 
-impl<'a> fmt::Display for Datasource<'a> {
+impl fmt::Display for Datasource<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref doc) = self.documentation {
             doc.fmt(f)?;

--- a/schema-engine/datamodel-renderer/src/configuration/generator.rs
+++ b/schema-engine/datamodel-renderer/src/configuration/generator.rs
@@ -122,7 +122,7 @@ impl<'a> Generator<'a> {
     }
 }
 
-impl<'a> fmt::Display for Generator<'a> {
+impl fmt::Display for Generator<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref doc) = self.documentation {
             doc.fmt(f)?;

--- a/schema-engine/datamodel-renderer/src/datamodel/attributes.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/attributes.rs
@@ -37,7 +37,7 @@ impl<'a> FieldAttribute<'a> {
     }
 }
 
-impl<'a> fmt::Display for FieldAttribute<'a> {
+impl fmt::Display for FieldAttribute<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("@")?;
 
@@ -70,7 +70,7 @@ impl<'a> BlockAttribute<'a> {
     }
 }
 
-impl<'a> fmt::Display for BlockAttribute<'a> {
+impl fmt::Display for BlockAttribute<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("@@")?;
         self.0.fmt(f)?;

--- a/schema-engine/datamodel-renderer/src/datamodel/composite_type.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/composite_type.rs
@@ -55,7 +55,7 @@ impl<'a> CompositeType<'a> {
     }
 }
 
-impl<'a> fmt::Display for CompositeType<'a> {
+impl fmt::Display for CompositeType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref docs) = self.documentation {
             docs.fmt(f)?;

--- a/schema-engine/datamodel-renderer/src/datamodel/default.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/default.rs
@@ -113,7 +113,7 @@ impl<'a> DefaultValue<'a> {
     }
 }
 
-impl<'a> fmt::Display for DefaultValue<'a> {
+impl fmt::Display for DefaultValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/schema-engine/datamodel-renderer/src/datamodel/enumerator.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/enumerator.rs
@@ -74,7 +74,7 @@ impl<'a> From<&'a str> for EnumVariant<'a> {
     }
 }
 
-impl<'a> fmt::Display for EnumVariant<'a> {
+impl fmt::Display for EnumVariant<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref docs) = self.documentation {
             docs.fmt(f)?;
@@ -184,7 +184,7 @@ impl<'a> Enum<'a> {
     }
 }
 
-impl<'a> fmt::Display for Enum<'a> {
+impl fmt::Display for Enum<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(doc) = &self.documentation {
             doc.fmt(f)?;

--- a/schema-engine/datamodel-renderer/src/datamodel/field.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/field.rs
@@ -225,7 +225,7 @@ impl<'a> Field<'a> {
     }
 }
 
-impl<'a> fmt::Display for Field<'a> {
+impl fmt::Display for Field<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref docs) = self.documentation {
             docs.fmt(f)?;

--- a/schema-engine/datamodel-renderer/src/datamodel/field_type.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/field_type.rs
@@ -89,7 +89,7 @@ impl<'a> FieldType<'a> {
     }
 }
 
-impl<'a> fmt::Display for FieldType<'a> {
+impl fmt::Display for FieldType<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.inner {
             FieldKind::Required(ref t) => t.fmt(f),

--- a/schema-engine/datamodel-renderer/src/datamodel/index.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/index.rs
@@ -64,7 +64,7 @@ impl<'a> IndexDefinition<'a> {
     }
 }
 
-impl<'a> fmt::Display for IndexDefinition<'a> {
+impl fmt::Display for IndexDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -102,7 +102,7 @@ impl<'a> IndexOps<'a> {
     }
 }
 
-impl<'a> fmt::Display for IndexOps<'a> {
+impl fmt::Display for IndexOps<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.0 {
             InnerOps::Managed(ref s) => f.write_str(s),

--- a/schema-engine/datamodel-renderer/src/datamodel/index/field.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/index/field.rs
@@ -93,7 +93,7 @@ impl<'a> From<IndexFieldInput<'a>> for Function<'a> {
 #[derive(Debug)]
 pub struct UniqueFieldAttribute<'a>(FieldAttribute<'a>);
 
-impl<'a> Default for UniqueFieldAttribute<'a> {
+impl Default for UniqueFieldAttribute<'_> {
     fn default() -> Self {
         Self(FieldAttribute::new(Function::new("unique")))
     }
@@ -141,7 +141,7 @@ impl<'a> UniqueFieldAttribute<'a> {
     }
 }
 
-impl<'a> fmt::Display for UniqueFieldAttribute<'a> {
+impl fmt::Display for UniqueFieldAttribute<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/schema-engine/datamodel-renderer/src/datamodel/index/id.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/index/id.rs
@@ -58,7 +58,7 @@ impl<'a> IdDefinition<'a> {
     }
 }
 
-impl<'a> fmt::Display for IdDefinition<'a> {
+impl fmt::Display for IdDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
@@ -120,13 +120,13 @@ impl<'a> IdFieldDefinition<'a> {
     }
 }
 
-impl<'a> Default for IdFieldDefinition<'a> {
+impl Default for IdFieldDefinition<'_> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<'a> fmt::Display for IdFieldDefinition<'a> {
+impl fmt::Display for IdFieldDefinition<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/schema-engine/datamodel-renderer/src/datamodel/model.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/model.rs
@@ -192,7 +192,7 @@ impl<'a> Model<'a> {
     }
 }
 
-impl<'a> fmt::Display for Model<'a> {
+impl fmt::Display for Model<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Prefix everything with this, so if the model is commented out, so
         // is your line.

--- a/schema-engine/datamodel-renderer/src/datamodel/model/relation.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/model/relation.rs
@@ -9,7 +9,7 @@ use crate::{
 #[derive(Debug)]
 pub struct Relation<'a>(FieldAttribute<'a>);
 
-impl<'a> Default for Relation<'a> {
+impl Default for Relation<'_> {
     fn default() -> Self {
         Self::new()
     }
@@ -92,7 +92,7 @@ impl<'a> Relation<'a> {
     }
 }
 
-impl<'a> fmt::Display for Relation<'a> {
+impl fmt::Display for Relation<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }

--- a/schema-engine/datamodel-renderer/src/datamodel/view.rs
+++ b/schema-engine/datamodel-renderer/src/datamodel/view.rs
@@ -137,7 +137,7 @@ impl<'a> View<'a> {
     }
 }
 
-impl<'a> fmt::Display for View<'a> {
+impl fmt::Display for View<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // Prefix everything with this, so if the model is commented out, so
         // is your line.

--- a/schema-engine/datamodel-renderer/src/value.rs
+++ b/schema-engine/datamodel-renderer/src/value.rs
@@ -37,7 +37,7 @@ pub enum Value<'a> {
     IndexOps(IndexOps<'a>),
 }
 
-impl<'a> fmt::Debug for Value<'a> {
+impl fmt::Debug for Value<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::Text(t) => f.debug_tuple("Text").field(t).finish(),
@@ -59,7 +59,7 @@ impl<'a> From<IndexOps<'a>> for Value<'a> {
     }
 }
 
-impl<'a, T> From<Constant<T>> for Value<'a>
+impl<T> From<Constant<T>> for Value<'_>
 where
     T: fmt::Display,
 {
@@ -68,7 +68,7 @@ where
     }
 }
 
-impl<'a> From<Vec<u8>> for Value<'a> {
+impl From<Vec<u8>> for Value<'_> {
     fn from(bytes: Vec<u8>) -> Self {
         let display = Base64Display::with_config(&bytes, base64::STANDARD).to_string();
         Self::Text(Text::new(display))
@@ -133,7 +133,7 @@ impl<'a> FromIterator<Value<'a>> for Value<'a> {
     }
 }
 
-impl<'a> fmt::Display for Value<'a> {
+impl fmt::Display for Value<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::Text(val) => {

--- a/schema-engine/datamodel-renderer/src/value/constant.rs
+++ b/schema-engine/datamodel-renderer/src/value/constant.rs
@@ -4,27 +4,27 @@ use std::{borrow::Cow, fmt};
 #[derive(Debug)]
 pub struct Constant<T: fmt::Display>(pub(crate) T);
 
-impl<'a> Clone for Constant<&'a str> {
+impl Clone for Constant<&str> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a> Clone for Constant<Cow<'a, str>> {
+impl Clone for Constant<Cow<'_, str>> {
     fn clone(&self) -> Self {
         Constant(self.0.clone())
     }
 }
 
-impl<'a> Copy for Constant<&'a str> {}
+impl Copy for Constant<&str> {}
 
-impl<'a> AsRef<str> for Constant<&'a str> {
+impl AsRef<str> for Constant<&str> {
     fn as_ref(&self) -> &str {
         self.0
     }
 }
 
-impl<'a> AsRef<str> for Constant<Cow<'a, str>> {
+impl AsRef<str> for Constant<Cow<'_, str>> {
     fn as_ref(&self) -> &str {
         self.0.as_ref()
     }

--- a/schema-engine/datamodel-renderer/src/value/documentation.rs
+++ b/schema-engine/datamodel-renderer/src/value/documentation.rs
@@ -18,7 +18,7 @@ impl<'a> Documentation<'a> {
     }
 }
 
-impl<'a> fmt::Display for Documentation<'a> {
+impl fmt::Display for Documentation<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for line in self.0.split('\n') {
             f.write_str("///")?;

--- a/schema-engine/datamodel-renderer/src/value/env.rs
+++ b/schema-engine/datamodel-renderer/src/value/env.rs
@@ -36,7 +36,7 @@ impl<'a> From<&'a StringFromEnvVar> for Env<'a> {
     }
 }
 
-impl<'a> fmt::Display for Env<'a> {
+impl fmt::Display for Env<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Env::FromVar(var) => {

--- a/schema-engine/datamodel-renderer/src/value/function.rs
+++ b/schema-engine/datamodel-renderer/src/value/function.rs
@@ -55,7 +55,7 @@ where
     }
 }
 
-impl<'a> fmt::Display for FunctionParam<'a> {
+impl fmt::Display for FunctionParam<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FunctionParam::KeyValue(k, v) => {
@@ -105,7 +105,7 @@ impl<'a> Function<'a> {
     }
 }
 
-impl<'a> fmt::Display for Function<'a> {
+impl fmt::Display for Function<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)?;
 

--- a/schema-engine/datamodel-renderer/src/value/text.rs
+++ b/schema-engine/datamodel-renderer/src/value/text.rs
@@ -13,19 +13,19 @@ impl<'a> Text<Cow<'a, str>> {
     }
 }
 
-impl<'a> fmt::Display for Text<&'a str> {
+impl fmt::Display for Text<&str> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&psl::schema_ast::string_literal(self.0), f)
     }
 }
 
-impl<'a> fmt::Display for Text<Cow<'a, str>> {
+impl fmt::Display for Text<Cow<'_, str>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&psl::schema_ast::string_literal(self.0.as_ref()), f)
     }
 }
 
-impl<'a> fmt::Display for Text<Base64Display<'a>> {
+impl fmt::Display for Text<Base64Display<'_>> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("\"")?;
         self.0.fmt(f)?;

--- a/schema-engine/sql-migration-tests/src/assertions.rs
+++ b/schema-engine/sql-migration-tests/src/assertions.rs
@@ -295,7 +295,7 @@ impl SchemaAssertion {
 
 pub struct EnumAssertion<'a>(sql::EnumWalker<'a>);
 
-impl<'a> EnumAssertion<'a> {
+impl EnumAssertion<'_> {
     pub fn assert_namespace(self, namespace: &'static str) -> Self {
         assert_eq!(self.0.namespace(), Some(namespace));
         self
@@ -517,7 +517,7 @@ pub struct ColumnAssertion<'a> {
     column: TableColumnWalker<'a>,
 }
 
-impl<'a> ColumnAssertion<'a> {
+impl ColumnAssertion<'_> {
     pub fn assert_auto_increments(self) -> Self {
         assert!(
             self.column.is_autoincrement(),
@@ -795,7 +795,7 @@ pub struct PrimaryKeyAssertion<'a> {
     tags: BitFlags<Tags>,
 }
 
-impl<'a> PrimaryKeyAssertion<'a> {
+impl PrimaryKeyAssertion<'_> {
     pub fn assert_columns(self, column_names: &[&str]) -> Self {
         assert_eq!(&self.pk.column_names().collect::<Vec<_>>(), column_names);
 
@@ -875,7 +875,7 @@ pub struct ForeignKeyAssertion<'a> {
     tags: BitFlags<Tags>,
 }
 
-impl<'a> ForeignKeyAssertion<'a> {
+impl ForeignKeyAssertion<'_> {
     #[track_caller]
     pub fn assert_references(self, table: &str, columns: &[&str]) -> Self {
         assert!(
@@ -925,7 +925,7 @@ pub struct IndexAssertion<'a> {
     tags: BitFlags<Tags>,
 }
 
-impl<'a> IndexAssertion<'a> {
+impl IndexAssertion<'_> {
     #[track_caller]
     pub fn assert_name(self, name: &str) -> Self {
         assert_eq!(self.index.name(), name);
@@ -1018,7 +1018,7 @@ pub struct PostgresExtensionAssertion<'a> {
     extension: ExtensionWalker<'a>,
 }
 
-impl<'a> PostgresExtensionAssertion<'a> {
+impl PostgresExtensionAssertion<'_> {
     pub fn assert_schema(self, expected_schema: &str) -> Self {
         assert_eq!(
             self.extension.schema(), expected_schema,

--- a/schema-engine/sql-migration-tests/src/assertions/quaint_result_set_ext.rs
+++ b/schema-engine/sql-migration-tests/src/assertions/quaint_result_set_ext.rs
@@ -32,7 +32,7 @@ impl ResultSetExt for ResultSet {
 #[derive(Debug)]
 pub struct RowAssertion<'a>(ResultRowRef<'a>);
 
-impl<'a> RowAssertion<'a> {
+impl RowAssertion<'_> {
     pub fn assert_array_value(self, column_name: &str, expected_value: &[Value<'_>]) -> Self {
         let actual_value = self.0.get(column_name).and_then(|col: &Value<'_>| match &col.typed {
             ValueType::Array(x) => x.as_ref(),

--- a/schema-engine/sql-migration-tests/src/commands/apply_migrations.rs
+++ b/schema-engine/sql-migration-tests/src/commands/apply_migrations.rs
@@ -66,7 +66,7 @@ impl std::fmt::Debug for ApplyMigrationsAssertion<'_> {
     }
 }
 
-impl<'a> ApplyMigrationsAssertion<'a> {
+impl ApplyMigrationsAssertion<'_> {
     #[track_caller]
     pub fn assert_applied_migrations(self, names: &[&str]) -> Self {
         let found_names: Vec<&str> = self

--- a/schema-engine/sql-migration-tests/src/commands/create_migration.rs
+++ b/schema-engine/sql-migration-tests/src/commands/create_migration.rs
@@ -82,7 +82,7 @@ impl std::fmt::Debug for CreateMigrationAssertion<'_> {
     }
 }
 
-impl<'a> CreateMigrationAssertion<'a> {
+impl CreateMigrationAssertion<'_> {
     /// Assert that there are `expected_count` migrations in the migrations directory.
     #[tracing::instrument(skip(self))]
     #[track_caller]

--- a/schema-engine/sql-migration-tests/src/commands/dev_diagnostic.rs
+++ b/schema-engine/sql-migration-tests/src/commands/dev_diagnostic.rs
@@ -54,7 +54,7 @@ impl std::fmt::Debug for DevDiagnosticAssertions<'_> {
     }
 }
 
-impl<'a> DevDiagnosticAssertions<'a> {
+impl DevDiagnosticAssertions<'_> {
     pub fn into_output(self) -> DevDiagnosticOutput {
         self.output
     }

--- a/schema-engine/sql-migration-tests/src/commands/diagnose_migration_history.rs
+++ b/schema-engine/sql-migration-tests/src/commands/diagnose_migration_history.rs
@@ -67,7 +67,7 @@ impl std::fmt::Debug for DiagnoseMigrationHistoryAssertions<'_> {
     }
 }
 
-impl<'a> DiagnoseMigrationHistoryAssertions<'a> {
+impl DiagnoseMigrationHistoryAssertions<'_> {
     pub fn into_output(self) -> DiagnoseMigrationHistoryOutput {
         self.output
     }

--- a/schema-engine/sql-migration-tests/src/commands/evaluate_data_loss.rs
+++ b/schema-engine/sql-migration-tests/src/commands/evaluate_data_loss.rs
@@ -61,7 +61,7 @@ impl std::fmt::Debug for EvaluateDataLossAssertion<'_> {
     }
 }
 
-impl<'a> EvaluateDataLossAssertion<'a> {
+impl EvaluateDataLossAssertion<'_> {
     #[track_caller]
     pub fn assert_steps_count(self, count: u32) -> Self {
         assert!(

--- a/schema-engine/sql-migration-tests/src/commands/list_migration_directories.rs
+++ b/schema-engine/sql-migration-tests/src/commands/list_migration_directories.rs
@@ -44,7 +44,7 @@ impl std::fmt::Debug for ListMigrationDirectoriesAssertion<'_> {
     }
 }
 
-impl<'a> ListMigrationDirectoriesAssertion<'a> {
+impl ListMigrationDirectoriesAssertion<'_> {
     #[track_caller]
     pub fn assert_listed_directories(self, names: &[&str]) -> Self {
         let found_names: Vec<&str> = self.output.migrations.iter().map(|name| &name[15..]).collect();

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -310,7 +310,7 @@ impl TestApi {
         MarkMigrationRolledBack::new(&mut self.connector, migration_name.into())
     }
 
-    pub fn migration_persistence<'a>(&'a mut self) -> &mut (dyn MigrationPersistence + 'a) {
+    pub fn migration_persistence<'a>(&'a mut self) -> &'a mut (dyn MigrationPersistence + 'a) {
         &mut self.connector
     }
 

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -527,7 +527,7 @@ impl AsRef<str> for SQLOperatorClassKind {
 }
 
 #[async_trait::async_trait]
-impl<'a> super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'a> {
+impl super::SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
     async fn list_databases(&self) -> DescriberResult<Vec<String>> {
         Ok(self.get_databases().await?)
     }

--- a/schema-engine/sql-schema-describer/tests/test_api/mod.rs
+++ b/schema-engine/sql-schema-describer/tests/test_api/mod.rs
@@ -335,7 +335,7 @@ pub struct ForeignKeyAssertion<'a> {
     fk: ForeignKeyWalker<'a>,
 }
 
-impl<'a> ForeignKeyAssertion<'a> {
+impl ForeignKeyAssertion<'_> {
     pub fn assert_references(&self, table: &str, columns: &[&str]) -> &Self {
         assert_eq!(self.fk.referenced_table().name(), table);
         let referenced_columns = self.fk.referenced_columns();


### PR DESCRIPTION
Rust 1.83 was released on Thursday, it's time to update as usual.

* Update Rust to 1.83.0
* Update Nix flake
* Update the GitHub linting workflow to lint `prisma-schema-build` for WASM target on CI (it didn't use to 🤷)
* Fix all compiler and clippy warnings