### PR TITLE
fix: correctly handle foreign keys when dropping mysql indexes

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/apply_migration.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/apply_migration.rs
@@ -159,9 +159,7 @@ fn render_raw_sql(
             index_id,
             from_drop_and_recreate: _,
         } => vec![renderer.render_create_index(schemas.next.walk(*index_id))],
-        SqlMigrationStep::DropIndex { index_id } => {
-            vec![renderer.render_drop_index(schemas.previous.walk(*index_id))]
-        }
+        SqlMigrationStep::DropIndex { index_id } => vec![renderer.render_drop_index(schemas.previous.walk(*index_id))],
         SqlMigrationStep::RenameIndex { index } => renderer.render_rename_index(schemas.walk(*index)),
         SqlMigrationStep::DropView(drop_view) => {
             let view = schemas.previous.walk(drop_view.view_id);

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ.rs
@@ -388,7 +388,7 @@ fn push_dropped_index_steps(steps: &mut Vec<SqlMigrationStep>, db: &DifferDataba
 
                 // An edge case: if it looks like a normal index that has gone missing from the
                 // schema file and it precisely matches the columns of a foreign key, we assume it
-                // to be the index used for the foreign key and we do not drop it.
+                // to be the index created for the foreign key and we do not drop it.
                 // This prevents us from dropping and re-creating the FK index when the schema file
                 // has not changed.
                 if index.is_normal()

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/index.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/index.rs
@@ -1,15 +1,27 @@
-use sql_schema_describer::walkers::{IndexWalker, TableWalker};
+use either::Either;
+use sql_schema_describer::{
+    walkers::{IndexWalker, TableWalker},
+    ForeignKeyWalker, IndexType,
+};
+use std::iter;
 
-pub(super) fn index_covers_fk(table: TableWalker<'_>, index: IndexWalker<'_>) -> bool {
-    // Only normal indexes can cover foreign keys.
-    if index.index_type() != sql_schema_describer::IndexType::Normal {
-        return false;
+pub(super) fn get_fks_covered_by_index<'a>(
+    table: TableWalker<'a>,
+    index: IndexWalker<'a>,
+) -> impl Iterator<Item = ForeignKeyWalker<'a>> {
+    // Only normal, unique and primary key indexes can cover foreign keys.
+    if !matches!(
+        index.index_type(),
+        IndexType::Normal | IndexType::Unique | IndexType::PrimaryKey
+    ) {
+        return Either::Left(iter::empty());
     }
 
-    table.foreign_keys().any(|fk| {
+    Either::Right(table.foreign_keys().filter(move |fk| {
         let fk_cols = fk.constrained_columns().map(|col| col.name());
         let index_cols = index.column_names();
 
-        fk_cols.len() == index_cols.len() && fk_cols.zip(index_cols).all(|(a, b)| a == b)
-    })
+        // It's sufficient that leftmost columns of the index match the FK columns.
+        fk_cols.len() <= index_cols.len() && fk_cols.zip(index_cols).all(|(a, b)| a == b)
+    }))
 }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -118,8 +118,8 @@ pub(crate) trait SqlSchemaDifferFlavour {
         true
     }
 
-    /// Whether indexes matching a foreign key should be skipped.
-    fn should_skip_fk_indexes(&self) -> bool {
+    /// Whether foreign keys should be recreated when they are covered by deleted indexes.
+    fn should_recreate_fks_covered_by_deleted_indexes(&self) -> bool {
         false
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour/mysql.rs
@@ -91,7 +91,7 @@ impl SqlSchemaDifferFlavour for MysqlFlavour {
         true
     }
 
-    fn should_skip_fk_indexes(&self) -> bool {
+    fn should_recreate_fks_covered_by_deleted_indexes(&self) -> bool {
         true
     }
 

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -72,9 +72,10 @@ fn from_unique_index_to_without(mut api: TestApi) {
     .unwrap();
 
     let expected_printed_messages = if api.is_mysql() {
+        // MySQL requires dropping the foreign key before dropping the index.
         expect![[r#"
             [
-                "-- DropIndex\nDROP INDEX `Post_authorId_key` ON `Post`;\n",
+                "-- DropForeignKey\nALTER TABLE `Post` DROP FOREIGN KEY `Post_authorId_fkey`;\n\n-- DropIndex\nDROP INDEX `Post_authorId_key` ON `Post`;\n\n-- AddForeignKey\nALTER TABLE `Post` ADD CONSTRAINT `Post_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;\n",
             ]
         "#]]
     } else if api.is_sqlite() || api.is_postgres() || api.is_cockroach() {
@@ -1138,7 +1139,7 @@ fn from_multi_file_schema_datamodel_to_url(mut api: TestApi) {
                   provider = "sqlite"
                   url = "{}"
               }}
-    
+
               model cows {{
                 id Int @id
                 meows Boolean

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -71,7 +71,13 @@ fn from_unique_index_to_without(mut api: TestApi) {
     })
     .unwrap();
 
-    let expected_printed_messages = if api.is_mysql() {
+    let expected_printed_messages = if api.is_vitess() {
+        expect![[r#"
+            [
+                "-- DropIndex\nDROP INDEX `Post_authorId_key` ON `Post`;\n",
+            ]
+            "#]]
+    } else if api.is_mysql() {
         // MySQL requires dropping the foreign key before dropping the index.
         expect![[r#"
             [

--- a/schema-engine/sql-schema-describer/src/walkers/index.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/index.rs
@@ -39,6 +39,11 @@ impl<'a> IndexWalker<'a> {
         matches!(self.get().tpe, IndexType::Unique)
     }
 
+    /// Is this index a normal index?
+    pub fn is_normal(self) -> bool {
+        matches!(self.get().tpe, IndexType::Normal)
+    }
+
     /// The name of the index.
     pub fn name(self) -> &'a str {
         &self.get().index_name


### PR DESCRIPTION
Fixes prisma/prisma#22550.
See comments and tests for details.