### PR TITLE
feat(psl): add support for multi-line comments

### DIFF
--- a/psl/psl/tests/parsing/comments.rs
+++ b/psl/psl/tests/parsing/comments.rs
@@ -6,12 +6,12 @@ fn trailing_comments_allowed_in_configuration_blocks() {
       datasource db {
         provider     = "postgres" // "mysql" | "sqlite" ...
         url          = env("TEST_POSTGRES_URI")
-        relationMode = "prisma" // = on or set to "foreignKeys" to turn off emulation
+        relationMode = "prisma" /* = on or set to "foreignKeys" to turn off emulation */
       }
 
       generator js {
         provider        = "prisma-client-js" // optional
-        previewFeatures = ["referentialIntegrity"] // []
+        previewFeatures = ["referentialIntegrity"] /* [] */
       }     
     "#;
 

--- a/psl/psl/tests/reformatter/block_attribute_comments_are_canonised.prisma
+++ b/psl/psl/tests/reformatter/block_attribute_comments_are_canonised.prisma
@@ -1,3 +1,10 @@
+/**
+ * Models
+   With
+   Several
+   Lines
+ */
+
 model MyModel {
   // Example Comment
   field1 Int // Comment Field 1
@@ -10,6 +17,8 @@ model MyModel {
   // This one must stay too.
   @@unique([field1, field3]) // there too
 }
+
+/* Types */
 
 type YourType {
   // Example Comment

--- a/psl/psl/tests/reformatter/block_attribute_comments_are_canonised.reformatted.prisma
+++ b/psl/psl/tests/reformatter/block_attribute_comments_are_canonised.reformatted.prisma
@@ -1,3 +1,10 @@
+/**
+ * Models
+ * With
+ * Several
+ * Lines
+ */
+
 model MyModel {
   // Example Comment
   field1 Int // Comment Field 1
@@ -9,6 +16,10 @@ model MyModel {
   // This one must stay too.
   @@unique([field1, field3]) // there too
 }
+
+/**
+ * Types
+ */
 
 type YourType {
   // Example Comment

--- a/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.prisma
+++ b/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.prisma
@@ -1,11 +1,11 @@
 datasource db {
     provider     = "postgres" // "mysql" | "sqlite" ...
     url          = env("TEST_POSTGRES_URI")
-    relationMode = "prisma" // = on or set to "foreignKeys" to turn off emulation
+    relationMode = "prisma" /* = on or set to "foreignKeys" to turn off emulation */
 }
 
 generator js {
     provider        = "prisma-client-js" // optional
-    previewFeatures = ["referentialIntegrity"] // []
+    previewFeatures = ["referentialIntegrity"] /* [] */
 }     
 

--- a/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.reformatted.prisma
+++ b/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.reformatted.prisma
@@ -1,10 +1,10 @@
 datasource db {
   provider     = "postgres" // "mysql" | "sqlite" ...
   url          = env("TEST_POSTGRES_URI")
-  relationMode = "prisma" // = on or set to "foreignKeys" to turn off emulation
+  relationMode = "prisma" /* = on or set to "foreignKeys" to turn off emulation */
 }
 
 generator js {
   provider        = "prisma-client-js" // optional
-  previewFeatures = ["referentialIntegrity"] // []
+  previewFeatures = ["referentialIntegrity"] /* [] */
 }

--- a/psl/psl/tests/validation/comments/mixed_line_docs_field_block.prisma
+++ b/psl/psl/tests/validation/comments/mixed_line_docs_field_block.prisma
@@ -1,0 +1,18 @@
+/// Example Doc Comment
+model MyModel {
+  pk Int @id
+
+  /*
+   * Multi-line comment
+   * There are several lines here.
+   */
+
+  field1 Int // Comment Field 1
+  field2 Int // Comment Field 2
+
+  /**
+   * Multi-line comment for
+   * field3. This can contain **asterisks**.
+   */
+  field3 Int // Comment Field 3
+}

--- a/psl/psl/tests/validation/comments/multi_line_block.prisma
+++ b/psl/psl/tests/validation/comments/multi_line_block.prisma
@@ -1,0 +1,9 @@
+/**
+ * Comment MyModel
+ */
+model MyModel {
+  pk Int @id
+
+  field1 Int
+  field2 Int
+}

--- a/psl/psl/tests/validation/comments/muti_line_field.prisma
+++ b/psl/psl/tests/validation/comments/muti_line_field.prisma
@@ -1,0 +1,9 @@
+model MyModel {
+  pk Int @id
+
+  /**
+   * Multi-line comment for
+   * field1. This can contain **asterisks**.
+   */
+  field1 Int
+}

--- a/psl/psl/tests/validation/comments/single_line_block.prisma
+++ b/psl/psl/tests/validation/comments/single_line_block.prisma
@@ -1,0 +1,7 @@
+// Comment MyModel
+model MyModel {
+  pk Int @id
+
+  field1 Int
+  field2 Int
+}

--- a/psl/psl/tests/validation/comments/single_line_docs_field_block.prisma
+++ b/psl/psl/tests/validation/comments/single_line_docs_field_block.prisma
@@ -1,0 +1,9 @@
+/// Example Doc Comment
+model MyModel {
+  // Example Comment
+  pk Int @id
+
+  field1 Int // Comment Field 1
+  field2 Int // Comment Field 2
+  field3 Int // Comment Field 3
+}

--- a/psl/psl/tests/validation/comments/single_line_field.prisma
+++ b/psl/psl/tests/validation/comments/single_line_field.prisma
@@ -1,0 +1,6 @@
+model MyModel {
+  pk Int @id
+
+  field1 Int // Comment Field 1
+  field2 Int // Comment Field 2
+}

--- a/psl/schema-ast/src/parser/datamodel.pest
+++ b/psl/schema-ast/src/parser/datamodel.pest
@@ -121,11 +121,17 @@ trailing_comma = @{ "," }
 // ######################################
 // Comments and Documentation Comments
 // ######################################
-comment_block = ${ ((doc_comment | comment) ~ NEWLINE?)+ }
-trailing_comment = ${ doc_comment | comment }
+comment_block = ${ ((doc_comment | comment | multi_line_comment) ~ NEWLINE?)+ }
+trailing_comment = ${ doc_comment | comment | multi_line_comment }
 doc_comment = { WHITESPACE* ~ "///" ~ doc_content }
 comment = { WHITESPACE* ~ (!"///") ~ "//" ~ doc_content }
 doc_content = @{ (!NEWLINE ~ ANY)* }
+multi_line_comment = {
+    WHITESPACE*
+    ~ "/*"
+    ~ (!"*/" ~ ANY)*  // Match any characters until the closing */
+    ~ "*/"
+}
 
 // ######################################
 // shared building blocks

--- a/psl/schema-ast/src/parser/parse_comments.rs
+++ b/psl/schema-ast/src/parser/parse_comments.rs
@@ -10,6 +10,7 @@ pub(crate) fn parse_comment_block(token: Pair<'_>) -> Option<Comment> {
     for comment in token.clone().into_inner() {
         match comment.as_rule() {
             Rule::doc_comment => lines.push(parse_doc_comment(comment)),
+            Rule::multi_line_comment => lines.push(parse_multi_line_comment(comment)),
             Rule::comment | Rule::NEWLINE | Rule::WHITESPACE => {}
             _ => parsing_catch_all(&comment, "comment block"),
         }
@@ -28,6 +29,7 @@ pub(crate) fn parse_trailing_comment(pair: Pair<'_>) -> Option<Comment> {
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::doc_comment => lines.push(parse_doc_comment(current)),
+            Rule::multi_line_comment => lines.push(parse_multi_line_comment(current)),
             Rule::comment | Rule::NEWLINE | Rule::WHITESPACE => {}
             _ => parsing_catch_all(&current, "trailing comment"),
         }
@@ -51,4 +53,11 @@ pub(crate) fn parse_doc_comment(token: Pair<'_>) -> &str {
             child.tokens()
         ),
     }
+}
+
+fn parse_multi_line_comment(token: Pair<'_>) -> &str {
+    // The matched string includes `/*` and `*/`. Strip them off.
+    let text = token.as_str();
+    // Safety check: multi_line_comment matches `/* ... */`, so length is at least 4.
+    text[2..text.len() - 2].trim()
 }

--- a/psl/schema-ast/src/reformat.rs
+++ b/psl/schema-ast/src/reformat.rs
@@ -439,6 +439,32 @@ fn reformat_comment_block(pair: Pair<'_>, table: &mut TableFormat) {
                     }
                 }
             }
+            Rule::multi_line_comment => {
+                // Start the canonical multi-line comment block
+                table.start_new_line();
+                table.append_suffix_to_current_row("/**");
+
+                let content = current.as_str();
+                // Strip off `/*` and `*/`
+                let inner = &content[2..content.len() - 2];
+
+                // Normalize lines by removing leading `*` and extra whitespace.
+                for line in inner.lines() {
+                    let line = line.trim();
+                    // Remove a leading `*` if present, along with any following spaces.
+                    let line = line.strip_prefix('*').map(str::trim_start).unwrap_or(line);
+
+                    if !line.is_empty() {
+                        table.start_new_line();
+                        table.append_suffix_to_current_row(" * ");
+                        table.append_suffix_to_current_row(line);
+                    }
+                }
+
+                // Close the multi-line comment block
+                table.start_new_line();
+                table.append_suffix_to_current_row(" */");
+            }
             _ => unreachable!(),
         }
     }


### PR DESCRIPTION
This PR introduces support for multi-line comments in `schema.prisma`, using the `/* ... */` conventional syntax.
It expands `prisma validate`, `prisma format`, and other commands that rely on those two internal functionality.

This PR closes https://github.com/prisma/prisma/issues/4474, but it requires an additional PR in prisma/language-tools.