### PR TITLE
fix(driver-adapters): rename one missed span attribute

### DIFF
--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -216,7 +216,7 @@ impl JsBaseQueryable {
         let serialization_span = info_span!(
             "prisma:engine:js:query:args",
             "otel.kind" = "client",
-            "db.query.params.count" = params.len(),
+            "prisma.db_query.params.count" = params.len(),
             user_facing = true,
         );
         let query = self.build_query(sql, params).instrument(serialization_span).await?;


### PR DESCRIPTION
Fixup https://github.com/prisma/prisma-engines/pull/5049 and rename one missed span attribute. The tests on the client were updated to expect the new name but the attribute was only updated in one of two places.
