### PR TITLE
fix(query-engine-wasm): add response_json_serialization span

### DIFF
--- a/query-engine/query-engine-wasm/src/wasm/engine.rs
+++ b/query-engine/query-engine-wasm/src/wasm/engine.rs
@@ -222,7 +222,8 @@ impl QueryEngine {
                     .instrument(span)
                     .await;
 
-                Ok(serde_json::to_string(&response)?)
+                let serde_span = tracing::info_span!("prisma:engine:response_json_serialization", user_facing = true);
+                Ok(serde_span.in_scope(|| serde_json::to_string(&response))?)
             }
             .await
         }


### PR DESCRIPTION
Add missing `prisma:engine:response_json_serialization` span in the WASM query engine. After this we can enable running the tracing tests with WASM in the client repo.
