### PR TITLE
fix(telemetry): assign our own span IDs

### DIFF
--- a/libs/telemetry/src/exporter.rs
+++ b/libs/telemetry/src/exporter.rs
@@ -329,7 +329,7 @@ mod tests {
         let request_id = exporter.start_capturing(RequestId::next(), capture_all()).await;
 
         let span = CollectedSpan {
-            id: SpanId::from_u64(1).unwrap(),
+            id: SpanId::try_from(1).unwrap(),
             parent_id: None,
             name: "test_span".into(),
             start_time: SystemTime::UNIX_EPOCH,
@@ -383,7 +383,7 @@ mod tests {
         let request_id = exporter.start_capturing(RequestId::next(), capture_spans()).await;
 
         let span = CollectedSpan {
-            id: SpanId::from_u64(1).unwrap(),
+            id: SpanId::try_from(1).unwrap(),
             parent_id: None,
             name: "test_span".into(),
             start_time: SystemTime::UNIX_EPOCH,

--- a/libs/telemetry/src/exporter.rs
+++ b/libs/telemetry/src/exporter.rs
@@ -272,6 +272,8 @@ impl AllowAttribute for InternalAttributesFilter {
 mod tests {
     use std::time::{Duration, SystemTime};
 
+    use crate::NextId;
+
     use super::*;
 
     use CaptureTarget::*;
@@ -327,7 +329,7 @@ mod tests {
         let request_id = exporter.start_capturing(RequestId::next(), capture_all()).await;
 
         let span = CollectedSpan {
-            id: tracing::span::Id::from_u64(1).into(),
+            id: SpanId::from_u64(1).unwrap(),
             parent_id: None,
             name: "test_span".into(),
             start_time: SystemTime::UNIX_EPOCH,
@@ -381,7 +383,7 @@ mod tests {
         let request_id = exporter.start_capturing(RequestId::next(), capture_spans()).await;
 
         let span = CollectedSpan {
-            id: tracing::span::Id::from_u64(1).into(),
+            id: SpanId::from_u64(1).unwrap(),
             parent_id: None,
             name: "test_span".into(),
             start_time: SystemTime::UNIX_EPOCH,

--- a/libs/telemetry/src/id.rs
+++ b/libs/telemetry/src/id.rs
@@ -16,9 +16,13 @@ impl SerializableNonZeroU64 {
     pub fn into_u64(self) -> u64 {
         self.0.get()
     }
+}
 
-    pub fn from_u64(value: u64) -> Option<Self> {
-        NonZeroU64::new(value).map(Self)
+impl TryFrom<u64> for SerializableNonZeroU64 {
+    type Error = u64;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        NonZeroU64::new(value).map(Self).ok_or(value)
     }
 }
 
@@ -79,16 +83,17 @@ impl<'de> Deserialize<'de> for SerializableNonZeroU64 {
 #[repr(transparent)]
 pub struct SpanId(SerializableNonZeroU64);
 
-impl SpanId {
-    #[cfg(test)]
-    pub(crate) fn from_u64(value: u64) -> Option<Self> {
-        SerializableNonZeroU64::from_u64(value).map(Self)
-    }
-}
-
 impl From<NonZeroU64> for SpanId {
     fn from(value: NonZeroU64) -> Self {
         Self(SerializableNonZeroU64(value))
+    }
+}
+
+impl TryFrom<u64> for SpanId {
+    type Error = u64;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        SerializableNonZeroU64::try_from(value).map(Self)
     }
 }
 
@@ -119,15 +124,19 @@ impl RequestId {
     pub fn into_u64(self) -> u64 {
         self.0.into_u64()
     }
-
-    pub fn from_u64(value: u64) -> Option<Self> {
-        SerializableNonZeroU64::from_u64(value).map(Self)
-    }
 }
 
 impl From<NonZeroU64> for RequestId {
     fn from(value: NonZeroU64) -> Self {
         Self(SerializableNonZeroU64(value))
+    }
+}
+
+impl TryFrom<u64> for RequestId {
+    type Error = u64;
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        SerializableNonZeroU64::try_from(value).map(Self)
     }
 }
 

--- a/libs/telemetry/src/layer.rs
+++ b/libs/telemetry/src/layer.rs
@@ -72,7 +72,7 @@ where
 {
     fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
         let span = Self::require_span(id, &ctx);
-        let mut span_builder = SpanBuilder::new(span.name(), id, attrs.fields().len());
+        let mut span_builder = SpanBuilder::new(span.name(), attrs.fields().len());
 
         if let Some(request_id) = span
             .parent()
@@ -98,11 +98,16 @@ where
     }
 
     fn on_follows_from(&self, span: &Id, follows: &Id, ctx: Context<'_, S>) {
+        let followed_span = Self::require_span(follows, &ctx);
+        let Some(followed_id) = followed_span.extensions().get::<SpanBuilder>().map(|sb| sb.span_id()) else {
+            return;
+        };
+
         let span = Self::require_span(span, &ctx);
         let mut extensions = span.extensions_mut();
 
         if let Some(span_builder) = extensions.get_mut::<SpanBuilder>() {
-            span_builder.add_link(follows.into());
+            span_builder.add_link(followed_id);
         }
     }
 
@@ -116,12 +121,18 @@ where
             return;
         };
 
-        let Some(request_id) = parent.extensions().get::<SpanBuilder>().and_then(|sb| sb.request_id()) else {
+        let extensions = parent.extensions();
+
+        let Some(span_builder) = extensions.get::<SpanBuilder>() else {
+            return;
+        };
+
+        let Some(request_id) = span_builder.request_id() else {
             return;
         };
 
         let mut event_builder = EventBuilder::new(
-            parent.id().into(),
+            span_builder.span_id(),
             event.metadata().target(),
             event.metadata().level().into(),
             event.metadata().fields().len(),
@@ -145,7 +156,10 @@ where
             return;
         };
 
-        let parent_id = span.parent().map(|parent| parent.id());
+        let parent_id = span
+            .parent()
+            .and_then(|parent| parent.extensions().get::<SpanBuilder>().map(|sb| sb.span_id()));
+
         let collected_span = span_builder.end(parent_id);
 
         self.collector.add_span(request_id, collected_span);
@@ -280,6 +294,7 @@ impl<Filter: AllowAttribute> field::Visit for EventAttributeVisitor<'_, Filter> 
 mod tests {
     use crate::collector::{AllowAttribute, CollectedEvent, CollectedSpan};
     use crate::id::RequestId;
+    use crate::NextId;
 
     use super::*;
 

--- a/libs/telemetry/src/layer.rs
+++ b/libs/telemetry/src/layer.rs
@@ -196,7 +196,7 @@ impl<Filter: AllowAttribute> field::Visit for SpanAttributeVisitor<'_, Filter> {
     fn record_u64(&mut self, field: &field::Field, value: u64) {
         match field.name() {
             REQUEST_ID_FIELD => {
-                if let Some(request_id) = RequestId::from_u64(value) {
+                if let Ok(request_id) = RequestId::try_from(value) {
                     self.span_builder.set_request_id(request_id);
                 }
             }

--- a/libs/telemetry/src/layer.rs
+++ b/libs/telemetry/src/layer.rs
@@ -293,8 +293,7 @@ impl<Filter: AllowAttribute> field::Visit for EventAttributeVisitor<'_, Filter> 
 #[cfg(test)]
 mod tests {
     use crate::collector::{AllowAttribute, CollectedEvent, CollectedSpan};
-    use crate::id::RequestId;
-    use crate::NextId;
+    use crate::id::{NextId, RequestId};
 
     use super::*;
 

--- a/libs/telemetry/src/lib.rs
+++ b/libs/telemetry/src/lib.rs
@@ -9,6 +9,6 @@ pub mod time;
 pub mod traceparent;
 
 pub use exporter::Exporter;
-pub use id::RequestId;
+pub use id::{NextId, RequestId};
 pub use layer::layer;
 pub use traceparent::TraceParent;

--- a/query-engine/query-engine/src/cli.rs
+++ b/query-engine/query-engine/src/cli.rs
@@ -9,7 +9,7 @@ use psl::parser_database::Files;
 use query_core::{protocol::EngineProtocol, schema};
 use request_handlers::{dmmf, RequestBody, RequestHandler};
 use std::{env, sync::Arc};
-use telemetry::RequestId;
+use telemetry::{NextId, RequestId};
 
 pub struct ExecuteRequest {
     query: String,

--- a/query-engine/query-engine/src/context.rs
+++ b/query-engine/query-engine/src/context.rs
@@ -12,7 +12,7 @@ use query_core::{
 use request_handlers::{load_executor, ConnectorKind};
 use std::{env, fmt, sync::Arc};
 use telemetry::exporter::{CaptureSettings, CaptureTarget};
-use telemetry::RequestId;
+use telemetry::{NextId, RequestId};
 use tracing::Instrument;
 
 /// Prisma request context containing all immutable state of the process.

--- a/query-engine/query-engine/src/server/mod.rs
+++ b/query-engine/query-engine/src/server/mod.rs
@@ -13,7 +13,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use telemetry::exporter::{CaptureSettings, CaptureTarget, TraceData};
-use telemetry::{RequestId, TraceParent};
+use telemetry::{NextId, RequestId, TraceParent};
 use tracing::{Instrument, Span};
 
 /// Starts up the graphql query engine server

--- a/query-engine/query-engine/src/tests/errors.rs
+++ b/query-engine/query-engine/src/tests/errors.rs
@@ -3,7 +3,7 @@ use enumflags2::make_bitflags;
 use indoc::{formatdoc, indoc};
 use query_core::protocol::EngineProtocol;
 use serde_json::json;
-use telemetry::RequestId;
+use telemetry::{NextId, RequestId};
 
 #[tokio::test]
 async fn connection_string_problems_give_a_nice_error() {


### PR DESCRIPTION
Our logic assumed that span IDs were unique within a trace but that's incorrect: they can be reused as long as the spans don't overlap in time (e.g. sequential siblings). Now we assign our own IDs which are guaranteed to be unique within a trace as long as the trace has less than 18446744073709551616 (2**64) spans.

`tracing` tries not to reuse them immediately so this wasn't caught in tests until we started running tests with WASM where the issue immediately became evident (presumably due to the lack of a high quality source of randomness but I haven't actually investigated what the reason behind the difference in behaviour is).
