### PR TITLE
fix: avoid unreachable code with empty datamodel

### DIFF
--- a/psl/psl-core/src/datamodel_connector.rs
+++ b/psl/psl-core/src/datamodel_connector.rs
@@ -290,6 +290,14 @@ pub trait Connector: Send + Sync {
     ) -> prisma_value::PrismaValueResult<Vec<u8>> {
         unreachable!("This method is only implemented on connectors with lateral join support.")
     }
+
+    fn is_sql(&self) -> bool {
+        self.flavour().is_sql()
+    }
+
+    fn is_mongo(&self) -> bool {
+        self.flavour().is_mongo()
+    }
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]

--- a/psl/psl-core/src/datamodel_connector/empty_connector.rs
+++ b/psl/psl-core/src/datamodel_connector/empty_connector.rs
@@ -75,6 +75,14 @@ impl Connector for EmptyDatamodelConnector {
     fn flavour(&self) -> Flavour {
         unreachable!()
     }
+
+    fn is_sql(&self) -> bool {
+        false
+    }
+
+    fn is_mongo(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/query-engine/core-tests/tests/empty_datamodel.rs
+++ b/query-engine/core-tests/tests/empty_datamodel.rs
@@ -1,0 +1,10 @@
+use std::sync::Arc;
+
+#[test]
+fn empty_datamodel_loads() {
+    let schema = "";
+    let parsed_schema = psl::parse_schema(schema).unwrap();
+    let schema = schema::build(Arc::new(parsed_schema), true);
+    assert!(!schema.is_mongo());
+    assert!(!schema.is_sql());
+}

--- a/query-engine/schema/src/build/output_types/mutation_type.rs
+++ b/query-engine/schema/src/build/output_types/mutation_type.rs
@@ -37,12 +37,12 @@ pub(crate) fn mutation_fields(ctx: &QuerySchema) -> Vec<FieldFn> {
         field!(delete_many_field, model);
     }
 
-    if ctx.enable_raw_queries && ctx.connector_favlour().is_sql() {
+    if ctx.enable_raw_queries && ctx.is_sql() {
         fields.push(Box::new(|_| create_execute_raw_field()));
         fields.push(Box::new(|_| create_query_raw_field()));
     }
 
-    if ctx.enable_raw_queries && ctx.connector_favlour().is_mongo() {
+    if ctx.enable_raw_queries && ctx.is_mongo() {
         fields.push(Box::new(|_| create_mongodb_run_command_raw()));
     }
 

--- a/query-engine/schema/src/build/output_types/query_type.rs
+++ b/query-engine/schema/src/build/output_types/query_type.rs
@@ -21,7 +21,7 @@ pub(crate) fn query_fields(ctx: &QuerySchema) -> Vec<FieldFn> {
         field!(find_unique_field, model);
         field!(find_unique_or_throw_field, model);
 
-        if ctx.enable_raw_queries && ctx.connector_favlour().is_mongo() {
+        if ctx.enable_raw_queries && ctx.is_mongo() {
             let model_cloned = model.clone();
             fields.push(Box::new(move |_ctx| mongo_find_raw_field(&model_cloned)));
             fields.push(Box::new(move |_ctx| mongo_aggregate_raw_field(&model)));

--- a/query-engine/schema/src/query_schema.rs
+++ b/query-engine/schema/src/query_schema.rs
@@ -1,9 +1,7 @@
 use crate::{IdentifierType, ObjectType, OutputField};
 use psl::{
     can_support_relation_load_strategy,
-    datamodel_connector::{
-        Connector, ConnectorCapabilities, ConnectorCapability, Flavour, JoinStrategySupport, RelationMode,
-    },
+    datamodel_connector::{Connector, ConnectorCapabilities, ConnectorCapability, JoinStrategySupport, RelationMode},
     has_capability, parser_database as db, PreviewFeature, PreviewFeatures,
 };
 use query_structure::InternalDataModel;
@@ -220,8 +218,12 @@ impl QuerySchema {
             .contains(ConnectorCapability::NativeUpsert)
     }
 
-    pub fn connector_favlour(&self) -> Flavour {
-        self.connector.flavour()
+    pub fn is_sql(&self) -> bool {
+        self.connector.is_sql()
+    }
+
+    pub fn is_mongo(&self) -> bool {
+        self.connector.is_mongo()
     }
 }
 


### PR DESCRIPTION
Loading a datamodel with an empty connector currently hits `unreachable` because we're relying on `flavour` for mutations, I've added new methods to connector traits that are then implemented in `empty_connector` to avoid the panic, this fixes the build in prisma/prisma