### PR TITLE
fix: convert small integers of unknown type into i32 for driver adapters

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/typed_output.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/typed_output.rs
@@ -440,6 +440,86 @@ mod typed_output {
         Ok(())
     }
 
+    #[connector_test(schema(schema_sqlite), only(Sqlite("cfd1")))]
+    async fn all_scalars_cfd1(runner: Runner) -> TestResult<()> {
+        create_row(
+            &runner,
+            r#"{
+            id: 1,
+            string: "str",
+            int: 42,
+            bInt: 92233720368,
+            float: 1.5432,
+            bytes: "AQID",
+            bool: true,
+            dt: "1900-10-10T01:10:10.001Z",
+            dec: "123.45678910",
+          }"#,
+        )
+        .await?;
+        create_row(&runner, r#"{ id: 2 }"#).await?;
+
+        insta::assert_snapshot!(
+          run_query_pretty!(&runner, fmt_query_raw(r#"SELECT * FROM TestModel;"#, vec![])),
+          @r###"
+        {
+          "data": {
+            "queryRaw": {
+              "columns": [
+                "id",
+                "string",
+                "int",
+                "bInt",
+                "float",
+                "bytes",
+                "bool",
+                "dt",
+                "dec"
+              ],
+              "types": [
+                "int",
+                "string",
+                "int",
+                "bigint",
+                "double",
+                "bytes",
+                "int",
+                "datetime",
+                "double"
+              ],
+              "rows": [
+                [
+                  1,
+                  "str",
+                  42,
+                  "92233720368",
+                  1.5432,
+                  "AQID",
+                  1,
+                  "1900-10-10T01:10:10.001+00:00",
+                  123.4567891
+                ],
+                [
+                  2,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null
+                ]
+              ]
+            }
+          }
+        }
+        "###
+        );
+
+        Ok(())
+    }
+
     #[connector_test(schema(generic), only(Mysql))]
     async fn unknown_type_mysql(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(

--- a/query-engine/driver-adapters/src/conversion/js_to_quaint.rs
+++ b/query-engine/driver-adapters/src/conversion/js_to_quaint.rs
@@ -258,7 +258,11 @@ pub fn js_value_to_quaint(
         ColumnType::UnknownNumber => match json_value {
             serde_json::Value::Number(n) => n
                 .as_i64()
-                .map(QuaintValue::int64)
+                .map(|i| {
+                    i32::try_from(i)
+                        .map(QuaintValue::int32)
+                        .unwrap_or_else(|_| QuaintValue::int64(i))
+                })
                 .or(n.as_f64().map(QuaintValue::double))
                 .ok_or(conversion_error!(
                     "number must be an i64 or f64 in column '{column_name}', got {n}"


### PR DESCRIPTION
Handling the unknown number type as i64 has caused issues with `queryRaw` when used from `cfd1`: all integers were being returned as `BigInt`, this tries to fit smaller ints into a smaller type to provide less surprising behavior