### PR TITLE
fix: update test sqlite capabilities and fix some issues

### DIFF
--- a/libs/test-setup/src/test_api_args.rs
+++ b/libs/test-setup/src/test_api_args.rs
@@ -42,7 +42,7 @@ static DB_UNDER_TEST: Lazy<Result<DbUnderTest, String>> = Lazy::new(|| {
         "file" | "sqlite" => Ok(DbUnderTest {
             database_url,
             tags: Tags::Sqlite.into(),
-            capabilities: Capabilities::CreateDatabase.into(),
+            capabilities: Capabilities::CreateDatabase | Capabilities::Json,
             provider: "sqlite",
             shadow_database_url,
             max_ddl_refresh_delay: None,

--- a/schema-engine/sql-migration-tests/tests/migrations/json.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/json.rs
@@ -52,6 +52,10 @@ fn database_level_json_defaults_can_be_defined(api: TestApi) {
                     )))
                 } else if api.is_mysql() {
                     None
+                } else if api.is_sqlite() {
+                    Some(DefaultValue::value(PrismaValue::String(
+                        "[\"sticks\",\"chimken\",100,  \"dog park\"]".into(),
+                    )))
                 } else {
                     unreachable!()
                 })

--- a/schema-engine/sql-schema-describer/src/sqlite.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite.rs
@@ -393,8 +393,8 @@ async fn push_columns(
                             }
                             _ => DefaultValue::db_generated(default_string),
                         },
+                        ColumnTypeFamily::Json => DefaultValue::value(default_string),
                         ColumnTypeFamily::Binary => DefaultValue::db_generated(default_string),
-                        ColumnTypeFamily::Json => DefaultValue::db_generated(default_string),
                         ColumnTypeFamily::Uuid => DefaultValue::db_generated(default_string),
                         ColumnTypeFamily::Enum(_) => DefaultValue::value(PrismaValue::Enum(default_string)),
                         ColumnTypeFamily::Unsupported(_) => DefaultValue::db_generated(default_string),
@@ -581,6 +581,7 @@ fn get_column_type(mut tpe: String, arity: ColumnArity) -> ColumnType {
         "int[]" => ColumnTypeFamily::Int,
         "integer[]" => ColumnTypeFamily::Int,
         "text[]" => ColumnTypeFamily::String,
+        "jsonb" => ColumnTypeFamily::Json,
         // NUMERIC type affinity
         data_type if data_type.starts_with("decimal") => ColumnTypeFamily::Decimal,
         data_type => ColumnTypeFamily::Unsupported(data_type.into()),


### PR DESCRIPTION
Some functionality in schema describer was broken for sqlite and it wasn't caught because there are separate capability checks in some tests.
I've updated these tests and fixed the issues in this PR.