### PR TITLE
feat(driver-adapters): add "version()" support to QuaintQueryable

### DIFF
--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -68,6 +68,11 @@ pub trait Visitor<'a> {
     /// Write to the query.
     fn write<D: fmt::Display>(&mut self, s: D) -> Result;
 
+    /// Name of the function used to view the version of the database.
+    fn version_fn(&self) -> &'static str {
+        "version"
+    }
+
     /// A point to modify an incoming query to make it compatible with the
     /// underlying database.
     fn compatibility_modifications(&self, query: Query<'a>) -> Query<'a> {

--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -68,11 +68,6 @@ pub trait Visitor<'a> {
     /// Write to the query.
     fn write<D: fmt::Display>(&mut self, s: D) -> Result;
 
-    /// Name of the function used to view the version of the database.
-    fn version_fn(&self) -> &'static str {
-        "version"
-    }
-
     /// A point to modify an incoming query to make it compatible with the
     /// underlying database.
     fn compatibility_modifications(&self, query: Query<'a>) -> Query<'a> {

--- a/quaint/src/visitor/mysql.rs
+++ b/quaint/src/visitor/mysql.rs
@@ -16,6 +16,11 @@ pub struct Mysql<'a> {
 }
 
 impl<'a> Mysql<'a> {
+    /// Name of the function used to view the version of the database.
+    pub const fn version_fn() -> &'static str {
+        "version"
+    }
+
     fn visit_regular_equality_comparison(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
         self.visit_expression(left)?;
         self.write(" = ")?;

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -18,6 +18,11 @@ pub struct Postgres<'a> {
 }
 
 impl<'a> Postgres<'a> {
+    /// Name of the function used to view the version of the database.
+    pub const fn version_fn() -> &'static str {
+        "version"
+    }
+
     fn visit_json_build_obj_expr(&mut self, expr: Expression<'a>) -> crate::Result<()> {
         match expr.kind() {
             ExpressionKind::Column(col) => match (col.type_family.as_ref(), col.native_type.as_deref()) {

--- a/quaint/src/visitor/sqlite.rs
+++ b/quaint/src/visitor/sqlite.rs
@@ -95,6 +95,10 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         Ok(())
     }
 
+    fn version_fn(&self) -> &'static str {
+        "sqlite_version"
+    }
+
     fn visit_raw_value(&mut self, value: Value<'a>) -> visitor::Result {
         let res = match &value.typed {
             ValueType::Int32(i) => i.map(|i| self.write(i)),

--- a/quaint/src/visitor/sqlite.rs
+++ b/quaint/src/visitor/sqlite.rs
@@ -16,6 +16,11 @@ pub struct Sqlite<'a> {
 }
 
 impl<'a> Sqlite<'a> {
+    /// Name of the function used to view the version of the database.
+    pub const fn version_fn() -> &'static str {
+        "sqlite_version"
+    }
+
     fn returning(&mut self, returning: Option<Vec<Column<'a>>>) -> visitor::Result {
         if let Some(returning) = returning {
             if !returning.is_empty() {
@@ -93,10 +98,6 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
     fn write<D: fmt::Display>(&mut self, s: D) -> visitor::Result {
         write!(&mut self.query, "{s}")?;
         Ok(())
-    }
-
-    fn version_fn(&self) -> &'static str {
-        "sqlite_version"
     }
 
     fn visit_raw_value(&mut self, value: Value<'a>) -> visitor::Result {

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -142,7 +142,7 @@ impl QuaintQueryable for JsBaseQueryable {
         };
 
         let query = format!(r#"SELECT {}() AS version"#, version_fn);
-        let rows = self.query_raw(query, &[]).await?;
+        let rows = self.query_raw(query.as_str(), &[]).await?;
 
         let version_string = rows
             .first()

--- a/query-engine/driver-adapters/src/queryable.rs
+++ b/query-engine/driver-adapters/src/queryable.rs
@@ -130,9 +130,25 @@ impl QuaintQueryable for JsBaseQueryable {
         .await
     }
 
+    // Note: Needed by the Wasm Schema Engine only.
     async fn version(&self) -> quaint::Result<Option<String>> {
-        // Note: JS Connectors don't use this method.
-        Ok(None)
+        let version_fn: &'static str = match self.provider {
+            #[cfg(feature = "mysql")]
+            AdapterFlavour::Mysql => visitor::Mysql::version_fn(),
+            #[cfg(feature = "postgresql")]
+            AdapterFlavour::Postgres => visitor::Postgres::version_fn(),
+            #[cfg(feature = "sqlite")]
+            AdapterFlavour::Sqlite => visitor::Sqlite::version_fn(),
+        };
+
+        let query = format!(r#"SELECT {}() AS version"#, version_fn);
+        let rows = self.query_raw(query, &[]).await?;
+
+        let version_string = rows
+            .first()
+            .and_then(|row| row.get("version").and_then(|version| version.to_string()));
+
+        Ok(version_string)
     }
 
     fn is_healthy(&self) -> bool {


### PR DESCRIPTION
This PR adds a `version()` implementation to `QuaintQueryable` in `query-engine/driver-adapters/src/queryable.rs`.
This is needed for `schema-engine-wasm`.