### PR TITLE
feat(schema-engine-wasm): wasm-compatible `sql-schema-describer`, `schema-connector`

### DIFF
--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -179,7 +179,7 @@ jobs:
       #
       # Single threaded tests (excluding Vitess)
       #
-      - run: cargo nextest run -p sql-schema-describer --test-threads=1
+      - run: cargo nextest run -p sql-schema-describer --features all-native --test-threads=1
         if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -133,7 +133,7 @@ jobs:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
-      - run: cargo nextest run -p sql-schema-describer
+      - run: cargo nextest run -p sql-schema-describer --features all-native
         if: ${{ !matrix.database.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/quaint/src/lib.rs
+++ b/quaint/src/lib.rs
@@ -104,6 +104,9 @@
 //! # }
 //! ```
 
+// TODO: remove once `quaint` is no longer a transitive dependency of `mongodb-schema-connector`.
+#![allow(dead_code)]
+
 #[cfg(not(any(feature = "sqlite", feature = "postgresql", feature = "mysql", feature = "mssql")))]
 compile_error!("one of 'sqlite', 'postgresql', 'mysql' or 'mssql' features must be enabled");
 

--- a/schema-engine/cli/Cargo.toml
+++ b/schema-engine/cli/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-schema-connector = { path = "../connectors/schema-connector" }
+schema-connector = { path = "../connectors/schema-connector", features = [
+    "all-native",
+] }
 schema-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors", features = [
     "all-native",

--- a/schema-engine/connectors/schema-connector/Cargo.toml
+++ b/schema-engine/connectors/schema-connector/Cargo.toml
@@ -5,15 +5,15 @@ edition = "2021"
 
 [features]
 postgresql = ["psl/postgresql", "quaint/postgresql"]
-postgresql-native = ["postgresql", "quaint/pooled"]
+postgresql-native = ["postgresql", "quaint/postgresql-native", "quaint/pooled"]
 sqlite = ["psl/sqlite", "quaint/sqlite"]
-sqlite-native = ["sqlite", "quaint/pooled", "quaint/sqlite-native"]
+sqlite-native = ["sqlite", "quaint/sqlite-native", "quaint/pooled", "quaint/expose-drivers"]
 mysql = ["psl/mysql", "quaint/mysql"]
-mysql-native = ["mysql", "quaint/pooled"]
+mysql-native = ["mysql", "quaint/mysql-native", "quaint/pooled"]
 mssql = ["psl/mssql", "quaint/mssql"]
-mssql-native = ["mssql", "quaint/pooled"]
+mssql-native = ["mssql", "quaint/mssql-native", "quaint/pooled"]
 cockroachdb = ["psl/cockroachdb", "quaint/postgresql"]
-cockroachdb-native = ["cockroachdb", "quaint/pooled"]
+cockroachdb-native = ["cockroachdb", "quaint/postgresql-native", "quaint/pooled"]
 all-native = [
     "postgresql-native",
     "sqlite-native",

--- a/schema-engine/connectors/schema-connector/Cargo.toml
+++ b/schema-engine/connectors/schema-connector/Cargo.toml
@@ -3,13 +3,32 @@ name = "schema-connector"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+postgresql = ["psl/postgresql", "quaint/postgresql"]
+postgresql-native = ["postgresql", "quaint/pooled"]
+sqlite = ["psl/sqlite", "quaint/sqlite"]
+sqlite-native = ["sqlite", "quaint/pooled", "quaint/sqlite-native"]
+mysql = ["psl/mysql", "quaint/mysql"]
+mysql-native = ["mysql", "quaint/pooled"]
+mssql = ["psl/mssql", "quaint/mssql"]
+mssql-native = ["mssql", "quaint/pooled"]
+cockroachdb = ["psl/cockroachdb", "quaint/postgresql"]
+cockroachdb-native = ["cockroachdb", "quaint/pooled"]
+all-native = [
+    "postgresql-native",
+    "sqlite-native",
+    "mysql-native",
+    "mssql-native",
+    "cockroachdb-native",
+]
+
 [dependencies]
 psl.workspace = true
-quaint = { workspace = true, features = ["all-native", "pooled"] }
+quaint.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = [
-    "all-native",
+    "quaint",
 ] }
 
 chrono.workspace = true

--- a/schema-engine/connectors/schema-connector/src/introspection_context.rs
+++ b/schema-engine/connectors/schema-connector/src/introspection_context.rs
@@ -109,10 +109,15 @@ impl IntrospectionContext {
     /// The SQL family we're using currently.
     pub fn sql_family(&self) -> SqlFamily {
         match self.datasource().active_provider {
+            #[cfg(feature = "postgresql")]
             "postgresql" => SqlFamily::Postgres,
+            #[cfg(feature = "cockroachdb")]
             "cockroachdb" => SqlFamily::Postgres,
+            #[cfg(feature = "sqlite")]
             "sqlite" => SqlFamily::Sqlite,
+            #[cfg(feature = "mssql")]
             "sqlserver" => SqlFamily::Mssql,
+            #[cfg(feature = "mysql")]
             "mysql" => SqlFamily::Mysql,
             name => unreachable!("The name `{}` for the datamodel connector is not known", name),
         }

--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -21,7 +21,9 @@ uuid.workspace = true
 indexmap.workspace = true
 
 prisma-value = { path = "../../../libs/prisma-value" }
-schema-connector = { path = "../schema-connector" }
+schema-connector = { path = "../schema-connector", features = [
+    "all-native",
+] }
 sql-schema-describer = { path = "../../sql-schema-describer", features = [
     "all-native",
 ] }

--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -22,7 +22,9 @@ indexmap.workspace = true
 
 prisma-value = { path = "../../../libs/prisma-value" }
 schema-connector = { path = "../schema-connector" }
-sql-schema-describer = { path = "../../sql-schema-describer" }
+sql-schema-describer = { path = "../../sql-schema-describer", features = [
+    "all-native",
+] }
 datamodel-renderer = { path = "../../datamodel-renderer" }
 sql-ddl = { path = "../../../libs/sql-ddl" }
 user-facing-errors = { path = "../../../libs/user-facing-errors", features = [

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connection.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connection.rs
@@ -24,6 +24,7 @@ impl Connection {
     }
 
     pub(super) async fn describe_schema(&mut self) -> ConnectorResult<SqlSchema> {
+        // Note: this relies on quaint::connector::rusqlite::Connection, which is exposed by `quaint/expose-drivers`, and is not Wasm-compatible.
         describer::SqlSchemaDescriber::new(&self.0)
             .describe_impl()
             .await

--- a/schema-engine/core/Cargo.toml
+++ b/schema-engine/core/Cargo.toml
@@ -5,11 +5,13 @@ version = "0.1.0"
 
 [dependencies]
 psl = { workspace = true, features = ["all"] }
-schema-connector = { path = "../connectors/schema-connector" }
+schema-connector = { path = "../connectors/schema-connector", features = [
+    "all-native",
+] }
 mongodb-schema-connector = { path = "../connectors/mongodb-schema-connector" }
 sql-schema-connector = { path = "../connectors/sql-schema-connector" }
 user-facing-errors = { path = "../../libs/user-facing-errors", features = [
-    "all-native",
+    "quaint",
 ] }
 
 async-trait.workspace = true

--- a/schema-engine/sql-introspection-tests/Cargo.toml
+++ b/schema-engine/sql-introspection-tests/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-schema-connector = { path = "../connectors/schema-connector" }
+schema-connector = { path = "../connectors/schema-connector", features = [
+    "all-native",
+] }
 sql-schema-connector = { path = "../connectors/sql-schema-connector" }
 sql-schema-describer = { path = "../sql-schema-describer", features = [
     "all-native",

--- a/schema-engine/sql-introspection-tests/Cargo.toml
+++ b/schema-engine/sql-introspection-tests/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 [dependencies]
 schema-connector = { path = "../connectors/schema-connector" }
 sql-schema-connector = { path = "../connectors/sql-schema-connector" }
-sql-schema-describer = { path = "../sql-schema-describer" }
+sql-schema-describer = { path = "../sql-schema-describer", features = [
+    "all-native",
+] }
 psl = { workspace = true, features = ["all"] }
 test-macros = { path = "../../libs/test-macros" }
 user-facing-errors = { path = "../../libs/user-facing-errors", features = [

--- a/schema-engine/sql-migration-tests/Cargo.toml
+++ b/schema-engine/sql-migration-tests/Cargo.toml
@@ -6,9 +6,7 @@ edition = "2021"
 [dependencies]
 psl = { workspace = true, features = ["all"] }
 schema-core = { path = "../core" }
-sql-schema-connector = { path = "../connectors/sql-schema-connector", features = [
-    "all-native",
-] }
+sql-schema-connector = { path = "../connectors/sql-schema-connector" }
 sql-schema-describer = { path = "../sql-schema-describer", features = [
     "all-native",
 ] }

--- a/schema-engine/sql-migration-tests/Cargo.toml
+++ b/schema-engine/sql-migration-tests/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 [dependencies]
 psl = { workspace = true, features = ["all"] }
 schema-core = { path = "../core" }
-sql-schema-connector = { path = "../connectors/sql-schema-connector" }
+sql-schema-connector = { path = "../connectors/sql-schema-connector", features = [
+    "all-native",
+] }
 sql-schema-describer = { path = "../sql-schema-describer", features = [
     "all-native",
 ] }

--- a/schema-engine/sql-migration-tests/Cargo.toml
+++ b/schema-engine/sql-migration-tests/Cargo.toml
@@ -7,7 +7,9 @@ edition = "2021"
 psl = { workspace = true, features = ["all"] }
 schema-core = { path = "../core" }
 sql-schema-connector = { path = "../connectors/sql-schema-connector" }
-sql-schema-describer = { path = "../sql-schema-describer" }
+sql-schema-describer = { path = "../sql-schema-describer", features = [
+    "all-native",
+] }
 user-facing-errors = { path = "../../libs/user-facing-errors", features = [
     "all-native",
 ] }

--- a/schema-engine/sql-schema-describer/Cargo.toml
+++ b/schema-engine/sql-schema-describer/Cargo.toml
@@ -3,6 +3,12 @@ edition = "2021"
 name = "sql-schema-describer"
 version = "0.1.0"
 
+[features]
+sqlite-native = ["quaint/pooled", "quaint/sqlite-native", "quaint/expose-drivers"]
+all-native = [
+    "sqlite-native",
+]
+
 [dependencies]
 prisma-value = { path = "../../libs/prisma-value" }
 psl = { workspace = true, features = ["all"] }
@@ -20,9 +26,6 @@ tracing.workspace = true
 tracing-error = "0.2"
 tracing-futures.workspace = true
 quaint = { workspace = true, features = [
-    "all-native",
-    "pooled",
-    "expose-drivers",
     "fmt-sql",
 ] }
 

--- a/schema-engine/sql-schema-describer/Cargo.toml
+++ b/schema-engine/sql-schema-describer/Cargo.toml
@@ -4,9 +4,22 @@ name = "sql-schema-describer"
 version = "0.1.0"
 
 [features]
-sqlite-native = ["quaint/pooled", "quaint/sqlite-native", "quaint/expose-drivers"]
+postgresql = ["psl/postgresql", "quaint/postgresql"]
+postgresql-native = ["postgresql", "quaint/pooled"]
+sqlite = ["psl/sqlite", "quaint/sqlite"]
+sqlite-native = ["sqlite", "quaint/pooled", "quaint/sqlite-native", "quaint/expose-drivers"]
+mysql = ["psl/mysql", "quaint/mysql"]
+mysql-native = ["mysql", "quaint/pooled"]
+mssql = ["psl/mssql", "quaint/mssql"]
+mssql-native = ["mssql", "quaint/pooled"]
+cockroachdb = ["psl/cockroachdb", "quaint/postgresql"]
+cockroachdb-native = ["cockroachdb", "quaint/pooled"]
 all-native = [
+    "postgresql-native",
     "sqlite-native",
+    "mysql-native",
+    "mssql-native",
+    "cockroachdb-native",
 ]
 
 [dependencies]

--- a/schema-engine/sql-schema-describer/Cargo.toml
+++ b/schema-engine/sql-schema-describer/Cargo.toml
@@ -5,15 +5,15 @@ version = "0.1.0"
 
 [features]
 postgresql = ["psl/postgresql", "quaint/postgresql"]
-postgresql-native = ["postgresql", "quaint/pooled"]
+postgresql-native = ["postgresql", "quaint/postgresql-native", "quaint/pooled"]
 sqlite = ["psl/sqlite", "quaint/sqlite"]
-sqlite-native = ["sqlite", "quaint/pooled", "quaint/sqlite-native", "quaint/expose-drivers"]
+sqlite-native = ["sqlite", "quaint/sqlite-native", "quaint/pooled", "quaint/expose-drivers"]
 mysql = ["psl/mysql", "quaint/mysql"]
-mysql-native = ["mysql", "quaint/pooled"]
+mysql-native = ["mysql", "quaint/mysql-native", "quaint/pooled"]
 mssql = ["psl/mssql", "quaint/mssql"]
-mssql-native = ["mssql", "quaint/pooled"]
+mssql-native = ["mssql", "quaint/mssql-native", "quaint/pooled"]
 cockroachdb = ["psl/cockroachdb", "quaint/postgresql"]
-cockroachdb-native = ["cockroachdb", "quaint/pooled"]
+cockroachdb-native = ["cockroachdb", "quaint/postgresql-native", "quaint/pooled"]
 all-native = [
     "postgresql-native",
     "sqlite-native",

--- a/schema-engine/sql-schema-describer/src/sqlite.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite.rs
@@ -2,8 +2,7 @@
 
 use crate::{
     getters::Getter, ids::*, parsers::Parser, Column, ColumnArity, ColumnType, ColumnTypeFamily, DefaultValue,
-    DescriberResult, ForeignKeyAction, Lazy, PrismaValue, Regex, SQLSortOrder, SqlMetadata, SqlSchema,
-    SqlSchemaDescriberBackend,
+    DescriberResult, ForeignKeyAction, Lazy, PrismaValue, Regex, SQLSortOrder, SqlSchema,
 };
 use either::Either;
 use indexmap::IndexMap;
@@ -44,32 +43,6 @@ pub struct SqlSchemaDescriber<'a> {
 impl Debug for SqlSchemaDescriber<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct(type_name::<SqlSchemaDescriber<'_>>()).finish()
-    }
-}
-
-#[async_trait::async_trait]
-impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
-    async fn list_databases(&self) -> DescriberResult<Vec<String>> {
-        Ok(self.get_databases().await?)
-    }
-
-    async fn get_metadata(&self, _schema: &str) -> DescriberResult<SqlMetadata> {
-        let mut sql_schema = SqlSchema::default();
-        let table_count = self.get_table_names(&mut sql_schema).await?.len();
-        let size_in_bytes = self.get_size().await?;
-
-        Ok(SqlMetadata {
-            table_count,
-            size_in_bytes,
-        })
-    }
-
-    async fn describe(&self, _schemas: &[&str]) -> DescriberResult<SqlSchema> {
-        self.describe_impl().await
-    }
-
-    async fn version(&self) -> DescriberResult<Option<String>> {
-        Ok(Some(quaint::connector::sqlite_version().to_owned()))
     }
 }
 

--- a/schema-engine/sql-schema-describer/src/sqlite/native/mod.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite/native/mod.rs
@@ -1,9 +1,11 @@
-use crate::sqlite::Connection;
+use crate::{sqlite::Connection, DescriberResult, SqlMetadata, SqlSchema, SqlSchemaDescriberBackend};
 
 use quaint::{
     connector::{rusqlite, ColumnType as QuaintColumnType, GetRow, ToColumnNames},
     prelude::{ResultSet, Value},
 };
+
+use super::SqlSchemaDescriber;
 
 #[async_trait::async_trait]
 impl Connection for std::sync::Mutex<rusqlite::Connection> {
@@ -19,5 +21,31 @@ impl Connection for std::sync::Mutex<rusqlite::Connection> {
         }
 
         Ok(ResultSet::new(column_names, column_types, converted_rows))
+    }
+}
+
+#[async_trait::async_trait]
+impl SqlSchemaDescriberBackend for SqlSchemaDescriber<'_> {
+    async fn list_databases(&self) -> DescriberResult<Vec<String>> {
+        Ok(self.get_databases().await?)
+    }
+
+    async fn get_metadata(&self, _schema: &str) -> DescriberResult<SqlMetadata> {
+        let mut sql_schema = SqlSchema::default();
+        let table_count = self.get_table_names(&mut sql_schema).await?.len();
+        let size_in_bytes = self.get_size().await?;
+
+        Ok(SqlMetadata {
+            table_count,
+            size_in_bytes,
+        })
+    }
+
+    async fn describe(&self, _schemas: &[&str]) -> DescriberResult<SqlSchema> {
+        self.describe_impl().await
+    }
+
+    async fn version(&self) -> DescriberResult<Option<String>> {
+        Ok(Some(quaint::connector::sqlite_version().to_owned()))
     }
 }

--- a/schema-engine/sql-schema-describer/src/sqlite/native/mod.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite/native/mod.rs
@@ -1,0 +1,23 @@
+use crate::sqlite::Connection;
+
+use quaint::{
+    connector::{rusqlite, ColumnType as QuaintColumnType, GetRow, ToColumnNames},
+    prelude::{ResultSet, Value},
+};
+
+#[async_trait::async_trait]
+impl Connection for std::sync::Mutex<rusqlite::Connection> {
+    async fn query_raw<'a>(&'a self, sql: &'a str, params: &'a [Value<'a>]) -> quaint::Result<ResultSet> {
+        let conn = self.lock().unwrap();
+        let mut stmt = conn.prepare_cached(sql)?;
+        let column_types = stmt.columns().iter().map(QuaintColumnType::from).collect::<Vec<_>>();
+        let mut rows = stmt.query(rusqlite::params_from_iter(params.iter()))?;
+        let column_names = rows.to_column_names();
+        let mut converted_rows = Vec::new();
+        while let Some(row) = rows.next()? {
+            converted_rows.push(row.get_result_row().unwrap());
+        }
+
+        Ok(ResultSet::new(column_names, column_types, converted_rows))
+    }
+}

--- a/schema-engine/sql-schema-describer/tests/test_api/mod.rs
+++ b/schema-engine/sql-schema-describer/tests/test_api/mod.rs
@@ -80,6 +80,7 @@ impl TestApi {
 
     async fn describe_impl(&self, schemas: &[&str]) -> Result<SqlSchema, DescriberError> {
         match self.sql_family() {
+            #[cfg(any(feature = "postgresql", feature = "cockroachdb"))]
             SqlFamily::Postgres => {
                 use postgres::Circumstances;
                 sql_schema_describer::postgres::SqlSchemaDescriber::new(
@@ -93,11 +94,13 @@ impl TestApi {
                 .describe(schemas)
                 .await
             }
+            #[cfg(feature = "sqlite")]
             SqlFamily::Sqlite => {
                 sql_schema_describer::sqlite::SqlSchemaDescriber::new(&self.database)
                     .describe_impl()
                     .await
             }
+            #[cfg(feature = "mysql")]
             SqlFamily::Mysql => {
                 use mysql::Circumstances;
                 sql_schema_describer::mysql::SqlSchemaDescriber::new(
@@ -115,6 +118,7 @@ impl TestApi {
                 .describe(schemas)
                 .await
             }
+            #[cfg(feature = "mssql")]
             SqlFamily::Mssql => {
                 sql_schema_describer::mssql::SqlSchemaDescriber::new(&self.database)
                     .describe(schemas)


### PR DESCRIPTION
This PR:
- closes [ORM-456](https://linear.app/prisma-company/issue/ORM-456/make-sql-schema-describer-wasm-compatible)
- closes [ORM-457](https://linear.app/prisma-company/issue/ORM-457/make-schema-connector-wasm-compatible)
- allow `cargo build -p sql-schema-describer --features sqlite --target wasm32-unknown-unknown` to succeed (and `--features postgresql`, and so on)
- allow `cargo build -p schema-connector --features sqlite --target wasm32-unknown-unknown` to succeed (and `--features postgresql`, and so on)
-  allow `cargo build -p schema-engine-cli` to build as usual