### PR TITLE
fix(crdb): ignore crdb_internal schema when diffing the database

### DIFF
--- a/schema-engine/sql-schema-describer/src/postgres/namespaces_query.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/namespaces_query.sql
@@ -1,4 +1,5 @@
 SELECT namespace.nspname as namespace_name
 FROM pg_namespace as namespace
 WHERE namespace.nspname = ANY ( $1 )
+AND namespace.nspname <> 'crdb_internal'
 ORDER BY namespace_name;


### PR DESCRIPTION
There has been a change in a Nov release of Cockroach DB. The `crdb_internal_region` enum is coming up in the diff engine regardless of having a multi-region deployment. Prisma should not scan or alter the `crdb_internal` schema as it should never be directly under user manipulation. 

Since the cockroach connector is really just the postgres engine under the hood, perhaps the namespace scanning should be changed. This PR is rather naive in that it just force ignores the `crdb_internal` schema and should cause the engine to ignore the fields. 

I'm happy to hear a better way to approach this fix from the team. This issue described in [#25696](https://github.com/prisma/prisma/issues/25696) I believe is coming from the engine.