### PR TITLE
feat(queryEngine): add limit argument to updateMany

### DIFF
--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -5523,6 +5523,18 @@ mod tests {
                                   "isList": false
                                 }
                               ]
+                            },
+                            {
+                              "name": "limit",
+                              "isRequired": false,
+                              "isNullable": false,
+                              "inputTypes": [
+                                {
+                                  "type": "Int",
+                                  "location": "scalar",
+                                  "isList": false
+                                }
+                              ]
                             }
                           ],
                           "isNullable": false,
@@ -5564,6 +5576,18 @@ mod tests {
                                   "type": "AWhereInput",
                                   "namespace": "prisma",
                                   "location": "inputObjectTypes",
+                                  "isList": false
+                                }
+                              ]
+                            },
+                            {
+                              "name": "limit",
+                              "isRequired": false,
+                              "isNullable": false,
+                              "inputTypes": [
+                                {
+                                  "type": "Int",
+                                  "location": "scalar",
                                   "isList": false
                                 }
                               ]
@@ -5897,6 +5921,18 @@ mod tests {
                                   "isList": false
                                 }
                               ]
+                            },
+                            {
+                              "name": "limit",
+                              "isRequired": false,
+                              "isNullable": false,
+                              "inputTypes": [
+                                {
+                                  "type": "Int",
+                                  "location": "scalar",
+                                  "isList": false
+                                }
+                              ]
                             }
                           ],
                           "isNullable": false,
@@ -5938,6 +5974,18 @@ mod tests {
                                   "type": "BWhereInput",
                                   "namespace": "prisma",
                                   "location": "inputObjectTypes",
+                                  "isList": false
+                                }
+                              ]
+                            },
+                            {
+                              "name": "limit",
+                              "isRequired": false,
+                              "isNullable": false,
+                              "inputTypes": [
+                                {
+                                  "type": "Int",
+                                  "location": "scalar",
                                   "isList": false
                                 }
                               ]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many.rs
@@ -202,6 +202,24 @@ mod delete_many {
         Ok(())
     }
 
+    // "The delete many Mutation" should "fail if limit param is negative"
+    #[connector_test]
+    async fn should_fail_with_negative_limit(runner: Runner) -> TestResult<()> {
+        create_row(&runner, r#"{ id: 1, title: "title1" }"#).await?;
+        create_row(&runner, r#"{ id: 2, title: "title2" }"#).await?;
+        create_row(&runner, r#"{ id: 3, title: "title3" }"#).await?;
+        create_row(&runner, r#"{ id: 4, title: "title4" }"#).await?;
+
+        assert_error!(
+            &runner,
+            r#"mutation { deleteManyTodo(limit: -3){ count }}"#,
+            2019,
+            "Provided limit (-3) must be a positive integer."
+        );
+
+        Ok(())
+    }
+
     fn nested_del_many() -> String {
         let schema = indoc! {
             r#"model ZChild{

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/update_many.rs
@@ -156,6 +156,31 @@ mod update_many {
         Ok(())
     }
 
+    // "An updateMany mutation" should "fail if limit param is negative"
+    #[connector_test]
+    async fn should_fail_with_negative_limit(runner: Runner) -> TestResult<()> {
+        create_row(&runner, r#"{ id: 1, optStr: "str1" }"#).await?;
+        create_row(&runner, r#"{ id: 2, optStr: "str2" }"#).await?;
+        create_row(&runner, r#"{ id: 3, optStr: "str3" }"#).await?;
+
+        assert_error!(
+            &runner,
+            r#"mutation {
+              updateManyTestModel(
+                where: { }
+                data: { optStr: { set: "updated" } }
+                limit: -2
+              ){
+                count
+              }
+            }"#,
+            2019,
+            "Provided limit (-2) must be a positive integer."
+        );
+
+        Ok(())
+    }
+
     // "An updateMany mutation" should "correctly apply all number operations for Int"
     #[connector_test(exclude(CockroachDb))]
     async fn apply_number_ops_for_int(runner: Runner) -> TestResult<()> {

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -96,6 +96,7 @@ impl WriteOperations for MongoDbConnection {
         model: &Model,
         record_filter: connector_interface::RecordFilter,
         args: WriteArgs,
+        limit: Option<i64>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<usize> {
         catch(async move {
@@ -106,6 +107,7 @@ impl WriteOperations for MongoDbConnection {
                 record_filter,
                 args,
                 UpdateType::Many,
+                limit,
             )
             .await?;
 
@@ -120,6 +122,7 @@ impl WriteOperations for MongoDbConnection {
         _record_filter: connector_interface::RecordFilter,
         _args: WriteArgs,
         _selected_fields: FieldSelection,
+        _limit: Option<i64>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<ManyRecords> {
         unimplemented!()
@@ -141,6 +144,7 @@ impl WriteOperations for MongoDbConnection {
                 record_filter,
                 args,
                 UpdateType::One,
+                None,
             )
             .await?;
 

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -106,8 +106,7 @@ impl WriteOperations for MongoDbConnection {
                 model,
                 record_filter,
                 args,
-                UpdateType::Many,
-                limit,
+                UpdateType::Many { limit },
             )
             .await?;
 
@@ -144,7 +143,6 @@ impl WriteOperations for MongoDbConnection {
                 record_filter,
                 args,
                 UpdateType::One,
-                None,
             )
             .await?;
 

--- a/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/connection.rs
@@ -96,7 +96,7 @@ impl WriteOperations for MongoDbConnection {
         model: &Model,
         record_filter: connector_interface::RecordFilter,
         args: WriteArgs,
-        limit: Option<i64>,
+        limit: Option<usize>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<usize> {
         catch(async move {
@@ -121,7 +121,7 @@ impl WriteOperations for MongoDbConnection {
         _record_filter: connector_interface::RecordFilter,
         _args: WriteArgs,
         _selected_fields: FieldSelection,
-        _limit: Option<i64>,
+        _limit: Option<usize>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<ManyRecords> {
         unimplemented!()
@@ -164,7 +164,7 @@ impl WriteOperations for MongoDbConnection {
         &mut self,
         model: &Model,
         record_filter: connector_interface::RecordFilter,
-        limit: Option<i64>,
+        limit: Option<usize>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<usize> {
         catch(write::delete_records(

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -127,7 +127,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
         model: &Model,
         record_filter: connector_interface::RecordFilter,
         args: connector_interface::WriteArgs,
-        limit: Option<i64>,
+        limit: Option<usize>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<usize> {
         catch(async move {
@@ -151,7 +151,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
         _record_filter: connector_interface::RecordFilter,
         _args: connector_interface::WriteArgs,
         _selected_fields: FieldSelection,
-        _limit: Option<i64>,
+        _limit: Option<usize>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<ManyRecords> {
         unimplemented!()
@@ -193,7 +193,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
         &mut self,
         model: &Model,
         record_filter: connector_interface::RecordFilter,
-        limit: Option<i64>,
+        limit: Option<usize>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<usize> {
         catch(write::delete_records(

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -127,6 +127,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
         model: &Model,
         record_filter: connector_interface::RecordFilter,
         args: connector_interface::WriteArgs,
+        limit: Option<i64>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<usize> {
         catch(async move {
@@ -137,6 +138,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
                 record_filter,
                 args,
                 UpdateType::Many,
+                limit,
             )
             .await?;
             Ok(result.len())
@@ -150,6 +152,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
         _record_filter: connector_interface::RecordFilter,
         _args: connector_interface::WriteArgs,
         _selected_fields: FieldSelection,
+        _limit: Option<i64>,
         _traceparent: Option<TraceParent>,
     ) -> connector_interface::Result<ManyRecords> {
         unimplemented!()
@@ -171,6 +174,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
                 record_filter,
                 args,
                 UpdateType::One,
+                None, // This is a single record update already => no need for additional limit
             )
             .await?;
             // NOTE: Atomic updates are not yet implemented for MongoDB, so we only return ids.

--- a/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/interface/transaction.rs
@@ -137,8 +137,7 @@ impl WriteOperations for MongoDbTransaction<'_> {
                 model,
                 record_filter,
                 args,
-                UpdateType::Many,
-                limit,
+                UpdateType::Many { limit },
             )
             .await?;
             Ok(result.len())
@@ -174,7 +173,6 @@ impl WriteOperations for MongoDbTransaction<'_> {
                 record_filter,
                 args,
                 UpdateType::One,
-                None, // This is a single record update already => no need for additional limit
             )
             .await?;
             // NOTE: Atomic updates are not yet implemented for MongoDB, so we only return ids.

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -164,7 +164,7 @@ pub async fn update_records<'conn>(
             .take(match update_type {
                 UpdateType::Many { limit } => limit.unwrap_or(usize::MAX),
                 UpdateType::One => 1,
-            } as usize)
+            })
             .map(|p| {
                 (&id_field, p.values().next().unwrap())
                     .into_bson()

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -146,6 +146,7 @@ pub async fn update_records<'conn>(
     record_filter: RecordFilter,
     mut args: WriteArgs,
     update_type: UpdateType,
+    limit: Option<i64>,
 ) -> crate::Result<Vec<SelectionResult>> {
     let coll = database.collection::<Document>(model.db_name());
 
@@ -160,6 +161,7 @@ pub async fn update_records<'conn>(
     let ids: Vec<Bson> = if let Some(selectors) = record_filter.selectors {
         selectors
             .into_iter()
+            .take(limit.unwrap_or(i64::MAX) as usize)
             .map(|p| {
                 (&id_field, p.values().next().unwrap())
                     .into_bson()

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -286,7 +286,7 @@ pub trait WriteOperations {
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> crate::Result<usize>;
 
@@ -300,7 +300,7 @@ pub trait WriteOperations {
         record_filter: RecordFilter,
         args: WriteArgs,
         selected_fields: FieldSelection,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> crate::Result<ManyRecords>;
 
@@ -328,7 +328,7 @@ pub trait WriteOperations {
         &mut self,
         model: &Model,
         record_filter: RecordFilter,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> crate::Result<usize>;
 

--- a/query-engine/connectors/query-connector/src/interface.rs
+++ b/query-engine/connectors/query-connector/src/interface.rs
@@ -286,6 +286,7 @@ pub trait WriteOperations {
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
+        limit: Option<i64>,
         traceparent: Option<TraceParent>,
     ) -> crate::Result<usize>;
 
@@ -299,6 +300,7 @@ pub trait WriteOperations {
         record_filter: RecordFilter,
         args: WriteArgs,
         selected_fields: FieldSelection,
+        limit: Option<i64>,
         traceparent: Option<TraceParent>,
     ) -> crate::Result<ManyRecords>;
 

--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -20,6 +20,6 @@ pub type Result<T> = std::result::Result<T, error::ConnectorError>;
 /// However when we updating any records we want to return an empty array if zero items were updated
 #[derive(PartialEq)]
 pub enum UpdateType {
-    Many { limit: Option<i64> },
+    Many { limit: Option<usize> },
     One,
 }

--- a/query-engine/connectors/query-connector/src/lib.rs
+++ b/query-engine/connectors/query-connector/src/lib.rs
@@ -20,6 +20,6 @@ pub type Result<T> = std::result::Result<T, error::ConnectorError>;
 /// However when we updating any records we want to return an empty array if zero items were updated
 #[derive(PartialEq)]
 pub enum UpdateType {
-    Many,
+    Many { limit: Option<i64> },
     One,
 }

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -226,7 +226,7 @@ where
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<usize> {
         let ctx = Context::new(&self.connection_info, traceparent);
@@ -243,7 +243,7 @@ where
         record_filter: RecordFilter,
         args: WriteArgs,
         selected_fields: FieldSelection,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<ManyRecords> {
         let ctx = Context::new(&self.connection_info, traceparent);
@@ -274,7 +274,7 @@ where
         &mut self,
         model: &Model,
         record_filter: RecordFilter,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<usize> {
         let ctx = Context::new(&self.connection_info, traceparent);

--- a/query-engine/connectors/sql-query-connector/src/database/connection.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/connection.rs
@@ -226,12 +226,13 @@ where
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
+        limit: Option<i64>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<usize> {
         let ctx = Context::new(&self.connection_info, traceparent);
         catch(
             &self.connection_info,
-            write::update_records(&self.inner, model, record_filter, args, &ctx),
+            write::update_records(&self.inner, model, record_filter, args, limit, &ctx),
         )
         .await
     }
@@ -242,12 +243,13 @@ where
         record_filter: RecordFilter,
         args: WriteArgs,
         selected_fields: FieldSelection,
+        limit: Option<i64>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<ManyRecords> {
         let ctx = Context::new(&self.connection_info, traceparent);
         catch(
             &self.connection_info,
-            write::update_records_returning(&self.inner, model, record_filter, args, selected_fields, &ctx),
+            write::update_records_returning(&self.inner, model, record_filter, args, selected_fields, limit, &ctx),
         )
         .await
     }

--- a/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
@@ -104,7 +104,7 @@ pub(super) async fn update_many_from_filter(
     record_filter: RecordFilter,
     args: WriteArgs,
     selected_fields: Option<&ModelProjection>,
-    limit: Option<i64>,
+    limit: Option<usize>,
     ctx: &Context<'_>,
 ) -> crate::Result<Query<'static>> {
     let update = build_update_and_set_query(model, args, None, ctx);
@@ -133,7 +133,7 @@ pub(super) async fn update_many_from_ids_and_filter(
     record_filter: RecordFilter,
     args: WriteArgs,
     selected_fields: Option<&ModelProjection>,
-    limit: Option<i64>,
+    limit: Option<usize>,
     ctx: &Context<'_>,
 ) -> crate::Result<(Vec<Query<'static>>, Vec<SelectionResult>)> {
     let filter_condition = FilterBuilder::without_top_level_joins().visit_filter(record_filter.filter.clone(), ctx);
@@ -145,7 +145,7 @@ pub(super) async fn update_many_from_ids_and_filter(
 
     let updates = {
         let update = build_update_and_set_query(model, args, selected_fields, ctx);
-        let ids: Vec<&SelectionResult> = ids.iter().take(limit.unwrap_or(i64::MAX) as usize).collect();
+        let ids: Vec<&SelectionResult> = ids.iter().take(limit.unwrap_or(usize::MAX)).collect();
 
         chunk_update_with_ids(update, model, &ids, filter_condition, ctx)?
     };

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -379,7 +379,6 @@ async fn generate_updates(
     limit: Option<i64>,
     ctx: &Context<'_>,
 ) -> crate::Result<Vec<Query<'static>>> {
-    println!(">>>> DBFlo A {:?}", record_filter.selectors);
     if record_filter.has_selectors() {
         let (updates, _) =
             update_many_from_ids_and_filter(conn, model, record_filter, args, selected_fields, limit, ctx).await?;

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -476,7 +476,7 @@ pub(crate) async fn delete_records(
             if let Some(old_remaining_limit) = remaining_limit {
                 // u64 to usize cast here cannot 'overflow' as the number of rows was limited to MAX usize in the first place.
                 let new_remaining_limit = old_remaining_limit - row_count as usize;
-                if new_remaining_limit <= 0 {
+                if new_remaining_limit == 0 {
                     break;
                 }
                 remaining_limit = Some(new_remaining_limit);

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -220,7 +220,7 @@ impl WriteOperations for SqlConnectorTransaction<'_> {
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<usize> {
         let ctx = Context::new(&self.connection_info, traceparent);
@@ -237,7 +237,7 @@ impl WriteOperations for SqlConnectorTransaction<'_> {
         record_filter: RecordFilter,
         args: WriteArgs,
         selected_fields: FieldSelection,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<ManyRecords> {
         let ctx = Context::new(&self.connection_info, traceparent);
@@ -283,7 +283,7 @@ impl WriteOperations for SqlConnectorTransaction<'_> {
         &mut self,
         model: &Model,
         record_filter: RecordFilter,
-        limit: Option<i64>,
+        limit: Option<usize>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<usize> {
         catch(&self.connection_info, async {

--- a/query-engine/connectors/sql-query-connector/src/database/transaction.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/transaction.rs
@@ -220,12 +220,13 @@ impl WriteOperations for SqlConnectorTransaction<'_> {
         model: &Model,
         record_filter: RecordFilter,
         args: WriteArgs,
+        limit: Option<i64>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<usize> {
         let ctx = Context::new(&self.connection_info, traceparent);
         catch(
             &self.connection_info,
-            write::update_records(self.inner.as_queryable(), model, record_filter, args, &ctx),
+            write::update_records(self.inner.as_queryable(), model, record_filter, args, limit, &ctx),
         )
         .await
     }
@@ -236,6 +237,7 @@ impl WriteOperations for SqlConnectorTransaction<'_> {
         record_filter: RecordFilter,
         args: WriteArgs,
         selected_fields: FieldSelection,
+        limit: Option<i64>,
         traceparent: Option<TraceParent>,
     ) -> connector::Result<ManyRecords> {
         let ctx = Context::new(&self.connection_info, traceparent);
@@ -247,6 +249,7 @@ impl WriteOperations for SqlConnectorTransaction<'_> {
                 record_filter,
                 args,
                 selected_fields,
+                limit,
                 &ctx,
             ),
         )

--- a/query-engine/connectors/sql-query-connector/src/lib.rs
+++ b/query-engine/connectors/sql-query-connector/src/lib.rs
@@ -8,6 +8,7 @@ mod database;
 mod error;
 mod filter;
 mod join_utils;
+mod limit;
 mod model_extensions;
 mod nested_aggregations;
 mod ordering;

--- a/query-engine/connectors/sql-query-connector/src/limit.rs
+++ b/query-engine/connectors/sql-query-connector/src/limit.rs
@@ -1,0 +1,31 @@
+use crate::{model_extensions::*, Context};
+use quaint::ast::*;
+use query_structure::*;
+
+pub(crate) fn wrap_with_limit_subquery_if_needed<'a>(
+    model: &Model,
+    filter_condition: ConditionTree<'a>,
+    limit: Option<i64>,
+    ctx: &Context,
+) -> ConditionTree<'a> {
+    if let Some(limit) = limit {
+        let columns = model
+            .primary_identifier()
+            .as_scalar_fields()
+            .expect("primary identifier must contain scalar fields")
+            .into_iter()
+            .map(|f| f.as_column(ctx))
+            .collect::<Vec<_>>();
+
+        ConditionTree::from(
+            Row::from(columns.clone()).in_selection(
+                Select::from_table(model.as_table(ctx))
+                    .columns(columns)
+                    .so_that(filter_condition)
+                    .limit(limit as usize),
+            ),
+        )
+    } else {
+        filter_condition
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/limit.rs
+++ b/query-engine/connectors/sql-query-connector/src/limit.rs
@@ -5,7 +5,7 @@ use query_structure::*;
 pub(crate) fn wrap_with_limit_subquery_if_needed<'a>(
     model: &Model,
     filter_condition: ConditionTree<'a>,
-    limit: Option<i64>,
+    limit: Option<usize>,
     ctx: &Context,
 ) -> ConditionTree<'a> {
     if let Some(limit) = limit {
@@ -22,7 +22,7 @@ pub(crate) fn wrap_with_limit_subquery_if_needed<'a>(
                 Select::from_table(model.as_table(ctx))
                     .columns(columns)
                     .so_that(filter_condition)
-                    .limit(limit as usize),
+                    .limit(limit),
             ),
         )
     } else {

--- a/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_builder/write.rs
@@ -227,7 +227,7 @@ pub(crate) fn delete_returning(
 pub(crate) fn delete_many_from_filter(
     model: &Model,
     filter_condition: ConditionTree<'static>,
-    limit: Option<i64>,
+    limit: Option<usize>,
     ctx: &Context<'_>,
 ) -> Query<'static> {
     let filter_condition = wrap_with_limit_subquery_if_needed(model, filter_condition, limit, ctx);
@@ -242,7 +242,7 @@ pub(crate) fn delete_many_from_ids_and_filter(
     model: &Model,
     ids: &[&SelectionResult],
     filter_condition: ConditionTree<'static>,
-    limit: Option<i64>,
+    limit: Option<usize>,
     ctx: &Context<'_>,
 ) -> Vec<Query<'static>> {
     let columns: Vec<_> = ModelProjection::from(model.primary_identifier())

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -307,7 +307,14 @@ async fn update_many(
 ) -> InterpretationResult<QueryResult> {
     if let Some(selected_fields) = q.selected_fields {
         let records = tx
-            .update_records_returning(&q.model, q.record_filter, q.args, selected_fields.fields, traceparent)
+            .update_records_returning(
+                &q.model,
+                q.record_filter,
+                q.args,
+                selected_fields.fields,
+                q.limit,
+                traceparent,
+            )
             .await?;
 
         let nested: Vec<QueryResult> =
@@ -325,7 +332,7 @@ async fn update_many(
         Ok(QueryResult::RecordSelection(Some(Box::new(selection))))
     } else {
         let affected_records = tx
-            .update_records(&q.model, q.record_filter, q.args, traceparent)
+            .update_records(&q.model, q.record_filter, q.args, q.limit, traceparent)
             .await?;
 
         Ok(QueryResult::Count(affected_records))

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -368,7 +368,7 @@ pub struct UpdateManyRecords {
     /// Fields of updated records that client has requested to return.
     /// `None` if the connector does not support returning the updated rows.
     pub selected_fields: Option<UpdateManyRecordsFields>,
-    pub limit: Option<i64>,
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -398,7 +398,7 @@ pub struct DeleteRecordFields {
 pub struct DeleteManyRecords {
     pub model: Model,
     pub record_filter: RecordFilter,
-    pub limit: Option<i64>,
+    pub limit: Option<usize>,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -368,6 +368,7 @@ pub struct UpdateManyRecords {
     /// Fields of updated records that client has requested to return.
     /// `None` if the connector does not support returning the updated rows.
     pub selected_fields: Option<UpdateManyRecordsFields>,
+    pub limit: Option<i64>,
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -112,10 +112,7 @@ pub fn delete_many_records(
         None => Filter::empty(),
     };
 
-    let limit = match validate_limit(field.arguments.lookup(args::LIMIT)) {
-        Ok(limit) => limit,
-        Err(err) => return Err(err),
-    };
+    let limit = validate_limit(field.arguments.lookup(args::LIMIT))?;
 
     let model_id = model.primary_identifier();
     let record_filter = filter.clone().into();

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -1,12 +1,12 @@
 use super::*;
-use crate::query_document::ParsedInputValue;
+use crate::query_graph_builder::write::limit::validate_limit;
 use crate::{
     query_ast::*,
     query_graph::{Node, QueryGraph, QueryGraphDependency},
     ArgumentListLookup, FilteredQuery, ParsedField,
 };
 use psl::datamodel_connector::ConnectorCapability;
-use query_structure::{Filter, Model, PrismaValue};
+use query_structure::{Filter, Model};
 use schema::{constants::args, QuerySchema};
 use std::convert::TryInto;
 
@@ -111,13 +111,11 @@ pub fn delete_many_records(
         Some(where_arg) => extract_filter(where_arg.value.try_into()?, &model)?,
         None => Filter::empty(),
     };
-    let limit = field
-        .arguments
-        .lookup(args::LIMIT)
-        .and_then(|limit_arg| match limit_arg.value {
-            ParsedInputValue::Single(PrismaValue::Int(i)) => Some(i),
-            _ => None,
-        });
+
+    let limit = match validate_limit(field.arguments.lookup(args::LIMIT)) {
+        Ok(limit) => limit,
+        Err(err) => return Err(err),
+    };
 
     let model_id = model.primary_identifier();
     let record_filter = filter.clone().into();

--- a/query-engine/core/src/query_graph_builder/write/limit.rs
+++ b/query-engine/core/src/query_graph_builder/write/limit.rs
@@ -2,7 +2,7 @@ use crate::query_document::{ParsedArgument, ParsedInputValue};
 use crate::query_graph_builder::{QueryGraphBuilderError, QueryGraphBuilderResult};
 use query_structure::PrismaValue;
 
-pub(crate) fn validate_limit<'a>(limit_arg: Option<ParsedArgument<'a>>) -> QueryGraphBuilderResult<Option<usize>> {
+pub(crate) fn validate_limit(limit_arg: Option<ParsedArgument<'_>>) -> QueryGraphBuilderResult<Option<usize>> {
     let limit = limit_arg.and_then(|limit_arg| match limit_arg.value {
         ParsedInputValue::Single(PrismaValue::Int(i)) => Some(i),
         _ => None,

--- a/query-engine/core/src/query_graph_builder/write/limit.rs
+++ b/query-engine/core/src/query_graph_builder/write/limit.rs
@@ -1,0 +1,31 @@
+use crate::query_document::{ParsedArgument, ParsedInputValue};
+use crate::query_graph_builder::{QueryGraphBuilderError, QueryGraphBuilderResult};
+use query_structure::PrismaValue;
+
+pub(crate) fn validate_limit<'a>(limit_arg: Option<ParsedArgument<'a>>) -> QueryGraphBuilderResult<Option<usize>> {
+    let limit = limit_arg.and_then(|limit_arg| match limit_arg.value {
+        ParsedInputValue::Single(PrismaValue::Int(i)) => Some(i),
+        _ => None,
+    });
+
+    match limit {
+        Some(i) => {
+            if i < 0 {
+                return Err(QueryGraphBuilderError::InputError(format!(
+                    "Provided limit ({}) must be a positive integer.",
+                    i
+                )));
+            }
+
+            match usize::try_from(i) {
+                Ok(i) => Ok(Some(i)),
+                Err(_) => Err(QueryGraphBuilderError::InputError(format!(
+                    "Provided limit ({}) is beyond max int value for platform ({}).",
+                    i,
+                    usize::MAX
+                ))),
+            }
+        }
+        None => Ok(None),
+    }
+}

--- a/query-engine/core/src/query_graph_builder/write/mod.rs
+++ b/query-engine/core/src/query_graph_builder/write/mod.rs
@@ -2,6 +2,7 @@ mod connect;
 mod create;
 mod delete;
 mod disconnect;
+mod limit;
 mod nested;
 mod raw;
 mod update;

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -150,7 +150,7 @@ pub fn nested_update_many(
             None,
             None,
             data_map,
-            None, // TODO: would it make sense to support limit on nested updates?
+            None,
         )?;
 
         graph.create_edge(

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::query_graph_builder::write::update::UpdateManyRecordNodeOptionals;
 use crate::{
     query_ast::*,
     query_graph::{Node, NodeRef, QueryGraph, QueryGraphDependency},
@@ -147,10 +148,12 @@ pub fn nested_update_many(
             query_schema,
             Filter::empty(),
             child_model.clone(),
-            None,
-            None,
             data_map,
-            None,
+            UpdateManyRecordNodeOptionals {
+                name: None,
+                nested_field_selection: None,
+                limit: None,
+            },
         )?;
 
         graph.create_edge(

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -150,6 +150,7 @@ pub fn nested_update_many(
             None,
             None,
             data_map,
+            None, // TODO: would it make sense to support limit on nested updates?
         )?;
 
         graph.create_edge(

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -138,10 +138,7 @@ pub fn update_many_records(
     };
 
     // "limit"
-    let limit = match validate_limit(field.arguments.lookup(args::LIMIT)) {
-        Ok(limit) => limit,
-        Err(err) => return Err(err),
-    };
+    let limit = validate_limit(field.arguments.lookup(args::LIMIT))?;
 
     // "data"
     let data_argument = field.arguments.lookup(args::DATA).unwrap();

--- a/query-engine/core/src/query_graph_builder/write/utils.rs
+++ b/query-engine/core/src/query_graph_builder/write/utils.rs
@@ -229,6 +229,7 @@ where
         record_filter,
         args,
         selected_fields: None,
+        limit: None,
     };
 
     graph.create_node(Query::Write(WriteQuery::UpdateManyRecords(ur)))
@@ -618,6 +619,7 @@ pub fn emulate_on_delete_set_null(
         record_filter: RecordFilter::empty(),
         args: WriteArgs::new(child_update_args, crate::executor::get_request_now()),
         selected_fields: None,
+        limit: None,
     });
 
     let set_null_dependents_node = graph.create_node(Query::Write(set_null_query));
@@ -770,6 +772,7 @@ pub fn emulate_on_update_set_null(
         record_filter: RecordFilter::empty(),
         args: WriteArgs::new(child_update_args, crate::executor::get_request_now()),
         selected_fields: None,
+        limit: None,
     });
 
     let set_null_dependents_node = graph.create_node(Query::Write(set_null_query));
@@ -1095,6 +1098,7 @@ pub fn emulate_on_update_cascade(
             crate::executor::get_request_now(),
         ),
         selected_fields: None,
+        limit: None,
     });
 
     let update_dependents_node = graph.create_node(Query::Write(update_query));

--- a/query-engine/schema/src/build/input_types/fields/arguments.rs
+++ b/query-engine/schema/src/build/input_types/fields/arguments.rs
@@ -73,7 +73,7 @@ pub(crate) fn upsert_arguments(ctx: &QuerySchema, model: Model) -> Vec<InputFiel
     args
 }
 
-/// Builds "where" and "data" arguments intended for the update many field.
+/// Builds "where", "data" and "limit" arguments intended for the update many field.
 pub(crate) fn update_many_arguments(ctx: &QuerySchema, model: Model) -> Vec<InputField<'_>> {
     let update_many_types = update_many_objects::update_many_input_types(ctx, model.clone(), None);
     let where_arg = where_argument(ctx, &model);
@@ -86,7 +86,7 @@ pub(crate) fn update_many_arguments(ctx: &QuerySchema, model: Model) -> Vec<Inpu
     ]
 }
 
-/// Builds "where" argument intended for the delete many field.
+/// Builds "where" and "limit" argument intended for the delete many field.
 pub(crate) fn delete_many_arguments(ctx: &QuerySchema, model: Model) -> Vec<InputField<'_>> {
     let where_arg = where_argument(ctx, &model);
 

--- a/query-engine/schema/src/build/input_types/fields/arguments.rs
+++ b/query-engine/schema/src/build/input_types/fields/arguments.rs
@@ -77,8 +77,13 @@ pub(crate) fn upsert_arguments(ctx: &QuerySchema, model: Model) -> Vec<InputFiel
 pub(crate) fn update_many_arguments(ctx: &QuerySchema, model: Model) -> Vec<InputField<'_>> {
     let update_many_types = update_many_objects::update_many_input_types(ctx, model.clone(), None);
     let where_arg = where_argument(ctx, &model);
+    let limit_arg = input_field(args::LIMIT, vec![InputType::int()], None).optional();
 
-    vec![input_field(args::DATA.to_owned(), update_many_types, None), where_arg]
+    vec![
+        input_field(args::DATA.to_owned(), update_many_types, None),
+        where_arg,
+        limit_arg,
+    ]
 }
 
 /// Builds "where" argument intended for the delete many field.


### PR DESCRIPTION
This PR adds an optional `limit` argument to the `updateMany` call allowing to constraint the max number of affected rows by the update. As requested in https://github.com/prisma/prisma/issues/6957. 

It uses a subquery approach similar to `deleteMany` from #5105.

