### PR TITLE
fix(datamodel-renderer): sort generator fields deterministically

### DIFF
--- a/schema-engine/datamodel-renderer/Cargo.toml
+++ b/schema-engine/datamodel-renderer/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 once_cell = "1.15.0"
 psl.workspace = true
 regex.workspace = true
+itertools.workspace = true
 base64 = "0.13.1"
 
 [dev-dependencies]

--- a/schema-engine/datamodel-renderer/src/configuration/generator.rs
+++ b/schema-engine/datamodel-renderer/src/configuration/generator.rs
@@ -224,10 +224,9 @@ mod tests {
 
         let expected = expect![[r#"
             generator client {
-              provider        = "prisma-client-js"
-              previewFeatures = ["multiSchema", "postgresqlExtensions"]
-              first           = "A"
-              second          = "B"
+              provider = "prisma-client-js"
+              first    = "A"
+              second   = "B"
             }
         "#]];
 


### PR DESCRIPTION
This PR addresses an issue that caused generator fields to "randomly" change their ordering on `prisma db pull`. See https://github.com/prisma/prisma/issues/17899.