### PR TITLE
chore(ci): try to cache docker images in GitHub cache to reduce Docker pull rate limit issues

### DIFF
--- a/.github/workflows/test-driver-adapters-template.yml
+++ b/.github/workflows/test-driver-adapters-template.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: [ "20" ]
-        partition: [ "1/4", "2/4", "3/4", "4/4" ]
+        node_version: ["20"]
+        partition: ["1/4", "2/4", "3/4", "4/4"]
     env:
       LOG_LEVEL: "info" # Set to "debug" to trace the query engine and node process running the driver adapter
       LOG_QUERIES: "y"

--- a/.github/workflows/test-driver-adapters-template.yml
+++ b/.github/workflows/test-driver-adapters-template.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ["20"]
-        partition: ["1/4", "2/4", "3/4", "4/4"]
+        node_version: [ "20" ]
+        partition: [ "1/4", "2/4", "3/4", "4/4" ]
     env:
       LOG_LEVEL: "info" # Set to "debug" to trace the query engine and node process running the driver adapter
       LOG_QUERIES: "y"
@@ -54,6 +54,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ inputs.setup_task }}-${{hashFiles('docker-compose.yaml')}}
 
       - name: Extract Branch Name
         id: extract-branch

--- a/.github/workflows/test-query-engine-black-box.yml
+++ b/.github/workflows/test-query-engine-black-box.yml
@@ -58,6 +58,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ matrix.database.name }}-${{hashFiles('docker-compose.yaml')}}
+
       - name: "Start ${{ matrix.database.name }} (${{ matrix.engine_protocol }})"
         run: make start-${{ matrix.database.name }}
 

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        engine_protocol: [ graphql, json ]
+        engine_protocol: [graphql, json]
         relation_load_strategy: ${{ fromJson(inputs.relation_load_strategy) }}
-        partition: [ "1/4", "2/4", "3/4", "4/4" ]
+        partition: ["1/4", "2/4", "3/4", "4/4"]
 
     env:
       LOG_LEVEL: "info"

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -30,9 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        engine_protocol: [graphql, json]
+        engine_protocol: [ graphql, json ]
         relation_load_strategy: ${{ fromJson(inputs.relation_load_strategy) }}
-        partition: ["1/4", "2/4", "3/4", "4/4"]
+        partition: [ "1/4", "2/4", "3/4", "4/4" ]
 
     env:
       LOG_LEVEL: "info"
@@ -67,6 +67,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ inputs.name }}-${{hashFiles('docker-compose.yaml')}}
 
       - name: "Start ${{ inputs.name }} (${{ matrix.engine_protocol }})"
         run: make start-${{ inputs.name }}

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -45,6 +45,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ matrix.database.name }}-${{hashFiles('docker-compose.yaml')}}
+
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}-single
 
@@ -123,6 +128,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ matrix.database.name }}-${{hashFiles('docker-compose.yaml')}}
 
       - name: "Start ${{ matrix.database.name }}"
         run: make start-${{ matrix.database.name }}

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -47,6 +47,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-pg-bench-${{hashFiles('docker-compose.yaml')}}
+
       - name: Extract Branch Name
         run: |
           echo "Extracting branch name from: $(git show -s --format=%s)"


### PR DESCRIPTION
Using [this](https://github.com/marketplace/actions/docker-cache) github action we should be able to cache our docker images. I hope this also defacto caches them across branches once we have this on our default branch ([see](https://github.com/marketplace/actions/cache#cache-scopes)).

🧪 Let's see if this works and helps. 🤞 