### PR TITLE
chore: update Rust to 1.84.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,10 @@ members = [
   "quaint",
 ]
 
+[workspace.lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = ['cfg(wasm_bindgen_unstable_test_coverage)', 'cfg(debug_assert)']
+
 [workspace.dependencies]
 async-trait = { version = "0.1.77" }
 enumflags2 = { version = "0.7", features = ["serde"] }

--- a/libs/crosstarget-utils/Cargo.toml
+++ b/libs/crosstarget-utils/Cargo.toml
@@ -3,7 +3,8 @@ name = "crosstarget-utils"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lints]
+workspace = true
 
 [dependencies]
 derive_more.workspace = true

--- a/libs/driver-adapters/Cargo.toml
+++ b/libs/driver-adapters/Cargo.toml
@@ -8,6 +8,14 @@ mysql = ["quaint/mysql"]
 sqlite = ["quaint/sqlite"]
 postgresql = ["quaint/postgresql"]
 
+# napi-rs generated code has some cfg attributes that check for these features
+# so we declare them here to silence the warnings. They should not be enabled.
+noop = []
+used_linker = []
+
+[lints]
+workspace = true
+
 [dependencies]
 async-trait.workspace = true
 futures.workspace = true

--- a/libs/query-engine-common/Cargo.toml
+++ b/libs/query-engine-common/Cargo.toml
@@ -3,6 +3,9 @@ name = "query-engine-common"
 version = "0.1.0"
 edition = "2021"
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror = "1"
 url.workspace = true

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -206,12 +206,12 @@ fn find_where_used_in_relation_attribute<'a>(
                 attr.arguments
                     .arguments
                     .iter()
-                    .find(|arg| arg.name().map_or(false, |name| name == "fields") && arg.value.is_array())
+                    .find(|arg| arg.name() == Some("fields") && arg.value.is_array())
                     .and_then(|arg| {
                         arg.value.as_array().and_then(|arr| {
                             arr.0
                                 .iter()
-                                .find(|expr| expr.as_constant_value().map_or(false, |cv| cv.0 == name))
+                                .find(|expr| expr.as_constant_value().is_some_and(|cv| cv.0 == name))
                         })
                     })
             })
@@ -235,7 +235,7 @@ fn find_where_used_in_block_attribute<'ast>(
                 arg.value.as_array().and_then(|arr| {
                     arr.0
                         .iter()
-                        .find(|expr| expr.as_constant_value().map_or(false, |cv| cv.0 == name))
+                        .find(|expr| expr.as_constant_value().is_some_and(|cv| cv.0 == name))
                 })
             })
             .map(|arg| arg.span())

--- a/prisma-schema-wasm/Cargo.toml
+++ b/prisma-schema-wasm/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 wasm-bindgen.workspace = true
 wasm-logger = { version = "0.2.0", optional = true }

--- a/quaint/src/connector/postgres/native/query.rs
+++ b/quaint/src/connector/postgres/native/query.rs
@@ -61,7 +61,7 @@ impl<'a> TypedQuery<'a> {
 }
 
 #[async_trait]
-impl<'a> PreparedQuery for TypedQuery<'a> {
+impl PreparedQuery for TypedQuery<'_> {
     fn param_types(&self) -> impl ExactSizeIterator<Item = &Type> {
         self.metadata.param_types.iter()
     }

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/aggregate.rs
@@ -4,7 +4,7 @@ use connector_interface::*;
 use mongodb::{bson::Document, ClientSession, Database};
 use query_structure::{prelude::*, AggregationSelection, Filter, QueryArguments};
 
-pub async fn aggregate<'conn>(
+pub async fn aggregate(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/read.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/read.rs
@@ -8,7 +8,7 @@ use query_structure::*;
 use std::future::IntoFuture;
 
 /// Finds a single record. Joins are not required at the moment because the selector is always a unique one.
-pub async fn get_single_record<'conn>(
+pub async fn get_single_record(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -44,7 +44,7 @@ pub async fn get_single_record<'conn>(
 // - [x] Cursor
 // - [x] Distinct select (inherently given from core).
 // - [x] Relation aggregation count
-pub async fn get_many_records<'conn>(
+pub async fn get_many_records(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -81,7 +81,7 @@ pub async fn get_many_records<'conn>(
     Ok(records)
 }
 
-pub async fn get_related_m2m_record_ids<'conn>(
+pub async fn get_related_m2m_record_ids(
     database: &Database,
     session: &mut ClientSession,
     from_field: &RelationFieldRef,

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/write.rs
@@ -23,7 +23,7 @@ use update::IntoUpdateDocumentExtension;
 
 /// Create a single record to the database resulting in a
 /// `RecordProjection` as an identifier pointing to the just-created document.
-pub async fn create_record<'conn>(
+pub async fn create_record(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -69,7 +69,7 @@ pub async fn create_record<'conn>(
     })
 }
 
-pub async fn create_records<'conn>(
+pub async fn create_records(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -140,7 +140,7 @@ pub async fn create_records<'conn>(
     }
 }
 
-pub async fn update_records<'conn>(
+pub async fn update_records(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -228,7 +228,7 @@ pub async fn update_records<'conn>(
     Ok(ids)
 }
 
-pub async fn delete_records<'conn>(
+pub async fn delete_records(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -267,7 +267,7 @@ pub async fn delete_records<'conn>(
     Ok(delete_result.deleted_count as usize)
 }
 
-pub async fn delete_record<'conn>(
+pub async fn delete_record(
     database: &Database,
     session: &mut ClientSession,
     model: &Model,
@@ -347,7 +347,7 @@ async fn find_ids(
 
 /// Connect relations defined in `child_ids` to a parent defined in `parent_id`.
 /// The relation information is in the `RelationFieldRef`.
-pub async fn m2m_connect<'conn>(
+pub async fn m2m_connect(
     database: &Database,
     session: &mut ClientSession,
     field: &RelationFieldRef,
@@ -419,7 +419,7 @@ pub async fn m2m_connect<'conn>(
     Ok(())
 }
 
-pub async fn m2m_disconnect<'conn>(
+pub async fn m2m_disconnect(
     database: &Database,
     session: &mut ClientSession,
     field: &RelationFieldRef,
@@ -493,7 +493,7 @@ pub async fn m2m_disconnect<'conn>(
 }
 
 /// Execute raw is not implemented on MongoDB
-pub async fn execute_raw<'conn>(
+pub async fn execute_raw(
     _database: &Database,
     _session: &mut ClientSession,
     _inputs: HashMap<String, PrismaValue>,
@@ -502,7 +502,7 @@ pub async fn execute_raw<'conn>(
 }
 
 /// Execute a plain MongoDB query, returning the answer as a JSON `Value`.
-pub async fn query_raw<'conn>(
+pub async fn query_raw(
     database: &Database,
     session: &mut ClientSession,
     model: Option<&Model>,

--- a/query-engine/query-engine-node-api/Cargo.toml
+++ b/query-engine/query-engine-node-api/Cargo.toml
@@ -16,6 +16,14 @@ driver-adapters = [
     "sql-connector/driver-adapters",
 ]
 
+# napi-rs generated code has some cfg attributes that check for these features
+# so we declare them here to silence the warnings. They should not be enabled.
+noop = []
+used_linker = []
+
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1"
 async-trait.workspace = true

--- a/query-engine/query-engine-wasm/Cargo.toml
+++ b/query-engine/query-engine-wasm/Cargo.toml
@@ -28,6 +28,9 @@ mysql = [
     "request-handlers/mysql",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 
 query-connector = { path = "../connectors/query-connector" }

--- a/query-engine/request-handlers/src/handler.rs
+++ b/query-engine/request-handlers/src/handler.rs
@@ -244,7 +244,7 @@ impl<'a> RequestHandler<'a> {
         small.iter().all(|(key, small_value)| {
             large
                 .get(key)
-                .map_or(false, |large_value| Self::compare_values(small_value, large_value))
+                .is_some_and(|large_value| Self::compare_values(small_value, large_value))
         })
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.84.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/index_field.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/index_field.rs
@@ -65,16 +65,8 @@ impl<'a> IndexFieldPair<'a> {
         }
 
         let ext: &PostgresSchemaExt = self.context.sql_schema.downcast_connector_data();
-
-        let next = match self.next {
-            Some(next) => next,
-            None => return None,
-        };
-
-        let opclass = match ext.get_opclass(next.id) {
-            Some(opclass) => opclass,
-            None => return None,
-        };
+        let next = self.next?;
+        let opclass = ext.get_opclass(next.id)?;
 
         match &opclass.kind {
             _ if opclass.is_default => None,
@@ -153,13 +145,8 @@ impl<'a> IndexFieldPair<'a> {
     }
 
     fn field(self) -> Option<ScalarFieldPair<'a>> {
-        let next = match self.next {
-            Some(next) => next,
-            None => return None,
-        };
-
-        let previous = self.context.existing_table_scalar_field(next.as_column().id);
-        let next = next.as_column();
+        let next = self.next?.as_column();
+        let previous = self.context.existing_table_scalar_field(next.id);
 
         Some(IntrospectionPair::new(self.context, previous, next.coarsen()))
     }


### PR DESCRIPTION
- Update Rust to 1.84.0.
- Fix clippy and compiler lints.