### PR TITLE
fix(schema-engine): dynamically link openssl

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -16,7 +16,6 @@ mssql-native = ["mssql", "quaint/mssql-native", "quaint/pooled"]
 cockroachdb = ["psl/cockroachdb", "quaint/postgresql", "schema-connector/cockroachdb", "sql-schema-describer/cockroachdb"]
 cockroachdb-native = ["cockroachdb", "quaint/postgresql-native", "quaint/pooled"]
 all-native = [
-    "vendored-openssl",
     "quaint/fmt-sql",
     "postgresql-native",
     "sqlite-native",


### PR DESCRIPTION
Publishing the engines fails on `main` at the `ldd` output verification step starting with 2b21c24ccdb7f6811a6e69101b55e16a855ebcfd because https://github.com/prisma/prisma-engines/pull/5126 changed the schema engine to statically link OpenSSL. This commit fixes this.