### PR TITLE
fix(error handling): ORM-439 map query error to user facing error so it propagates correctly

### DIFF
--- a/libs/user-facing-errors/src/query_engine/mod.rs
+++ b/libs/user-facing-errors/src/query_engine/mod.rs
@@ -336,3 +336,11 @@ pub struct ExternalError {
 pub struct TooManyConnections {
     pub message: String,
 }
+
+// Note: Error code "P2038" is reserved for ClientEngine specific errors.
+
+#[derive(Debug, UserFacingError, Serialize)]
+#[user_facing(code = "P2039", message = "Query Error: {message}")]
+pub struct QueryError {
+    pub message: String,
+}

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -125,6 +125,11 @@ impl ConnectorError {
                     message: format!("{}", e),
                 },
             )),
+
+            ErrorKind::QueryError(e) => Some(KnownError::new(user_facing_errors::query_engine::QueryError {
+                message: format!("{}", e),
+            })),
+
             _ => None,
         };
 


### PR DESCRIPTION
This PR fixes an issue where a generic `QueryError` would not propagate through our error handling all the way to the user. This lead to interactive transactions not failing (although they rolled back). Such `QueryErrors` happen in particular in case of failing DB triggers.

Fixes https://github.com/prisma/prisma/issues/17303.