### PR TITLE
fix(views): ORM-454 fix panic when specifying view as either end of a m2m relation

### DIFF
--- a/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
+++ b/psl/parser-database/src/walkers/relation/implicit_many_to_many.rs
@@ -73,6 +73,11 @@ impl<'db> ImplicitManyToManyRelationWalker<'db> {
     pub fn table_name(self) -> ImplicitManyToManyRelationTableName<'db> {
         ImplicitManyToManyRelationTableName(self.relation_name())
     }
+
+    /// The relation starts or ends to a view.
+    pub fn one_side_is_view(self) -> bool {
+        self.model_a().ast_model().is_view() || self.model_b().ast_model().is_view()
+    }
 }
 
 /// A table name for an implicit relation's join table. Useful for its Display impl.

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -2,6 +2,7 @@ mod sql_schema_calculator_flavour;
 
 use sql_schema_calculator_flavour::JoinTableUniquenessConstraint;
 pub(super) use sql_schema_calculator_flavour::SqlSchemaCalculatorFlavour;
+use std::any::Any;
 
 use crate::{flavour::SqlFlavour, SqlDatabaseSchema};
 use psl::{
@@ -185,7 +186,8 @@ fn push_relation_tables(ctx: &mut Context<'_>) {
     let m2m_relations = datamodel
         .db
         .walk_relations()
-        .filter_map(|relation| relation.refine().as_many_to_many());
+        .filter_map(|relation| relation.refine().as_many_to_many())
+        .filter(|m2m| !m2m.one_side_is_view());
 
     for m2m in m2m_relations {
         let table_name = m2m.table_name().to_string();

--- a/schema-engine/sql-migration-tests/tests/migrations/views.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/views.rs
@@ -18,3 +18,30 @@ fn nothing_gets_written_in_migrations(api: TestApi) {
     let expected_sql = expect!["-- This is an empty migration."];
     api.expect_sql_for_schema(dm, &expected_sql);
 }
+
+#[test_connector(preview_features("views"))]
+fn creates_no_m2m_relations_to_views(api: TestApi) {
+    let dm = indoc! {r#"
+        generator js {
+          provider = "prisma-client-javascript"
+          previewFeatures = ["views"]
+        }
+
+        model Organization {
+          id         Int        @id @default(autoincrement())
+          viewUsers ViewUser[]
+        }
+
+        view ViewUser {
+          userId       Int            @id @unique
+          organizations Organization[]
+        }
+    "#};
+
+    api.schema_push_w_datasource(dm).send().assert_green();
+
+    api.assert_schema().assert_has_no_view("ViewUser");
+    api.assert_schema().assert_table("Organization", |table| {
+        table.assert_has_column("id").assert_does_not_have_column("viewUsers")
+    });
+}


### PR DESCRIPTION
Prisma does not currently support creating views. So it also cannot create relationships to them. But it should not blow up with an engine panic in this case.

Fixes https://github.com/prisma/prisma/issues/19249.