### PR TITLE
fix(ci): specify explicit aws cli version on "release-artifacts" job

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -1,9 +1,6 @@
 name: Build Engines
 run-name: Build Engines for ${{ github.sha }}
 
-env:
-  AWS_CLI_VERSION: 1.36.40
-
 # Run on `push` only for main, if not it will trigger `push` & `pull_request` on PRs at the same time
 on:
   push:
@@ -218,12 +215,6 @@ jobs:
           # run-id: 9526334324
           # github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup AWS CLI
-        run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install awscli==$AWS_CLI_VERSION
-
       - name: "R2: Check if artifacts were already built and uploaded before via `.finished` file"
         env:
           FILE_PATH: "all_commits/${{ github.sha }}/.finished"
@@ -319,18 +310,14 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ vars.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL_S3: ${{ vars.R2_ENDPOINT }}
-        run: |
-          source .venv/bin/activate
-          bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-r2
+        run: bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-r2
 
       - name: "AWS S3: Upload to bucket and verify uploaded files then create `.finished` file"
         env:
           AWS_DEFAULT_REGION: "eu-west-1"
           AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: |
-          source .venv/bin/activate
-          bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-s3
+        run: bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-s3
 
       - name: Repository dispatch to prisma/engines-wrapper
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -215,6 +215,15 @@ jobs:
           # run-id: 9526334324
           # github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup AWS CLI
+        uses: sagarsthorat/aws-cli@v1
+        with:
+          region: 'auto'
+          aws-cli-version: '2.22.35'
+          aws-access-key-id: ${{ vars.R2_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          output-format: json
+
       - name: "R2: Check if artifacts were already built and uploaded before via `.finished` file"
         env:
           FILE_PATH: "all_commits/${{ github.sha }}/.finished"

--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -319,14 +319,18 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ vars.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL_S3: ${{ vars.R2_ENDPOINT }}
-        run: bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-r2
+        run: |
+          source .venv/bin/activate
+          bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-r2
 
       - name: "AWS S3: Upload to bucket and verify uploaded files then create `.finished` file"
         env:
           AWS_DEFAULT_REGION: "eu-west-1"
           AWS_ACCESS_KEY_ID: ${{ vars.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-s3
+        run: |
+          source .venv/bin/activate
+          bash .github/workflows/utils/uploadAndVerify.sh engines-artifacts-for-s3
 
       - name: Repository dispatch to prisma/engines-wrapper
         uses: peter-evans/repository-dispatch@v3

--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -1,6 +1,9 @@
 name: Build Engines
 run-name: Build Engines for ${{ github.sha }}
 
+env:
+  AWS_CLI_VERSION: 1.36.40
+
 # Run on `push` only for main, if not it will trigger `push` & `pull_request` on PRs at the same time
 on:
   push:
@@ -216,13 +219,10 @@ jobs:
           # github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup AWS CLI
-        uses: sagarsthorat/aws-cli@v1
-        with:
-          region: 'auto'
-          aws-cli-version: '1.36.40'
-          aws-access-key-id: ${{ vars.R2_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          output-format: json
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install awscli==$AWS_CLI_VERSION
 
       - name: "R2: Check if artifacts were already built and uploaded before via `.finished` file"
         env:

--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -219,7 +219,7 @@ jobs:
         uses: sagarsthorat/aws-cli@v1
         with:
           region: 'auto'
-          aws-cli-version: '2.22.35'
+          aws-cli-version: '1.36.40'
           aws-access-key-id: ${{ vars.R2_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           output-format: json

--- a/.github/workflows/utils/uploadAndVerify.sh
+++ b/.github/workflows/utils/uploadAndVerify.sh
@@ -2,6 +2,12 @@
 
 set -eux;
 
+AWS_CLI_VERSION=1.36.40
+
+python -m venv .venv
+source .venv/bin/activate
+pip install awscli==$AWS_CLI_VERSION
+
 # engines-artifacts-for-r2
 # engines-artifacts-for-s3
 LOCAL_DIR_PATH=$1
@@ -48,7 +54,7 @@ if [ "$FILECOUNT_FOR_SIG" -eq 0 ]; then
 fi
 
 # Manual check
-# 
+#
 # Set PROD env vars
 # mkdir engines-artifacts-from-prod
 # Download the artifacts from the S3 bucket
@@ -56,9 +62,9 @@ fi
 # Print the files and save the output to a file
 # cd engines-artifacts-from-prod
 # find . | sort > ../expectedFiles.txt
-# 
+#
 # cd ..
-# 
+#
 # Set DEV env vars
 # mkdir engines-artifacts-from-dev
 # Download the artifacts from the S3 bucket
@@ -107,11 +113,11 @@ fi
 FILES_TO_VALIDATE_WITH_LDD=$(find . -type f | grep -E "./(rhel|debian)-openssl-(3.0|1.1).*(query-engine|schema-engine|libquery_engine.so.node)$")
 echo "FILES_TO_VALIDATE_WITH_LDD: $FILES_TO_VALIDATE_WITH_LDD"
 
-for filename in $FILES_TO_VALIDATE_WITH_LDD  
-do  
+for filename in $FILES_TO_VALIDATE_WITH_LDD
+do
     echo "Validating libssl linking for $filename."
     GREP_OUTPUT=$(ldd "$filename" | grep "libssl")
-    OUTPUT=$(echo "$GREP_OUTPUT" | cut -f2 | cut -d'.' -f1) 
+    OUTPUT=$(echo "$GREP_OUTPUT" | cut -f2 | cut -d'.' -f1)
 
     if [[ "$OUTPUT" == "libssl" ]]; then
         echo "Linux build linked correctly to libssl."


### PR DESCRIPTION
The "release-artifacts" CI job is currently failing in main ([Slack](https://prisma-company.slack.com/archives/C4GCG53BP/p1737993946518879)).
This is caused by a recent incompatibility between Cloudflare R2 and AWS S3, triggered by the most recent `aws` CLI version.

This PR applies a recommendation of the Cloudflare team: we fix the `aws` CLI version to ~~`2.22.35`~~ `1.36.40`.

---

From https://developers.cloudflare.com/r2/examples/aws/aws-cli/:

<img width="774" alt="Screenshot 2025-01-28 at 11 41 01 AM" src="https://github.com/user-attachments/assets/f2c50d2b-ce0d-443a-9272-16f57228e1f6" />

From https://www.cloudflarestatus.com:

<img width="943" alt="Screenshot 2025-01-28 at 11 41 27 AM" src="https://github.com/user-attachments/assets/bd8515a1-9684-40f7-8cdf-13fc1b3cdc67" />

/integration