### PR TITLE
chore: improve query graph rendering with graphviz

### DIFF
--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -88,12 +88,12 @@ impl Display for ReadQuery {
         match self {
             Self::RecordQuery(q) => write!(
                 f,
-                "RecordQuery(name: '{}', selection: {}, filter: {:?})",
+                "RecordQuery(name: '{}', selection: {}, filter: {:#?})",
                 q.name, q.selected_fields, q.filter
             ),
             Self::ManyRecordsQuery(q) => write!(
                 f,
-                r#"ManyRecordsQuery(name: '{}', model: '{}', selection: {}, args: {:?})"#,
+                r#"ManyRecordsQuery(name: '{}', model: '{}', selection: {}, args: {:#?})"#,
                 q.name,
                 q.model.name(),
                 q.selected_fields,

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -226,29 +226,29 @@ impl std::fmt::Display for WriteQuery {
 impl ToGraphviz for WriteQuery {
     fn to_graphviz(&self) -> String {
         match self {
-            Self::CreateRecord(q) => format!("CreateRecord(model: {}, args: {:?})", q.model.name(), q.args),
+            Self::CreateRecord(q) => format!("CreateRecord(model: {}, args: {:#?})", q.model.name(), q.args),
             Self::CreateManyRecords(q) => format!(
-                "CreateManyRecord(model: {}, selected_fields: {:?})",
+                "CreateManyRecord(model: {}, selected_fields: {:#?})",
                 q.model.name(),
                 q.selected_fields
             ),
             Self::UpdateRecord(q) => format!(
-                "UpdateRecord(model: {}, selection: {:?})",
+                "UpdateRecord(model: {}, selection: {:#?})",
                 q.model().name(),
                 q.selected_fields()
             ),
             Self::DeleteRecord(q) => format!(
-                "DeleteRecord: {}, {:?}, {:?}",
+                "DeleteRecord: {}, {:#?}, {:#?}",
                 q.model.name(),
                 q.record_filter,
                 q.selected_fields
             ),
-            Self::UpdateManyRecords(q) => format!("UpdateManyRecords(model: {}, args: {:?})", q.model.name(), q.args),
+            Self::UpdateManyRecords(q) => format!("UpdateManyRecords(model: {}, args: {:#?})", q.model.name(), q.args),
             Self::DeleteManyRecords(q) => format!("DeleteManyRecords: {}", q.model.name()),
             Self::ConnectRecords(_) => "ConnectRecords".to_string(),
             Self::DisconnectRecords(_) => "DisconnectRecords".to_string(),
-            Self::ExecuteRaw(r) => format!("ExecuteRaw: {:?}", r.inputs),
-            Self::QueryRaw(r) => format!("QueryRaw: {:?}", r.inputs),
+            Self::ExecuteRaw(r) => format!("ExecuteRaw: {:#?}", r.inputs),
+            Self::QueryRaw(r) => format!("QueryRaw: {:#?}", r.inputs),
             Self::Upsert(q) => format!("Upsert(model: {}", q.model().name()),
         }
     }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -949,6 +949,8 @@ pub trait ToGraphviz {
 
 impl ToGraphviz for QueryGraph {
     fn to_graphviz(&self) -> String {
+        let label_from_node = |node: &Node| node.to_graphviz().replace('\"', "\\\"").replace('\n', "\\l") + "\\l";
+
         let nodes = self
             .graph
             .node_indices()
@@ -958,7 +960,7 @@ impl ToGraphviz for QueryGraph {
                     format!(
                         "    {} [label=\"{}\", fillcolor=blue, style=filled, shape=rectangle, fontcolor=white]",
                         idx.index(),
-                        node.to_graphviz().replace('\"', "\\\"")
+                        label_from_node(node)
                     )
                 } else if self
                     .root_nodes()
@@ -968,13 +970,13 @@ impl ToGraphviz for QueryGraph {
                     format!(
                         "    {} [label=\"{}\", fillcolor=red, style=filled, shape=rectangle, fontcolor=white]",
                         idx.index(),
-                        node.to_graphviz().replace('\"', "\\\"")
+                        label_from_node(node)
                     )
                 } else {
                     format!(
                         "    {} [label=\"{}\", shape=rectangle]",
                         idx.index(),
-                        node.to_graphviz().replace('\"', "\\\"")
+                        label_from_node(node)
                     )
                 }
             })


### PR DESCRIPTION
1. Use `{:#?}` instead of `{:?}` for better formatting where we use `Debug` trait to print fields of query graph nodes.

2. Left-align multiline text in graph nodes (it's centered by default).

Before:

![image](https://github.com/user-attachments/assets/9d820b34-1646-4628-9b9c-ef6af07f7bc3)

After:

![image](https://github.com/user-attachments/assets/15d86c61-c35c-498c-9257-839908555cf3)
