### PR TITLE
chore: rename adapter error kinds and flavour

### DIFF
--- a/libs/driver-adapters/src/error.rs
+++ b/libs/driver-adapters/src/error.rs
@@ -48,9 +48,12 @@ pub(crate) enum DriverAdapterError {
         native_type: String,
     },
     #[cfg(feature = "postgresql")]
+    #[serde(rename = "postgres")]
     Postgres(#[serde(with = "PostgresErrorDef")] PostgresError),
     #[cfg(feature = "mysql")]
+    #[serde(rename = "mysql")]
     Mysql(#[serde(with = "MysqlErrorDef")] MysqlError),
     #[cfg(feature = "sqlite")]
+    #[serde(rename = "sqlite")]
     Sqlite(#[serde(with = "SqliteErrorDef")] SqliteError),
 }

--- a/libs/driver-adapters/src/lib.rs
+++ b/libs/driver-adapters/src/lib.rs
@@ -47,7 +47,7 @@ impl From<DriverAdapterError> for QuaintError {
 
 pub use queryable::from_js;
 pub(crate) use transaction::JsTransaction;
-pub use types::AdapterFlavour;
+pub use types::AdapterProvider;
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm::JsObjectExtern as JsObject;

--- a/libs/driver-adapters/src/types.rs
+++ b/libs/driver-adapters/src/types.rs
@@ -16,7 +16,7 @@ use serde_repr::{Deserialize_repr, Serialize_repr};
 
 #[cfg_attr(target_arch = "wasm32", derive(Deserialize))]
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub enum AdapterFlavour {
+pub enum AdapterProvider {
     #[cfg(feature = "mysql")]
     Mysql,
     #[cfg(feature = "postgresql")]
@@ -25,7 +25,7 @@ pub enum AdapterFlavour {
     Sqlite,
 }
 
-impl AdapterFlavour {
+impl AdapterProvider {
     pub fn db_system_name(&self) -> &'static str {
         match self {
             #[cfg(feature = "mysql")]
@@ -38,7 +38,7 @@ impl AdapterFlavour {
     }
 }
 
-impl FromStr for AdapterFlavour {
+impl FromStr for AdapterProvider {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -54,15 +54,15 @@ impl FromStr for AdapterFlavour {
     }
 }
 
-impl From<&AdapterFlavour> for SqlFamily {
-    fn from(value: &AdapterFlavour) -> Self {
+impl From<&AdapterProvider> for SqlFamily {
+    fn from(value: &AdapterProvider) -> Self {
         match value {
             #[cfg(feature = "mysql")]
-            AdapterFlavour::Mysql => SqlFamily::Mysql,
+            AdapterProvider::Mysql => SqlFamily::Mysql,
             #[cfg(feature = "postgresql")]
-            AdapterFlavour::Postgres => SqlFamily::Postgres,
+            AdapterProvider::Postgres => SqlFamily::Postgres,
             #[cfg(feature = "sqlite")]
-            AdapterFlavour::Sqlite => SqlFamily::Sqlite,
+            AdapterProvider::Sqlite => SqlFamily::Sqlite,
         }
     }
 }
@@ -77,7 +77,7 @@ pub(crate) struct JsConnectionInfo {
 }
 
 impl JsConnectionInfo {
-    pub fn into_external_connection_info(self, provider: &AdapterFlavour) -> ExternalConnectionInfo {
+    pub fn into_external_connection_info(self, provider: &AdapterProvider) -> ExternalConnectionInfo {
         let schema_name = self.get_schema_name(provider);
         let sql_family = SqlFamily::from(provider);
 
@@ -88,21 +88,21 @@ impl JsConnectionInfo {
         )
     }
 
-    fn get_schema_name(&self, provider: &AdapterFlavour) -> &str {
+    fn get_schema_name(&self, provider: &AdapterProvider) -> &str {
         match self.schema_name.as_ref() {
             Some(name) => name,
             None => self.default_schema_name(provider),
         }
     }
 
-    fn default_schema_name(&self, provider: &AdapterFlavour) -> &str {
+    fn default_schema_name(&self, provider: &AdapterProvider) -> &str {
         match provider {
             #[cfg(feature = "mysql")]
-            AdapterFlavour::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
+            AdapterProvider::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
             #[cfg(feature = "postgresql")]
-            AdapterFlavour::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
+            AdapterProvider::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
             #[cfg(feature = "sqlite")]
-            AdapterFlavour::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
+            AdapterProvider::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
         }
     }
 }

--- a/query-compiler/query-compiler-wasm/src/compiler.rs
+++ b/query-compiler/query-compiler-wasm/src/compiler.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use tsify::Tsify;
 use wasm_bindgen::prelude::wasm_bindgen;
 
-use crate::params::{AdapterFlavour, JsConnectionInfo};
+use crate::params::{AdapterProvider, JsConnectionInfo};
 
 const CONNECTOR_REGISTRY: ConnectorRegistry<'_> = &[
     #[cfg(feature = "postgresql")]
@@ -49,7 +49,7 @@ fn register_panic_hook() {
 pub struct QueryCompilerParams {
     // TODO: support multiple datamodels
     datamodel: String,
-    flavour: AdapterFlavour,
+    provider: AdapterProvider,
     connection_info: JsConnectionInfo,
 }
 
@@ -66,7 +66,7 @@ impl QueryCompiler {
     pub fn new(params: QueryCompilerParams) -> Result<QueryCompiler, wasm_bindgen::JsError> {
         let QueryCompilerParams {
             datamodel,
-            flavour,
+            provider,
             connection_info,
         } = params;
 
@@ -79,7 +79,7 @@ impl QueryCompiler {
 
         Ok(Self {
             schema,
-            connection_info: ConnectionInfo::External(connection_info.into_external_connection_info(flavour)),
+            connection_info: ConnectionInfo::External(connection_info.into_external_connection_info(provider)),
             protocol: EngineProtocol::Json,
         })
     }

--- a/query-compiler/query-compiler-wasm/src/params.rs
+++ b/query-compiler/query-compiler-wasm/src/params.rs
@@ -13,7 +13,7 @@ pub struct JsConnectionInfo {
 }
 
 impl JsConnectionInfo {
-    pub fn into_external_connection_info(self, provider: AdapterFlavour) -> ExternalConnectionInfo {
+    pub fn into_external_connection_info(self, provider: AdapterProvider) -> ExternalConnectionInfo {
         let schema_name = self.get_schema_name(provider);
         let sql_family = SqlFamily::from(provider);
 
@@ -24,28 +24,28 @@ impl JsConnectionInfo {
         )
     }
 
-    fn get_schema_name(&self, provider: AdapterFlavour) -> &str {
+    fn get_schema_name(&self, provider: AdapterProvider) -> &str {
         match self.schema_name.as_ref() {
             Some(name) => name,
             None => self.default_schema_name(provider),
         }
     }
 
-    fn default_schema_name(&self, provider: AdapterFlavour) -> &str {
+    fn default_schema_name(&self, provider: AdapterProvider) -> &str {
         match provider {
             #[cfg(feature = "mysql")]
-            AdapterFlavour::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
+            AdapterProvider::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
             #[cfg(feature = "postgresql")]
-            AdapterFlavour::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
+            AdapterProvider::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
             #[cfg(feature = "sqlite")]
-            AdapterFlavour::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
+            AdapterProvider::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
         }
     }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone, Copy, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub enum AdapterFlavour {
+pub enum AdapterProvider {
     #[cfg(feature = "mysql")]
     Mysql,
     #[cfg(feature = "postgresql")]
@@ -54,15 +54,15 @@ pub enum AdapterFlavour {
     Sqlite,
 }
 
-impl From<AdapterFlavour> for SqlFamily {
-    fn from(f: AdapterFlavour) -> Self {
+impl From<AdapterProvider> for SqlFamily {
+    fn from(f: AdapterProvider) -> Self {
         match f {
             #[cfg(feature = "mysql")]
-            AdapterFlavour::Mysql => SqlFamily::Mysql,
+            AdapterProvider::Mysql => SqlFamily::Mysql,
             #[cfg(feature = "postgresql")]
-            AdapterFlavour::Postgres => SqlFamily::Postgres,
+            AdapterProvider::Postgres => SqlFamily::Postgres,
             #[cfg(feature = "sqlite")]
-            AdapterFlavour::Sqlite => SqlFamily::Sqlite,
+            AdapterProvider::Sqlite => SqlFamily::Sqlite,
         }
     }
 }


### PR DESCRIPTION
[ORM-588](https://linear.app/prisma-company/issue/ORM-588/driver-adapter-api-rename-error-kinds-to-match-the-flavour-provider) and [ORM-568](https://linear.app/prisma-company/issue/ORM-568/align-naming-of-env-and-flavour)