### PR TITLE
fix(qc): don't recurse into children of result nodes

### DIFF
--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -72,7 +72,12 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
     fn translate_query(&mut self) -> TranslateResult<Expression> {
         self.graph.mark_visited(&self.node);
 
-        let children = self.process_children()?;
+        // Don't recurse into children if the current node is already a result node.
+        let children = if !self.graph.is_result_node(&self.node) {
+            self.process_children()?
+        } else {
+            Vec::new()
+        };
 
         let mut node = self.graph.pluck_node(&self.node);
 

--- a/query-compiler/query-compiler/tests/data/update-one-returning.json
+++ b/query-compiler/query-compiler/tests/data/update-one-returning.json
@@ -1,0 +1,13 @@
+{
+  "modelName": "User",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "where": { "email": "user.1737556028164@prisma.io" },
+      "data": { "email": "user.2737556028164@prisma.io" }
+    },
+    "selection": {
+      "email": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-one-returning.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-one-returning.json.snap
@@ -1,0 +1,10 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-one-returning.json
+---
+unique (query «UPDATE "public"."User" SET "email" = $1 WHERE
+               ("public"."User"."email" = $2 AND 1=1) RETURNING
+               "public"."User"."id", "public"."User"."email"»
+        params [const(String("user.2737556028164@prisma.io")),
+                const(String("user.1737556028164@prisma.io"))])


### PR DESCRIPTION
Fixes the broken query plans generated for updates and inserts where the result of the query can satisfied by the mutation node itself and the graph looks like this:

![graph](https://github.com/user-attachments/assets/037206fe-6313-4b61-9620-f039ab88b601)

Before:

```
let 0 = unique (query «UPDATE "public"."User" SET "email" = $1 WHERE
                       ("public"."User"."email" = $2 AND 1=1) RETURNING
                       "public"."User"."id", "public"."User"."email"»
                params [var(newEmail as String), var(userEmail as String)])
in let 0 = mapField id (get 0)
   in
```

After:

```
unique (query «UPDATE "public"."User" SET "email" = $1 WHERE
               ("public"."User"."email" = $2 AND 1=1) RETURNING
               "public"."User"."id", "public"."User"."email"»
        params [var(newEmail as String), var(userEmail as String)])
```