### PR TITLE
feat(query-compiler-playground): render query graphs to png

### DIFF
--- a/query-compiler/query-compiler-playground/.gitignore
+++ b/query-compiler/query-compiler-playground/.gitignore
@@ -1,0 +1,2 @@
+graph.dot
+graph.png


### PR DESCRIPTION
Render the query graph for the query in playground using Graphviz. This is useful because we can't use the usual mechanism with the `PRISMA_RENDER_DOT_FILE` environment variable when running the TypeScript playground with WASM query compiler.