### PR TITLE
chore(qc): change an outdated log message in `build.sh`

### DIFF
--- a/query-compiler/query-compiler-wasm/build.sh
+++ b/query-compiler/query-compiler-wasm/build.sh
@@ -54,7 +54,7 @@ fi
 
 
 build() {
-    echo "ℹ️  Note that query-compiler compiled to WASM uses a different Rust toolchain"
+    echo "ℹ️  Current Rust toolchain version:"
     cargo --version
 
     local CONNECTOR="$1"


### PR DESCRIPTION
This message was grandfathered from the `build.sh` script for query-engine-wasm, however we don't actually use a nightly toolchain for query-compiler-wasm.