### PR TITLE
chore: update rust to 1.84.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.0"
+channel = "1.84.1"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.


### PR DESCRIPTION
Update Rust from 1.84.0 to 1.84.1.