### PR TITLE
feat: implement read aggregate in the compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5188,6 +5188,7 @@ dependencies = [
  "quaint",
  "query-builder",
  "query-structure",
+ "schema",
  "serde_json",
  "telemetry",
 ]

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use itertools::Itertools;
 use query_builder::{QueryArgumentsExt, QueryBuilder, RelationLink};
-use query_core::{FilteredQuery, ReadQuery, RelatedRecordsQuery};
+use query_core::{AggregateRecordsQuery, FilteredQuery, ReadQuery, RelatedRecordsQuery};
 use query_structure::{
     ConditionValue, FieldSelection, Filter, PrismaValue, QueryArguments, QueryMode, RelationField, ScalarCondition,
     ScalarFilter, ScalarProjection,
@@ -66,7 +66,22 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
             expr
         }
 
-        _ => todo!(),
+        ReadQuery::AggregateRecordsQuery(AggregateRecordsQuery {
+            name: _,
+            alias: _,
+            // TODO: use selection_order
+            selection_order: _,
+            model,
+            args,
+            selectors,
+            group_by,
+            having,
+        }) => {
+            let query = builder
+                .build_aggregate(&model, args, &selectors, group_by, having)
+                .map_err(TranslateError::QueryBuildFailure)?;
+            Expression::Query(query)
+        }
     })
 }
 

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -69,7 +69,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
         ReadQuery::AggregateRecordsQuery(AggregateRecordsQuery {
             name: _,
             alias: _,
-            // TODO: use selection_order
+            // TODO: we're ignoring selection order
             selection_order: _,
             model,
             args,
@@ -80,7 +80,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
             let query = builder
                 .build_aggregate(&model, args, &selectors, group_by, having)
                 .map_err(TranslateError::QueryBuildFailure)?;
-            Expression::Query(query)
+            Expression::Unique(Box::new(Expression::Query(query)))
         }
     })
 }

--- a/query-compiler/query-compiler/tests/data/aggregate.json
+++ b/query-compiler/query-compiler/tests/data/aggregate.json
@@ -1,0 +1,16 @@
+{
+  "modelName": "User",
+  "action": "aggregate",
+  "query": {
+    "arguments": {
+      "where": {
+        "email": {
+          "contains": "prisma.io"
+        }
+      }
+    },
+    "selection": {
+      "_count": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/group-by.json
+++ b/query-compiler/query-compiler/tests/data/group-by.json
@@ -1,0 +1,17 @@
+{
+  "modelName": "Post",
+  "action": "groupBy",
+  "query": {
+    "arguments": {
+      "where": {
+        "title": {
+          "contains": "something"
+        }
+      },
+      "by": "title"
+    },
+    "selection": {
+      "_count": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
@@ -1,0 +1,9 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/aggregate.json
+---
+query «SELECT COUNT("id"), COUNT("email"), COUNT(*) FROM (SELECT
+       "public"."User"."id", "public"."User"."email" FROM "public"."User" WHERE
+       "public"."User"."email"::text LIKE $1 OFFSET $2) AS "sub"»
+params [const(String("%prisma.io%")), const(BigInt(0))]

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
@@ -3,8 +3,9 @@ source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/aggregate.json
 ---
-unique (query «SELECT COUNT("id") AS "id", COUNT("email") AS "email", COUNT(*)
-               AS "_count" FROM (SELECT "public"."User"."id",
-               "public"."User"."email" FROM "public"."User" WHERE
-               "public"."User"."email"::text LIKE $1 OFFSET $2) AS "sub"»
+unique (query «SELECT COUNT("id") AS "_count.id", COUNT("email") AS
+               "_count.email", COUNT(*) AS "_count" FROM (SELECT
+               "public"."User"."id", "public"."User"."email" FROM
+               "public"."User" WHERE "public"."User"."email"::text LIKE $1
+               OFFSET $2) AS "sub"»
         params [const(String("%prisma.io%")), const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
@@ -3,7 +3,8 @@ source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/aggregate.json
 ---
-query «SELECT COUNT("id"), COUNT("email"), COUNT(*) FROM (SELECT
-       "public"."User"."id", "public"."User"."email" FROM "public"."User" WHERE
-       "public"."User"."email"::text LIKE $1 OFFSET $2) AS "sub"»
-params [const(String("%prisma.io%")), const(BigInt(0))]
+unique (query «SELECT COUNT("id") AS "id", COUNT("email") AS "email", COUNT(*)
+               AS "_count" FROM (SELECT "public"."User"."id",
+               "public"."User"."email" FROM "public"."User" WHERE
+               "public"."User"."email"::text LIKE $1 OFFSET $2) AS "sub"»
+        params [const(String("%prisma.io%")), const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
@@ -4,7 +4,7 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/aggregate.json
 ---
 unique (query «SELECT COUNT("id") AS "_count.id", COUNT("email") AS
-               "_count.email", COUNT(*) AS "_count" FROM (SELECT
+               "_count.email", COUNT(*) AS "_count._all" FROM (SELECT
                "public"."User"."id", "public"."User"."email" FROM
                "public"."User" WHERE "public"."User"."email"::text LIKE $1
                OFFSET $2) AS "sub"»

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
@@ -3,8 +3,9 @@ source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/group-by.json
 ---
-query «SELECT COUNT("public"."Post"."id"), COUNT("public"."Post"."title"),
-       COUNT("public"."Post"."userId"), COUNT(*) FROM "public"."Post" WHERE
-       "public"."Post"."title"::text LIKE $1 GROUP BY "public"."Post"."title"
-       OFFSET $2»
-params [const(String("%something%")), const(BigInt(0))]
+unique (query «SELECT COUNT("public"."Post"."id") AS "id",
+               COUNT("public"."Post"."title") AS "title",
+               COUNT("public"."Post"."userId") AS "userId", COUNT(*) AS "_count"
+               FROM "public"."Post" WHERE "public"."Post"."title"::text LIKE $1
+               GROUP BY "public"."Post"."title" OFFSET $2»
+        params [const(String("%something%")), const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
@@ -1,0 +1,10 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/group-by.json
+---
+query «SELECT COUNT("public"."Post"."id"), COUNT("public"."Post"."title"),
+       COUNT("public"."Post"."userId"), COUNT(*) FROM "public"."Post" WHERE
+       "public"."Post"."title"::text LIKE $1 GROUP BY "public"."Post"."title"
+       OFFSET $2»
+params [const(String("%something%")), const(BigInt(0))]

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
@@ -6,6 +6,7 @@ input_file: query-compiler/query-compiler/tests/data/group-by.json
 unique (query «SELECT COUNT("public"."Post"."id") AS "_count.id",
                COUNT("public"."Post"."title") AS "_count.title",
                COUNT("public"."Post"."userId") AS "_count.userId", COUNT(*) AS
-               "_count" FROM "public"."Post" WHERE "public"."Post"."title"::text
-               LIKE $1 GROUP BY "public"."Post"."title" OFFSET $2»
+               "_count._all" FROM "public"."Post" WHERE
+               "public"."Post"."title"::text LIKE $1 GROUP BY
+               "public"."Post"."title" OFFSET $2»
         params [const(String("%something%")), const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
@@ -3,9 +3,9 @@ source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/group-by.json
 ---
-unique (query «SELECT COUNT("public"."Post"."id") AS "id",
-               COUNT("public"."Post"."title") AS "title",
-               COUNT("public"."Post"."userId") AS "userId", COUNT(*) AS "_count"
-               FROM "public"."Post" WHERE "public"."Post"."title"::text LIKE $1
-               GROUP BY "public"."Post"."title" OFFSET $2»
+unique (query «SELECT COUNT("public"."Post"."id") AS "_count.id",
+               COUNT("public"."Post"."title") AS "_count.title",
+               COUNT("public"."Post"."userId") AS "_count.userId", COUNT(*) AS
+               "_count" FROM "public"."Post" WHERE "public"."Post"."title"::text
+               LIKE $1 GROUP BY "public"."Post"."title" OFFSET $2»
         params [const(String("%something%")), const(BigInt(0))])

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read.rs
@@ -10,7 +10,11 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use quaint::ast::*;
 use query_builder::QueryArgumentsExt;
 use query_structure::*;
-use sql_query_builder::{column_metadata, read, AsColumns, AsTable, Context, RelationFieldExt};
+use sql_query_builder::{
+    column_metadata,
+    read::{self, no_alias},
+    AsColumns, AsTable, Context, RelationFieldExt,
+};
 
 pub(crate) async fn get_single_record(
     conn: &dyn Queryable,
@@ -381,7 +385,7 @@ async fn plain_aggregate(
     selections: Vec<AggregationSelection>,
     ctx: &Context<'_>,
 ) -> crate::Result<Vec<AggregationResult>> {
-    let query = read::aggregate(model, &selections, query_arguments, ctx);
+    let query = read::aggregate(model, &selections, query_arguments, no_alias(), ctx);
 
     let idents: Vec<_> = selections
         .iter()
@@ -408,7 +412,7 @@ async fn group_by_aggregate(
     having: Option<Filter>,
     ctx: &Context<'_>,
 ) -> crate::Result<Vec<AggregationRow>> {
-    let query = read::group_by_aggregate(model, query_arguments, &selections, group_by, having, ctx);
+    let query = read::group_by_aggregate(model, query_arguments, &selections, group_by, having, no_alias(), ctx);
 
     let idents: Vec<_> = selections
         .iter()

--- a/query-engine/query-builders/query-builder/src/lib.rs
+++ b/query-engine/query-builders/query-builder/src/lib.rs
@@ -1,8 +1,8 @@
 use std::{collections::HashMap, fmt};
 
 use query_structure::{
-    FieldSelection, Filter, Model, PrismaValue, QueryArguments, RecordFilter, RelationField, ScalarCondition,
-    ScalarField, SelectionResult, WriteArgs,
+    AggregationSelection, FieldSelection, Filter, Model, PrismaValue, QueryArguments, RecordFilter, RelationField,
+    ScalarCondition, ScalarField, SelectionResult, WriteArgs,
 };
 use serde::Serialize;
 mod query_arguments_ext;
@@ -24,6 +24,15 @@ pub trait QueryBuilder {
         link: RelationLink,
         query_arguments: QueryArguments,
         selected_fields: &FieldSelection,
+    ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>>;
+
+    fn build_aggregate(
+        &self,
+        model: &Model,
+        args: QueryArguments,
+        selections: &[AggregationSelection],
+        group_by: Vec<ScalarField>,
+        having: Option<Filter>,
     ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>>;
 
     fn build_create_record(

--- a/query-engine/query-builders/sql-query-builder/Cargo.toml
+++ b/query-engine/query-builders/sql-query-builder/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [dependencies]
 quaint = { path = "../../../quaint" }
 query-structure = { path = "../../query-structure" }
+schema = { path = "../../schema" }
 query-builder = { path = "../query-builder" }
 telemetry = { path = "../../../libs/telemetry" }
 prisma-value = { path = "../../../libs/prisma-value" }

--- a/query-engine/query-builders/sql-query-builder/src/lib.rs
+++ b/query-engine/query-builders/sql-query-builder/src/lib.rs
@@ -31,6 +31,7 @@ pub use column_metadata::ColumnMetadata;
 pub use context::Context;
 pub use filter::FilterBuilder;
 pub use model_extensions::{AsColumn, AsColumns, AsTable, RelationFieldExt, SelectionResultExt};
+use read::alias_with_prisma_name;
 pub use sql_trace::SqlTraceComment;
 
 const PARAMETER_LIMIT: usize = 2000;
@@ -154,9 +155,17 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
         having: Option<Filter>,
     ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>> {
         let query = if group_by.is_empty() {
-            read::aggregate(model, selections, args, &self.context)
+            read::aggregate(model, selections, args, alias_with_prisma_name(), &self.context)
         } else {
-            read::group_by_aggregate(model, args, selections, group_by, having, &self.context)
+            read::group_by_aggregate(
+                model,
+                args,
+                selections,
+                group_by,
+                having,
+                alias_with_prisma_name(),
+                &self.context,
+            )
         };
         self.convert_query(query)
     }

--- a/query-engine/query-builders/sql-query-builder/src/lib.rs
+++ b/query-engine/query-builders/sql-query-builder/src/lib.rs
@@ -145,6 +145,22 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
         self.convert_query(select)
     }
 
+    fn build_aggregate(
+        &self,
+        model: &Model,
+        args: QueryArguments,
+        selections: &[query_structure::AggregationSelection],
+        group_by: Vec<query_structure::ScalarField>,
+        having: Option<Filter>,
+    ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>> {
+        let query = if group_by.is_empty() {
+            read::aggregate(model, selections, args, &self.context)
+        } else {
+            read::group_by_aggregate(model, args, selections, group_by, having, &self.context)
+        };
+        self.convert_query(query)
+    }
+
     fn build_create_record(
         &self,
         model: &Model,

--- a/query-engine/query-builders/sql-query-builder/src/lib.rs
+++ b/query-engine/query-builders/sql-query-builder/src/lib.rs
@@ -23,8 +23,8 @@ use quaint::{
 };
 use query_builder::{DbQuery, QueryBuilder};
 use query_structure::{
-    FieldSelection, Filter, Model, ModelProjection, QueryArguments, RecordFilter, RelationField, ScalarField,
-    SelectionResult, WriteArgs,
+    AggregationSelection, FieldSelection, Filter, Model, ModelProjection, QueryArguments, RecordFilter, RelationField,
+    ScalarField, SelectionResult, WriteArgs,
 };
 
 pub use column_metadata::ColumnMetadata;
@@ -149,8 +149,8 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
         &self,
         model: &Model,
         args: QueryArguments,
-        selections: &[query_structure::AggregationSelection],
-        group_by: Vec<query_structure::ScalarField>,
+        selections: &[AggregationSelection],
+        group_by: Vec<ScalarField>,
         having: Option<Filter>,
     ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>> {
         let query = if group_by.is_empty() {

--- a/query-engine/query-builders/sql-query-builder/src/read.rs
+++ b/query-engine/query-builders/sql-query-builder/src/read.rs
@@ -360,7 +360,7 @@ fn extract_columns(model: &Model, selections: &[AggregationSelection], ctx: &Con
     fields.as_columns(ctx).collect()
 }
 
-pub trait AliasGenerator: Copy {
+pub trait AliasGenerator {
     fn generate(&self, field: &ScalarField) -> Option<String>;
 
     /// Creates a new alias generator that prefixes all generated aliases with the given prefix.

--- a/query-engine/query-builders/sql-query-builder/src/read.rs
+++ b/query-engine/query-builders/sql-query-builder/src/read.rs
@@ -1,6 +1,9 @@
 use itertools::Itertools;
 use quaint::ast::*;
 use query_structure::*;
+use schema::constants::aggregations::{
+    UNDERSCORE_AVG, UNDERSCORE_COUNT, UNDERSCORE_MAX, UNDERSCORE_MIN, UNDERSCORE_SUM,
+};
 
 use crate::{
     context::Context,
@@ -177,6 +180,7 @@ pub fn aggregate(
     model: &Model,
     selections: &[AggregationSelection],
     args: QueryArguments,
+    alias: impl AliasGenerator,
     ctx: &Context<'_>,
 ) -> Select<'static> {
     let columns = extract_columns(model, selections, ctx);
@@ -187,16 +191,19 @@ pub fn aggregate(
         Select::from_table(sub_table).add_traceparent(ctx.traceparent),
         |select, next_op| match next_op {
             AggregationSelection::Field(field) => select.column(
-                Column::from(field.db_name().to_owned())
-                    .alias(field.name().to_owned())
+                alias
+                    .apply(Column::from(field.db_name().to_owned()), field)
                     .set_is_enum(field.type_identifier().is_enum())
                     .set_is_selected(true),
             ),
 
             AggregationSelection::Count { all, fields } => {
                 let select = fields.iter().fold(select, |select, next_field| {
-                    select
-                        .value(count(Column::from(next_field.db_name().to_owned())).alias(next_field.name().to_owned()))
+                    select.value(
+                        alias
+                            .with_prefix(UNDERSCORE_COUNT)
+                            .apply(count(Column::from(next_field.db_name().to_owned())), next_field),
+                    )
                 });
 
                 if *all {
@@ -207,28 +214,40 @@ pub fn aggregate(
             }
 
             AggregationSelection::Average(fields) => fields.iter().fold(select, |select, next_field| {
-                select.value(avg(Column::from(next_field.db_name().to_owned())).alias(next_field.name().to_owned()))
+                select.value(
+                    alias
+                        .with_prefix(UNDERSCORE_AVG)
+                        .apply(avg(Column::from(next_field.db_name().to_owned())), next_field),
+                )
             }),
 
             AggregationSelection::Sum(fields) => fields.iter().fold(select, |select, next_field| {
-                select.value(sum(Column::from(next_field.db_name().to_owned())).alias(next_field.name().to_owned()))
+                select.value(
+                    alias
+                        .with_prefix(UNDERSCORE_SUM)
+                        .apply(sum(Column::from(next_field.db_name().to_owned())), next_field),
+                )
             }),
 
             AggregationSelection::Min(fields) => fields.iter().fold(select, |select, next_field| {
                 select.value(
-                    min(Column::from(next_field.db_name().to_owned())
-                        .set_is_enum(next_field.type_identifier().is_enum())
-                        .set_is_selected(true))
-                    .alias(next_field.name().to_owned()),
+                    alias.with_prefix(UNDERSCORE_MIN).apply(
+                        min(Column::from(next_field.db_name().to_owned())
+                            .set_is_enum(next_field.type_identifier().is_enum())
+                            .set_is_selected(true)),
+                        next_field,
+                    ),
                 )
             }),
 
             AggregationSelection::Max(fields) => fields.iter().fold(select, |select, next_field| {
                 select.value(
-                    max(Column::from(next_field.db_name().to_owned())
-                        .set_is_enum(next_field.type_identifier().is_enum())
-                        .set_is_selected(true))
-                    .alias(next_field.name().to_owned()),
+                    alias.apply(
+                        max(Column::from(next_field.db_name().to_owned())
+                            .set_is_enum(next_field.type_identifier().is_enum())
+                            .set_is_selected(true)),
+                        next_field,
+                    ),
                 )
             }),
         },
@@ -241,21 +260,22 @@ pub fn group_by_aggregate(
     selections: &[AggregationSelection],
     group_by: Vec<ScalarFieldRef>,
     having: Option<Filter>,
+    alias: impl AliasGenerator,
     ctx: &Context<'_>,
 ) -> Select<'static> {
     let (base_query, _) = args.into_select(model, &[], ctx);
-
     let select_query = selections.iter().fold(base_query, |select, next_op| match next_op {
-        AggregationSelection::Field(field) => select.column(
-            field
-                .as_column(ctx)
-                .alias(field.name().to_owned())
-                .set_is_selected(true),
-        ),
+        AggregationSelection::Field(field) => {
+            select.column(alias.apply(field.as_column(ctx), field).set_is_selected(true))
+        }
 
         AggregationSelection::Count { all, fields } => {
             let select = fields.iter().fold(select, |select, next_field| {
-                select.value(count(next_field.as_column(ctx)).alias(next_field.name().to_owned()))
+                select.value(
+                    alias
+                        .with_prefix(UNDERSCORE_COUNT)
+                        .apply(count(next_field.as_column(ctx)), next_field),
+                )
             });
 
             if *all {
@@ -266,19 +286,35 @@ pub fn group_by_aggregate(
         }
 
         AggregationSelection::Average(fields) => fields.iter().fold(select, |select, next_field| {
-            select.value(avg(next_field.as_column(ctx)))
+            select.value(
+                alias
+                    .with_prefix(UNDERSCORE_AVG)
+                    .apply(avg(next_field.as_column(ctx)), next_field),
+            )
         }),
 
         AggregationSelection::Sum(fields) => fields.iter().fold(select, |select, next_field| {
-            select.value(sum(next_field.as_column(ctx)))
+            select.value(
+                alias
+                    .with_prefix(UNDERSCORE_SUM)
+                    .apply(sum(next_field.as_column(ctx)), next_field),
+            )
         }),
 
         AggregationSelection::Min(fields) => fields.iter().fold(select, |select, next_field| {
-            select.value(min(next_field.as_column(ctx).set_is_selected(true)))
+            select.value(
+                alias
+                    .with_prefix(UNDERSCORE_MIN)
+                    .apply(min(next_field.as_column(ctx).set_is_selected(true)), next_field),
+            )
         }),
 
         AggregationSelection::Max(fields) => fields.iter().fold(select, |select, next_field| {
-            select.value(max(next_field.as_column(ctx).set_is_selected(true)))
+            select.value(
+                alias
+                    .with_prefix(UNDERSCORE_MAX)
+                    .apply(max(next_field.as_column(ctx).set_is_selected(true)), next_field),
+            )
         }),
     });
 
@@ -322,4 +358,64 @@ fn extract_columns(model: &Model, selections: &[AggregationSelection], ctx: &Con
         .collect();
 
     fields.as_columns(ctx).collect()
+}
+
+pub trait AliasGenerator: Copy {
+    fn generate(&self, field: &ScalarField) -> Option<String>;
+
+    /// Creates a new alias generator that prefixes all generated aliases with the given prefix.
+    fn with_prefix<'a>(&'a self, prefix: &'a str) -> impl AliasGenerator + 'a
+    where
+        Self: Sized,
+    {
+        DotPrefixedAlias(prefix, self)
+    }
+
+    fn apply<'a, A: Aliasable<'a, Target = A>>(&self, expr: A, field: &ScalarField) -> A::Target {
+        match self.generate(field) {
+            Some(alias) => expr.alias(alias),
+            None => expr,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct NoAlias;
+
+impl AliasGenerator for NoAlias {
+    fn generate(&self, _: &ScalarField) -> Option<String> {
+        None
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct PrismaNameAlias;
+
+impl AliasGenerator for PrismaNameAlias {
+    fn generate(&self, field: &ScalarField) -> Option<String> {
+        Some(field.name().to_owned())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DotPrefixedAlias<'a, Inner>(&'a str, &'a Inner);
+
+impl<Inner> AliasGenerator for DotPrefixedAlias<'_, Inner>
+where
+    Inner: AliasGenerator,
+{
+    fn generate(&self, field: &ScalarField) -> Option<String> {
+        let suffix = self.1.generate(field)?;
+        Some(format!("{prefix}.{suffix}", prefix = self.0))
+    }
+}
+
+/// Alias generator that uses the prisma name of the field.
+pub fn alias_with_prisma_name() -> impl AliasGenerator {
+    PrismaNameAlias
+}
+
+/// Alias generator that does not generate any aliases.
+pub fn no_alias() -> impl AliasGenerator {
+    NoAlias
 }

--- a/query-engine/query-builders/sql-query-builder/src/read.rs
+++ b/query-engine/query-builders/sql-query-builder/src/read.rs
@@ -207,7 +207,7 @@ pub fn aggregate(
                 });
 
                 if *all {
-                    select.value(count(asterisk()).alias(UNDERSCORE_COUNT))
+                    select.value(count(asterisk()).alias(format!("{UNDERSCORE_COUNT}._all")))
                 } else {
                     select
                 }
@@ -279,7 +279,7 @@ pub fn group_by_aggregate(
             });
 
             if *all {
-                select.value(count(asterisk()).alias(UNDERSCORE_COUNT))
+                select.value(count(asterisk()).alias(format!("{UNDERSCORE_COUNT}._all")))
             } else {
                 select
             }

--- a/query-engine/query-builders/sql-query-builder/src/read.rs
+++ b/query-engine/query-builders/sql-query-builder/src/read.rs
@@ -207,7 +207,7 @@ pub fn aggregate(
                 });
 
                 if *all {
-                    select.value(count(asterisk()).alias("_count"))
+                    select.value(count(asterisk()).alias(UNDERSCORE_COUNT))
                 } else {
                     select
                 }
@@ -279,7 +279,7 @@ pub fn group_by_aggregate(
             });
 
             if *all {
-                select.value(count(asterisk()).alias("_count"))
+                select.value(count(asterisk()).alias(UNDERSCORE_COUNT))
             } else {
                 select
             }


### PR DESCRIPTION
Closes [ORM-563](https://linear.app/prisma-company/issue/ORM-563/implement-aggregate-read-node-support)

This modifies aggregates slightly to use aliases to make it possible to retrieve the appropriate fields from the interpreter. Also requires a small patch on the frontend: prisma/prisma#26290