### PR TITLE
fix: extract panic-utils crate and fix occasional incorrect downcasting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "napi",
  "napi-derive",
  "once_cell",
+ "panic-utils",
  "pin-project",
  "prisma-metrics",
  "quaint",
@@ -3117,6 +3118,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "panic-utils"
+version = "0.1.0"
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,6 +3869,7 @@ dependencies = [
  "indexmap 2.2.2",
  "indoc 2.0.3",
  "mongodb-query-connector",
+ "panic-utils",
  "prisma-metrics",
  "psl",
  "quaint",
@@ -4090,6 +4096,7 @@ dependencies = [
  "log",
  "nom",
  "once_cell",
+ "panic-utils",
  "parse-hyperlinks",
  "prisma-metrics",
  "psl",
@@ -4720,6 +4727,7 @@ dependencies = [
  "expect-test",
  "indoc 2.0.3",
  "jsonrpc-core",
+ "panic-utils",
  "quaint",
  "schema-connector",
  "schema-core",
@@ -5197,6 +5205,7 @@ dependencies = [
  "futures",
  "itertools 0.12.0",
  "once_cell",
+ "panic-utils",
  "prisma-value",
  "psl",
  "quaint",
@@ -6163,6 +6172,7 @@ dependencies = [
  "backtrace",
  "indoc 2.0.3",
  "itertools 0.12.0",
+ "panic-utils",
  "quaint",
  "serde",
  "serde_json",

--- a/libs/driver-adapters/Cargo.toml
+++ b/libs/driver-adapters/Cargo.toml
@@ -20,6 +20,7 @@ workspace = true
 async-trait.workspace = true
 futures.workspace = true
 once_cell = "1.15"
+panic-utils.path = "../../libs/panic-utils"
 prisma-metrics.path = "../../libs/metrics"
 serde.workspace = true
 serde_json.workspace = true

--- a/libs/driver-adapters/src/napi/error.rs
+++ b/libs/driver-adapters/src/napi/error.rs
@@ -25,10 +25,7 @@ where
 }
 
 fn panic_to_napi_err<R>(panic_payload: Box<dyn Any + Send>) -> napi::Result<R> {
-    panic_payload
-        .downcast_ref::<&str>()
-        .map(|s| -> String { (*s).to_owned() })
-        .or_else(|| panic_payload.downcast_ref::<String>().map(|s| s.to_owned()))
+    panic_utils::downcast_box_to_string(panic_payload)
         .map(|message| Err(napi::Error::from_reason(format!("PANIC: {message}"))))
         .ok_or(napi::Error::from_reason("PANIC: unknown panic".to_string()))
         .unwrap()

--- a/libs/panic-utils/Cargo.toml
+++ b/libs/panic-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "panic-utils"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/libs/panic-utils/src/lib.rs
+++ b/libs/panic-utils/src/lib.rs
@@ -1,0 +1,18 @@
+use std::{any::Any, borrow::Cow};
+
+/// Downcasts a boxed [`Any`] from a panic payload to a string.
+pub fn downcast_box_to_string(object: Box<dyn Any>) -> Option<Cow<'static, str>> {
+    object
+        .downcast::<&'static str>()
+        .map(|s| Cow::Borrowed(*s))
+        .or_else(|object| object.downcast::<String>().map(|s| Cow::Owned(*s)))
+        .ok()
+}
+
+/// Downcasts a reference to [`Any`] from panic info hook to a string.
+pub fn downcast_ref_to_string(object: &dyn Any) -> Option<&str> {
+    object
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| object.downcast_ref::<String>().map(|s| s.as_str()))
+}

--- a/libs/user-facing-errors/Cargo.toml
+++ b/libs/user-facing-errors/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+panic-utils.path = "../panic-utils"
 user-facing-error-macros = { path = "../user-facing-error-macros" }
 serde_json.workspace = true
 serde.workspace = true

--- a/libs/user-facing-errors/src/lib.rs
+++ b/libs/user-facing-errors/src/lib.rs
@@ -122,12 +122,7 @@ impl Error {
     /// Construct a new UnknownError from a [`PanicHookInfo`] in a panic hook. [`UnknownError`]s
     /// created with this constructor will have a proper, useful backtrace.
     pub fn new_in_panic_hook(panic_info: &std::panic::PanicHookInfo<'_>) -> Self {
-        let message = panic_info
-            .payload()
-            .downcast_ref::<&str>()
-            .map(|s| -> String { (*s).to_owned() })
-            .or_else(|| panic_info.payload().downcast_ref::<String>().map(|s| s.to_owned()))
-            .unwrap_or_else(|| "<unknown panic>".to_owned());
+        let message = panic_utils::downcast_ref_to_string(panic_info.payload()).unwrap_or("<unknown panic>");
 
         let backtrace = Some(format!("{:?}", backtrace::Backtrace::new()));
         let location = panic_info

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -35,6 +35,7 @@ prisma-metrics.path = "../../../libs/metrics"
 quaint.workspace = true
 jsonrpc-core = "17"
 insta.workspace = true
+panic-utils.path = "../../../libs/panic-utils"
 
 # Only this version is vetted, upgrade only after going through the code,
 # as this is a small crate with little user base.

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js/external_process.rs
@@ -28,7 +28,7 @@ impl ExecutorProcess {
             Ok(Ok(process)) => process,
             Ok(Err(err)) => exit_with_message(1, &format!("Failed to start node process. Details: {err}")),
             Err(err) => {
-                let err = err.downcast_ref::<String>().map(ToOwned::to_owned).unwrap_or_default();
+                let err = panic_utils::downcast_box_to_string(err).unwrap_or_default();
                 exit_with_message(1, &format!("Panic while trying to start node process.\nDetails: {err}"))
             }
         }
@@ -50,7 +50,7 @@ impl ExecutorProcess {
                     1,
                     &format!(
                         "rpc thread panicked with: {}",
-                        e.downcast::<String>().unwrap_or_default()
+                        panic_utils::downcast_box_to_string(e).unwrap_or_default()
                     ),
                 );
             }

--- a/query-engine/connectors/sql-query-connector/Cargo.toml
+++ b/query-engine/connectors/sql-query-connector/Cargo.toml
@@ -85,3 +85,6 @@ version = "1.0"
 [dependencies.user-facing-errors]
 features = ["sql"]
 path = "../../../libs/user-facing-errors"
+
+[dependencies.panic-utils]
+path = "../../../libs/panic-utils"

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -1,7 +1,7 @@
 use connector_interface::error::*;
 use quaint::error::ErrorKind as QuaintKind;
 use query_structure::{prelude::DomainError, Filter};
-use std::{any::Any, string::FromUtf8Error};
+use std::{any::Any, borrow::Cow, string::FromUtf8Error};
 use thiserror::Error;
 use user_facing_errors::query_engine::DatabaseConstraint;
 
@@ -100,7 +100,7 @@ impl From<Box<dyn Any + Send>> for RawError {
     fn from(e: Box<dyn Any + Send>) -> Self {
         Self::Database {
             code: None,
-            message: Some(*e.downcast::<String>().unwrap()),
+            message: panic_utils::downcast_box_to_string(e).map(Cow::into_owned),
         }
     }
 }

--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -30,6 +30,7 @@ hyper = { version = "0.14", features = ["server", "http1", "http2", "runtime"] }
 tracing.workspace = true
 tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
 prisma-metrics.path = "../../libs/metrics"
+panic-utils.path = "../../libs/panic-utils"
 
 user-facing-errors = { path = "../../libs/user-facing-errors" }
 telemetry = { path = "../../libs/telemetry" }

--- a/query-engine/query-engine/src/main.rs
+++ b/query-engine/query-engine/src/main.rs
@@ -38,25 +38,21 @@ async fn main() -> Result<(), AnyError> {
 fn set_panic_hook(log_format: LogFormat) {
     if let LogFormat::Json = log_format {
         std::panic::set_hook(Box::new(|info| {
-            let payload = info
-                .payload()
-                .downcast_ref::<String>()
-                .cloned()
-                .unwrap_or_else(|| info.payload().downcast_ref::<&str>().unwrap().to_string());
+            let payload = panic_utils::downcast_ref_to_string(info.payload()).unwrap_or_default();
 
             match info.location() {
                 Some(location) => {
                     tracing::event!(
                         tracing::Level::ERROR,
                         message = "PANIC",
-                        reason = payload.as_str(),
+                        reason = payload,
                         file = location.file(),
                         line = location.line(),
                         column = location.column(),
                     );
                 }
                 None => {
-                    tracing::event!(tracing::Level::ERROR, message = "PANIC", reason = payload.as_str());
+                    tracing::event!(tracing::Level::ERROR, message = "PANIC", reason = payload);
                 }
             }
 

--- a/schema-engine/cli/Cargo.toml
+++ b/schema-engine/cli/Cargo.toml
@@ -11,6 +11,7 @@ schema-core = { path = "../core" }
 user-facing-errors = { path = "../../libs/user-facing-errors", features = [
     "all-native",
 ] }
+panic-utils = { path = "../../libs/panic-utils" }
 
 backtrace = "0.3.59"
 base64 = "0.13"

--- a/schema-engine/cli/src/main.rs
+++ b/schema-engine/cli/src/main.rs
@@ -46,12 +46,7 @@ async fn main() {
 
 fn set_panic_hook() {
     std::panic::set_hook(Box::new(move |panic_info| {
-        let message = panic_info
-            .payload()
-            .downcast_ref::<&str>()
-            .copied()
-            .or_else(|| panic_info.payload().downcast_ref::<String>().map(|s| s.as_str()))
-            .unwrap_or("<unknown panic>");
+        let message = panic_utils::downcast_ref_to_string(panic_info.payload()).unwrap_or("<unknown panic>");
 
         let location = panic_info
             .location()

--- a/schema-engine/cli/tests/cli_tests.rs
+++ b/schema-engine/cli/tests/cli_tests.rs
@@ -45,13 +45,10 @@ where
     match res {
         Ok(_) => (),
         Err(panic_payload) => {
-            let res = panic_payload
-                .downcast_ref::<&str>()
-                .map(|s| -> String { (*s).to_owned() })
-                .or_else(|| panic_payload.downcast_ref::<String>().map(|s| s.to_owned()))
-                .unwrap_or_default();
-
-            panic!("Error: '{}'", res);
+            panic!(
+                "Error: '{}'",
+                panic_utils::downcast_box_to_string(panic_payload).unwrap_or_default()
+            );
         }
     }
 }


### PR DESCRIPTION
Extract `panic-utils` crate and consistently use it for downcasting panic payloads to strings across the codebase.

The implementation is a bit more efficient than what was used previously and avoids unnecessary allocations, and also fixes a few bugs related to only one of the two possible cases handled when downcasting panic payloads. The most egregious was the case in `sql-query-connector` where we tried downcasting a panic from the database driver to `String` and then unwrapped the result, leading to possible double panics if the original panic was of the form `panic!("message")` and not `panic!("message: {details}")` and thus the panic payload was a `&static str` and not a `String`.