### PR TITLE
fix(sql-schema-describer/postgres): correct varchar[] column with empty array default value

### DIFF
--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1719,6 +1719,7 @@ fn array_column_defaults_with_array_constructor_syntax(api: TestApi) {
             text_empty TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
             text TEXT[] NOT NULL DEFAULT ARRAY['abc']::TEXT[],
             text_c_escape TEXT[] NOT NULL DEFAULT ARRAY[E'abc', E'def']::TEXT[],
+            varchar_empty VARCHAR(255)[] NOT NULL DEFAULT ARRAY[]::VARCHAR(255)[],
             colors COLOR[] NOT NULL DEFAULT ARRAY['RED', 'GREEN']::COLOR[],
             int_defaults INT4[] NOT NULL DEFAULT ARRAY[9, 12999, -4, 0, 1249849]::INT4[],
             float_defaults DOUBLE PRECISION[] NOT NULL DEFAULT ARRAY[0, 9.12, 3.14, 0.1242, 124949.124949]::DOUBLE PRECISION[],
@@ -1740,6 +1741,7 @@ fn array_column_defaults_with_array_constructor_syntax(api: TestApi) {
     assert_default("text_empty", vec![]);
     assert_default("text", vec!["abc".into()]);
     assert_default("text_c_escape", vec!["abc".into(), "def".into()]);
+    assert_default("varchar_empty", vec![]);
     assert_default(
         "colors",
         vec![


### PR DESCRIPTION
Fix: https://github.com/prisma/prisma/issues/17430

This PR enables to handle empty cast array constructor like `(ARRAY[]::character varying[])::character varying(10)[]`.

I confirmed that this resolves issue by the following.
```
$ PRISMA_SCHEMA_ENGINE_BINARY=/home/notomo/workspace/prisma-engines/target/debug/schema-engine npx prisma migrate dev
Environment variables loaded from prisma/.env
Prisma schema loaded from prisma/schema.prisma
Datasource "db": PostgreSQL database "issue", schema "public" at "localhost:5433"

Already in sync, no schema change or pending migration was found.
```

<details>
<summary>📝 query to check actual column_default string</summary>

- docker image: `postgres:16`
- schema
  ```prisma
  datasource db {
    provider = "postgresql"
    url      = env("DATABASE_URL")
  }

  model Test {
    id Int      @id @default(autoincrement())
    s1 String[] @default([]) @db.VarChar(10)
    s2 String[] @default(["test"]) @db.VarChar(10)
  }
  ```
- query
  ```sql
  SELECT
      oid.namespace,
      info.table_name,
      info.column_name,
      pg_get_expr(attdef.adbin, attdef.adrelid) AS column_default
  FROM information_schema.columns info
  JOIN pg_attribute att ON att.attname = info.column_name
  JOIN (
        SELECT pg_class.oid, relname, pg_namespace.nspname as namespace
        FROM pg_class
        JOIN pg_namespace on pg_namespace.oid = pg_class.relnamespace
        WHERE reltype > 0
      ) as oid on oid.oid = att.attrelid
        AND relname = info.table_name
        AND namespace = info.table_schema
  LEFT OUTER JOIN pg_attrdef attdef ON attdef.adrelid = att.attrelid AND attdef.adnum = att.attnum AND table_schema = namespace
  WHERE table_name = 'Test' AND column_name IN ('s1', 's2')
  ORDER BY namespace, table_name, ordinal_position;
  ```
  ref. https://github.com/prisma/prisma-engines/blob/08b0da61b89855d81a37b120c20ccb3019379e22/schema-engine/sql-schema-describer/src/postgres.rs#L900-L934
- result
  ```
  namespace | table_name | column_name |                     column_default                      
  -----------+------------+-------------+---------------------------------------------------------
  public    | Test       | s1          | (ARRAY[]::character varying[])::character varying(10)[]
  public    | Test       | s2          | ARRAY['test'::character varying(10)]
  ```

</details>
