### PR TITLE
fix(qc): support projected data dependencies with multiple fields

### DIFF
--- a/query-compiler/query-compiler/tests/data/create-nested-create-with-composite-id.json
+++ b/query-compiler/query-compiler/tests/data/create-nested-create-with-composite-id.json
@@ -1,0 +1,23 @@
+{
+  "modelName": "ParentModelWithCompositeId",
+  "action": "createOne",
+  "query": {
+    "arguments": {
+      "data": {
+        "a": 1,
+        "b": 1,
+        "children": {
+          "create": [{ "id": 1 }, { "id": 2 }]
+        }
+      }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "children": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/schema.prisma
+++ b/query-compiler/query-compiler/tests/data/schema.prisma
@@ -26,3 +26,18 @@ model Category {
   name  String
   posts Post[]
 }
+
+model ParentModelWithCompositeId {
+  a        Int
+  b        Int
+  children ChildOfModelWithCompositeId[]
+
+  @@id([a, b])
+}
+
+model ChildOfModelWithCompositeId {
+  id      Int                        @id
+  parent  ParentModelWithCompositeId @relation(fields: [parentA, parentB], references: [a, b])
+  parentA Int
+  parentB Int
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
@@ -1,0 +1,46 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/create-nested-create-with-composite-id.json
+---
+let 0 = unique (query «INSERT INTO "public"."ParentModelWithCompositeId"
+                       ("a","b") VALUES ($1,$2) RETURNING
+                       "public"."ParentModelWithCompositeId"."a",
+                       "public"."ParentModelWithCompositeId"."b"»
+                params [const(BigInt(1)), const(BigInt(1))])
+in let 0$a = mapField a (get 0);
+       0$b = mapField b (get 0)
+   in sum (execute «INSERT INTO "public"."ChildOfModelWithCompositeId"
+                    ("id","parentA","parentB") VALUES ($1,$2,$3), ($4,$5,$6)»
+           params [const(BigInt(1)), var(0$a as Int), var(0$b as Int),
+                   const(BigInt(2)), var(0$a as Int), var(0$b as Int)]);
+   let 2 = let 0$a = mapField a (get 0);
+               0$b = mapField b (get 0)
+       in let @parent = unique (query «SELECT
+                                       "public"."ParentModelWithCompositeId"."a",
+                                       "public"."ParentModelWithCompositeId"."b"
+                                       FROM
+                                       "public"."ParentModelWithCompositeId"
+                                       WHERE
+                                       ("public"."ParentModelWithCompositeId"."a"
+                                       = $1 AND
+                                       "public"."ParentModelWithCompositeId"."b"
+                                       = $2) LIMIT $3 OFFSET $4»
+                                params [var(0$a as Int), var(0$b as Int),
+                                        const(BigInt(1)), const(BigInt(0))])
+          in let @parent$b = mapField b (get @parent);
+                 @parent$a = mapField a (get @parent)
+             in join (get @parent)
+                with (query «SELECT "public"."ChildOfModelWithCompositeId"."id",
+                             "public"."ChildOfModelWithCompositeId"."parentA",
+                             "public"."ChildOfModelWithCompositeId"."parentB"
+                             FROM "public"."ChildOfModelWithCompositeId" WHERE
+                             ("public"."ChildOfModelWithCompositeId"."parentA" =
+                             $1 OR
+                             "public"."ChildOfModelWithCompositeId"."parentB" =
+                             $2) OFFSET $3»
+                      params [var(@parent$a as Int), var(@parent$b as Int),
+                              const(BigInt(0))]) on left.(a,
+                                                          b) = right.(parentA,
+                                                                      parentB) as children
+   in get 2


### PR DESCRIPTION
The ticket and the code comment were suggesting to support multiple fields in `MapField` but that's not what we actually needed to support projected data dependencies with multiple fields. We use `MapField` to extract either a scalar to generate an equality filter or a list of scalars to generate an `IN` clause. Therefore, we need separate `MapField` operations and separate bindings for each field.

Closes: https://linear.app/prisma-company/issue/ORM-573/make-mapfield-support-projecting-to-multiple-fields