### PR TITLE
chore: install newer wasm-opt

### DIFF
--- a/.github/workflows/build-prisma-schema-wasm.yml
+++ b/.github/workflows/build-prisma-schema-wasm.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - "!.github/workflows/build-prisma-schema-wasm.yml"
+      - "!.github/workflows/include/rust-wasm-setup/action.yml"
       - ".github/**"
       - ".buildkite/**"
       - "*.md"

--- a/.github/workflows/include/rust-wasm-setup/action.yml
+++ b/.github/workflows/include/rust-wasm-setup/action.yml
@@ -13,12 +13,17 @@ runs:
 
     - uses: cargo-bins/cargo-binstall@main
 
-    - name: Install wasm-bindgen, wasm-opt
+    - name: Install wasm-bindgen
       shell: bash
-      run: |
-        cargo binstall -y \
-            wasm-bindgen-cli@0.2.93 \
-            wasm-opt@0.116.0
+      run: cargo binstall -y wasm-bindgen-cli@0.2.93
+
+    - name: Install Binaryen (includes wasm-opt)
+      uses: jaxxstorm/action-install-gh-release@v1.14.0
+      with:
+        repo: WebAssembly/binaryen
+        tag: version_122
+        binaries-location: binaryen-version_122/bin
+        cache: true
 
     - name: Install bc
       shell: bash

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - "!.github/workflows/test-query-engine.yml"
       - "!.github/workflows/test-query-engine-template.yml"
+      - "!.github/workflows/include/rust-wasm-setup/action.yml"
       - ".github/**"
       - ".buildkite/**"
       - "*.md"

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -4,6 +4,7 @@ on:
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/wasm-benchmarks.yml"
+      - "!.github/workflows/include/rust-wasm-setup/action.yml"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -4,6 +4,7 @@ on:
     paths-ignore:
       - ".github/**"
       - "!.github/workflows/wasm-size.yml"
+      - "!.github/workflows/include/rust-wasm-setup/action.yml"
       - ".buildkite/**"
       - "*.md"
       - "LICENSE"


### PR DESCRIPTION
We installed `wasm-opt` from crates.io but it's not the real thing, those are just Rust bindings to `wasm-opt` that happen to ship the binary as well. They haven't been updated in almost a year, while `wasm-opt` was getting updates and improvements.

This commit installs `wasm-opt` from the official repository.