### PR TITLE
fix(qc): make the order of join fields bindings deterministic

### DIFF
--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::{
     expression::{Binding, Expression, JoinExpression},
     translate::TranslateResult,
@@ -96,10 +94,10 @@ fn add_inmemory_join(
             ReadQuery::RelatedRecordsQuery(rrq) => rrq.parent_field.linking_fields(),
             _ => unreachable!(),
         })
-        .collect::<HashSet<_>>();
+        .unique()
+        .sorted_by(|a, b| a.prisma_name().cmp(&b.prisma_name()));
 
     let linking_fields_bindings = all_linking_fields
-        .into_iter()
         .map(|sf| Binding {
             name: format!("@parent${}", sf.prisma_name().into_owned()),
             expr: Expression::MapField {

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
@@ -28,8 +28,8 @@ in let 0$a = mapField a (get 0);
                                        = $2) LIMIT $3 OFFSET $4»
                                 params [var(0$a as Int), var(0$b as Int),
                                         const(BigInt(1)), const(BigInt(0))])
-          in let @parent$b = mapField b (get @parent);
-                 @parent$a = mapField a (get @parent)
+          in let @parent$a = mapField a (get @parent);
+                 @parent$b = mapField b (get @parent)
              in join (get @parent)
                 with (query «SELECT "public"."ChildOfModelWithCompositeId"."id",
                              "public"."ChildOfModelWithCompositeId"."parentA",


### PR DESCRIPTION
We were collecting all linking fields we saw for each relation we join on into a HashSet without sorting them afterwards, which made the order unpredictable, failing the snapshot tests sometimes. It didn't use to fail until another unrelated change because we didn't actually have snapshot tests that would exercise this code path.

Closes: https://linear.app/prisma-company/issue/ORM-642/sort-let-bindings-in-joins