### PR TITLE
feat: enable dependabot for cargo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: 'cargo'
+    directory: '/'
+    schedule:
+      interval: 'daily'


### PR DESCRIPTION
[ORM-620](https://linear.app/prisma-company/issue/ORM-620/set-up-dependabot)

Idea: maybe we should extract all versions to the workspace Cargo.toml, currently they're scattered all over the place.