### PR TITLE
chore: update to Rust 1.85.0

### DIFF
--- a/quaint/src/connector/mssql/native/conversion.rs
+++ b/quaint/src/connector/mssql/native/conversion.rs
@@ -45,8 +45,8 @@ impl TryFrom<ColumnData<'static>> for Value<'static> {
         let res = match cd {
             ColumnData::U8(num) => ValueType::Int32(num.map(i32::from)),
             ColumnData::I16(num) => ValueType::Int32(num.map(i32::from)),
-            ColumnData::I32(num) => ValueType::Int32(num.map(i32::from)),
-            ColumnData::I64(num) => ValueType::Int64(num.map(i64::from)),
+            ColumnData::I32(num) => ValueType::Int32(num),
+            ColumnData::I64(num) => ValueType::Int64(num),
             ColumnData::F32(num) => ValueType::Float(num),
             ColumnData::F64(num) => ValueType::Double(num),
             ColumnData::Bit(b) => ValueType::Boolean(b),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.84.1"
+channel = "1.85.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/native/shadow_db.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/native/shadow_db.rs
@@ -1,5 +1,5 @@
 use crate::flavour::{MssqlFlavour, SqlFlavour};
-use schema_connector::{migrations_directory::MigrationDirectory, ConnectorError, ConnectorResult, Namespaces};
+use schema_connector::{migrations_directory::MigrationDirectory, ConnectorResult, Namespaces};
 use sql_schema_describer::SqlSchema;
 
 pub async fn sql_schema_from_migrations_history(
@@ -15,13 +15,9 @@ pub async fn sql_schema_from_migrations_history(
             migration.migration_name()
         );
 
-        shadow_db
-            .raw_cmd(&script)
-            .await
-            .map_err(ConnectorError::from)
-            .map_err(|connector_error| {
-                connector_error.into_migration_does_not_apply_cleanly(migration.migration_name().to_owned())
-            })?;
+        shadow_db.raw_cmd(&script).await.map_err(|connector_error| {
+            connector_error.into_migration_does_not_apply_cleanly(migration.migration_name().to_owned())
+        })?;
     }
 
     shadow_db.describe_schema(namespaces).await

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/shadow_db.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/shadow_db.rs
@@ -131,13 +131,9 @@ pub async fn sql_schema_from_migrations_and_db(
             migration.migration_name()
         );
 
-        shadow_db
-            .raw_cmd(&script)
-            .await
-            .map_err(ConnectorError::from)
-            .map_err(|connector_error| {
-                connector_error.into_migration_does_not_apply_cleanly(migration.migration_name().to_owned())
-            })?;
+        shadow_db.raw_cmd(&script).await.map_err(|connector_error| {
+            connector_error.into_migration_does_not_apply_cleanly(migration.migration_name().to_owned())
+        })?;
     }
 
     if shadow_db.provider == PostgresProvider::CockroachDb {


### PR DESCRIPTION
Update the Rust version to 1.85.0 and fix new clippy warnings.

This doesn't update the edition yet, it will be done separately.