### PR TITLE
chore: upgrade nightly toolchain for query-engine-wasm

### DIFF
--- a/query-engine/query-engine-wasm/rust-toolchain.toml
+++ b/query-engine/query-engine-wasm/rust-toolchain.toml
@@ -1,6 +1,4 @@
 [toolchain]
-channel = "nightly-2024-11-20"
+channel = "nightly-2025-02-14"
 components = ["clippy", "rustfmt", "rust-src"]
-targets = [
-    "wasm32-unknown-unknown",
-]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
It's pretty old at this point and we need a newer one to migrate to Rust 2024 after the stable toolchain is updated to 1.85.0.

An alternative is to use the stable toolchain for the wasm build (https://github.com/prisma/prisma-engines/pull/5167) but it's currently blocked on the last comment in that PR.