### PR TITLE
fix: add write perm on report diff

### DIFF
--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -1,14 +1,14 @@
-name: "QE: WASM Query Engine size"
+name: 'QE: WASM Query Engine size'
 on:
   pull_request:
     paths-ignore:
-      - ".github/**"
-      - "!.github/workflows/wasm-size.yml"
-      - "!.github/workflows/include/rust-wasm-setup/action.yml"
-      - ".buildkite/**"
-      - "*.md"
-      - "LICENSE"
-      - "CODEOWNERS"
+      - '.github/**'
+      - '!.github/workflows/wasm-size.yml'
+      - '!.github/workflows/include/rust-wasm-setup/action.yml'
+      - '.buildkite/**'
+      - '*.md'
+      - 'LICENSE'
+      - 'CODEOWNERS'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -67,6 +67,8 @@ jobs:
     needs:
       - pr-wasm-size
       - base-wasm-size
+    permissions:
+      pull-requests: write
 
     steps:
       - name: Compute difference
@@ -102,7 +104,7 @@ jobs:
         id: findReportComment
         with:
           issue-number: ${{ github.event.pull_request.number }}
-          body-includes: "<!-- wasm-size -->"
+          body-includes: '<!-- wasm-size -->'
 
       - name: Create or update report
         uses: peter-evans/create-or-update-comment@v4


### PR DESCRIPTION
I think the permissions block is necessary for dependanbot PRs to successfully run `report module size`

Ref: https://github.com/peter-evans/create-or-update-comment/issues/212#issuecomment-1913096833
Failing PR: https://github.com/prisma/prisma-engines/actions/runs/13500143538/job/37717425807?pr=5186