### PR TITLE
fix(qc-test-worker): remove obsolete JS property

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -55,10 +55,7 @@ class QueryPipeline {
       })
     } else {
       const queryable = txId
-        ? this.transactionManager.getTransaction(
-            { id: txId, payload: undefined },
-            query.action,
-          )
+        ? this.transactionManager.getTransaction({ id: txId }, query.action)
         : this.driverAdapter
 
       if (!queryable) {


### PR DESCRIPTION
The types changed after the refactoring on the client side, `payload: undefined` property no longer exists.