### PR TITLE
fix(psl): fix a typo in feature gates for `schemas_completion`

### DIFF
--- a/psl/psl-core/src/builtin_connectors/completions.rs
+++ b/psl/psl-core/src/builtin_connectors/completions.rs
@@ -18,7 +18,7 @@ pub(crate) fn extensions_completion(completion_list: &mut lsp_types::CompletionL
     })
 }
 
-#[cfg(any(feature = "postgresql", feature = "cockroachdb", feature = "mysql"))]
+#[cfg(any(feature = "postgresql", feature = "cockroachdb", feature = "mssql"))]
 pub(crate) fn schemas_completion(completion_list: &mut lsp_types::CompletionList) {
     use lsp_types::*;
     completion_list.items.push(CompletionItem {


### PR DESCRIPTION
This function should be enabled for `mssql`, not `mysql`. It happened to work despite the typo because ultimately the completions are only used by the language server via `prisma-schema-wasm`, which compiles `psl` with all features enabled. However, when `psl` was compiled with `mysql` feature only (as part of MySQL specific builds of `query-engine-wasm` and `query-compiler-wasm`) this led to a dead code warning.