### PR TITLE
fix(schema-engine): Fixed introspecting enum array types

### DIFF
--- a/schema-engine/sql-introspection-tests/tests/enums/cockroachdb.rs
+++ b/schema-engine/sql-introspection-tests/tests/enums/cockroachdb.rs
@@ -287,3 +287,47 @@ async fn an_enum_with_invalid_value_names_should_have_them_commented_out(api: &m
     api.expect_datamodel(&expected).await;
     Ok(())
 }
+
+// Regression: https://github.com/prisma/prisma/issues/22456
+#[test_connector(tags(CockroachDb))]
+async fn enum_array_type(api: &mut TestApi) -> TestResult {
+    let setup = indoc! {r#"
+        CREATE TYPE "_foo" AS ENUM ('FIRST', 'SECOND');
+
+        CREATE TABLE "Post" (
+            "id" TEXT NOT NULL,
+            "contentFilters" "_foo"[],
+            CONSTRAINT "Post_pkey" PRIMARY KEY ("id")
+        );
+    "#};
+
+    api.raw_cmd(setup).await;
+
+    let expectation = expect![[r#"
+        generator client {
+          provider = "prisma-client-js"
+        }
+
+        datasource db {
+          provider = "cockroachdb"
+          url      = "env(TEST_DATABASE_URL)"
+        }
+
+        model Post {
+          id             String @id
+          contentFilters foo[]
+        }
+
+        enum foo {
+          FIRST
+          SECOND
+
+          @@map("_foo")
+        }
+    "#]];
+
+    api.expect_datamodel(&expectation).await;
+    api.expect_no_warnings().await;
+
+    Ok(())
+}

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -1615,7 +1615,7 @@ fn get_column_type_postgresql(row: &ResultRow, schema: &SqlSchema) -> ColumnType
     let enum_id: Option<_> = match data_type.as_str() {
         "ARRAY" if full_data_type.starts_with('_') => {
             let namespace = row.get_string("type_schema_name");
-            schema.find_enum(full_data_type.trim_start_matches('_'), namespace.as_deref())
+            schema.find_enum(&full_data_type[1..], namespace.as_deref())
         }
         _ => {
             let namespace = row.get_string("type_schema_name");
@@ -1709,7 +1709,7 @@ fn get_column_type_cockroachdb(row: &ResultRow, schema: &SqlSchema) -> ColumnTyp
     let enum_id: Option<_> = match data_type.as_str() {
         "ARRAY" if full_data_type.starts_with('_') => {
             let namespace = row.get_string("type_schema_name");
-            schema.find_enum(full_data_type.trim_start_matches('_'), namespace.as_deref())
+            schema.find_enum(&full_data_type[1..], namespace.as_deref())
         }
         _ => {
             let namespace = row.get_string("type_schema_name");


### PR DESCRIPTION
**Issue**
https://github.com/prisma/prisma/issues/22456

**Affected databases**
- PostgreSQL
- CockroachDB

**Root cause**

PostgreSQL prepends an underscore to produce ARRAY types from each type defined. (The enum is defined as a type.) The database introspection code trimmed all underscores from the type name of the column, which resulted in a loss of the underscore in the name of the original enum type. As a consequence the enum type was not found and ended up as unsupported. The unsupported type did not match the original type, resulted in a unwanted migration.

**Solution**

Remove only a single underscore prefix from the type name.

**Remarks**

Quoting from the PostgreSQL [CREATE TYPE](https://www.postgresql.org/docs/current/sql-createtype.html) documentation:

> Whenever a user-defined type is created, PostgreSQL automatically creates an associated array type, whose name consists of the element type's name prepended with an underscore, and truncated if necessary to keep it less than `NAMEDATALEN` bytes long.

Unrelated to the underscore prefix problem, but will affect the generality of any solution: By default `NAMEDATALEN` is 63. It can be queried by `SHOW max_identifier_length;`

If the original type name was `NAMEDATALEN` long, then the last character would be truncated by PostgreSQL. It would still prevent finding the correct type on introspection. A workaround could be made to search for a matching type. However, it is a very rare corner case, it is is not worth the additional code. Such cases could be fixed by increasing `NAMEDATALEN` on the database side.