### PR TITLE
fix(qe): Change Array(None) to return Null value.

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
@@ -380,7 +380,7 @@ mod json {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"{ findManyTestModel { child { json_list } } }"#),
-          @r###"{"data":{"findManyTestModel":[{"child":{"json_list":["1","2"]}},{"child":{"json_list":["{}"]}},{"child":{"json_list":["\"hello\"","\"world\""]}},{"child":{"json_list":[]}}]}}"###
+          @r###"{"data":{"findManyTestModel":[{"child":{"json_list":["1","2"]}},{"child":{"json_list":["{}"]}},{"child":{"json_list":["\"hello\"","\"world\""]}},{"child":{"json_list":null}}]}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -270,7 +270,7 @@ mod scalar_relations {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"{ findUniqueParent(where: { id: 1 }) { id children { childId string int bInt float bytes bool dt empty unset } } }"#),
-          @r###"{"data":{"findUniqueParent":{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"],"empty":[],"unset":[]}]}}}"###
+          @r###"{"data":{"findUniqueParent":{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"],"empty":[],"unset":null}]}}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -265,7 +265,7 @@ mod scalar_relations {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"{ findManyParent { id children { childId string int bInt float bytes bool dt empty unset } } }"#),
-          @r###"{"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"],"empty":[],"unset":[]}]}]}}"###
+          @r###"{"data":{"findManyParent":[{"id":1,"children":[{"childId":1,"string":["abc","def"],"int":[1,-1,1234567],"bInt":["1","-1","9223372036854775807","-9223372036854775807"],"float":[1.5,-1.5,1.234567],"bytes":["AQID","Qk9OSk9VUg=="],"bool":[false,true],"dt":["1900-10-10T01:10:10.001Z","1999-12-12T21:12:12.121Z"],"empty":[],"unset":null}]}]}}"###
         );
 
         insta::assert_snapshot!(

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/composites/list.rs
@@ -326,7 +326,7 @@ mod create {
           }
         }
         "#),
-          @r###"{"data":{"createOneTestModel":{"to_many_as":[],"to_one_b":null}}}"###
+          @r###"{"data":{"createOneTestModel":{"to_many_as":null,"to_one_b":null}}}"###
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_list.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_list.rs
@@ -27,7 +27,7 @@ mod create_list {
 
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation { createOneUser(data: { id: 1 }){ id, test }}"#),
-          @r###"{"data":{"createOneUser":{"id":1,"test":[]}}}"###
+          @r###"{"data":{"createOneUser":{"id":1,"test":null}}}"###
         );
 
         Ok(())

--- a/query-engine/connectors/mongodb-query-connector/src/value.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/value.rs
@@ -297,7 +297,7 @@ fn read_scalar_value(bson: Bson, meta: &ScalarOutputMeta) -> crate::Result<Prism
     let val = match (&meta.ident, bson) {
         // We expect a list to be returned.
         (type_identifier, bson) if meta.list => match bson {
-            Bson::Null => PrismaValue::List(Vec::new()),
+            Bson::Null => PrismaValue::Null,
 
             Bson::Array(list) => PrismaValue::List(
                 list.into_iter()
@@ -392,7 +392,7 @@ fn read_composite_value(bson: Bson, meta: &CompositeOutputMeta) -> crate::Result
     let val = if meta.list {
         match bson {
             // Coerce null to empty list (Prisma doesn't have nullable lists)
-            Bson::Null => PrismaValue::List(Vec::new()),
+            Bson::Null => PrismaValue::Null,
 
             Bson::Array(list) => PrismaValue::List(
                 list.into_iter()

--- a/query-engine/connectors/sql-query-connector/src/database/operations/read/coerce.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/read/coerce.rs
@@ -25,7 +25,7 @@ pub(crate) fn coerce_record_with_json_relation(
             IndexedSelection::Relation(rs) => {
                 match val {
                     PrismaValue::Null if rs.field.is_list() => {
-                        *val = PrismaValue::List(vec![]);
+                        *val = PrismaValue::Null;
                     }
                     PrismaValue::Null if rs.field.is_optional() => {
                         continue;
@@ -127,7 +127,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
 
     if sf.type_identifier().is_json() && sf.is_list() {
         return match value {
-            serde_json::Value::Null => Ok(PrismaValue::List(vec![])),
+            serde_json::Value::Null => Ok(PrismaValue::Null),
             serde_json::Value::Array(values) => Ok(PrismaValue::List(
                 values
                     .iter()
@@ -139,13 +139,7 @@ pub(crate) fn coerce_json_scalar_to_pv(value: serde_json::Value, sf: &ScalarFiel
     }
 
     match value {
-        serde_json::Value::Null => {
-            if sf.is_list() {
-                Ok(PrismaValue::List(vec![]))
-            } else {
-                Ok(PrismaValue::Null)
-            }
-        }
+        serde_json::Value::Null => Ok(PrismaValue::Null),
         serde_json::Value::Bool(b) => Ok(PrismaValue::Boolean(b)),
         serde_json::Value::Number(n) => match sf.type_identifier() {
             TypeIdentifier::Int => Ok(PrismaValue::Int(n.as_i64().ok_or_else(|| {

--- a/query-engine/connectors/sql-query-connector/src/row.rs
+++ b/query-engine/connectors/sql-query-connector/src/row.rs
@@ -95,8 +95,8 @@ impl ToSqlRow for ResultRow {
         for (i, p_value) in self.into_iter().enumerate().take(row_width) {
             let pv = match (meta[i].identifier(), meta[i].arity()) {
                 (type_identifier, FieldArity::List) => match p_value.typed {
-                    value if value.is_null() => Ok(PrismaValue::List(Vec::new())),
-                    ValueType::Array(None) => Ok(PrismaValue::List(Vec::new())),
+                    value if value.is_null() => Ok(PrismaValue::Null),
+                    ValueType::Array(None) => Ok(PrismaValue::Null),
                     ValueType::Array(Some(l)) => l
                         .into_iter()
                         .map(|val| row_value_to_prisma_value(val, meta[i]))


### PR DESCRIPTION
## Description

In PostgreSQL, a nullable array column can hold either a `null` value or an empty array (`{}`), and these are semantically different. Previously, Prisma treated both cases as an empty array. This fix ensures that when the database returns a `null` for a nullable array column, Prisma correctly returns a `null` instead of an empty list.

## Related Issue

- Issue: [#25482](https://github.com/prisma/prisma/issues/25482)

## Changes Made

- Updated the conversion logic for list fields in the SQL row conversion. The branch that previously matched any null value and returned an empty list has been modified (or removed) so that a SQL `null` is properly recognized.

## Screenshots (if applicable)

Before the fix, the following query would return an empty array for a `null` column:

```sql
CREATE OR REPLACE TABLE nullable_array ( arr text[] );
INSERT INTO nullable_array VALUES (null);
