### PR TITLE
fix(quaint): add missing tiberius features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
 
 [[package]]
+name = "async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
+dependencies = [
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5701,6 +5713,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
 dependencies = [
+ "async-native-tls",
  "async-trait",
  "asynchronous-codec",
  "bigdecimal",

--- a/quaint/Cargo.toml
+++ b/quaint/Cargo.toml
@@ -137,7 +137,14 @@ optional = true
 [target.'cfg(not(any(target_os = "macos", target_os = "ios")))'.dependencies.tiberius]
 workspace = true
 optional = true
-features = ["sql-browser-tokio", "chrono", "tds73", "bigdecimal"]
+features = [
+  "sql-browser-tokio",
+  "chrono",
+  "tds73",
+  "bigdecimal",
+  "native-tls",
+  "winauth",
+]
 
 [target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies.tiberius]
 workspace = true


### PR DESCRIPTION
Add missing `native_tls` and `winauth` features. They were previously inherited from the default features of `tiberius` and now they aren't.