### PR TITLE
chore: migrate query compiler crates to Rust 2024

### DIFF
--- a/query-compiler/query-compiler-playground/Cargo.toml
+++ b/query-compiler/query-compiler-playground/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "query-compiler-playground"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 anyhow.workspace = true

--- a/query-compiler/query-compiler-playground/src/main.rs
+++ b/query-compiler/query-compiler-playground/src/main.rs
@@ -4,7 +4,7 @@ use quaint::{
     prelude::{ConnectionInfo, ExternalConnectionInfo, SqlFamily},
     visitor::Postgres,
 };
-use query_core::{query_graph_builder::QueryGraphBuilder, QueryDocument, QueryGraph, ToGraphviz};
+use query_core::{QueryDocument, QueryGraph, ToGraphviz, query_graph_builder::QueryGraphBuilder};
 use request_handlers::{JsonBody, JsonSingleQuery, RequestBody};
 use serde_json::json;
 use sql_query_builder::{Context, SqlQueryBuilder};

--- a/query-compiler/query-compiler-wasm/Cargo.toml
+++ b/query-compiler/query-compiler-wasm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "query-compiler-wasm"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 doc = false

--- a/query-compiler/query-compiler/Cargo.toml
+++ b/query-compiler/query-compiler/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "query-compiler"
 version = "0.1.0"
 

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -1,6 +1,6 @@
 use pretty::{
-    termcolor::{Color, ColorSpec},
     DocAllocator, DocBuilder,
+    termcolor::{Color, ColorSpec},
 };
 use query_structure::PrismaValue;
 

--- a/query-compiler/query-compiler/src/lib.rs
+++ b/query-compiler/query-compiler/src/lib.rs
@@ -8,10 +8,10 @@ use quaint::{
     prelude::{ConnectionInfo, SqlFamily},
     visitor,
 };
-use query_core::{schema::QuerySchema, QueryGraphBuilderError};
+use query_core::{QueryGraphBuilderError, schema::QuerySchema};
 use sql_query_builder::{Context, SqlQueryBuilder};
 use thiserror::Error;
-pub use translate::{translate, TranslateError};
+pub use translate::{TranslateError, translate};
 
 use query_core::{QueryDocument, QueryGraphBuilder};
 

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -1,7 +1,7 @@
 use crate::{
+    TranslateError,
     expression::{Binding, Expression, JoinExpression},
     translate::TranslateResult,
-    TranslateError,
 };
 use itertools::Itertools;
 use query_builder::{QueryArgumentsExt, QueryBuilder, RelationLink};

--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -5,7 +5,7 @@ use query_core::{
 };
 use query_structure::QueryArguments;
 
-use crate::{expression::Expression, translate::TranslateResult, TranslateError};
+use crate::{TranslateError, expression::Expression, translate::TranslateResult};
 
 pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilder) -> TranslateResult<Expression> {
     Ok(match query {

--- a/query-compiler/query-engine-tests-todo/Cargo.toml
+++ b/query-compiler/query-engine-tests-todo/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "query-compiler-engine-tests-todo"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lints]
 workspace = true


### PR DESCRIPTION
No real code changes required in these crates, only different import sorting due to the new rustfmt edition.