### PR TITLE
refactor: remove set_params and connection_string flavour methods

### DIFF
--- a/query-engine/connector-test-kit-rs/qe-setup/src/cockroachdb.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/cockroachdb.rs
@@ -1,7 +1,7 @@
 use std::sync::OnceLock;
 
 use quaint::{connector::PostgresFlavour, prelude::*, single::Quaint};
-use schema_core::schema_connector::{ConnectorError, ConnectorResult};
+use schema_core::schema_connector::{ConnectorError, ConnectorParams, ConnectorResult};
 use url::Url;
 
 pub(crate) async fn cockroach_setup(url: String, prisma_schema: &str) -> ConnectorResult<()> {
@@ -22,8 +22,9 @@ pub(crate) async fn cockroach_setup(url: String, prisma_schema: &str) -> Connect
     conn.raw_cmd(&query).await.unwrap();
 
     drop_db_when_thread_exits(parsed_url, db_name);
-    let mut connector = sql_schema_connector::SqlSchemaConnector::new_cockroach();
-    crate::diff_and_apply(prisma_schema, url, &mut connector).await
+    let params = ConnectorParams::new(url, Default::default(), None);
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_cockroach(params)?;
+    crate::diff_and_apply(prisma_schema, &mut connector).await
 }
 
 async fn create_admin_conn(url: &mut Url) -> ConnectorResult<Quaint> {

--- a/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
@@ -18,7 +18,7 @@ use driver_adapters::DriverAdapter;
 use enumflags2::BitFlags;
 use providers::Provider;
 use psl::{builtin_connectors::*, Datasource};
-use schema_core::schema_connector::{ConnectorResult, DiffTarget, SchemaConnector};
+use schema_core::schema_connector::{ConnectorParams, ConnectorResult, DiffTarget, SchemaConnector};
 use std::env;
 
 #[derive(Debug, serde::Deserialize, PartialEq)]
@@ -77,8 +77,9 @@ pub async fn setup_external<'a>(
         DriverAdapter::D1 => {
             // 1. Compute the diff migration script.
             std::fs::remove_file(source.url.as_literal().unwrap().trim_start_matches("file:")).ok();
-            let mut connector = sql_schema_connector::SqlSchemaConnector::new_sqlite();
-            let migration_script = crate::diff(prisma_schema, url, &mut connector).await?;
+            let params = ConnectorParams::new(url, Default::default(), None);
+            let mut connector = sql_schema_connector::SqlSchemaConnector::new_sqlite(params)?;
+            let migration_script = crate::diff(prisma_schema, &mut connector).await?;
 
             // 2. Tell JavaScript to take care of the schema migration.
             //    This results in a JSON-RPC call to the JS runtime.
@@ -147,12 +148,7 @@ pub async fn teardown(prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResu
 
 /// Compute an initialisation migration script via
 /// `prisma migrate diff --from-empty --to-schema-datamodel $SCHEMA_PATH --script`.
-pub(crate) async fn diff(schema: &str, url: String, connector: &mut dyn SchemaConnector) -> ConnectorResult<String> {
-    connector.set_params(schema_core::schema_connector::ConnectorParams {
-        connection_string: url,
-        preview_features: Default::default(),
-        shadow_database_connection_string: None,
-    })?;
+pub(crate) async fn diff(schema: &str, connector: &mut dyn SchemaConnector) -> ConnectorResult<String> {
     let from = connector
         .database_schema_from_diff_target(DiffTarget::Empty, None, None)
         .await?;
@@ -168,11 +164,7 @@ pub(crate) async fn diff(schema: &str, url: String, connector: &mut dyn SchemaCo
 }
 
 /// Apply the script returned by [`diff`] against the database.
-pub(crate) async fn diff_and_apply(
-    schema: &str,
-    url: String,
-    connector: &mut dyn SchemaConnector,
-) -> ConnectorResult<()> {
-    let script = diff(schema, url, connector).await.unwrap();
+pub(crate) async fn diff_and_apply(schema: &str, connector: &mut dyn SchemaConnector) -> ConnectorResult<()> {
+    let script = diff(schema, connector).await.unwrap();
     connector.db_execute(script).await
 }

--- a/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
@@ -1,6 +1,6 @@
 use connection_string::JdbcString;
 use quaint::{prelude::*, single::Quaint};
-use schema_core::schema_connector::{ConnectorError, ConnectorResult};
+use schema_core::schema_connector::{ConnectorError, ConnectorParams, ConnectorResult};
 use std::str::FromStr;
 
 pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResult<()> {
@@ -39,6 +39,7 @@ pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[
             .unwrap();
     }
 
-    let mut connector = sql_schema_connector::SqlSchemaConnector::new_mssql();
-    crate::diff_and_apply(prisma_schema, url, &mut connector).await
+    let params = ConnectorParams::new(url, Default::default(), None);
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_mssql(params)?;
+    crate::diff_and_apply(prisma_schema, &mut connector).await
 }

--- a/query-engine/connector-test-kit-rs/qe-setup/src/mysql.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/mysql.rs
@@ -1,5 +1,5 @@
 use quaint::{prelude::Queryable, single::Quaint};
-use schema_core::schema_connector::{ConnectorError, ConnectorResult};
+use schema_core::schema_connector::{ConnectorError, ConnectorParams, ConnectorResult};
 use std::{
     future::Future,
     pin::Pin,
@@ -10,8 +10,9 @@ use url::Url;
 
 pub(crate) async fn mysql_setup(url: String, prisma_schema: &str) -> ConnectorResult<()> {
     mysql_reset(&url).await?;
-    let mut connector = sql_schema_connector::SqlSchemaConnector::new_mysql();
-    crate::diff_and_apply(prisma_schema, url, &mut connector).await
+    let params = ConnectorParams::new(url, Default::default(), None);
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_mysql(params)?;
+    crate::diff_and_apply(prisma_schema, &mut connector).await
 }
 
 async fn mysql_reset(original_url: &str) -> ConnectorResult<()> {

--- a/query-engine/connector-test-kit-rs/qe-setup/src/postgres.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/postgres.rs
@@ -1,5 +1,5 @@
 use quaint::{connector::PostgresFlavour, prelude::*, single::Quaint};
-use schema_core::schema_connector::{ConnectorError, ConnectorResult};
+use schema_core::schema_connector::{ConnectorError, ConnectorParams, ConnectorResult};
 use std::collections::HashMap;
 use url::Url;
 
@@ -38,8 +38,9 @@ pub(crate) async fn postgres_setup(url: String, prisma_schema: &str, db_schemas:
             .map_err(|e| ConnectorError::from_source(e, ""))?;
     }
 
-    let mut connector = sql_schema_connector::SqlSchemaConnector::new_postgres();
-    crate::diff_and_apply(prisma_schema, url, &mut connector).await
+    let params = ConnectorParams::new(url, Default::default(), None);
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_postgres(params)?;
+    crate::diff_and_apply(prisma_schema, &mut connector).await
 }
 
 pub(crate) async fn postgres_teardown(url: &str, db_schemas: &[&str]) -> ConnectorResult<()> {

--- a/query-engine/connector-test-kit-rs/qe-setup/src/sqlite.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/sqlite.rs
@@ -1,7 +1,8 @@
-use schema_core::schema_connector::ConnectorResult;
+use schema_core::schema_connector::{ConnectorParams, ConnectorResult};
 
 pub(crate) async fn sqlite_setup(source: psl::Datasource, url: String, prisma_schema: &str) -> ConnectorResult<()> {
     std::fs::remove_file(source.url.as_literal().unwrap().trim_start_matches("file:")).ok();
-    let mut connector = sql_schema_connector::SqlSchemaConnector::new_sqlite();
-    crate::diff_and_apply(prisma_schema, url, &mut connector).await
+    let params = ConnectorParams::new(url, Default::default(), None);
+    let mut connector = sql_schema_connector::SqlSchemaConnector::new_sqlite(params)?;
+    crate::diff_and_apply(prisma_schema, &mut connector).await
 }

--- a/schema-engine/connectors/mongodb-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/src/lib.rs
@@ -30,6 +30,15 @@ pub struct MongoDbSchemaConnector {
 }
 
 impl MongoDbSchemaConnector {
+    pub fn new_uninitialized() -> Self {
+        Self {
+            connection_string: String::new(),
+            preview_features: BitFlags::empty(),
+            client: OnceCell::new(),
+            host: Arc::new(EmptyHost),
+        }
+    }
+
     pub fn new(params: ConnectorParams) -> Self {
         Self {
             connection_string: params.connection_string,
@@ -66,10 +75,6 @@ impl MongoDbSchemaConnector {
 }
 
 impl SchemaConnector for MongoDbSchemaConnector {
-    fn connection_string(&self) -> Option<&str> {
-        Some(&self.connection_string)
-    }
-
     fn database_schema_from_diff_target<'a>(
         &'a mut self,
         diff_target: DiffTarget<'a>,
@@ -188,12 +193,6 @@ impl SchemaConnector for MongoDbSchemaConnector {
         Err(ConnectorError::from_msg(
             "Rendering to a script is not supported on MongoDB.".to_owned(),
         ))
-    }
-
-    fn set_params(&mut self, params: ConnectorParams) -> ConnectorResult<()> {
-        self.connection_string = params.connection_string;
-        self.preview_features = params.preview_features;
-        Ok(())
     }
 
     fn set_preview_features(&mut self, preview_features: BitFlags<psl::PreviewFeature>) {

--- a/schema-engine/connectors/schema-connector/src/connector_params.rs
+++ b/schema-engine/connectors/schema-connector/src/connector_params.rs
@@ -11,3 +11,18 @@ pub struct ConnectorParams {
     /// The shadow database connection string.
     pub shadow_database_connection_string: Option<String>,
 }
+
+impl ConnectorParams {
+    /// Creates new [`ConnectorParams`].
+    pub fn new(
+        connection_string: String,
+        preview_features: BitFlags<PreviewFeature>,
+        shadow_database_connection_string: Option<String>,
+    ) -> Self {
+        Self {
+            connection_string,
+            preview_features,
+            shadow_database_connection_string,
+        }
+    }
+}

--- a/schema-engine/connectors/schema-connector/src/schema_connector.rs
+++ b/schema-engine/connectors/schema-connector/src/schema_connector.rs
@@ -4,8 +4,8 @@ use enumflags2::BitFlags;
 use psl::ValidatedSchema;
 
 use crate::{
-    migrations_directory::MigrationDirectory, BoxFuture, ConnectorHost, ConnectorParams, ConnectorResult,
-    DatabaseSchema, DestructiveChangeChecker, DestructiveChangeDiagnostics, DiffTarget, IntrospectSqlQueryInput,
+    migrations_directory::MigrationDirectory, BoxFuture, ConnectorHost, ConnectorResult, DatabaseSchema,
+    DestructiveChangeChecker, DestructiveChangeDiagnostics, DiffTarget, IntrospectSqlQueryInput,
     IntrospectSqlQueryOutput, IntrospectionContext, IntrospectionResult, Migration, MigrationPersistence, Namespaces,
 };
 
@@ -16,10 +16,6 @@ pub trait SchemaConnector: Send + Sync + 'static {
 
     /// Accept a new ConnectorHost.
     fn set_host(&mut self, host: Arc<dyn ConnectorHost>);
-
-    /// Accept and validate new ConnectorParams. This should fail if it is called twice on the same
-    /// connector.
-    fn set_params(&mut self, params: ConnectorParams) -> ConnectorResult<()>;
 
     /// Accept a new set of enabled preview features.
     fn set_preview_features(&mut self, preview_features: BitFlags<psl::PreviewFeature>);
@@ -39,9 +35,6 @@ pub trait SchemaConnector: Send + Sync + 'static {
     /// A string that should identify what database backend is being used. Note that this is not necessarily
     /// the connector name. The SQL connector for example can return "postgresql", "mysql" or "sqlite".
     fn connector_type(&self) -> &'static str;
-
-    /// Return the connection string that was used to initialize this connector in set_params().
-    fn connection_string(&self) -> Option<&str>;
 
     /// Create the database referenced by Prisma schema that was used to initialize the connector.
     fn create_database(&mut self) -> BoxFuture<'_, ConnectorResult<String>>;

--- a/schema-engine/connectors/sql-schema-connector/src/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour.rs
@@ -34,8 +34,8 @@ use enumflags2::BitFlags;
 use psl::{PreviewFeature, ValidatedSchema};
 use quaint::prelude::{ConnectionInfo, Table};
 use schema_connector::{
-    migrations_directory::MigrationDirectory, BoxFuture, ConnectorError, ConnectorParams, ConnectorResult,
-    IntrospectionContext, MigrationRecord, Namespaces, PersistenceNotInitializedError,
+    migrations_directory::MigrationDirectory, BoxFuture, ConnectorError, ConnectorResult, IntrospectionContext,
+    MigrationRecord, Namespaces, PersistenceNotInitializedError,
 };
 use sql_schema_describer::SqlSchema;
 use std::fmt::Debug;
@@ -80,14 +80,6 @@ where
             State::Initial => panic!("Internal logic error: get_unwrapped_params() on State::Initial"),
             State::WithParams(p) => p,
             State::Connected(p, _) => p,
-        }
-    }
-
-    #[track_caller]
-    fn set_params(&mut self, params: P) {
-        match self {
-            State::WithParams(_) | State::Connected(_, _) => panic!("state error"),
-            State::Initial => *self = State::WithParams(params),
         }
     }
 
@@ -141,9 +133,6 @@ pub(crate) trait SqlFlavour:
     fn check_schema_features(&self, _schema: &psl::ValidatedSchema) -> ConnectorResult<()> {
         Ok(())
     }
-
-    /// The connection string received in set_params().
-    fn connection_string(&self) -> Option<&str>;
 
     /// See MigrationConnector::connector_type()
     fn connector_type(&self) -> &'static str;
@@ -291,9 +280,6 @@ pub(crate) trait SqlFlavour:
         shadow_database_url: Option<String>,
         namespaces: Option<Namespaces>,
     ) -> BoxFuture<'a, ConnectorResult<SqlSchema>>;
-
-    /// Receive and validate connector params.
-    fn set_params(&mut self, connector_params: ConnectorParams) -> ConnectorResult<()>;
 
     /// Sets the preview features. This is currently useful for MultiSchema, as we want to
     /// grab the namespaces we're expected to diff/work on, which are generally set in

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -22,14 +22,13 @@ use std::{future, str::FromStr};
 
 type State = super::State<Params, Connection>;
 
-#[derive(Clone)]
-pub(crate) struct Params {
-    pub(crate) connector_params: ConnectorParams,
-    pub(crate) url: MssqlUrl,
+struct Params {
+    connector_params: ConnectorParams,
+    url: MssqlUrl,
 }
 
 impl Params {
-    pub(crate) fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
+    fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         let url = MssqlUrl::new(&connector_params.connection_string).map_err(ConnectorError::url_parse_error)?;
         Ok(Self { connector_params, url })
     }
@@ -45,7 +44,7 @@ pub(crate) struct MssqlFlavour {
 
 impl Default for MssqlFlavour {
     fn default() -> Self {
-        MssqlFlavour { state: State::Initial }
+        Self { state: State::Initial }
     }
 }
 
@@ -57,7 +56,7 @@ impl std::fmt::Debug for MssqlFlavour {
 
 impl MssqlFlavour {
     pub fn new_with_params(params: ConnectorParams) -> ConnectorResult<Self> {
-        Ok(MssqlFlavour {
+        Ok(Self {
             state: State::WithParams(Params::new(params)?),
         })
     }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -29,14 +29,13 @@ static QUALIFIED_NAME_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"`[^ ]+
 
 type State = super::State<Params, (BitFlags<Circumstances>, Connection)>;
 
-#[derive(Clone)]
-pub struct Params {
+struct Params {
     connector_params: ConnectorParams,
     url: MysqlUrl,
 }
 
 impl Params {
-    pub(crate) fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
+    fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         let url = connector_params
             .connection_string
             .parse()
@@ -52,7 +51,7 @@ pub(crate) struct MysqlFlavour {
 
 impl Default for MysqlFlavour {
     fn default() -> Self {
-        MysqlFlavour { state: State::Initial }
+        Self { state: State::Initial }
     }
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -42,7 +42,6 @@ SET enable_experimental_alter_column_type_general = true;
 "#;
 
 type State = imp::State;
-pub type Params = imp::Params;
 
 #[derive(Debug, Clone)]
 struct MigratePostgresUrl(PostgresUrl);
@@ -160,24 +159,24 @@ impl PostgresFlavour {
 
     #[cfg(feature = "postgresql-native")]
     pub(crate) fn new_postgres(params: schema_connector::ConnectorParams) -> ConnectorResult<Self> {
-        Ok(PostgresFlavour {
-            state: State::WithParams(Params::new(params)?),
+        Ok(Self {
+            state: State::WithParams(imp::Params::new(params)?),
             provider: PostgresProvider::PostgreSql,
         })
     }
 
     #[cfg(feature = "postgresql-native")]
     pub(crate) fn new_cockroach(params: schema_connector::ConnectorParams) -> ConnectorResult<Self> {
-        Ok(PostgresFlavour {
-            state: State::WithParams(Params::new(params)?),
+        Ok(Self {
+            state: State::WithParams(imp::Params::new(params)?),
             provider: PostgresProvider::CockroachDb,
         })
     }
 
     #[cfg(feature = "postgresql-native")]
     pub(crate) fn new_with_params(params: schema_connector::ConnectorParams) -> ConnectorResult<Self> {
-        Ok(PostgresFlavour {
-            state: State::WithParams(Params::new(params)?),
+        Ok(Self {
+            state: State::WithParams(imp::Params::new(params)?),
             provider: PostgresProvider::Unspecified,
         })
     }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/mod.rs
@@ -26,13 +26,13 @@ use super::{Circumstances, MigratePostgresUrl, PostgresProvider, ADVISORY_LOCK_T
 pub(super) type State = crate::flavour::State<Params, (BitFlags<Circumstances>, Connection)>;
 
 #[derive(Debug, Clone)]
-pub struct Params {
+pub(super) struct Params {
     connector_params: ConnectorParams,
     url: MigratePostgresUrl,
 }
 
 impl Params {
-    pub(crate) fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
+    pub fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         let mut url: Url = connector_params
             .connection_string
             .parse()
@@ -99,7 +99,7 @@ impl Connection {
             };
         }
 
-        Ok(Connection(quaint))
+        Ok(Self(quaint))
     }
 
     pub fn as_connector(&self) -> &connector::PostgreSqlWithNoCache {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/mod.rs
@@ -31,6 +31,19 @@ pub struct Params {
     url: MigratePostgresUrl,
 }
 
+impl Params {
+    pub(crate) fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
+        let mut url: Url = connector_params
+            .connection_string
+            .parse()
+            .map_err(ConnectorError::url_parse_error)?;
+        disable_postgres_statement_cache(&mut url)?;
+
+        let url = MigratePostgresUrl::new(url)?;
+        Ok(Self { connector_params, url })
+    }
+}
+
 pub(super) struct Connection(connector::PostgreSqlWithNoCache);
 
 impl Connection {
@@ -256,12 +269,6 @@ pub(super) async fn drop_database(state: &State) -> ConnectorResult<()> {
     Ok(())
 }
 
-pub(super) fn get_connection_string(state: &State) -> Option<&str> {
-    state
-        .params()
-        .map(|params| params.connector_params.connection_string.as_str())
-}
-
 pub(super) fn get_circumstances(state: &State) -> Option<BitFlags<Circumstances>> {
     match state {
         State::Connected(_, (circumstances, _)) => Some(*circumstances),
@@ -299,20 +306,6 @@ pub(super) async fn get_connection_and_params(
 ) -> ConnectorResult<(&Connection, &Params)> {
     let (conn, params, _) = get_connection_and_params_and_circumstances(state, provider).await?;
     Ok((conn, params))
-}
-
-pub(super) fn set_params(state: &mut State, mut connector_params: ConnectorParams) -> ConnectorResult<()> {
-    let mut url: Url = connector_params
-        .connection_string
-        .parse()
-        .map_err(ConnectorError::url_parse_error)?;
-    disable_postgres_statement_cache(&mut url)?;
-    let connection_string = url.to_string();
-    let url = MigratePostgresUrl::new(url)?;
-    connector_params.connection_string = connection_string;
-    let params = Params { connector_params, url };
-    state.set_params(params);
-    Ok(())
 }
 
 pub(super) fn get_preview_features(state: &State) -> BitFlags<PreviewFeature> {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/shadow_db.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/native/shadow_db.rs
@@ -19,7 +19,6 @@ pub async fn sql_schema_from_migration_history(
             .params()
             .and_then(|p| p.connector_params.shadow_database_connection_string.clone())
     });
-    let mut shadow_database = PostgresFlavour::default();
 
     let is_postgres = provider == PostgresProvider::PostgreSql
         && super::get_circumstances(state).is_none_or(|c| !c.contains(Circumstances::IsCockroachDb));
@@ -33,19 +32,15 @@ pub async fn sql_schema_from_migration_history(
                 )?;
             }
 
-            let shadow_db_params = ConnectorParams {
-                connection_string: shadow_database_connection_string,
-                preview_features: state
-                    .params()
-                    .map(|p| p.connector_params.preview_features)
-                    .unwrap_or_default(),
-                shadow_database_connection_string: None,
-            };
-
-            shadow_database.set_params(shadow_db_params)?;
-            shadow_database.ensure_connection_validity().await?;
+            let preview_features = state
+                .params()
+                .map(|p| p.connector_params.preview_features)
+                .unwrap_or_default();
+            let connector_params = ConnectorParams::new(shadow_database_connection_string, preview_features, None);
+            let mut shadow_database = PostgresFlavour::new_with_params(connector_params)?;
 
             tracing::info!("Connecting to user-provided shadow database.");
+            shadow_database.ensure_connection_validity().await?;
 
             if shadow_database.reset(namespaces.clone()).await.is_err() {
                 crate::best_effort_reset(&mut shadow_database, namespaces.clone()).await?;
@@ -78,12 +73,10 @@ pub async fn sql_schema_from_migration_history(
             } else {
                 shadow_database_url.set_path(&format!("/{shadow_database_name}"));
             }
-            let shadow_db_params = ConnectorParams {
-                connection_string: shadow_database_url.to_string(),
-                preview_features: params.connector_params.preview_features,
-                shadow_database_connection_string: None,
-            };
-            shadow_database.set_params(shadow_db_params)?;
+
+            let preview_features = params.connector_params.preview_features;
+            let connector_params = ConnectorParams::new(shadow_database_url.to_string(), preview_features, None);
+            let mut shadow_database = PostgresFlavour::new_with_params(connector_params)?;
             tracing::debug!("Connecting to shadow database `{}`", shadow_database_name);
             shadow_database.ensure_connection_validity().await?;
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/wasm/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/wasm/mod.rs
@@ -15,7 +15,6 @@ pub(super) struct State {
     preview_features: BitFlags<PreviewFeature>,
 }
 
-#[derive(Default)]
 pub(super) struct Params;
 
 impl State {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/wasm/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/wasm/mod.rs
@@ -15,6 +15,7 @@ pub(super) struct State {
     preview_features: BitFlags<PreviewFeature>,
 }
 
+#[derive(Default)]
 pub(super) struct Params;
 
 impl State {
@@ -88,10 +89,6 @@ pub(super) async fn drop_database(state: &State) -> ConnectorResult<()> {
     panic!("[sql-schema-connector::flavour::postgres::wasm] Not implemented");
 }
 
-pub(super) fn get_connection_string(_state: &State) -> Option<&str> {
-    panic!("[sql-schema-connector::flavour::postgres::wasm] Not implemented");
-}
-
 pub(super) fn get_circumstances(state: &State) -> Option<BitFlags<Circumstances>> {
     Some(state.circumstances)
 }
@@ -112,10 +109,6 @@ pub(super) async fn get_connection_and_params(
     _provider: PostgresProvider,
 ) -> ConnectorResult<(&Connection, &Params)> {
     Ok((&state.connection, &Params))
-}
-
-pub(super) fn set_params(_state: &mut State, _params: ConnectorParams) -> ConnectorResult<()> {
-    panic!("[sql-schema-connector::flavour::postgres::wasm] Not implemented");
 }
 
 pub(super) fn get_preview_features(state: &State) -> BitFlags<PreviewFeature> {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
@@ -20,7 +20,6 @@ use schema_connector::{
 use sql_schema_describer::{sqlite::SqlSchemaDescriber, DescriberErrorKind, SqlSchema};
 
 type State = imp::State;
-pub type Params = imp::Params;
 
 pub(crate) struct SqliteFlavour {
     state: State,
@@ -43,22 +42,22 @@ impl SqliteFlavour {
 #[cfg(feature = "sqlite-native")]
 impl Default for SqliteFlavour {
     fn default() -> Self {
-        SqliteFlavour { state: State::Initial }
+        Self { state: State::Initial }
     }
 }
 
 impl SqliteFlavour {
     #[cfg(not(feature = "sqlite-native"))]
     pub(crate) fn new_external(adapter: std::sync::Arc<dyn quaint::connector::ExternalConnector>) -> Self {
-        SqliteFlavour {
+        Self {
             state: State::new(adapter, Default::default()),
         }
     }
 
     #[cfg(feature = "sqlite-native")]
     pub fn new_with_params(params: schema_connector::ConnectorParams) -> ConnectorResult<Self> {
-        Ok(SqliteFlavour {
-            state: State::WithParams(Params::new(params)?),
+        Ok(Self {
+            state: State::WithParams(imp::Params::new(params)?),
         })
     }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/native/mod.rs
@@ -12,7 +12,7 @@ use user_facing_errors::schema_engine::ApplyMigrationError;
 
 pub(super) type State = crate::flavour::State<Params, Connection>;
 
-pub struct Params {
+pub(super) struct Params {
     connector_params: ConnectorParams,
     file_path: String,
 }
@@ -33,8 +33,8 @@ impl Params {
 pub(super) struct Connection(Mutex<rusqlite::Connection>);
 
 impl Connection {
-    pub fn new(params: &super::Params) -> ConnectorResult<Self> {
-        Ok(Connection(Mutex::new(
+    pub fn new(params: &Params) -> ConnectorResult<Self> {
+        Ok(Self(Mutex::new(
             rusqlite::Connection::open(&params.file_path).map_err(convert_error)?,
         )))
     }
@@ -44,7 +44,7 @@ impl Connection {
     }
 
     pub fn new_in_memory() -> Self {
-        Connection(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()))
+        Self(Mutex::new(rusqlite::Connection::open_in_memory().unwrap()))
     }
 
     pub async fn raw_cmd(&self, sql: &str) -> ConnectorResult<()> {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/native/mod.rs
@@ -11,7 +11,24 @@ use std::sync::Mutex;
 use user_facing_errors::schema_engine::ApplyMigrationError;
 
 pub(super) type State = crate::flavour::State<Params, Connection>;
-pub(super) type Params = super::Params;
+
+pub struct Params {
+    connector_params: ConnectorParams,
+    file_path: String,
+}
+
+impl Params {
+    pub fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
+        let quaint::connector::SqliteParams { file_path, .. } =
+            quaint::connector::SqliteParams::try_from(connector_params.connection_string.as_str())
+                .map_err(ConnectorError::url_parse_error)?;
+
+        Ok(Self {
+            connector_params,
+            file_path,
+        })
+    }
+}
 
 pub(super) struct Connection(Mutex<rusqlite::Connection>);
 
@@ -228,12 +245,6 @@ pub(super) async fn introspect(state: &mut State) -> ConnectorResult<SqlSchema> 
     super::describe_schema(get_connection_and_params(state)?.0).await
 }
 
-pub(super) fn get_connection_string(state: &State) -> Option<&str> {
-    state
-        .params()
-        .map(|params| params.connector_params.connection_string.as_str())
-}
-
 pub(super) fn get_connection_and_params(state: &mut State) -> ConnectorResult<(&mut Connection, &mut Params)> {
     match state {
         super::State::Initial => panic!("logic error: Initial"),
@@ -248,18 +259,6 @@ pub(super) fn get_connection_and_params(state: &mut State) -> ConnectorResult<(&
             get_connection_and_params(state)
         }
     }
-}
-
-pub(super) fn set_params(state: &mut State, params: ConnectorParams) -> ConnectorResult<()> {
-    let quaint::connector::SqliteParams { file_path, .. } =
-        quaint::connector::SqliteParams::try_from(params.connection_string.as_str())
-            .map_err(ConnectorError::url_parse_error)?;
-
-    state.set_params(Params {
-        connector_params: params,
-        file_path,
-    });
-    Ok(())
 }
 
 pub(super) fn set_preview_features(state: &mut State, preview_features: enumflags2::BitFlags<psl::PreviewFeature>) {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/wasm/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/wasm/mod.rs
@@ -95,16 +95,8 @@ pub(super) async fn introspect(state: &mut State) -> ConnectorResult<SqlSchema> 
     super::describe_schema(&state.connection).await
 }
 
-pub(super) fn get_connection_string(_state: &State) -> Option<&str> {
-    panic!("[sql-schema-connector::flavour::sqlite::wasm] Not implemented");
-}
-
 pub(super) fn get_connection_and_params(state: &mut State) -> ConnectorResult<(&Connection, &Params)> {
     Ok((&state.connection, &Params))
-}
-
-pub(super) fn set_params(_state: &mut State, params: ConnectorParams) -> ConnectorResult<()> {
-    panic!("[sql-schema-connector::flavour::sqlite::wasm] Not implemented");
 }
 
 pub(super) fn set_preview_features(state: &mut State, features: BitFlags<PreviewFeature>) {

--- a/schema-engine/connectors/sql-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/lib.rs
@@ -59,20 +59,20 @@ impl SqlSchemaConnector {
 
     /// Initialize a PostgreSQL migration connector.
     #[cfg(feature = "postgresql-native")]
-    pub fn new_postgres() -> Self {
-        SqlSchemaConnector {
-            flavour: Box::new(flavour::PostgresFlavour::new_postgres()),
+    pub fn new_postgres(params: ConnectorParams) -> ConnectorResult<Self> {
+        Ok(SqlSchemaConnector {
+            flavour: Box::new(flavour::PostgresFlavour::new_postgres(params)?),
             host: Arc::new(EmptyHost),
-        }
+        })
     }
 
     /// Initialize a CockroachDb migration connector.
     #[cfg(feature = "cockroachdb-native")]
-    pub fn new_cockroach() -> Self {
-        SqlSchemaConnector {
-            flavour: Box::new(flavour::PostgresFlavour::new_cockroach()),
+    pub fn new_cockroach(params: ConnectorParams) -> ConnectorResult<Self> {
+        Ok(SqlSchemaConnector {
+            flavour: Box::new(flavour::PostgresFlavour::new_cockroach(params)?),
             host: Arc::new(EmptyHost),
-        }
+        })
     }
 
     /// Initialize a PostgreSQL-like schema connector.
@@ -80,36 +80,76 @@ impl SqlSchemaConnector {
     /// Use [`Self::new_postgres()`] or [`Self::new_cockroach()`] instead when the provider is
     /// explicitly specified by user or already known otherwise.
     #[cfg(any(feature = "postgresql-native", feature = "cockroachdb-native"))]
-    pub fn new_postgres_like() -> Self {
-        SqlSchemaConnector {
-            flavour: Box::<flavour::PostgresFlavour>::default(),
+    pub fn new_postgres_like(params: ConnectorParams) -> ConnectorResult<Self> {
+        Ok(SqlSchemaConnector {
+            flavour: Box::new(flavour::PostgresFlavour::new_with_params(params)?),
             host: Arc::new(EmptyHost),
-        }
+        })
     }
 
     /// Initialize a SQLite migration connector.
     #[cfg(feature = "sqlite-native")]
-    pub fn new_sqlite() -> Self {
-        SqlSchemaConnector {
-            flavour: Box::<flavour::SqliteFlavour>::default(),
+    pub fn new_sqlite(params: ConnectorParams) -> ConnectorResult<Self> {
+        Ok(SqlSchemaConnector {
+            flavour: Box::new(flavour::SqliteFlavour::new_with_params(params)?),
             host: Arc::new(EmptyHost),
-        }
+        })
     }
 
     /// Initialize a MySQL migration connector.
     #[cfg(feature = "mysql-native")]
-    pub fn new_mysql() -> Self {
-        SqlSchemaConnector {
-            flavour: Box::<flavour::MysqlFlavour>::default(),
+    pub fn new_mysql(params: ConnectorParams) -> ConnectorResult<Self> {
+        Ok(SqlSchemaConnector {
+            flavour: Box::new(flavour::MysqlFlavour::new_with_params(params)?),
             host: Arc::new(EmptyHost),
-        }
+        })
     }
 
     /// Initialize a MSSQL migration connector.
     #[cfg(feature = "mssql-native")]
-    pub fn new_mssql() -> Self {
-        SqlSchemaConnector {
-            flavour: Box::<flavour::MssqlFlavour>::default(),
+    pub fn new_mssql(params: ConnectorParams) -> ConnectorResult<Self> {
+        Ok(SqlSchemaConnector {
+            flavour: Box::new(flavour::MssqlFlavour::new_with_params(params)?),
+            host: Arc::new(EmptyHost),
+        })
+    }
+
+    /// Create a new uninitialized MySQL migration connector.
+    #[cfg(feature = "mysql-native")]
+    pub fn new_uninitialized_mysql() -> Self {
+        Self::new_uninitialized_flavour::<flavour::MysqlFlavour>()
+    }
+
+    /// Create a new uninitialized MSSQL migration connector.
+    #[cfg(feature = "mssql-native")]
+    pub fn new_uninitialized_mssql() -> Self {
+        Self::new_uninitialized_flavour::<flavour::MssqlFlavour>()
+    }
+
+    /// Create a new uninitialized SQLite migration connector.
+    #[cfg(feature = "sqlite-native")]
+    pub fn new_uninitialized_sqlite() -> Self {
+        Self::new_uninitialized_flavour::<flavour::SqliteFlavour>()
+    }
+
+    /// Create a new uninitialized PostgreSQL migration connector.
+    #[cfg(feature = "postgresql-native")]
+    pub fn new_uninitialized_postgres() -> Self {
+        Self::new_uninitialized_flavour::<flavour::PostgresFlavour>()
+    }
+
+    /// Create a new uninitialized CockroachDB migration connector.
+    #[cfg(feature = "cockroachdb-native")]
+    pub fn new_uninitialized_cockroachdb() -> Self {
+        Self {
+            flavour: Box::new(flavour::PostgresFlavour::new_uninitialized_cockroach()),
+            host: Arc::new(EmptyHost),
+        }
+    }
+
+    fn new_uninitialized_flavour<Flavour: SqlFlavour + Default + 'static>() -> Self {
+        Self {
+            flavour: Box::new(Flavour::default()),
             host: Arc::new(EmptyHost),
         }
     }
@@ -146,11 +186,6 @@ impl SqlSchemaConnector {
     /// For tests
     pub async fn raw_cmd(&mut self, sql: &str) -> ConnectorResult<()> {
         self.flavour.raw_cmd(sql).await
-    }
-
-    /// Prepare the connector to connect.
-    pub fn set_params(&mut self, params: ConnectorParams) -> ConnectorResult<()> {
-        self.flavour.set_params(params)
     }
 
     async fn db_schema_from_diff_target(
@@ -193,16 +228,8 @@ impl SchemaConnector for SqlSchemaConnector {
         self.host = host;
     }
 
-    fn set_params(&mut self, params: ConnectorParams) -> ConnectorResult<()> {
-        self.flavour.set_params(params)
-    }
-
     fn set_preview_features(&mut self, preview_features: BitFlags<psl::PreviewFeature>) {
         self.flavour.set_preview_features(preview_features)
-    }
-
-    fn connection_string(&self) -> Option<&str> {
-        self.flavour.connection_string()
     }
 
     fn connector_type(&self) -> &'static str {

--- a/schema-engine/core/src/commands/diff.rs
+++ b/schema-engine/core/src/commands/diff.rs
@@ -176,7 +176,7 @@ async fn json_rpc_diff_target_to_connector(
             let provider = schema_connector::migrations_directory::read_provider_from_lock_file(path);
             match (provider.as_deref(), shadow_database_url) {
                 (Some(provider), Some(shadow_database_url)) => {
-                    let mut connector = crate::connector_for_provider(provider)?;
+                    let mut connector = crate::uninitialized_connector_for_provider(provider)?;
                     connector.set_preview_features(preview_features);
                     let directories = schema_connector::migrations_directory::list_migrations(Path::new(path))?;
                     let schema = connector
@@ -189,7 +189,7 @@ async fn json_rpc_diff_target_to_connector(
                     Ok(Some((connector, schema)))
                 }
                 (Some("sqlite"), None) => {
-                    let mut connector = crate::connector_for_provider("sqlite")?;
+                    let mut connector = crate::uninitialized_connector_for_provider("sqlite")?;
                     connector.set_preview_features(preview_features);
                     let directories = schema_connector::migrations_directory::list_migrations(Path::new(path))?;
                     let schema = connector

--- a/schema-engine/sql-introspection-tests/src/test_api.rs
+++ b/schema-engine/sql-introspection-tests/src/test_api.rs
@@ -45,14 +45,12 @@ impl TestApi {
         let namespaces: Vec<String> = args.namespaces().iter().map(|ns| ns.to_string()).collect();
         let (database, connection_string, api): (Quaint, String, SqlSchemaConnector) = if tags.intersects(Tags::Vitess)
         {
-            let mut me = SqlSchemaConnector::new_mysql();
-
             let params = ConnectorParams {
                 connection_string: connection_string.to_owned(),
                 preview_features,
                 shadow_database_connection_string: None,
             };
-            me.set_params(params).unwrap();
+            let mut me = SqlSchemaConnector::new_mysql(params).unwrap();
 
             me.reset(true, schema_connector::Namespaces::from_vec(&mut namespaces.clone()))
                 .await
@@ -65,26 +63,22 @@ impl TestApi {
             )
         } else if tags.contains(Tags::Mysql) {
             let (_, cs) = args.create_mysql_database().await;
-            let mut me = SqlSchemaConnector::new_mysql();
-
             let params = ConnectorParams {
                 connection_string: cs.to_owned(),
                 preview_features,
                 shadow_database_connection_string: None,
             };
-            me.set_params(params).unwrap();
+            let me = SqlSchemaConnector::new_mysql(params).unwrap();
 
             (Quaint::new(&cs).await.unwrap(), cs, me)
         } else if tags.contains(Tags::Postgres) && !tags.contains(Tags::CockroachDb) {
             let (_, q, cs) = args.create_postgres_database().await;
-            let mut me = SqlSchemaConnector::new_postgres();
-
             let params = ConnectorParams {
                 connection_string: cs.to_owned(),
                 preview_features,
                 shadow_database_connection_string: None,
             };
-            me.set_params(params).unwrap();
+            let me = SqlSchemaConnector::new_postgres(params).unwrap();
 
             (q, cs, me)
         } else if tags.contains(Tags::CockroachDb) {
@@ -98,40 +92,34 @@ impl TestApi {
             .await
             .unwrap();
 
-            let mut me = SqlSchemaConnector::new_cockroach();
-
             let params = ConnectorParams {
                 connection_string: cs.to_owned(),
                 preview_features,
                 shadow_database_connection_string: None,
             };
-            me.set_params(params).unwrap();
+            let me = SqlSchemaConnector::new_cockroach(params).unwrap();
 
             (q, cs, me)
         } else if tags.contains(Tags::Mssql) {
             let (q, cs) = args.create_mssql_database().await;
 
-            let mut me = SqlSchemaConnector::new_mssql();
-
             let params = ConnectorParams {
                 connection_string: cs.to_owned(),
                 preview_features,
                 shadow_database_connection_string: None,
             };
-            me.set_params(params).unwrap();
+            let me = SqlSchemaConnector::new_mssql(params).unwrap();
 
             (q, cs, me)
         } else if tags.contains(Tags::Sqlite) {
             let url = sqlite_test_url(args.test_function_name());
-
-            let mut me = SqlSchemaConnector::new_sqlite();
 
             let params = ConnectorParams {
                 connection_string: url.to_owned(),
                 preview_features,
                 shadow_database_connection_string: None,
             };
-            me.set_params(params).unwrap();
+            let me = SqlSchemaConnector::new_sqlite(params).unwrap();
 
             (Quaint::new(&url).await.unwrap(), url, me)
         } else {

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
@@ -36,13 +36,12 @@ async fn introspecting_cockroach_db_with_postgres_provider_fails(api: TestApi) {
     // Instantiate the schema connector manually for this test because `TestApi`
     // chooses the provider type based on the current database under test and
     // not on the `provider` field in the schema.
-    let mut engine = SqlSchemaConnector::new_postgres();
     let params = ConnectorParams {
         connection_string: api.connection_string().to_owned(),
         preview_features: api.preview_features(),
         shadow_database_connection_string: None,
     };
-    engine.set_params(params).unwrap();
+    let mut engine = SqlSchemaConnector::new_postgres(params).unwrap();
 
     let err = engine.introspect(&ctx).await.unwrap_err().to_string();
 

--- a/schema-engine/sql-introspection-tests/tests/simple.rs
+++ b/schema-engine/sql-introspection-tests/tests/simple.rs
@@ -146,31 +146,11 @@ source .test_database_urls/mysql_5_6
     };
 
     let mut api = match provider {
-        "cockroachdb" => {
-            let mut api = SqlSchemaConnector::new_cockroach();
-            api.set_params(params).unwrap();
-            api
-        }
-        "postgres" | "postgresql" => {
-            let mut api = SqlSchemaConnector::new_postgres();
-            api.set_params(params).unwrap();
-            api
-        }
-        "mysql" => {
-            let mut api = SqlSchemaConnector::new_mysql();
-            api.set_params(params).unwrap();
-            api
-        }
-        "sqlserver" => {
-            let mut api = SqlSchemaConnector::new_mssql();
-            api.set_params(params).unwrap();
-            api
-        }
-        "sqlite" => {
-            let mut api = SqlSchemaConnector::new_sqlite();
-            api.set_params(params).unwrap();
-            api
-        }
+        "cockroachdb" => SqlSchemaConnector::new_cockroach(params).unwrap(),
+        "postgres" | "postgresql" => SqlSchemaConnector::new_postgres(params).unwrap(),
+        "mysql" => SqlSchemaConnector::new_mysql(params).unwrap(),
+        "sqlserver" => SqlSchemaConnector::new_mssql(params).unwrap(),
+        "sqlite" => SqlSchemaConnector::new_sqlite(params).unwrap(),
         _ => unreachable!(),
     };
 

--- a/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
+++ b/schema-engine/sql-introspection-tests/tests/tables/mysql.rs
@@ -111,7 +111,7 @@ async fn a_table_with_length_prefixed_index(api: &mut TestApi) -> TestResult {
             `a`  TEXT NOT NULL,
             `b`  TEXT NOT NULL
         );
-        
+
         CREATE INDEX A_a_b_idx ON `A` (a(30), b(20));
     "#};
 
@@ -140,7 +140,7 @@ async fn a_table_with_non_length_prefixed_index(api: &mut TestApi) -> TestResult
             `a`  VARCHAR(190) NOT NULL,
             `b`  VARCHAR(192) NOT NULL
         );
-        
+
         CREATE INDEX A_a_idx ON `A` (a);
         CREATE INDEX A_b_idx ON `A` (b(191));
     "#};
@@ -171,7 +171,7 @@ async fn a_table_with_descending_index(api: &mut TestApi) -> TestResult {
             `a`  INT NOT NULL,
             `b`  INT NOT NULL
         );
-        
+
         CREATE INDEX A_a_b_idx ON `A` (a ASC, b DESC);
     "#};
 
@@ -200,7 +200,7 @@ async fn a_table_with_descending_unique(api: &mut TestApi) -> TestResult {
             `a`  INT NOT NULL,
             `b`  INT NOT NULL
         );
-        
+
         CREATE UNIQUE INDEX A_a_b_key ON `A` (a ASC, b DESC);
     "#};
 
@@ -229,7 +229,7 @@ async fn a_table_with_fulltext_index(api: &mut TestApi) -> TestResult {
             `a`  VARCHAR(255) NOT NULL,
             `b`  TEXT         NOT NULL
         );
-        
+
         CREATE FULLTEXT INDEX A_a_b_idx ON `A` (a, b);
     "#};
 
@@ -258,7 +258,7 @@ async fn a_table_with_fulltext_index_with_custom_name(api: &mut TestApi) -> Test
             `a`  VARCHAR(255) NOT NULL,
             `b`  TEXT         NOT NULL
         );
-        
+
         CREATE FULLTEXT INDEX custom_name ON `A` (a, b);
     "#};
 
@@ -378,8 +378,7 @@ async fn missing_select_rights(api: &mut TestApi) -> TestResult {
         shadow_database_connection_string: None,
     };
 
-    let mut conn = SqlSchemaConnector::new_mysql();
-    conn.set_params(params).unwrap();
+    let mut conn = SqlSchemaConnector::new_mysql(params).unwrap();
 
     let datasource = formatdoc!(
         r#"

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -50,8 +50,7 @@ impl TestApi {
                 preview_features,
                 shadow_database_connection_string: args.shadow_database_url().map(String::from),
             };
-            let mut conn = SqlSchemaConnector::new_mysql();
-            conn.set_params(params).unwrap();
+            let mut conn = SqlSchemaConnector::new_mysql(params).unwrap();
             tok(conn.reset(false, None)).unwrap();
 
             (
@@ -195,22 +194,23 @@ impl TestApi {
             shadow_database_connection_string,
         };
 
-        let mut connector = match &connection_info {
+        let connector = match &connection_info {
             ConnectionInfo::Native(NativeConnectionInfo::Postgres(_)) => {
                 if self.args.provider() == "cockroachdb" {
-                    SqlSchemaConnector::new_cockroach()
+                    SqlSchemaConnector::new_cockroach(params).unwrap()
                 } else {
-                    SqlSchemaConnector::new_postgres()
+                    SqlSchemaConnector::new_postgres(params).unwrap()
                 }
             }
-            ConnectionInfo::Native(NativeConnectionInfo::Mysql(_)) => SqlSchemaConnector::new_mysql(),
-            ConnectionInfo::Native(NativeConnectionInfo::Mssql(_)) => SqlSchemaConnector::new_mssql(),
-            ConnectionInfo::Native(NativeConnectionInfo::Sqlite { .. }) => SqlSchemaConnector::new_sqlite(),
+            ConnectionInfo::Native(NativeConnectionInfo::Mysql(_)) => SqlSchemaConnector::new_mysql(params).unwrap(),
+            ConnectionInfo::Native(NativeConnectionInfo::Mssql(_)) => SqlSchemaConnector::new_mssql(params).unwrap(),
+            ConnectionInfo::Native(NativeConnectionInfo::Sqlite { .. }) => {
+                SqlSchemaConnector::new_sqlite(params).unwrap()
+            }
             ConnectionInfo::Native(NativeConnectionInfo::InMemorySqlite { .. }) | ConnectionInfo::External(_) => {
                 unreachable!()
             }
         };
-        connector.set_params(params).unwrap();
 
         EngineTestApi {
             connector,

--- a/schema-engine/sql-migration-tests/tests/migrations/mssql/multi_schema.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/mssql/multi_schema.rs
@@ -1177,9 +1177,8 @@ async fn migration_with_shadow_database() {
     let namespaces = Namespaces::from_vec(&mut vec![String::from("dbo"), String::from("one"), String::from("two")]);
 
     let mut conn = {
-        let mut conn = SqlSchemaConnector::new_mssql();
+        let mut conn = SqlSchemaConnector::new_mssql(params).unwrap();
 
-        conn.set_params(params).unwrap();
         let _ = conn.raw_cmd("DROP DATABASE shadow").await;
 
         conn.raw_cmd("CREATE DATABASE shadow").await.unwrap();

--- a/schema-engine/sql-migration-tests/tests/migrations/postgres/multi_schema.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/postgres/multi_schema.rs
@@ -1410,9 +1410,8 @@ async fn migration_with_shadow_database() {
     let namespaces = Namespaces::from_vec(&mut vec![String::from("dbo"), String::from("one"), String::from("two")]);
 
     let mut conn = {
-        let mut conn = SqlSchemaConnector::new_postgres();
+        let mut conn = SqlSchemaConnector::new_postgres(params).unwrap();
 
-        conn.set_params(params).unwrap();
         let _ = conn.raw_cmd("DROP DATABASE shadow").await;
 
         conn.raw_cmd("CREATE DATABASE shadow").await.unwrap();

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
@@ -83,8 +83,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
             preview_features: Default::default(),
             shadow_database_connection_string: None,
         };
-        let mut conn = SqlSchemaConnector::new_mysql();
-        conn.set_params(params).unwrap();
+        let mut conn = SqlSchemaConnector::new_mysql(params).unwrap();
         tok(conn.reset(false, None)).unwrap();
         test_api_args.database_url().to_owned()
     } else if tags.contains(Tags::Mysql) {


### PR DESCRIPTION
Closes [ORM-704](https://linear.app/prisma-company/issue/ORM-704/get-rid-of-every-reference-to-set-params-and-connection-string).
The changes are pretty simple, one thing worth noting is that I needed to add a `uninitialized_connector_for_provider` in order to support creating connectors that never connect to a database, we require that for some CLI workflows like diffing against a model from a schema file.