### PR TITLE
fix(driver-adapters): Partially removed error capturing

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -1,6 +1,6 @@
 import * as util from 'node:util'
 import {
-  ErrorCapturingSqlQueryable,
+  SqlQueryable,
   IsolationLevel,
 } from '@prisma/driver-adapter-utils'
 import { JsonProtocolQuery, QueryParams } from '../types/jsonRpc'
@@ -25,7 +25,7 @@ export function query(
 
 class QueryPipeline {
   private compiler: QueryCompiler
-  private driverAdapter: ErrorCapturingSqlQueryable
+  private driverAdapter: SqlQueryable
   private transactionManager: TransactionManager
 
   constructor(
@@ -75,7 +75,7 @@ class QueryPipeline {
   }
 
   private async executeQuery(
-    queryable: ErrorCapturingSqlQueryable,
+    queryable: SqlQueryable,
     query: JsonProtocolQuery,
   ) {
     const queryPlanString = withLocalPanicHandler(() =>

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -1,233 +1,227 @@
-import { Schema as S } from '@effect/schema'
-import {
-  bindAdapter,
-  ConnectionInfo,
-  ErrorCapturingSqlDriverAdapter,
-} from '@prisma/driver-adapter-utils'
-import { DriverAdaptersManager } from '../driver-adapters-manager'
+import {Schema as S} from '@effect/schema'
+import type {ConnectionInfo, SqlDriverAdapter} from '@prisma/driver-adapter-utils'
+import {DriverAdaptersManager} from '../driver-adapters-manager'
 import * as qc from '../query-compiler'
-import { TransactionManager } from '@prisma/client-engine-runtime'
-import { parentPort } from 'worker_threads'
+import {TransactionManager} from '@prisma/client-engine-runtime'
+import {parentPort} from 'worker_threads'
 import {
-  CommitTxParams,
-  InitializeSchemaParams,
-  QueryParams,
-  RollbackTxParams,
-  StartTxParams,
+    CommitTxParams,
+    InitializeSchemaParams,
+    QueryParams,
+    RollbackTxParams,
+    StartTxParams,
 } from '../types/jsonRpc'
-import { assertNever, debug } from '../utils'
-import { setupDriverAdaptersManager } from '../setup'
-import { Env } from '../types'
-import { query } from './worker-query'
+import {assertNever, debug} from '../utils'
+import {setupDriverAdaptersManager} from '../setup'
+import {Env} from '../types'
+import {query} from './worker-query'
 import {
-  commitTransaction,
-  rollbackTransaction,
-  startTransaction,
+    commitTransaction,
+    rollbackTransaction,
+    startTransaction,
 } from './worker-transaction'
-import { setupDefaultPanicHandler } from '../panic'
+import {setupDefaultPanicHandler} from '../panic'
 
 const InitializeSchemaMessage = S.struct({
-  type: S.literal('initializeSchema'),
-  responsePort: S.instanceOf(MessagePort),
-  params: InitializeSchemaParams,
-  env: Env,
+    type: S.literal('initializeSchema'),
+    responsePort: S.instanceOf(MessagePort),
+    params: InitializeSchemaParams,
+    env: Env,
 })
 
 const QueryMessage = S.struct({
-  type: S.literal('query'),
-  responsePort: S.instanceOf(MessagePort),
-  params: QueryParams,
+    type: S.literal('query'),
+    responsePort: S.instanceOf(MessagePort),
+    params: QueryParams,
 })
 
 const StartTransactionMessage = S.struct({
-  type: S.literal('startTx'),
-  responsePort: S.instanceOf(MessagePort),
-  params: StartTxParams,
+    type: S.literal('startTx'),
+    responsePort: S.instanceOf(MessagePort),
+    params: StartTxParams,
 })
 
 const CommitTransactionMessage = S.struct({
-  type: S.literal('commitTx'),
-  responsePort: S.instanceOf(MessagePort),
-  params: CommitTxParams,
+    type: S.literal('commitTx'),
+    responsePort: S.instanceOf(MessagePort),
+    params: CommitTxParams,
 })
 
 const RollbackTransactionMessage = S.struct({
-  type: S.literal('rollbackTx'),
-  responsePort: S.instanceOf(MessagePort),
-  params: RollbackTxParams,
+    type: S.literal('rollbackTx'),
+    responsePort: S.instanceOf(MessagePort),
+    params: RollbackTxParams,
 })
 
 const TeardownMessage = S.struct({
-  type: S.literal('teardown'),
-  responsePort: S.instanceOf(MessagePort),
+    type: S.literal('teardown'),
+    responsePort: S.instanceOf(MessagePort),
 })
 
 const GetLogsMessage = S.struct({
-  type: S.literal('getLogs'),
-  responsePort: S.instanceOf(MessagePort),
+    type: S.literal('getLogs'),
+    responsePort: S.instanceOf(MessagePort),
 })
 
 const Message = S.union(
-  InitializeSchemaMessage,
-  QueryMessage,
-  StartTransactionMessage,
-  CommitTransactionMessage,
-  RollbackTransactionMessage,
-  TeardownMessage,
-  GetLogsMessage,
+    InitializeSchemaMessage,
+    QueryMessage,
+    StartTransactionMessage,
+    CommitTransactionMessage,
+    RollbackTransactionMessage,
+    TeardownMessage,
+    GetLogsMessage,
 )
 
 export type Message = S.Schema.Type<typeof Message>
 
 export type State = {
-  compiler: qc.QueryCompiler
-  driverAdapterManager: DriverAdaptersManager
-  driverAdapter: ErrorCapturingSqlDriverAdapter
-  transactionManager: TransactionManager
+    compiler: qc.QueryCompiler
+    driverAdapterManager: DriverAdaptersManager
+    driverAdapter: SqlDriverAdapter
+    transactionManager: TransactionManager
 }
 
 let state: State | undefined
 const logs: string[] = []
 
 if (!parentPort) {
-  throw new Error('This module must be run in a worker thread')
+    throw new Error('This module must be run in a worker thread')
 }
 
 setupDefaultPanicHandler()
 
 parentPort.on('message', async (rawMsg: unknown) => {
-  const msg = S.decodeUnknownSync(Message)(rawMsg)
-  let response: unknown
+    const msg = S.decodeUnknownSync(Message)(rawMsg)
+    let response: unknown
 
-  debug('worker received message:', msg.type)
+    debug('worker received message:', msg.type)
 
-  try {
-    response = await dispatchMessage(msg)
-  } catch (error) {
-    if (!(error instanceof Error)) {
-      // TODO: we should have a nicer mapping for driver adapter errors
-      error = new Error(JSON.stringify(error))
+    try {
+        response = await dispatchMessage(msg)
+    } catch (error) {
+        if (!(error instanceof Error)) {
+            // TODO: we should have a nicer mapping for driver adapter errors
+            error = new Error(JSON.stringify(error))
+        }
+        msg.responsePort.postMessage(error)
+        return
     }
-    msg.responsePort.postMessage(error)
-    return
-  }
 
-  msg.responsePort.postMessage(response)
+    msg.responsePort.postMessage(response)
 })
 
 async function dispatchMessage(msg: Message): Promise<unknown> {
-  switch (msg.type) {
-    case 'initializeSchema':
-      return initializeSchema(msg.params, msg.env)
-    case 'query':
-      return query(msg.params, unwrapState(), logs)
-    case 'startTx':
-      return startTransaction(msg.params.options, unwrapState())
-    case 'commitTx':
-      return commitTransaction(msg.params.txId, unwrapState())
-    case 'rollbackTx':
-      return rollbackTransaction(msg.params.txId, unwrapState())
-    case 'teardown':
-      return teardown(unwrapState())
-    case 'getLogs':
-      return logs
-    default:
-      assertNever(
-        msg,
-        `Unknown message type: \`${(msg as { type: unknown }).type}\``,
-      )
-  }
+    switch (msg.type) {
+        case 'initializeSchema':
+            return initializeSchema(msg.params, msg.env)
+        case 'query':
+            return query(msg.params, unwrapState(), logs)
+        case 'startTx':
+            return startTransaction(msg.params.options, unwrapState())
+        case 'commitTx':
+            return commitTransaction(msg.params.txId, unwrapState())
+        case 'rollbackTx':
+            return rollbackTransaction(msg.params.txId, unwrapState())
+        case 'teardown':
+            return teardown(unwrapState())
+        case 'getLogs':
+            return logs
+        default:
+            assertNever(
+                msg,
+                `Unknown message type: \`${(msg as { type: unknown }).type}\``,
+            )
+    }
 }
 
 function unwrapState(): State {
-  if (state === undefined) {
-    throw new Error('State is not initialized, call `initializeSchema` first')
-  }
-  return state
+    if (state === undefined) {
+        throw new Error('State is not initialized, call `initializeSchema` first')
+    }
+    return state
 }
 
 async function initializeSchema(
-  params: InitializeSchemaParams,
-  env: Env,
+    params: InitializeSchemaParams,
+    env: Env,
 ): Promise<ConnectionInfo> {
-  const { url, schema, migrationScript } = params
+    const {url, schema, migrationScript} = params
 
-  const driverAdapterManager = await setupDriverAdaptersManager(
-    env,
-    migrationScript,
-  )
+    const driverAdapterManager = await setupDriverAdaptersManager(
+        env,
+        migrationScript,
+    )
 
-  const { compiler, adapter } = await initQueryCompiler({
-    url,
-    driverAdapterManager,
-    schema,
-  })
+    const {compiler, adapter} = await initQueryCompiler({
+        url,
+        driverAdapterManager,
+        schema,
+    })
 
-  const errorCapturingAdapter = bindAdapter(adapter)
+    const transactionManager = new TransactionManager({
+        driverAdapter: adapter,
+    })
 
-  const transactionManager = new TransactionManager({
-    driverAdapter: errorCapturingAdapter,
-  })
+    state = {
+        compiler,
+        driverAdapterManager,
+        driverAdapter: adapter,
+        transactionManager,
+    }
 
-  state = {
-    compiler,
-    driverAdapterManager,
-    driverAdapter: errorCapturingAdapter,
-    transactionManager,
-  }
+    if (adapter.getConnectionInfo) {
+        return adapter.getConnectionInfo()
+    }
 
-  if (adapter.getConnectionInfo) {
-    return adapter.getConnectionInfo()
-  }
-
-  return { maxBindValues: undefined }
+    return {maxBindValues: undefined}
 }
 
 type InitQueryCompilerParams = {
-  driverAdapterManager: DriverAdaptersManager
-  url: string
-  schema: string
+    driverAdapterManager: DriverAdaptersManager
+    url: string
+    schema: string
 }
 
 async function initQueryCompiler({
-  driverAdapterManager,
-  url,
-  schema,
-}: InitQueryCompilerParams) {
-  const adapter = await driverAdapterManager.connect({ url })
+                                     driverAdapterManager,
+                                     url,
+                                     schema,
+                                 }: InitQueryCompilerParams) {
+    const adapter = await driverAdapterManager.connect({url})
 
-  let connectionInfo: ConnectionInfo = {}
-  if (adapter.getConnectionInfo) {
-    connectionInfo = adapter.getConnectionInfo()
-  }
+    let connectionInfo: ConnectionInfo = {}
+    if (adapter.getConnectionInfo) {
+        connectionInfo = adapter.getConnectionInfo()
+    }
 
-  const compiler = await qc.initQueryCompiler({
-    datamodel: schema,
-    provider: adapter.provider,
-    connectionInfo,
-  })
+    const compiler = await qc.initQueryCompiler({
+        datamodel: schema,
+        provider: adapter.provider,
+        connectionInfo,
+    })
 
-  return {
-    compiler,
-    adapter,
-  }
+    return {
+        compiler,
+        adapter,
+    }
 }
 
 async function teardown(unwrappedState: State) {
-  const { compiler, transactionManager, driverAdapterManager } = unwrappedState
+    const {compiler, transactionManager, driverAdapterManager} = unwrappedState
 
-  process.nextTick(() => {
-    try {
-      compiler.free()
-    } catch (error) {
-      debug('Error dropping compiler:', error)
-    }
-  })
+    process.nextTick(() => {
+        try {
+            compiler.free()
+        } catch (error) {
+            debug('Error dropping compiler:', error)
+        }
+    })
 
-  await transactionManager.cancelAllTransactions()
-  await driverAdapterManager.teardown()
+    await transactionManager.cancelAllTransactions()
+    await driverAdapterManager.teardown()
 
-  state = undefined
+    state = undefined
 
-  return {}
+    return {}
 }

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -225,3 +225,4 @@ async function teardown(unwrappedState: State) {
 
     return {}
 }
+

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -384,7 +384,12 @@ fn run_connector_test_impl(
             .with_recorder(recorder)
             .await
         {
-            panic!("💥 Test failed due to an error: {err:?}");
+            // Print any traceback directly to stdout, so it remains readable
+            eprintln!("Test failed due to an error:");
+            eprintln!("=====");
+            eprintln!("{err}");
+            eprintln!("=====");
+            panic!("💥 Test failed due to an error (see above)");
         }
 
         if let Err(e) = crate::teardown_project(&datamodel, db_schemas, schema_id).await {


### PR DESCRIPTION
- Removed error capturing from QC test workers
- Printing tracebacks to stderr

Prisma PR: https://github.com/prisma/prisma/pull/26579

Implements [ORM-803](https://linear.app/prisma-company/issue/ORM-803/dont-set-up-error-capturing-in-the-client-engine)