### PR TITLE
chore: remove outdated comment

### DIFF
--- a/psl/psl-core/src/validate/generator_loader.rs
+++ b/psl/psl-core/src/validate/generator_loader.rs
@@ -98,7 +98,6 @@ fn lift_generator(
         .and_then(|arg| coerce_array(arg, &StringFromEnvVar::coerce, diagnostics))
         .unwrap_or_default();
 
-    // for compatibility reasons we still accept the old experimental key
     let preview_features = args
         .get(PREVIEW_FEATURES_KEY)
         .and_then(|v| coerce_array(v, &coerce::string, diagnostics).map(|arr| (arr, v.span())))


### PR DESCRIPTION
The `.or_else(|| args.get(EXPERIMENTAL_FEATURES_KEY))` branch is long gone but the outdated comment was still there.