### PR TITLE
refactor: migrate to the new adapter interface

### DIFF
--- a/libs/driver-adapters/src/queryable.rs
+++ b/libs/driver-adapters/src/queryable.rs
@@ -362,43 +362,8 @@ impl JsQueryable {
         &'a self,
         isolation: Option<IsolationLevel>,
     ) -> quaint::Result<Box<dyn Transaction + 'a>> {
-        // 1. Obtain a transaction context from the driver.
-        //    Any command run on this context is guaranteed to be part of the same session
-        //    as the transaction spawned from it.
-        let tx_ctx = self.driver_proxy.transaction_context().await?;
-
-        let requires_isolation_first = tx_ctx.requires_isolation_first();
-
-        // 2. Set the isolation level (if specified) if the provider requires it to be set before
-        //    creating the transaction.
-        if requires_isolation_first {
-            if let Some(isolation) = isolation {
-                tx_ctx.set_tx_isolation_level(isolation).await?;
-            }
-        }
-
-        // 3. Spawn a transaction from the context.
-        let tx = tx_ctx.start_transaction().await?;
-
-        let begin_stmt = tx.begin_statement();
-        let tx_opts = tx.options();
-
-        if tx_opts.use_phantom_query {
-            let begin_stmt = JsBaseQueryable::phantom_query_message(begin_stmt);
-            tx.raw_phantom_cmd(begin_stmt.as_str()).await?;
-        } else {
-            tx.raw_cmd(begin_stmt).await?;
-        }
-
-        // 4. Set the isolation level (if specified) if we didn't do it before.
-        if !requires_isolation_first {
-            if let Some(isolation) = isolation {
-                tx.set_tx_isolation_level(isolation).await?;
-            }
-        }
-
+        let tx = self.driver_proxy.start_transaction(isolation).await?;
         self.server_reset_query(tx.as_ref()).await?;
-
         Ok(tx)
     }
 

--- a/libs/driver-adapters/src/transaction.rs
+++ b/libs/driver-adapters/src/transaction.rs
@@ -1,5 +1,3 @@
-use std::future::Future;
-
 use async_trait::async_trait;
 use prisma_metrics::gauge;
 use quaint::{
@@ -8,77 +6,9 @@ use quaint::{
     Value,
 };
 
-use crate::proxy::{TransactionContextProxy, TransactionOptions, TransactionProxy};
+use crate::proxy::{TransactionOptions, TransactionProxy};
 use crate::{proxy::CommonProxy, queryable::JsBaseQueryable, send_future::UnsafeFuture};
 use crate::{JsObject, JsResult};
-
-pub(crate) struct JsTransactionContext {
-    tx_ctx_proxy: TransactionContextProxy,
-    inner: JsBaseQueryable,
-}
-
-// Wrapper around JS transaction context objects that implements Queryable. Can be used in place of quaint transaction,
-// context, but delegates most operations to JS
-impl JsTransactionContext {
-    pub(crate) fn new(inner: JsBaseQueryable, tx_ctx_proxy: TransactionContextProxy) -> Self {
-        Self { inner, tx_ctx_proxy }
-    }
-
-    pub fn start_transaction(&self) -> impl Future<Output = quaint::Result<Box<JsTransaction>>> + '_ {
-        UnsafeFuture(self.tx_ctx_proxy.start_transaction())
-    }
-}
-
-#[async_trait]
-impl Queryable for JsTransactionContext {
-    async fn query(&self, q: QuaintQuery<'_>) -> quaint::Result<ResultSet> {
-        self.inner.query(q).await
-    }
-
-    async fn query_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
-        self.inner.query_raw(sql, params).await
-    }
-
-    async fn query_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<ResultSet> {
-        self.inner.query_raw_typed(sql, params).await
-    }
-
-    async fn execute(&self, q: QuaintQuery<'_>) -> quaint::Result<u64> {
-        self.inner.execute(q).await
-    }
-
-    async fn execute_raw(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        self.inner.execute_raw(sql, params).await
-    }
-
-    async fn execute_raw_typed(&self, sql: &str, params: &[Value<'_>]) -> quaint::Result<u64> {
-        self.inner.execute_raw_typed(sql, params).await
-    }
-
-    async fn raw_cmd(&self, cmd: &str) -> quaint::Result<()> {
-        self.inner.raw_cmd(cmd).await
-    }
-
-    async fn version(&self) -> quaint::Result<Option<String>> {
-        self.inner.version().await
-    }
-
-    async fn describe_query(&self, sql: &str) -> quaint::Result<DescribedQuery> {
-        self.inner.describe_query(sql).await
-    }
-
-    fn is_healthy(&self) -> bool {
-        self.inner.is_healthy()
-    }
-
-    async fn set_tx_isolation_level(&self, isolation_level: IsolationLevel) -> quaint::Result<()> {
-        self.inner.set_tx_isolation_level(isolation_level).await
-    }
-
-    fn requires_isolation_first(&self) -> bool {
-        self.inner.requires_isolation_first()
-    }
-}
 
 // Wrapper around JS transaction objects that implements Queryable
 // and quaint::Transaction. Can be used in place of quaint transaction,
@@ -224,32 +154,5 @@ impl ::napi::bindgen_prelude::FromNapiValue for JsTransaction {
         let tx_proxy = TransactionProxy::new(&object)?;
 
         Ok(Self::new(JsBaseQueryable::new(common_proxy), tx_proxy))
-    }
-}
-
-#[cfg(target_arch = "wasm32")]
-impl super::wasm::FromJsValue for JsTransactionContext {
-    fn from_js_value(value: wasm_bindgen::prelude::JsValue) -> JsResult<Self> {
-        use wasm_bindgen::JsCast;
-
-        let object = value.dyn_into::<JsObject>()?;
-        let common_proxy = CommonProxy::new(&object)?;
-        let base = JsBaseQueryable::new(common_proxy);
-        let tx_ctx_proxy = TransactionContextProxy::new(&object)?;
-
-        Ok(Self::new(base, tx_ctx_proxy))
-    }
-}
-
-/// Implementing unsafe `from_napi_value` allows retrieving a threadsafe `JsTransactionContext` in `DriverProxy`
-/// while keeping derived futures `Send`.
-#[cfg(not(target_arch = "wasm32"))]
-impl ::napi::bindgen_prelude::FromNapiValue for JsTransactionContext {
-    unsafe fn from_napi_value(env: napi::sys::napi_env, napi_val: napi::sys::napi_value) -> JsResult<Self> {
-        let object = JsObject::from_napi_value(env, napi_val)?;
-        let common_proxy = CommonProxy::new(&object)?;
-        let tx_ctx_proxy = TransactionContextProxy::new(&object)?;
-
-        Ok(Self::new(JsBaseQueryable::new(common_proxy), tx_ctx_proxy))
     }
 }


### PR DESCRIPTION
[ORM-762](https://linear.app/prisma-company/issue/ORM-762/migrate-sql-adapters-to-the-new-driver-adapter-interface)
