### PR TITLE
feat(psl): add `esm` preview feature

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -48,6 +48,7 @@ features!(
     Deno,
     Distinct,
     DriverAdapters,
+    Esm,
     ExtendedIndexes,
     ExtendedWhereUnique,
     FieldReference,
@@ -153,6 +154,7 @@ impl<'a> FeatureMapWithProvider<'a> {
             active: enumflags2::make_bitflags!(PreviewFeature::{
                 Deno
                  | DriverAdapters
+                 | Esm
                  | Metrics
                  | MultiSchema
                  | NativeDistinct

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -256,7 +256,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, views, relationJoins, prismaSchemaFolder, strictUndefinedChecks[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, esm, metrics, multiSchema, nativeDistinct, postgresqlExtensions, views, relationJoins, prismaSchemaFolder, strictUndefinedChecks[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@fulltext([content, title])
 }
-// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, views, relationJoins, prismaSchemaFolder, strictUndefinedChecks[0m
+// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: deno, driverAdapters, esm, metrics, multiSchema, nativeDistinct, postgresqlExtensions, views, relationJoins, prismaSchemaFolder, strictUndefinedChecks[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"


### PR DESCRIPTION
Marking as draft because it might not be necessary given the latest discussions.

Ref: https://linear.app/prisma-company/issue/ORM-690/psl-add-esm-preview-feature-support-accept-new-options-in-prisma