### PR TITLE
test(psl): add a missing test for a validation error

### DIFF
--- a/psl/psl/tests/validation/generator/missing_property_value.prisma
+++ b/psl/psl/tests/validation/generator/missing_property_value.prisma
@@ -1,0 +1,13 @@
+generator gen {
+  provider = "fancy-generator"
+  configValue =
+}
+// [1;91merror[0m: [1mProperty configValue in generator gen needs to be assigned a value[0m
+//   [1;94m-->[0m  [4mschema.prisma:1[0m
+// [1;94m   | [0m
+// [1;94m   | [0m
+// [1;94m 1 | [0m[1;91mgenerator gen {[0m
+// [1;94m 2 | [0m  provider = "fancy-generator"
+// [1;94m 3 | [0m  configValue =
+// [1;94m 4 | [0m}
+// [1;94m   | [0m


### PR DESCRIPTION
Add a missing test for the validation error created in `psl_core::validate::generator_loader::lift_generator`.

Ideally this should have been a parsing error and not a validation error, but it needs to be tested either way.