### PR TITLE
feat(psl): allow custom generator attributes to reference env

### DIFF
--- a/psl/psl-core/src/configuration/env_vars.rs
+++ b/psl/psl-core/src/configuration/env_vars.rs
@@ -56,12 +56,12 @@ impl StringFromEnvVar {
     }
 }
 
-struct EnvFunction {
+pub(crate) struct EnvFunction {
     var_name: String,
 }
 
 impl EnvFunction {
-    fn from_ast(expr: &ast::Expression, diagnostics: &mut Diagnostics) -> Option<EnvFunction> {
+    pub(crate) fn from_ast(expr: &ast::Expression, diagnostics: &mut Diagnostics) -> Option<EnvFunction> {
         let args = if let ast::Expression::Function(name, args, _) = &expr {
             if name == "env" {
                 args.arguments
@@ -112,7 +112,7 @@ impl EnvFunction {
         Some(Self { var_name })
     }
 
-    fn var_name(&self) -> &str {
+    pub(crate) fn var_name(&self) -> &str {
         &self.var_name
     }
 }

--- a/psl/psl-core/src/validate/generator_loader.rs
+++ b/psl/psl-core/src/validate/generator_loader.rs
@@ -101,8 +101,13 @@ fn lift_generator(
 
     let config = args
         .into_iter()
-        .map(|(key, value)| (key.to_owned(), GeneratorConfigValue::from(value)))
-        .collect();
+        .map(|(key, value)| -> Option<_> {
+            Some((
+                key.to_owned(),
+                GeneratorConfigValue::try_from_expression(value, diagnostics)?,
+            ))
+        })
+        .collect::<Option<_>>()?;
 
     Some(Generator {
         name: ast_generator.name.name.clone(),

--- a/psl/psl/tests/reformatter/generator_config.prisma
+++ b/psl/psl/tests/reformatter/generator_config.prisma
@@ -11,4 +11,5 @@ generator custom {
   customVersion = 1
   customFeatures = ["gc", "timers"]
   customProgram = ["defn", "handler", [], ["ring-bell"]]
+  customEnv = env("var")
 }

--- a/psl/psl/tests/reformatter/generator_config.reformatted.prisma
+++ b/psl/psl/tests/reformatter/generator_config.reformatted.prisma
@@ -11,4 +11,5 @@ generator custom {
   customVersion  = 1
   customFeatures = ["gc", "timers"]
   customProgram  = ["defn", "handler", [], ["ring-bell"]]
+  customEnv      = env("var")
 }

--- a/psl/psl/tests/validation/generator/custom_env_values_are_supported.prisma
+++ b/psl/psl/tests/validation/generator/custom_env_values_are_supported.prisma
@@ -1,0 +1,4 @@
+generator gen {
+  provider    = "fancy-generator"
+  configValue = env("SOME_VAR")
+}

--- a/schema-engine/datamodel-renderer/src/configuration/generator.rs
+++ b/schema-engine/datamodel-renderer/src/configuration/generator.rs
@@ -189,6 +189,8 @@ mod tests {
             ],
         );
 
+        generator.push_config_value("customEnvValue", Env::variable("var"));
+
         let expected = expect![[r#"
             /// Here comes the sun.
             ///
@@ -200,6 +202,7 @@ mod tests {
               previewFeatures = ["multiSchema", "postgresqlExtensions"]
               binaryTargets   = [env("BINARY TARGET")]
               afterGenerate   = ["lambda", [], ["print", ["quote", "done!"]]]
+              customEnvValue  = env("var")
               customFeatures  = ["enums", "models"]
               customValue     = "meow"
               otherValue      = "purr"

--- a/schema-engine/datamodel-renderer/src/value.rs
+++ b/schema-engine/datamodel-renderer/src/value.rs
@@ -123,6 +123,7 @@ impl<'a> From<&'a GeneratorConfigValue> for Value<'a> {
         match value {
             GeneratorConfigValue::String(s) => s.as_str().into(),
             GeneratorConfigValue::Array(elements) => elements.iter().map(From::from).collect(),
+            GeneratorConfigValue::Env(var_name) => Env::variable(var_name).into(),
         }
     }
 }


### PR DESCRIPTION
Allow all generator configuration attributes to reference environment variables. This allows to use `env("VAR_NAME")` syntax for the new options (such as `module` and `runtime`) in the new client generator without making PSL aware of these new attributes. This also enables `env` support for all third party generators as well.

We may also want to remove the special handling for the attributes such as `binaryTargets` and so on, because `config` now provides all functionality needed for them.

Refs: https://linear.app/prisma-company/issue/ORM-690/psl-add-esm-preview-feature-support-accept-new-options-in-prisma