### PR TITLE
chore(ci): Selecting Prisma branch from PR description

### DIFF
--- a/.github/workflows/select-prisma-branch.yml
+++ b/.github/workflows/select-prisma-branch.yml
@@ -29,7 +29,7 @@ jobs:
             github.event.pull_request.author_association == 'CONTRIBUTOR'
           )
         run: |
-          BRANCH_NAME=$(echo "$PR_BODY" | sed -n 's|.*\/prisma-branch \([^[:space:]]*\).*|\1|p' | head -n 1)
+          BRANCH_NAME=$(echo "$PR_BODY" | sed -n 's|.*\/prisma-branch \([^[:space:]]\+\).*|\1|p' | head -n 1)
           if [ -n "$BRANCH_NAME" ] && [ "$BRANCH_NAME" != "main" ]; then
             echo "PRISMA_BRANCH=$BRANCH_NAME" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/select-prisma-branch.yml
+++ b/.github/workflows/select-prisma-branch.yml
@@ -1,0 +1,41 @@
+name: Select Prisma branch
+on:
+  workflow_call:
+    outputs:
+      prismaBranch:
+        description: Name of the Prisma branch
+        value: ${{ jobs.selectPrismaBranch.outputs.prismaBranch }}
+
+jobs:
+  selectPrismaBranch:
+    name: Select Prisma branch
+    runs-on: ubuntu-latest
+    outputs:
+      prismaBranch: ${{ steps.setPrismaBranch.outputs.prismaBranch }}
+    steps:
+      - name: Default to the main branch
+        run: echo "PRISMA_BRANCH=main" >> "$GITHUB_ENV"
+
+      - name: Extract Prisma branch name from PR description
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        if: |
+          github.event_name == 'pull_request' &&
+          contains(env.PR_BODY, '/prisma-branch') &&
+          (
+            github.event.pull_request.author_association == 'OWNER' ||
+            github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'COLLABORATOR' ||
+            github.event.pull_request.author_association == 'CONTRIBUTOR'
+          )
+        run: |
+          BRANCH_NAME=$(echo "$PR_BODY" | sed -n 's|.*\/prisma-branch \([^[:space:]]*\).*|\1|p' | head -n 1)
+          if [ -n "$BRANCH_NAME" ] && [ "$BRANCH_NAME" != "main" ]; then
+            echo "PRISMA_BRANCH=$BRANCH_NAME" >> "$GITHUB_ENV"
+          fi
+
+      - name: Store Prisma branch name
+        id: setPrismaBranch
+        run: |
+          echo "Prisma branch requested: $PRISMA_BRANCH"
+          echo "prismaBranch=$PRISMA_BRANCH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-driver-adapters-template.yml
+++ b/.github/workflows/test-driver-adapters-template.yml
@@ -7,8 +7,13 @@ on:
         required: true
 
 jobs:
+  select_prisma_branch:
+    name: Select the Prisma branch to use
+    uses: ./.github/workflows/select-prisma-branch.yml
+
   rust-query-engine-tests:
     name: "${{ matrix.partition }}"
+    needs: select_prisma_branch
 
     strategy:
       fail-fast: false
@@ -60,16 +65,13 @@ jobs:
         with:
           key: docker-${{ inputs.setup_task }}-${{hashFiles('docker-compose.yaml')}}
 
-      - name: Extract Branch Name
-        id: extract-branch
+      - name: Set Prisma branch
+        id: set-prisma-branch
         run: |
-          echo "Extracting branch name from: $(git show -s --format=%s)"
-          branch="$(git show -s --format=%s | grep -o "DRIVER_ADAPTERS_BRANCH=[^ ]*" | cut -f2 -d=)"
-          echo "branch=$branch"
-          if [ -n "$branch" ]; then
-            echo "Using $branch branch of driver adapters"
-            echo "DRIVER_ADAPTERS_BRANCH=$branch" >> "$GITHUB_ENV"
-          fi
+          PRISMA_BRANCH="${{ needs.select_prisma_branch.outputs.prismaBranch }}"
+          test -n "$PRISMA_BRANCH"
+          echo "PRISMA_BRANCH=$PRISMA_BRANCH" >> "$GITHUB_ENV"
+          echo "Using Prisma branch: $PRISMA_BRANCH"
 
       - uses: ./.github/workflows/include/rust-wasm-setup
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/test-query-compiler-template.yml
+++ b/.github/workflows/test-query-compiler-template.yml
@@ -13,8 +13,13 @@ on:
         required: true
 
 jobs:
+  select_prisma_branch:
+    name: Select the Prisma branch to use
+    uses: ./.github/workflows/select-prisma-branch.yml
+
   query-compiler-wasm-tests:
     name: '${{ matrix.partition }}'
+    needs: select_prisma_branch
 
     strategy:
       fail-fast: false
@@ -68,16 +73,13 @@ jobs:
         with:
           key: docker-${{ inputs.setup_task }}-${{hashFiles('docker-compose.yaml')}}
 
-      - name: Extract Branch Name
-        id: extract-branch
+      - name: Set Prisma branch
+        id: set-prisma-branch
         run: |
-          echo "Extracting branch name from: $(git show -s --format=%s)"
-          branch="$(git show -s --format=%s | grep -o "DRIVER_ADAPTERS_BRANCH=[^ ]*" | cut -f2 -d=)"
-          echo "branch=$branch"
-          if [ -n "$branch" ]; then
-            echo "Using $branch branch of driver adapters"
-            echo "DRIVER_ADAPTERS_BRANCH=$branch" >> "$GITHUB_ENV"
-          fi
+          PRISMA_BRANCH="${{ needs.select_prisma_branch.outputs.prismaBranch }}"
+          test -n "$PRISMA_BRANCH"
+          echo "PRISMA_BRANCH=$PRISMA_BRANCH" >> "$GITHUB_ENV"
+          echo "Using Prisma branch: $PRISMA_BRANCH"
 
       - uses: ./.github/workflows/include/rust-wasm-setup
       - uses: taiki-e/install-action@nextest

--- a/.github/workflows/wasm-benchmarks.yml
+++ b/.github/workflows/wasm-benchmarks.yml
@@ -15,7 +15,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  select_prisma_branch:
+    name: Select the Prisma branch to use
+    uses: ./.github/workflows/select-prisma-branch.yml
+
   benchmarks:
+    name: "Benchmarks"
+    needs: select_prisma_branch
+
     runs-on: ubuntu-latest
     env: # Set environment variables for the whole job
       PROFILE: release
@@ -52,15 +59,13 @@ jobs:
         with:
           key: docker-pg-bench-${{hashFiles('docker-compose.yaml')}}
 
-      - name: Extract Branch Name
+      - name: Set Prisma branch
+        id: set-prisma-branch
         run: |
-          echo "Extracting branch name from: $(git show -s --format=%s)"
-          branch="$(git show -s --format=%s | grep -o "DRIVER_ADAPTERS_BRANCH=[^ ]*" | cut -f2 -d=)"
-          echo "branch=$branch"
-          if [ -n "$branch" ]; then
-            echo "Using $branch branch of driver adapters"
-            echo "DRIVER_ADAPTERS_BRANCH=$branch" >> "$GITHUB_ENV"
-          fi
+          PRISMA_BRANCH="${{ needs.select_prisma_branch.outputs.prismaBranch }}"
+          test -n "$PRISMA_BRANCH"
+          echo "PRISMA_BRANCH=$PRISMA_BRANCH" >> "$GITHUB_ENV"
+          echo "Using Prisma branch: $PRISMA_BRANCH"
 
       - name: Setup benchmark
         run: make setup-pg-bench

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CONFIG_PATH = ./query-engine/connector-test-kit-rs/test-configs
 CONFIG_FILE = .test_config
 SCHEMA_EXAMPLES_PATH = ./query-engine/example_schemas
 DEV_SCHEMA_FILE = dev_datamodel.prisma
-DRIVER_ADAPTERS_BRANCH ?= main
+PRISMA_BRANCH ?= main
 ENGINE_SIZE_OUTPUT ?= /dev/stdout
 QE_WASM_VERSION ?= 0.0.0
 SCHEMA_WASM_VERSION ?= 0.0.0
@@ -452,8 +452,8 @@ ensure-prisma-present:
 		  echo "⚠️ ../prisma diverges from prisma/prisma main branch. Test results might diverge from those in CI ⚠️ "; \
 		fi \
 	else \
-		echo "git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(DRIVER_ADAPTERS_BRANCH) ../prisma"; \
-		git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(DRIVER_ADAPTERS_BRANCH) "../prisma" && echo "Prisma repository has been cloned to ../prisma"; \
+		echo "git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(PRISMA_BRANCH) ../prisma"; \
+		git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(PRISMA_BRANCH) "../prisma" && echo "Prisma repository has been cloned to ../prisma"; \
 	fi;
 
 qe:

--- a/README.md
+++ b/README.md
@@ -246,11 +246,13 @@ Locally, each time you run `DRIVER_ADAPTER=$adapter make test-qe` tests will run
 
 In CI, tho', we need to denote which branch of prisma/prisma we want to use for tests. In CI, there's no working copy of prisma/prisma before tests run.
 The CI jobs clones prisma/prisma `main` branch by default, which doesn't include your local changes. To test in integration, we can tell CI to use the branch of prisma/prisma containing
-the changes in adapters. To do it, you can use a simple convention in commit messages. Like this:
+the changes in adapters. To do it, add the following tag to your PR's description on a separate line:
 
 ```
-git commit -m "DRIVER_ADAPTERS_BRANCH=prisma-branch-with-changes-in-adapters [...]"
+/prisma-branch your/branch
 ```
+
+Replace `your/branch` with the name of your branch in the `prisma` repository.
 
 GitHub actions will then pick up the branch name and use it to clone that branch's code of prisma/prisma, and build the driver adapters code from there.
 


### PR DESCRIPTION
## Background
Sometimes we need to make PRs to both the `prisma-engines` and `prisma` repositories, then they need to be tested together on CI. 

Prisma PRs accept an `/engine-branch` tag in their description, which is a very convenient way to trigger such builds.

Unfortunately, `prisma-engines` PRs require a special commit message which is harder to maintain while committing changes during the review process.

## Solution
We decided to port the PR description tag mechanism to the `prisma-engines` repository with the tag name modified to `prisma-branch`.

## Changes made
- Parsing the `prisma-branch` tag from the PR description (default to `main` if no tag found)
- Checking out the specified Prisma branch in the CI workflows
- Updated `README`

Implements [ORM-821](https://linear.app/prisma-company/issue/ORM-821/selecting-the-prisma-branch-in-the-pr-description)