### PR TITLE
feat(dmmf): ORM-596 expose model grouping meta info on DMMF types for file splitting in generator

### DIFF
--- a/prisma-fmt/src/get_dmmf.rs
+++ b/prisma-fmt/src/get_dmmf.rs
@@ -513,7 +513,8 @@ mod tests {
                     {
                       "name": "AWhereInput",
                       "meta": {
-                        "source": "A"
+                        "source": "A",
+                        "grouping": "A"
                       },
                       "constraints": {
                         "maxNumFields": null,
@@ -630,6 +631,9 @@ mod tests {
                     },
                     {
                       "name": "AOrderByWithRelationInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 0
@@ -679,7 +683,8 @@ mod tests {
                     {
                       "name": "AWhereUniqueInput",
                       "meta": {
-                        "source": "A"
+                        "source": "A",
+                        "grouping": "A"
                       },
                       "constraints": {
                         "maxNumFields": null,
@@ -788,6 +793,9 @@ mod tests {
                     },
                     {
                       "name": "AOrderByWithAggregationInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 0
@@ -863,7 +871,8 @@ mod tests {
                     {
                       "name": "AScalarWhereWithAggregatesInput",
                       "meta": {
-                        "source": "A"
+                        "source": "A",
+                        "grouping": "A"
                       },
                       "constraints": {
                         "maxNumFields": null,
@@ -962,7 +971,8 @@ mod tests {
                     {
                       "name": "BWhereInput",
                       "meta": {
-                        "source": "B"
+                        "source": "B",
+                        "grouping": "B"
                       },
                       "constraints": {
                         "maxNumFields": null,
@@ -1066,6 +1076,9 @@ mod tests {
                     },
                     {
                       "name": "BOrderByWithRelationInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 0
@@ -1102,7 +1115,8 @@ mod tests {
                     {
                       "name": "BWhereUniqueInput",
                       "meta": {
-                        "source": "B"
+                        "source": "B",
+                        "grouping": "B"
                       },
                       "constraints": {
                         "maxNumFields": null,
@@ -1203,6 +1217,9 @@ mod tests {
                     },
                     {
                       "name": "BOrderByWithAggregationInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 0
@@ -1265,7 +1282,8 @@ mod tests {
                     {
                       "name": "BScalarWhereWithAggregatesInput",
                       "meta": {
-                        "source": "B"
+                        "source": "B",
+                        "grouping": "B"
                       },
                       "constraints": {
                         "maxNumFields": null,
@@ -1345,6 +1363,9 @@ mod tests {
                     },
                     {
                       "name": "ACreateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1379,6 +1400,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedCreateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1412,6 +1436,9 @@ mod tests {
                     },
                     {
                       "name": "AUpdateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1452,6 +1479,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedUpdateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1497,6 +1527,9 @@ mod tests {
                     },
                     {
                       "name": "ACreateManyInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1530,6 +1563,9 @@ mod tests {
                     },
                     {
                       "name": "AUpdateManyMutationInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1557,6 +1593,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedUpdateManyInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1602,6 +1641,9 @@ mod tests {
                     },
                     {
                       "name": "BCreateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1636,6 +1678,9 @@ mod tests {
                     },
                     {
                       "name": "BUncheckedCreateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1670,6 +1715,9 @@ mod tests {
                     },
                     {
                       "name": "BUpdateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1710,6 +1758,9 @@ mod tests {
                     },
                     {
                       "name": "BUncheckedUpdateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1750,6 +1801,9 @@ mod tests {
                     },
                     {
                       "name": "BCreateManyInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1771,6 +1825,9 @@ mod tests {
                     },
                     {
                       "name": "BUpdateManyMutationInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -1798,6 +1855,9 @@ mod tests {
                     },
                     {
                       "name": "BUncheckedUpdateManyInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2045,6 +2105,9 @@ mod tests {
                     },
                     {
                       "name": "BScalarRelationFilter",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2080,6 +2143,9 @@ mod tests {
                     },
                     {
                       "name": "ACountOrderByAggregateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2115,6 +2181,9 @@ mod tests {
                     },
                     {
                       "name": "AMaxOrderByAggregateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2150,6 +2219,9 @@ mod tests {
                     },
                     {
                       "name": "AMinOrderByAggregateInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2444,6 +2516,9 @@ mod tests {
                     },
                     {
                       "name": "ANullableScalarRelationFilter",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2489,6 +2564,9 @@ mod tests {
                     },
                     {
                       "name": "BCountOrderByAggregateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2511,6 +2589,9 @@ mod tests {
                     },
                     {
                       "name": "BMaxOrderByAggregateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2533,6 +2614,9 @@ mod tests {
                     },
                     {
                       "name": "BMinOrderByAggregateInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2555,6 +2639,9 @@ mod tests {
                     },
                     {
                       "name": "BCreateNestedOneWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2609,6 +2696,9 @@ mod tests {
                     },
                     {
                       "name": "StringFieldUpdateOperationsInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": 1,
                         "minNumFields": 1
@@ -2630,6 +2720,9 @@ mod tests {
                     },
                     {
                       "name": "BUpdateOneRequiredWithoutANestedInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2722,6 +2815,9 @@ mod tests {
                     },
                     {
                       "name": "ACreateNestedOneWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2776,6 +2872,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedCreateNestedOneWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2830,6 +2929,9 @@ mod tests {
                     },
                     {
                       "name": "AUpdateOneWithoutBNestedInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -2958,6 +3060,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedUpdateOneWithoutBNestedInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3692,6 +3797,9 @@ mod tests {
                     },
                     {
                       "name": "BCreateWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3713,6 +3821,9 @@ mod tests {
                     },
                     {
                       "name": "BUncheckedCreateWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3734,6 +3845,9 @@ mod tests {
                     },
                     {
                       "name": "BCreateOrConnectWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3775,6 +3889,9 @@ mod tests {
                     },
                     {
                       "name": "BUpsertWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3835,6 +3952,9 @@ mod tests {
                     },
                     {
                       "name": "BUpdateToOneWithWhereWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3876,6 +3996,9 @@ mod tests {
                     },
                     {
                       "name": "BUpdateWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3903,6 +4026,9 @@ mod tests {
                     },
                     {
                       "name": "BUncheckedUpdateWithoutAInput",
+                      "meta": {
+                        "grouping": "B"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3930,6 +4056,9 @@ mod tests {
                     },
                     {
                       "name": "ACreateWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3951,6 +4080,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedCreateWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -3972,6 +4104,9 @@ mod tests {
                     },
                     {
                       "name": "ACreateOrConnectWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -4013,6 +4148,9 @@ mod tests {
                     },
                     {
                       "name": "AUpsertWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -4073,6 +4211,9 @@ mod tests {
                     },
                     {
                       "name": "AUpdateToOneWithWhereWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -4114,6 +4255,9 @@ mod tests {
                     },
                     {
                       "name": "AUpdateWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null
@@ -4141,6 +4285,9 @@ mod tests {
                     },
                     {
                       "name": "AUncheckedUpdateWithoutBInput",
+                      "meta": {
+                        "grouping": "A"
+                      },
                       "constraints": {
                         "maxNumFields": null,
                         "minNumFields": null

--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/object_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/object_renderer.rs
@@ -34,12 +34,16 @@ impl<'a> DmmfObjectRenderer<'a> {
             rendered_fields.push(render_input_field(field, ctx));
         }
 
-        let meta = input_object.tag().and_then(|tag| match tag {
-            ObjectTag::WhereInputType(container) => Some(DmmfInputTypeMeta {
-                source: Some(container.name()),
+        let meta = match (input_object.tag(), input_object.container()) {
+            (None, None) => None,
+            (tag, container) => Some(DmmfInputTypeMeta {
+                source: tag.and_then(|tag| match tag {
+                    ObjectTag::WhereInputType(c) => Some(c.name()),
+                    _ => None,
+                }),
+                grouping: container.map(|c| c.name()),
             }),
-            _ => None,
-        });
+        };
 
         let input_type = DmmfInputType {
             name: input_object.identifier.name(),

--- a/query-engine/dmmf/src/serialization_ast/schema_ast.rs
+++ b/query-engine/dmmf/src/serialization_ast/schema_ast.rs
@@ -46,6 +46,10 @@ pub struct DmmfInputTypeConstraints {
 pub struct DmmfInputTypeMeta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source: Option<String>,
+    /// Used by the generator to group input types roughly by model.
+    /// Note that it is not strictly the model name but can also be a composite type name or empty for generic input types.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub grouping: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/query-engine/schema/src/build/input_types/fields/data_input_mapper/create.rs
+++ b/query-engine/schema/src/build/input_types/fields/data_input_mapper/create.rs
@@ -40,10 +40,10 @@ impl DataInputFieldMapper for CreateDataInputFieldMapper {
         let cloned_typ = typ.clone();
         let ident = Identifier::new_prisma(IdentifierType::CreateOneScalarList(sf.clone()));
 
-        let mut input_object = input_object_type(ident, move || {
-            vec![simple_input_field(operations::SET, cloned_typ.clone(), None)]
-        });
+        let mut input_object = init_input_object_type(ident);
+        input_object.set_container(sf.container());
         input_object.require_exactly_one_field();
+        input_object.set_fields(move || vec![simple_input_field(operations::SET, cloned_typ.clone(), None)]);
 
         let input_type = InputType::object(input_object);
 
@@ -60,6 +60,7 @@ impl DataInputFieldMapper for CreateDataInputFieldMapper {
 
         let cloned_rf = rf.clone();
         let mut input_object = init_input_object_type(ident);
+        input_object.set_container(rf.related_model());
         input_object.set_fields(move || {
             let rf = &cloned_rf;
             let mut fields = vec![];
@@ -137,6 +138,7 @@ fn composite_create_envelope_object_type(ctx: &'_ QuerySchema, cf: CompositeFiel
     let cf_is_required = cf.is_required();
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.typ());
     input_object.require_exactly_one_field();
     input_object.set_tag(ObjectTag::CompositeEnvelope);
     input_object.set_fields(move || {
@@ -160,10 +162,13 @@ pub(crate) fn composite_create_object_type(ctx: &'_ QuerySchema, cf: CompositeFi
     // It's called "Create" input because it's used across multiple create-type operations, not only "set".
     let ident = Identifier::new_prisma(IdentifierType::CompositeCreateInput(cf.typ()));
 
-    input_object_type(ident, move || {
+    let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.container());
+    input_object.set_fields(move || {
         let mapper = CreateDataInputFieldMapper::new_checked();
         let typ = cf.typ();
         let mut fields = typ.fields();
         mapper.map_all(ctx, &mut fields)
-    })
+    });
+    input_object
 }

--- a/query-engine/schema/src/build/input_types/fields/data_input_mapper/update.rs
+++ b/query-engine/schema/src/build/input_types/fields/data_input_mapper/update.rs
@@ -72,7 +72,9 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
         let ident = Identifier::new_prisma(IdentifierType::ScalarListUpdateInput(sf.clone()));
         let type_identifier = sf.type_identifier();
 
-        let mut input_object = input_object_type(ident, move || {
+        let mut input_object = init_input_object_type(ident);
+        input_object.set_container(sf.container());
+        input_object.set_fields(move || {
             let mut object_fields = vec![simple_input_field(operations::SET, list_input_type.clone(), None).optional()];
 
             if ctx.has_capability(ConnectorCapability::ScalarLists)
@@ -101,6 +103,7 @@ impl DataInputFieldMapper for UpdateDataInputFieldMapper {
         let rf_name = rf.name().to_owned();
 
         let mut input_object = init_input_object_type(ident);
+        input_object.set_container(rf.related_model());
         input_object.set_fields(move || {
             let mut fields = vec![];
 
@@ -164,6 +167,7 @@ fn update_operations_object_type<'a>(
     ));
 
     let mut obj = init_input_object_type(ident);
+    obj.set_container(sf.container());
     obj.require_exactly_one_field();
     obj.set_fields(move || {
         let typ = map_scalar_input_type_for_field(ctx, &sf);
@@ -200,6 +204,7 @@ fn composite_update_envelope_object_type(ctx: &'_ QuerySchema, cf: CompositeFiel
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpdateEnvelopeInput(cf.typ(), cf.arity()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.typ());
     input_object.require_exactly_one_field();
     input_object.set_tag(ObjectTag::CompositeEnvelope);
     input_object.set_fields(move || {
@@ -222,6 +227,7 @@ fn composite_update_object_type(ctx: &'_ QuerySchema, cf: CompositeFieldRef) -> 
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpdateInput(cf.typ()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.typ());
     input_object.set_min_fields(1);
     input_object.set_fields(move || {
         let mapper = UpdateDataInputFieldMapper::new_checked();
@@ -284,6 +290,7 @@ fn composite_upsert_object_type(ctx: &'_ QuerySchema, cf: CompositeFieldRef) -> 
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpsertObjectInput(cf.typ()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.typ());
     input_object.set_tag(ObjectTag::CompositeEnvelope);
     input_object.set_fields(move || {
         let update_object_type = composite_update_object_type(ctx, cf.clone());
@@ -310,6 +317,7 @@ fn composite_update_many_object_type(ctx: &'_ QuerySchema, cf: CompositeFieldRef
     let ident = Identifier::new_prisma(IdentifierType::CompositeUpdateManyInput(cf.typ()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.typ());
     input_object.set_tag(ObjectTag::CompositeEnvelope);
     input_object.set_fields(move || {
         let where_object_type = objects::filter_objects::where_object_type(ctx, cf.typ().into());
@@ -328,6 +336,7 @@ fn composite_delete_many_object_type(ctx: &'_ QuerySchema, cf: CompositeFieldRef
     let ident = Identifier::new_prisma(IdentifierType::CompositeDeleteManyInput(cf.typ()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.typ());
     input_object.set_tag(ObjectTag::CompositeEnvelope);
     input_object.set_fields(move || {
         let where_object_type = objects::filter_objects::where_object_type(ctx, cf.typ().into());

--- a/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
+++ b/query-engine/schema/src/build/input_types/fields/field_filter_types.rs
@@ -65,6 +65,7 @@ fn to_many_relation_filter_object(ctx: &'_ QuerySchema, rf: RelationFieldRef) ->
     let ident = Identifier::new_prisma(IdentifierType::ToManyRelationFilterInput(rf.related_model()));
 
     let mut object = init_input_object_type(ident);
+    object.set_container(rf.related_model());
     object.set_tag(ObjectTag::RelationEnvelope);
 
     object.set_fields(move || {
@@ -82,6 +83,7 @@ fn to_one_relation_filter_object(ctx: &'_ QuerySchema, rf: RelationFieldRef) -> 
     let ident = Identifier::new_prisma(IdentifierType::ToOneRelationFilterInput(rf.related_model(), rf.arity()));
 
     let mut object = init_input_object_type(ident);
+    object.set_container(rf.related_model());
     object.set_tag(ObjectTag::RelationEnvelope);
     object.set_fields(move || {
         let related_input_type = filter_objects::where_object_type(ctx, rf.related_model().into());
@@ -109,6 +111,7 @@ fn to_one_composite_filter_object(ctx: &'_ QuerySchema, cf: CompositeFieldRef) -
 
     let mut object = init_input_object_type(ident);
     object.require_exactly_one_field();
+    object.set_container(cf.typ());
     object.set_tag(ObjectTag::CompositeEnvelope);
 
     object.set_fields(move || {
@@ -141,6 +144,7 @@ fn to_many_composite_filter_object(ctx: &'_ QuerySchema, cf: CompositeFieldRef) 
 
     let mut object = init_input_object_type(ident);
     object.require_exactly_one_field();
+    object.set_container(cf.typ());
     object.set_tag(ObjectTag::CompositeEnvelope);
     object.set_fields(move || {
         let composite_where_object = filter_objects::where_object_type(ctx, cf.typ().into());
@@ -178,6 +182,7 @@ fn scalar_list_filter_type(ctx: &'_ QuerySchema, sf: ScalarFieldRef) -> InputObj
 
     let mut object = init_input_object_type(ident);
     object.require_exactly_one_field();
+    object.set_container(sf.container());
     object.set_fields(move || {
         let mapped_nonlist_type = map_scalar_input_type(ctx, sf.type_identifier(), false);
         let mapped_list_type = InputType::list(mapped_nonlist_type.clone());

--- a/query-engine/schema/src/build/input_types/fields/input_fields.rs
+++ b/query-engine/schema/src/build/input_types/fields/input_fields.rs
@@ -53,10 +53,12 @@ pub(crate) fn nested_create_many_input_field(
 }
 
 fn nested_create_many_envelope(ctx: &'_ QuerySchema, parent_field: RelationFieldRef) -> InputObjectType<'_> {
-    let create_type = create_many::create_many_object_type(ctx, parent_field.related_model(), Some(parent_field));
+    let create_type =
+        create_many::create_many_object_type(ctx, parent_field.related_model(), Some(parent_field.clone()));
     let name = format!("{}Envelope", create_type.identifier.name());
     let ident = Identifier::new_prisma(name);
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(parent_field.related_model());
     input_object.set_fields(move || {
         let create_many_type = InputType::object(create_type.clone());
         let data_arg = input_field(args::DATA, list_union_type(create_many_type, true), None);

--- a/query-engine/schema/src/build/input_types/objects/connect_or_create_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/connect_or_create_objects.rs
@@ -17,6 +17,7 @@ pub(crate) fn nested_connect_or_create_input_object(
     let where_object = filter_objects::where_unique_object_type(ctx, related_model.clone());
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(related_model.clone());
     input_object.set_fields(move || {
         let create_types = create_one::create_one_input_types(ctx, related_model.clone(), Some(parent_field.clone()));
         vec![

--- a/query-engine/schema/src/build/input_types/objects/filter_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/filter_objects.rs
@@ -10,6 +10,7 @@ pub(crate) fn scalar_filter_object_type(
     let ident = Identifier::new_prisma(IdentifierType::ScalarFilterInput(model.clone(), include_aggregates));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_tag(ObjectTag::WhereInputType(ParentContainer::Model(model.clone())));
     input_object.set_fields(move || {
         let object_type = InputType::object(scalar_filter_object_type(ctx, model.clone(), include_aggregates));
@@ -45,6 +46,7 @@ pub(crate) fn where_object_type(ctx: &'_ QuerySchema, container: ParentContainer
     let ident = Identifier::new_prisma(IdentifierType::WhereInput(container.clone()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(container.clone());
     input_object.set_tag(ObjectTag::WhereInputType(container.clone()));
     input_object.set_fields(move || {
         let object_type = InputType::object(where_object_type(ctx, container.clone()));
@@ -80,6 +82,7 @@ pub(crate) fn where_unique_object_type(ctx: &'_ QuerySchema, model: Model) -> In
     let ident = Identifier::new_prisma(IdentifierType::WhereUniqueInput(model.clone()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_tag(ObjectTag::WhereInputType(ParentContainer::Model(model.clone())));
 
     // Concatenated list of uniques/@@unique/@@id fields on which the input type constraints should be applied (that at least one of them is set).
@@ -210,6 +213,7 @@ fn compound_field_unique_object_type<'a>(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         from_fields
             .clone()
@@ -231,6 +235,7 @@ pub(crate) fn composite_equality_object(ctx: &'_ QuerySchema, cf: CompositeField
     let ident = Identifier::new_prisma(format!("{}ObjectEqualityInput", cf.typ().name()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(cf.container());
     input_object.set_fields(move || {
         let mut fields = vec![];
 

--- a/query-engine/schema/src/build/input_types/objects/order_by_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/order_by_objects.rs
@@ -218,7 +218,7 @@ fn order_by_object_type_aggregate<'a>(
 
 fn order_by_to_many_aggregate_object_type<'a>(container: &ParentContainer) -> InputObjectType<'a> {
     let ident = Identifier::new_prisma(IdentifierType::OrderByToManyAggregateInput(container.clone()));
-    let mut input_object: InputObjectType<'_> = init_input_object_type(ident);
+    let mut input_object = init_input_object_type(ident);
     input_object.set_container(container.clone());
     input_object.require_exactly_one_field();
     input_object.set_fields(|| {

--- a/query-engine/schema/src/build/input_types/objects/order_by_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/order_by_objects.rs
@@ -47,6 +47,7 @@ pub(crate) fn order_by_object_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(container.clone());
     input_object.require_at_most_one_field();
     input_object.set_fields(move || {
         // Basic orderBy fields.
@@ -202,6 +203,7 @@ fn order_by_object_type_aggregate<'a>(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(container.clone());
     input_object.require_exactly_one_field();
     input_object.set_fields(move || {
         let sort_order_enum = InputType::Enum(sort_order_enum());
@@ -216,7 +218,8 @@ fn order_by_object_type_aggregate<'a>(
 
 fn order_by_to_many_aggregate_object_type<'a>(container: &ParentContainer) -> InputObjectType<'a> {
     let ident = Identifier::new_prisma(IdentifierType::OrderByToManyAggregateInput(container.clone()));
-    let mut input_object = init_input_object_type(ident);
+    let mut input_object: InputObjectType<'_> = init_input_object_type(ident);
+    input_object.set_container(container.clone());
     input_object.require_exactly_one_field();
     input_object.set_fields(|| {
         let sort_order_enum = InputType::Enum(sort_order_enum());
@@ -250,6 +253,7 @@ fn order_by_object_type_text_search<'a>(
     let ident = Identifier::new_prisma(IdentifierType::OrderByRelevanceInput(container.clone()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(container.clone());
     input_object.set_fields(move || {
         let fields_enum_type = InputType::enum_type(order_by_relevance_enum(
             container.clone(),

--- a/query-engine/schema/src/build/input_types/objects/update_many_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/update_many_objects.rs
@@ -18,6 +18,7 @@ pub(crate) fn checked_update_many_input_type(ctx: &'_ QuerySchema, model: Model)
     let ident = Identifier::new_prisma(IdentifierType::CheckedUpdateManyInput(model.clone()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields = update_one_objects::filter_checked_update_fields(ctx, &model, None)
             .filter(|field| matches!(field, ModelField::Scalar(_) | ModelField::Composite(_)));
@@ -40,6 +41,7 @@ pub(crate) fn unchecked_update_many_input_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields =
             update_one_objects::filter_unchecked_update_fields(ctx, &model, parent_field.as_ref())
@@ -62,6 +64,7 @@ pub(crate) fn update_many_where_combination_object(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(parent_field.related_model());
     input_object.set_fields(move || {
         let related_model = parent_field.related_model();
         let where_input_object = filter_objects::scalar_filter_object_type(ctx, related_model.clone(), false);

--- a/query-engine/schema/src/build/input_types/objects/update_one_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/update_one_objects.rs
@@ -25,6 +25,7 @@ fn checked_update_one_input_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields = filter_checked_update_fields(ctx, &model, parent_field.as_ref());
         let field_mapper = UpdateDataInputFieldMapper::new_checked();
@@ -45,6 +46,7 @@ fn unchecked_update_one_input_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields = filter_unchecked_update_fields(ctx, &model, parent_field.as_ref());
         let field_mapper = UpdateDataInputFieldMapper::new_unchecked();
@@ -171,6 +173,7 @@ pub(crate) fn update_one_where_combination_object<'a>(
     let where_input_object = filter_objects::where_unique_object_type(ctx, related_model);
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(parent_field.related_model());
     input_object.set_fields(move || {
         vec![
             simple_input_field(args::WHERE, InputType::object(where_input_object.clone()), None),
@@ -192,6 +195,7 @@ pub(crate) fn update_to_one_rel_where_combination_object<'a>(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(parent_field.related_model());
     input_object.set_tag(ObjectTag::NestedToOneUpdateEnvelope);
     input_object.set_fields(move || {
         let related_model = parent_field.related_model();

--- a/query-engine/schema/src/build/input_types/objects/upsert_objects.rs
+++ b/query-engine/schema/src/build/input_types/objects/upsert_objects.rs
@@ -27,6 +27,7 @@ fn nested_upsert_list_input_object(
     let ident = Identifier::new_prisma(IdentifierType::NestedUpsertManyInput(parent_field.related_field()));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(parent_field.related_model());
     input_object.set_fields(move || {
         vec![
             input_field(args::WHERE, vec![InputType::object(where_object.clone())], None),
@@ -48,7 +49,9 @@ fn nested_upsert_nonlist_input_object(
 
     let ident = Identifier::new_prisma(IdentifierType::NestedUpsertOneInput(parent_field.related_field()));
 
-    Some(input_object_type(ident, move || {
+    let mut input_object = init_input_object_type(ident);
+    input_object.set_container(related_model.clone());
+    input_object.set_fields(move || {
         let update_types =
             update_one_objects::update_one_input_types(ctx, related_model.clone(), Some(parent_field.clone()));
 
@@ -59,5 +62,6 @@ fn nested_upsert_nonlist_input_object(
         ];
 
         fields
-    }))
+    });
+    Some(input_object)
 }

--- a/query-engine/schema/src/build/mutations/create_many.rs
+++ b/query-engine/schema/src/build/mutations/create_many.rs
@@ -95,6 +95,7 @@ pub(crate) fn create_many_object_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields = filter_create_many_fields(ctx, &model, parent_field.clone());
         let field_mapper = CreateDataInputFieldMapper::new_checked();

--- a/query-engine/schema/src/build/mutations/create_one.rs
+++ b/query-engine/schema/src/build/mutations/create_one.rs
@@ -68,6 +68,7 @@ fn checked_create_input_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields = filter_checked_create_fields(&model, parent_field.clone());
         let field_mapper = CreateDataInputFieldMapper::new_checked();
@@ -94,6 +95,7 @@ fn unchecked_create_input_type(
     ));
 
     let mut input_object = init_input_object_type(ident);
+    input_object.set_container(model.clone());
     input_object.set_fields(move || {
         let mut filtered_fields = filter_unchecked_create_fields(&model, parent_field.as_ref());
         let field_mapper = CreateDataInputFieldMapper::new_unchecked();

--- a/query-engine/schema/src/build/utils.rs
+++ b/query-engine/schema/src/build/utils.rs
@@ -2,16 +2,6 @@ use super::*;
 use query_structure::{walkers, DefaultKind};
 use std::{borrow::Cow, sync::LazyLock};
 
-/// Input object type convenience wrapper function.
-pub(crate) fn input_object_type<'a>(
-    ident: Identifier,
-    fields: impl FnOnce() -> Vec<InputField<'a>> + Send + Sync + 'a,
-) -> InputObjectType<'a> {
-    let mut object_type = init_input_object_type(ident);
-    object_type.set_fields(fields);
-    object_type
-}
-
 /// Input object type initializer for cases where only the name is known, and fields are computed later.
 pub(crate) fn init_input_object_type<'a>(ident: Identifier) -> InputObjectType<'a> {
     InputObjectType {
@@ -19,6 +9,7 @@ pub(crate) fn init_input_object_type<'a>(ident: Identifier) -> InputObjectType<'
         constraints: InputObjectTypeConstraints::default(),
         fields: None,
         tag: None,
+        container: None,
     }
 }
 

--- a/query-engine/schema/src/input_types.rs
+++ b/query-engine/schema/src/input_types.rs
@@ -12,6 +12,7 @@ pub struct InputObjectType<'a> {
     pub constraints: InputObjectTypeConstraints<'a>,
     pub(crate) fields: InputObjectFields<'a>,
     pub(crate) tag: Option<ObjectTag<'a>>,
+    pub(crate) container: Option<ParentContainer>,
 }
 
 impl PartialEq for InputObjectType<'_> {
@@ -52,6 +53,7 @@ impl Debug for InputObjectType<'_> {
             .field("identifier", &self.identifier)
             .field("constraints", &self.constraints)
             .field("fields", &"#Input Fields Cell#")
+            .field("container", &self.container)
             .finish()
     }
 }
@@ -67,6 +69,14 @@ impl<'a> InputObjectType<'a> {
 
     pub fn tag(&self) -> Option<&ObjectTag<'a>> {
         self.tag.as_ref()
+    }
+
+    pub fn container(&self) -> Option<&ParentContainer> {
+        self.container.as_ref()
+    }
+
+    pub fn set_container(&mut self, container: impl Into<ParentContainer>) {
+        self.container = Some(container.into());
     }
 
     pub fn find_field(&self, name: &str) -> Option<&InputField<'a>> {


### PR DESCRIPTION
Adding additional metadata on the generated DMMF input types so the TS generator can know which type belongs to which model and group related input types into dedicated files.

Note that the grouping is not strictly the model name as we also have to deal with composite types. Hence we named this meta field explicitly `grouping` as it is intended only for this purpose.

/integration