### PR TITLE
feat(qc): Transactional graphs

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -43,9 +43,9 @@ class QueryPipeline {
 
       const results = transaction
         ? await this.executeTransactionalBatch(
-            batch,
-            parseIsolationLevel(transaction.isolationLevel),
-          )
+          batch,
+          parseIsolationLevel(transaction.isolationLevel),
+        )
         : await this.executeIndependentBatch(batch)
 
       debug('🟢 Batch query results: ', results)
@@ -86,8 +86,11 @@ class QueryPipeline {
 
     debug('🟢 Query plan: ', util.inspect(queryPlan, false, null, true))
 
+    const transactionManager = this.transactionManager
+
     const interpreter = new QueryInterpreter({
       queryable,
+      transactionManager,
       placeholderValues: {},
       onQuery: (event) => {
         this.logs.push(JSON.stringify(event))

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -8,7 +8,8 @@ import type { State } from './worker'
 import { debug } from '../utils'
 import {
   QueryInterpreter,
-  TransactionManager,
+  type QueryInterpreterTransactionManager,
+  type TransactionManager,
 } from '@prisma/client-engine-runtime'
 import { QueryCompiler } from '../query-compiler'
 import { parseIsolationLevel } from './worker-transaction'
@@ -87,11 +88,12 @@ class QueryPipeline {
 
     debug('🟢 Query plan: ', util.inspect(queryPlan, false, null, true))
 
-    const transactionManager = this.transactionManager
+    const qiTransactionManager = (
+      allowTransaction ? { enabled: true, manager: this.transactionManager } : { enabled: false }
+    ) satisfies QueryInterpreterTransactionManager
 
     const interpreter = new QueryInterpreter({
-      transactionManager,
-      allowTransaction: allowTransaction,
+      transactionManager: qiTransactionManager,
       placeholderValues: {},
       onQuery: (event) => {
         this.logs.push(JSON.stringify(event))

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -161,9 +161,10 @@ async function initializeSchema(
 
     const transactionManager = new TransactionManager({
         driverAdapter: adapter,
+        // Transaction timeouts matching `TransactionManager.test.ts` in the `prisma` repo
         transactionOptions: {
-            maxWait: 30,
-            timeout: 30,
+            maxWait: 200,
+            timeout: 500,
             isolationLevel: 'SERIALIZABLE'
         } satisfies TransactionOptions,
     })

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -2,7 +2,7 @@ import {Schema as S} from '@effect/schema'
 import type {ConnectionInfo, SqlDriverAdapter} from '@prisma/driver-adapter-utils'
 import {DriverAdaptersManager} from '../driver-adapters-manager'
 import * as qc from '../query-compiler'
-import {TransactionManager} from '@prisma/client-engine-runtime'
+import {TransactionManager, type TransactionOptions} from '@prisma/client-engine-runtime'
 import {parentPort} from 'worker_threads'
 import {
     CommitTxParams,
@@ -161,6 +161,11 @@ async function initializeSchema(
 
     const transactionManager = new TransactionManager({
         driverAdapter: adapter,
+        transactionOptions: {
+            maxWait: 30,
+            timeout: 30,
+            isolationLevel: 'SERIALIZABLE'
+        } satisfies TransactionOptions,
     })
 
     state = {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -77,6 +77,9 @@ pub enum Expression {
     /// Get a field from a record or records. If the argument is a list of records,
     /// returns a list of values of this field.
     MapField { field: String, records: Box<Expression> },
+
+    /// Run the query inside a transaction
+    Transaction(Box<Expression>),
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +140,7 @@ impl Expression {
             Expression::Required(expression) => expression.r#type(),
             Expression::Join { parent, .. } => parent.r#type(),
             Expression::MapField { records, .. } => records.r#type(),
+            Expression::Transaction(expression) => expression.r#type(),
         }
     }
 }

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -254,11 +254,13 @@ where
             .append(self.expression(records).parens())
     }
 
-    fn transaction(&'a self, body: &'a Expression) -> DocBuilder<'a, PrettyPrinter<'a, D>, ColorSpec> {
-        self.text("transaction")
-            .annotate(color_kw())
+    fn transaction(&'a self, expr: &'a Expression) -> DocBuilder<'a, PrettyPrinter<'a, D>, ColorSpec> {
+        self.keyword("transaction")
+            .append(self.line())
             .append(self.softline())
-            .append(self.expression(body).indent(1).braces())
+            .append(self.softline())
+            .append(self.softline())
+            .append(self.expression(expr).align())
     }
 }
 

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -55,6 +55,7 @@ where
             Expression::Required(expression) => self.unary_function("required", expression),
             Expression::Join { parent, children } => self.join(parent, children),
             Expression::MapField { field, records } => self.map_field(field, records),
+            Expression::Transaction(expression) => self.transaction(expression),
         }
     }
 
@@ -251,6 +252,13 @@ where
             .append(self.field_name(field))
             .append(self.space())
             .append(self.expression(records).parens())
+    }
+
+    fn transaction(&'a self, body: &'a Expression) -> DocBuilder<'a, PrettyPrinter<'a, D>, ColorSpec> {
+        self.text("transaction")
+            .annotate(color_kw())
+            .append(self.softline())
+            .append(self.expression(body).indent(1).braces())
     }
 }
 

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
@@ -5,43 +5,38 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-m2m.json
 snapshot_kind: text
 ---
-transaction { let 0 = unique (query «INSERT INTO "public"."User" ("email")
-                                     VALUES ($1) RETURNING "public"."User"."id"»
-                              params [const(String("user.1737556027349@prisma.io"))])
-              in let 0$id = mapField id (get 0)
-                 in let 1 = unique (query «INSERT INTO "public"."Post"
-                                           ("title","userId") VALUES ($1,$2)
-                                           RETURNING "public"."Post"."id"»
-                                    params [const(String("How to make an omelette")),
-                                            var(0$id as Int)])
-                    in let 2 = unique (query «INSERT INTO "public"."Category"
-                                              ("name") VALUES ($1) RETURNING
-                                              "public"."Category"."id"»
-                                       params [const(String("cooking"))])
-                       in let 1$id = mapField id (get 1);
-                              2$id = mapField id (get 2)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES ($1,$2) ON CONFLICT DO
-                                      NOTHING»
-                             params [var(1$id as Int), var(2$id as Int)];
-                 let 4 = let 0$id = mapField id (get 0)
-                     in let @parent = unique (query «SELECT
-                                                     "public"."User"."id",
-                                                     "public"."User"."email"
-                                                     FROM "public"."User" WHERE
-                                                     "public"."User"."id" = $1
-                                                     LIMIT $2 OFFSET $3»
-                                              params [var(0$id as Int),
-                                                      const(BigInt(1)),
-                                                      const(BigInt(0))])
-                        in let @parent$id = mapField id (get @parent)
-                           in join (get @parent)
-                              with (query «SELECT "public"."Post"."id",
-                                           "public"."Post"."title",
-                                           "public"."Post"."userId" FROM
-                                           "public"."Post" WHERE
-                                           "public"."Post"."userId" = $1 OFFSET
-                                           $2»
-                                    params [var(@parent$id as Int),
-                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
-                 in get 4}
+transaction
+   let 0 = unique (query «INSERT INTO "public"."User" ("email") VALUES ($1)
+                          RETURNING "public"."User"."id"»
+                   params [const(String("user.1737556027349@prisma.io"))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = unique (query «INSERT INTO "public"."Post" ("title","userId")
+                                VALUES ($1,$2) RETURNING "public"."Post"."id"»
+                         params [const(String("How to make an omelette")),
+                                 var(0$id as Int)])
+         in let 2 = unique (query «INSERT INTO "public"."Category" ("name")
+                                   VALUES ($1) RETURNING
+                                   "public"."Category"."id"»
+                            params [const(String("cooking"))])
+            in let 1$id = mapField id (get 1);
+                   2$id = mapField id (get 2)
+               in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                           VALUES ($1,$2) ON CONFLICT DO NOTHING»
+                  params [var(1$id as Int), var(2$id as Int)];
+      let 4 = let 0$id = mapField id (get 0)
+          in let @parent = unique (query «SELECT "public"."User"."id",
+                                          "public"."User"."email" FROM
+                                          "public"."User" WHERE
+                                          "public"."User"."id" = $1 LIMIT $2
+                                          OFFSET $3»
+                                   params [var(0$id as Int), const(BigInt(1)),
+                                           const(BigInt(0))])
+             in let @parent$id = mapField id (get @parent)
+                in join (get @parent)
+                   with (query «SELECT "public"."Post"."id",
+                                "public"."Post"."title",
+                                "public"."Post"."userId" FROM "public"."Post"
+                                WHERE "public"."Post"."userId" = $1 OFFSET $2»
+                         params [var(@parent$id as Int),
+                                 const(BigInt(0))]) on left.(id) = right.(userId) as posts
+      in get 4

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
@@ -1,38 +1,47 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 46
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-m2m.json
+snapshot_kind: text
 ---
-let 0 = unique (query «INSERT INTO "public"."User" ("email") VALUES ($1)
-                       RETURNING "public"."User"."id"»
-                params [const(String("user.1737556027349@prisma.io"))])
-in let 0$id = mapField id (get 0)
-   in let 1 = unique (query «INSERT INTO "public"."Post" ("title","userId")
-                             VALUES ($1,$2) RETURNING "public"."Post"."id"»
-                      params [const(String("How to make an omelette")),
-                              var(0$id as Int)])
-      in let 2 = unique (query «INSERT INTO "public"."Category" ("name") VALUES
-                                ($1) RETURNING "public"."Category"."id"»
-                         params [const(String("cooking"))])
-         in let 1$id = mapField id (get 1);
-                2$id = mapField id (get 2)
-            in execute «INSERT INTO "public"."_CategoryToPost" ("B","A") VALUES
-                        ($1,$2) ON CONFLICT DO NOTHING»
-               params [var(1$id as Int), var(2$id as Int)];
-   let 4 = let 0$id = mapField id (get 0)
-       in let @parent = unique (query «SELECT "public"."User"."id",
-                                       "public"."User"."email" FROM
-                                       "public"."User" WHERE
-                                       "public"."User"."id" = $1 LIMIT $2 OFFSET
-                                       $3»
-                                params [var(0$id as Int), const(BigInt(1)),
-                                        const(BigInt(0))])
-          in let @parent$id = mapField id (get @parent)
-             in join (get @parent)
-                with (query «SELECT "public"."Post"."id",
-                             "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE "public"."Post"."userId"
-                             = $1 OFFSET $2»
-                      params [var(@parent$id as Int),
-                              const(BigInt(0))]) on left.(id) = right.(userId) as posts
-   in get 4
+transaction { let 0 = unique (query «INSERT INTO "public"."User" ("email")
+                                     VALUES ($1) RETURNING "public"."User"."id"»
+                              params [const(String("user.1737556027349@prisma.io"))])
+              in let 0$id = mapField id (get 0)
+                 in let 1 = unique (query «INSERT INTO "public"."Post"
+                                           ("title","userId") VALUES ($1,$2)
+                                           RETURNING "public"."Post"."id"»
+                                    params [const(String("How to make an omelette")),
+                                            var(0$id as Int)])
+                    in let 2 = unique (query «INSERT INTO "public"."Category"
+                                              ("name") VALUES ($1) RETURNING
+                                              "public"."Category"."id"»
+                                       params [const(String("cooking"))])
+                       in let 1$id = mapField id (get 1);
+                              2$id = mapField id (get 2)
+                          in execute «INSERT INTO "public"."_CategoryToPost"
+                                      ("B","A") VALUES ($1,$2) ON CONFLICT DO
+                                      NOTHING»
+                             params [var(1$id as Int), var(2$id as Int)];
+                 let 4 = let 0$id = mapField id (get 0)
+                     in let @parent = unique (query «SELECT
+                                                     "public"."User"."id",
+                                                     "public"."User"."email"
+                                                     FROM "public"."User" WHERE
+                                                     "public"."User"."id" = $1
+                                                     LIMIT $2 OFFSET $3»
+                                              params [var(0$id as Int),
+                                                      const(BigInt(1)),
+                                                      const(BigInt(0))])
+                        in let @parent$id = mapField id (get @parent)
+                           in join (get @parent)
+                              with (query «SELECT "public"."Post"."id",
+                                           "public"."Post"."title",
+                                           "public"."Post"."userId" FROM
+                                           "public"."Post" WHERE
+                                           "public"."Post"."userId" = $1 OFFSET
+                                           $2»
+                                    params [var(@parent$id as Int),
+                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                 in get 4}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -1,33 +1,40 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 46
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-connect.json
+snapshot_kind: text
 ---
-let 0 = unique (query «INSERT INTO "public"."User" ("email") VALUES ($1)
-                       RETURNING "public"."User"."id"»
-                params [const(String("user.1737556028164@prisma.io"))])
-in let 0$id = mapField id (get 0)
-   in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                            (("public"."Post"."id" = $2 AND 1=1) OR
-                            ("public"."Post"."id" = $3 AND 1=1) OR
-                            ("public"."Post"."id" = $4 AND 1=1))»
-                   params [var(0$id as Int), const(BigInt(8)), const(BigInt(9)),
-                           const(BigInt(10))])
-      in ;
-   let 3 = let 0$id = mapField id (get 0)
-       in let @parent = unique (query «SELECT "public"."User"."id",
-                                       "public"."User"."email" FROM
-                                       "public"."User" WHERE
-                                       "public"."User"."id" = $1 LIMIT $2 OFFSET
-                                       $3»
-                                params [var(0$id as Int), const(BigInt(1)),
-                                        const(BigInt(0))])
-          in let @parent$id = mapField id (get @parent)
-             in join (get @parent)
-                with (query «SELECT "public"."Post"."id",
-                             "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE "public"."Post"."userId"
-                             = $1 OFFSET $2»
-                      params [var(@parent$id as Int),
-                              const(BigInt(0))]) on left.(id) = right.(userId) as posts
-   in get 3
+transaction { let 0 = unique (query «INSERT INTO "public"."User" ("email")
+                                     VALUES ($1) RETURNING "public"."User"."id"»
+                              params [const(String("user.1737556028164@prisma.io"))])
+              in let 0$id = mapField id (get 0)
+                 in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" =
+                                          $1 WHERE (("public"."Post"."id" = $2
+                                          AND 1=1) OR ("public"."Post"."id" = $3
+                                          AND 1=1) OR ("public"."Post"."id" = $4
+                                          AND 1=1))»
+                                 params [var(0$id as Int), const(BigInt(8)),
+                                         const(BigInt(9)), const(BigInt(10))])
+                    in ;
+                 let 3 = let 0$id = mapField id (get 0)
+                     in let @parent = unique (query «SELECT
+                                                     "public"."User"."id",
+                                                     "public"."User"."email"
+                                                     FROM "public"."User" WHERE
+                                                     "public"."User"."id" = $1
+                                                     LIMIT $2 OFFSET $3»
+                                              params [var(0$id as Int),
+                                                      const(BigInt(1)),
+                                                      const(BigInt(0))])
+                        in let @parent$id = mapField id (get @parent)
+                           in join (get @parent)
+                              with (query «SELECT "public"."Post"."id",
+                                           "public"."Post"."title",
+                                           "public"."Post"."userId" FROM
+                                           "public"."Post" WHERE
+                                           "public"."Post"."userId" = $1 OFFSET
+                                           $2»
+                                    params [var(@parent$id as Int),
+                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                 in get 3}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -5,36 +5,32 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-connect.json
 snapshot_kind: text
 ---
-transaction { let 0 = unique (query «INSERT INTO "public"."User" ("email")
-                                     VALUES ($1) RETURNING "public"."User"."id"»
-                              params [const(String("user.1737556028164@prisma.io"))])
-              in let 0$id = mapField id (get 0)
-                 in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" =
-                                          $1 WHERE (("public"."Post"."id" = $2
-                                          AND 1=1) OR ("public"."Post"."id" = $3
-                                          AND 1=1) OR ("public"."Post"."id" = $4
-                                          AND 1=1))»
-                                 params [var(0$id as Int), const(BigInt(8)),
-                                         const(BigInt(9)), const(BigInt(10))])
-                    in ;
-                 let 3 = let 0$id = mapField id (get 0)
-                     in let @parent = unique (query «SELECT
-                                                     "public"."User"."id",
-                                                     "public"."User"."email"
-                                                     FROM "public"."User" WHERE
-                                                     "public"."User"."id" = $1
-                                                     LIMIT $2 OFFSET $3»
-                                              params [var(0$id as Int),
-                                                      const(BigInt(1)),
-                                                      const(BigInt(0))])
-                        in let @parent$id = mapField id (get @parent)
-                           in join (get @parent)
-                              with (query «SELECT "public"."Post"."id",
-                                           "public"."Post"."title",
-                                           "public"."Post"."userId" FROM
-                                           "public"."Post" WHERE
-                                           "public"."Post"."userId" = $1 OFFSET
-                                           $2»
-                                    params [var(@parent$id as Int),
-                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
-                 in get 3}
+transaction
+   let 0 = unique (query «INSERT INTO "public"."User" ("email") VALUES ($1)
+                          RETURNING "public"."User"."id"»
+                   params [const(String("user.1737556028164@prisma.io"))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
+                               (("public"."Post"."id" = $2 AND 1=1) OR
+                               ("public"."Post"."id" = $3 AND 1=1) OR
+                               ("public"."Post"."id" = $4 AND 1=1))»
+                      params [var(0$id as Int), const(BigInt(8)),
+                              const(BigInt(9)), const(BigInt(10))])
+         in ;
+      let 3 = let 0$id = mapField id (get 0)
+          in let @parent = unique (query «SELECT "public"."User"."id",
+                                          "public"."User"."email" FROM
+                                          "public"."User" WHERE
+                                          "public"."User"."id" = $1 LIMIT $2
+                                          OFFSET $3»
+                                   params [var(0$id as Int), const(BigInt(1)),
+                                           const(BigInt(0))])
+             in let @parent$id = mapField id (get @parent)
+                in join (get @parent)
+                   with (query «SELECT "public"."Post"."id",
+                                "public"."Post"."title",
+                                "public"."Post"."userId" FROM "public"."Post"
+                                WHERE "public"."Post"."userId" = $1 OFFSET $2»
+                         params [var(@parent$id as Int),
+                                 const(BigInt(0))]) on left.(id) = right.(userId) as posts
+      in get 3

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
@@ -5,54 +5,47 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-create-with-composite-id.json
 snapshot_kind: text
 ---
-transaction { let 0 = unique (query «INSERT INTO
-                                     "public"."ParentModelWithCompositeId"
-                                     ("a","b") VALUES ($1,$2) RETURNING
-                                     "public"."ParentModelWithCompositeId"."a",
-                                     "public"."ParentModelWithCompositeId"."b"»
-                              params [const(BigInt(1)), const(BigInt(1))])
-              in let 0$a = mapField a (get 0);
-                     0$b = mapField b (get 0)
-                 in sum (execute «INSERT INTO
-                                  "public"."ChildOfModelWithCompositeId"
-                                  ("id","parentA","parentB") VALUES ($1,$2,$3),
-                                  ($4,$5,$6)»
-                         params [const(BigInt(1)), var(0$a as Int),
-                                 var(0$b as Int), const(BigInt(2)),
-                                 var(0$a as Int), var(0$b as Int)]);
-                 let 2 = let 0$a = mapField a (get 0);
-                             0$b = mapField b (get 0)
-                     in let @parent = unique (query «SELECT
-                                                     "public"."ParentModelWithCompositeId"."a",
-                                                     "public"."ParentModelWithCompositeId"."b"
-                                                     FROM
-                                                     "public"."ParentModelWithCompositeId"
-                                                     WHERE
-                                                     ("public"."ParentModelWithCompositeId"."a"
-                                                     = $1 AND
-                                                     "public"."ParentModelWithCompositeId"."b"
-                                                     = $2) LIMIT $3 OFFSET $4»
-                                              params [var(0$a as Int),
-                                                      var(0$b as Int),
-                                                      const(BigInt(1)),
-                                                      const(BigInt(0))])
-                        in let @parent$a = mapField a (get @parent);
-                               @parent$b = mapField b (get @parent)
-                           in join (get @parent)
-                              with (query «SELECT
-                                           "public"."ChildOfModelWithCompositeId"."id",
-                                           "public"."ChildOfModelWithCompositeId"."parentA",
-                                           "public"."ChildOfModelWithCompositeId"."parentB"
-                                           FROM
-                                           "public"."ChildOfModelWithCompositeId"
-                                           WHERE
-                                           ("public"."ChildOfModelWithCompositeId"."parentA"
-                                           = $1 OR
-                                           "public"."ChildOfModelWithCompositeId"."parentB"
-                                           = $2) OFFSET $3»
-                                    params [var(@parent$a as Int),
-                                            var(@parent$b as Int),
-                                            const(BigInt(0))]) on left.(a,
-                                                                        b) = right.(parentA,
-                                                                                    parentB) as children
-                 in get 2}
+transaction
+   let 0 = unique (query «INSERT INTO "public"."ParentModelWithCompositeId"
+                          ("a","b") VALUES ($1,$2) RETURNING
+                          "public"."ParentModelWithCompositeId"."a",
+                          "public"."ParentModelWithCompositeId"."b"»
+                   params [const(BigInt(1)), const(BigInt(1))])
+   in let 0$a = mapField a (get 0);
+          0$b = mapField b (get 0)
+      in sum (execute «INSERT INTO "public"."ChildOfModelWithCompositeId"
+                       ("id","parentA","parentB") VALUES ($1,$2,$3), ($4,$5,$6)»
+              params [const(BigInt(1)), var(0$a as Int), var(0$b as Int),
+                      const(BigInt(2)), var(0$a as Int), var(0$b as Int)]);
+      let 2 = let 0$a = mapField a (get 0);
+                  0$b = mapField b (get 0)
+          in let @parent = unique (query «SELECT
+                                          "public"."ParentModelWithCompositeId"."a",
+                                          "public"."ParentModelWithCompositeId"."b"
+                                          FROM
+                                          "public"."ParentModelWithCompositeId"
+                                          WHERE
+                                          ("public"."ParentModelWithCompositeId"."a"
+                                          = $1 AND
+                                          "public"."ParentModelWithCompositeId"."b"
+                                          = $2) LIMIT $3 OFFSET $4»
+                                   params [var(0$a as Int), var(0$b as Int),
+                                           const(BigInt(1)), const(BigInt(0))])
+             in let @parent$a = mapField a (get @parent);
+                    @parent$b = mapField b (get @parent)
+                in join (get @parent)
+                   with (query «SELECT
+                                "public"."ChildOfModelWithCompositeId"."id",
+                                "public"."ChildOfModelWithCompositeId"."parentA",
+                                "public"."ChildOfModelWithCompositeId"."parentB"
+                                FROM "public"."ChildOfModelWithCompositeId"
+                                WHERE
+                                ("public"."ChildOfModelWithCompositeId"."parentA"
+                                = $1 OR
+                                "public"."ChildOfModelWithCompositeId"."parentB"
+                                = $2) OFFSET $3»
+                         params [var(@parent$a as Int), var(@parent$b as Int),
+                                 const(BigInt(0))]) on left.(a,
+                                                             b) = right.(parentA,
+                                                                         parentB) as children
+      in get 2

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
@@ -1,46 +1,58 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 46
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-create-with-composite-id.json
+snapshot_kind: text
 ---
-let 0 = unique (query «INSERT INTO "public"."ParentModelWithCompositeId"
-                       ("a","b") VALUES ($1,$2) RETURNING
-                       "public"."ParentModelWithCompositeId"."a",
-                       "public"."ParentModelWithCompositeId"."b"»
-                params [const(BigInt(1)), const(BigInt(1))])
-in let 0$a = mapField a (get 0);
-       0$b = mapField b (get 0)
-   in sum (execute «INSERT INTO "public"."ChildOfModelWithCompositeId"
-                    ("id","parentA","parentB") VALUES ($1,$2,$3), ($4,$5,$6)»
-           params [const(BigInt(1)), var(0$a as Int), var(0$b as Int),
-                   const(BigInt(2)), var(0$a as Int), var(0$b as Int)]);
-   let 2 = let 0$a = mapField a (get 0);
-               0$b = mapField b (get 0)
-       in let @parent = unique (query «SELECT
-                                       "public"."ParentModelWithCompositeId"."a",
-                                       "public"."ParentModelWithCompositeId"."b"
-                                       FROM
-                                       "public"."ParentModelWithCompositeId"
-                                       WHERE
-                                       ("public"."ParentModelWithCompositeId"."a"
-                                       = $1 AND
-                                       "public"."ParentModelWithCompositeId"."b"
-                                       = $2) LIMIT $3 OFFSET $4»
-                                params [var(0$a as Int), var(0$b as Int),
-                                        const(BigInt(1)), const(BigInt(0))])
-          in let @parent$a = mapField a (get @parent);
-                 @parent$b = mapField b (get @parent)
-             in join (get @parent)
-                with (query «SELECT "public"."ChildOfModelWithCompositeId"."id",
-                             "public"."ChildOfModelWithCompositeId"."parentA",
-                             "public"."ChildOfModelWithCompositeId"."parentB"
-                             FROM "public"."ChildOfModelWithCompositeId" WHERE
-                             ("public"."ChildOfModelWithCompositeId"."parentA" =
-                             $1 OR
-                             "public"."ChildOfModelWithCompositeId"."parentB" =
-                             $2) OFFSET $3»
-                      params [var(@parent$a as Int), var(@parent$b as Int),
-                              const(BigInt(0))]) on left.(a,
-                                                          b) = right.(parentA,
-                                                                      parentB) as children
-   in get 2
+transaction { let 0 = unique (query «INSERT INTO
+                                     "public"."ParentModelWithCompositeId"
+                                     ("a","b") VALUES ($1,$2) RETURNING
+                                     "public"."ParentModelWithCompositeId"."a",
+                                     "public"."ParentModelWithCompositeId"."b"»
+                              params [const(BigInt(1)), const(BigInt(1))])
+              in let 0$a = mapField a (get 0);
+                     0$b = mapField b (get 0)
+                 in sum (execute «INSERT INTO
+                                  "public"."ChildOfModelWithCompositeId"
+                                  ("id","parentA","parentB") VALUES ($1,$2,$3),
+                                  ($4,$5,$6)»
+                         params [const(BigInt(1)), var(0$a as Int),
+                                 var(0$b as Int), const(BigInt(2)),
+                                 var(0$a as Int), var(0$b as Int)]);
+                 let 2 = let 0$a = mapField a (get 0);
+                             0$b = mapField b (get 0)
+                     in let @parent = unique (query «SELECT
+                                                     "public"."ParentModelWithCompositeId"."a",
+                                                     "public"."ParentModelWithCompositeId"."b"
+                                                     FROM
+                                                     "public"."ParentModelWithCompositeId"
+                                                     WHERE
+                                                     ("public"."ParentModelWithCompositeId"."a"
+                                                     = $1 AND
+                                                     "public"."ParentModelWithCompositeId"."b"
+                                                     = $2) LIMIT $3 OFFSET $4»
+                                              params [var(0$a as Int),
+                                                      var(0$b as Int),
+                                                      const(BigInt(1)),
+                                                      const(BigInt(0))])
+                        in let @parent$a = mapField a (get @parent);
+                               @parent$b = mapField b (get @parent)
+                           in join (get @parent)
+                              with (query «SELECT
+                                           "public"."ChildOfModelWithCompositeId"."id",
+                                           "public"."ChildOfModelWithCompositeId"."parentA",
+                                           "public"."ChildOfModelWithCompositeId"."parentB"
+                                           FROM
+                                           "public"."ChildOfModelWithCompositeId"
+                                           WHERE
+                                           ("public"."ChildOfModelWithCompositeId"."parentA"
+                                           = $1 OR
+                                           "public"."ChildOfModelWithCompositeId"."parentB"
+                                           = $2) OFFSET $3»
+                                    params [var(@parent$a as Int),
+                                            var(@parent$b as Int),
+                                            const(BigInt(0))]) on left.(a,
+                                                                        b) = right.(parentA,
+                                                                                    parentB) as children
+                 in get 2}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
@@ -5,34 +5,30 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-create.json
 snapshot_kind: text
 ---
-transaction { let 0 = unique (query «INSERT INTO "public"."User" ("email")
-                                     VALUES ($1) RETURNING "public"."User"."id"»
-                              params [const(String("user.1737556027349@prisma.io"))])
-              in let 0$id = mapField id (get 0)
-                 in sum (execute «INSERT INTO "public"."Post" ("title","userId")
-                                  VALUES ($1,$2), ($3,$4)»
-                         params [const(String("How to make an omelette")),
-                                 var(0$id as Int),
-                                 const(String("How to eat an omelette")),
-                                 var(0$id as Int)]);
-                 let 2 = let 0$id = mapField id (get 0)
-                     in let @parent = unique (query «SELECT
-                                                     "public"."User"."id",
-                                                     "public"."User"."email"
-                                                     FROM "public"."User" WHERE
-                                                     "public"."User"."id" = $1
-                                                     LIMIT $2 OFFSET $3»
-                                              params [var(0$id as Int),
-                                                      const(BigInt(1)),
-                                                      const(BigInt(0))])
-                        in let @parent$id = mapField id (get @parent)
-                           in join (get @parent)
-                              with (query «SELECT "public"."Post"."id",
-                                           "public"."Post"."title",
-                                           "public"."Post"."userId" FROM
-                                           "public"."Post" WHERE
-                                           "public"."Post"."userId" = $1 OFFSET
-                                           $2»
-                                    params [var(@parent$id as Int),
-                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
-                 in get 2}
+transaction
+   let 0 = unique (query «INSERT INTO "public"."User" ("email") VALUES ($1)
+                          RETURNING "public"."User"."id"»
+                   params [const(String("user.1737556027349@prisma.io"))])
+   in let 0$id = mapField id (get 0)
+      in sum (execute «INSERT INTO "public"."Post" ("title","userId") VALUES
+                       ($1,$2), ($3,$4)»
+              params [const(String("How to make an omelette")),
+                      var(0$id as Int), const(String("How to eat an omelette")),
+                      var(0$id as Int)]);
+      let 2 = let 0$id = mapField id (get 0)
+          in let @parent = unique (query «SELECT "public"."User"."id",
+                                          "public"."User"."email" FROM
+                                          "public"."User" WHERE
+                                          "public"."User"."id" = $1 LIMIT $2
+                                          OFFSET $3»
+                                   params [var(0$id as Int), const(BigInt(1)),
+                                           const(BigInt(0))])
+             in let @parent$id = mapField id (get @parent)
+                in join (get @parent)
+                   with (query «SELECT "public"."Post"."id",
+                                "public"."Post"."title",
+                                "public"."Post"."userId" FROM "public"."Post"
+                                WHERE "public"."Post"."userId" = $1 OFFSET $2»
+                         params [var(@parent$id as Int),
+                                 const(BigInt(0))]) on left.(id) = right.(userId) as posts
+      in get 2

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
@@ -1,30 +1,38 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 46
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-create.json
+snapshot_kind: text
 ---
-let 0 = unique (query «INSERT INTO "public"."User" ("email") VALUES ($1)
-                       RETURNING "public"."User"."id"»
-                params [const(String("user.1737556027349@prisma.io"))])
-in let 0$id = mapField id (get 0)
-   in sum (execute «INSERT INTO "public"."Post" ("title","userId") VALUES
-                    ($1,$2), ($3,$4)»
-           params [const(String("How to make an omelette")), var(0$id as Int),
-                   const(String("How to eat an omelette")), var(0$id as Int)]);
-   let 2 = let 0$id = mapField id (get 0)
-       in let @parent = unique (query «SELECT "public"."User"."id",
-                                       "public"."User"."email" FROM
-                                       "public"."User" WHERE
-                                       "public"."User"."id" = $1 LIMIT $2 OFFSET
-                                       $3»
-                                params [var(0$id as Int), const(BigInt(1)),
-                                        const(BigInt(0))])
-          in let @parent$id = mapField id (get @parent)
-             in join (get @parent)
-                with (query «SELECT "public"."Post"."id",
-                             "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE "public"."Post"."userId"
-                             = $1 OFFSET $2»
-                      params [var(@parent$id as Int),
-                              const(BigInt(0))]) on left.(id) = right.(userId) as posts
-   in get 2
+transaction { let 0 = unique (query «INSERT INTO "public"."User" ("email")
+                                     VALUES ($1) RETURNING "public"."User"."id"»
+                              params [const(String("user.1737556027349@prisma.io"))])
+              in let 0$id = mapField id (get 0)
+                 in sum (execute «INSERT INTO "public"."Post" ("title","userId")
+                                  VALUES ($1,$2), ($3,$4)»
+                         params [const(String("How to make an omelette")),
+                                 var(0$id as Int),
+                                 const(String("How to eat an omelette")),
+                                 var(0$id as Int)]);
+                 let 2 = let 0$id = mapField id (get 0)
+                     in let @parent = unique (query «SELECT
+                                                     "public"."User"."id",
+                                                     "public"."User"."email"
+                                                     FROM "public"."User" WHERE
+                                                     "public"."User"."id" = $1
+                                                     LIMIT $2 OFFSET $3»
+                                              params [var(0$id as Int),
+                                                      const(BigInt(1)),
+                                                      const(BigInt(0))])
+                        in let @parent$id = mapField id (get @parent)
+                           in join (get @parent)
+                              with (query «SELECT "public"."Post"."id",
+                                           "public"."Post"."title",
+                                           "public"."Post"."userId" FROM
+                                           "public"."Post" WHERE
+                                           "public"."Post"."userId" = $1 OFFSET
+                                           $2»
+                                    params [var(@parent$id as Int),
+                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                 in get 2}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -5,37 +5,31 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect.json
 snapshot_kind: text
 ---
-transaction { let 0 = unique (query «SELECT "public"."User"."id",
-                                     "public"."User"."email" FROM
-                                     "public"."User" WHERE
-                                     ("public"."User"."email" = $1 AND 1=1)
-                                     LIMIT $2 OFFSET $3»
-                              params [const(String("user.1737556028164@prisma.io")),
-                                      const(BigInt(1)), const(BigInt(0))])
-              in let 0$id = mapField id (get 0)
-                 in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" =
-                                          $1 WHERE ("public"."Post"."id" = $2
-                                          AND 1=1)»
-                                 params [var(0$id as Int), const(BigInt(11))])
-                    in ;
-                 let 3 = let 0$id = mapField id (get 0)
-                     in let @parent = unique (query «SELECT
-                                                     "public"."User"."id",
-                                                     "public"."User"."email"
-                                                     FROM "public"."User" WHERE
-                                                     "public"."User"."id" = $1
-                                                     LIMIT $2 OFFSET $3»
-                                              params [var(0$id as Int),
-                                                      const(BigInt(1)),
-                                                      const(BigInt(0))])
-                        in let @parent$id = mapField id (get @parent)
-                           in join (get @parent)
-                              with (query «SELECT "public"."Post"."id",
-                                           "public"."Post"."title",
-                                           "public"."Post"."userId" FROM
-                                           "public"."Post" WHERE
-                                           "public"."Post"."userId" = $1 OFFSET
-                                           $2»
-                                    params [var(@parent$id as Int),
-                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
-                 in get 3}
+transaction
+   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email"
+                          FROM "public"."User" WHERE ("public"."User"."email" =
+                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                   params [const(String("user.1737556028164@prisma.io")),
+                           const(BigInt(1)), const(BigInt(0))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
+                               ("public"."Post"."id" = $2 AND 1=1)»
+                      params [var(0$id as Int), const(BigInt(11))])
+         in ;
+      let 3 = let 0$id = mapField id (get 0)
+          in let @parent = unique (query «SELECT "public"."User"."id",
+                                          "public"."User"."email" FROM
+                                          "public"."User" WHERE
+                                          "public"."User"."id" = $1 LIMIT $2
+                                          OFFSET $3»
+                                   params [var(0$id as Int), const(BigInt(1)),
+                                           const(BigInt(0))])
+             in let @parent$id = mapField id (get @parent)
+                in join (get @parent)
+                   with (query «SELECT "public"."Post"."id",
+                                "public"."Post"."title",
+                                "public"."Post"."userId" FROM "public"."Post"
+                                WHERE "public"."Post"."userId" = $1 OFFSET $2»
+                         params [var(@parent$id as Int),
+                                 const(BigInt(0))]) on left.(id) = right.(userId) as posts
+      in get 3

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -1,32 +1,41 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 46
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect.json
+snapshot_kind: text
 ---
-let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email" FROM
-                       "public"."User" WHERE ("public"."User"."email" = $1 AND
-                       1=1) LIMIT $2 OFFSET $3»
-                params [const(String("user.1737556028164@prisma.io")),
-                        const(BigInt(1)), const(BigInt(0))])
-in let 0$id = mapField id (get 0)
-   in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                            ("public"."Post"."id" = $2 AND 1=1)»
-                   params [var(0$id as Int), const(BigInt(11))])
-      in ;
-   let 3 = let 0$id = mapField id (get 0)
-       in let @parent = unique (query «SELECT "public"."User"."id",
-                                       "public"."User"."email" FROM
-                                       "public"."User" WHERE
-                                       "public"."User"."id" = $1 LIMIT $2 OFFSET
-                                       $3»
-                                params [var(0$id as Int), const(BigInt(1)),
-                                        const(BigInt(0))])
-          in let @parent$id = mapField id (get @parent)
-             in join (get @parent)
-                with (query «SELECT "public"."Post"."id",
-                             "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE "public"."Post"."userId"
-                             = $1 OFFSET $2»
-                      params [var(@parent$id as Int),
-                              const(BigInt(0))]) on left.(id) = right.(userId) as posts
-   in get 3
+transaction { let 0 = unique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email" FROM
+                                     "public"."User" WHERE
+                                     ("public"."User"."email" = $1 AND 1=1)
+                                     LIMIT $2 OFFSET $3»
+                              params [const(String("user.1737556028164@prisma.io")),
+                                      const(BigInt(1)), const(BigInt(0))])
+              in let 0$id = mapField id (get 0)
+                 in let 1 = sum (execute «UPDATE "public"."Post" SET "userId" =
+                                          $1 WHERE ("public"."Post"."id" = $2
+                                          AND 1=1)»
+                                 params [var(0$id as Int), const(BigInt(11))])
+                    in ;
+                 let 3 = let 0$id = mapField id (get 0)
+                     in let @parent = unique (query «SELECT
+                                                     "public"."User"."id",
+                                                     "public"."User"."email"
+                                                     FROM "public"."User" WHERE
+                                                     "public"."User"."id" = $1
+                                                     LIMIT $2 OFFSET $3»
+                                              params [var(0$id as Int),
+                                                      const(BigInt(1)),
+                                                      const(BigInt(0))])
+                        in let @parent$id = mapField id (get @parent)
+                           in join (get @parent)
+                              with (query «SELECT "public"."Post"."id",
+                                           "public"."Post"."title",
+                                           "public"."Post"."userId" FROM
+                                           "public"."Post" WHERE
+                                           "public"."Post"."userId" = $1 OFFSET
+                                           $2»
+                                    params [var(@parent$id as Int),
+                                            const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                 in get 3}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -5,25 +5,30 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-disconnect.json
 snapshot_kind: text
 ---
-let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                       "public"."Post"."userId" FROM "public"."Post" WHERE
-                       ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET $3»
-                params [const(BigInt(1)), const(BigInt(1)), const(BigInt(0))])
-in let 0$id = mapField id (get 0)
-   in let 1 = query «SELECT "t1"."id", "t0"."B" AS "CategoryToPost@Post" FROM
-                     "public"."_CategoryToPost" AS "t0" INNER JOIN
-                     "public"."Category" AS "t1" ON "t0"."A" = "t1"."id" WHERE
-                     ("t1"."id" = $1 AND 1=1)»
-              params [const(BigInt(1))]
-      in let 0$id = mapField id (get 0);
-             1$id = mapField id (get 1)
-         in execute «DELETE FROM "public"."_CategoryToPost" WHERE
-                     ("public"."_CategoryToPost"."B" = ($1) AND
-                     "public"."_CategoryToPost"."A" IN [$2])»
-            params [var(0$id as Int), var(1$id as Int)];
-   let 3 = let 0$id = mapField id (get 0)
-       in unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                         "public"."Post"."userId" FROM "public"."Post" WHERE
-                         "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
-                  params [var(0$id as Int), const(BigInt(1)), const(BigInt(0))])
-   in get 3
+transaction
+   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                          "public"."Post"."userId" FROM "public"."Post" WHERE
+                          ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = query «SELECT "t1"."id", "t0"."B" AS "CategoryToPost@Post" FROM
+                        "public"."_CategoryToPost" AS "t0" INNER JOIN
+                        "public"."Category" AS "t1" ON "t0"."A" = "t1"."id"
+                        WHERE ("t1"."id" = $1 AND 1=1)»
+                 params [const(BigInt(1))]
+         in let 0$id = mapField id (get 0);
+                1$id = mapField id (get 1)
+            in execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                        ("public"."_CategoryToPost"."B" = ($1) AND
+                        "public"."_CategoryToPost"."A" IN [$2])»
+               params [var(0$id as Int), var(1$id as Int)];
+      let 3 = let 0$id = mapField id (get 0)
+          in unique (query «SELECT "public"."Post"."id",
+                            "public"."Post"."title", "public"."Post"."userId"
+                            FROM "public"."Post" WHERE "public"."Post"."id" = $1
+                            LIMIT $2 OFFSET $3»
+                     params [var(0$id as Int), const(BigInt(1)),
+                             const(BigInt(0))])
+      in get 3

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -194,7 +194,7 @@ pub struct QueryGraph {
 
     finalized: bool,
 
-    /// For now a stupid marker if the query graph needs to be run inside a
+    /// For now a simple marker if the query graph needs to be run inside a
     /// transaction. Should happen if any of the queries is writing data.
     needs_transaction: bool,
 
@@ -334,7 +334,7 @@ impl QueryGraph {
     }
 
     /// If true, the graph should be executed inside of a transaction.
-    pub(crate) fn needs_transaction(&self) -> bool {
+    pub fn needs_transaction(&self) -> bool {
         self.needs_transaction
     }
 


### PR DESCRIPTION
- Introduced `Expression::Transaction` to Query Compiler

Implements [ORM-742](https://linear.app/prisma-company/issue/ORM-742/run-transactional-graphs-in-transactions)

[Prisma PR](https://github.com/prisma/prisma/pull/26720)