### PR TITLE
feat(driver-adapters): add `AdapterName` binding; bypass `version()` for Cloudflare D1

### DIFF
--- a/libs/driver-adapters/executor/src/demo-se.ts
+++ b/libs/driver-adapters/executor/src/demo-se.ts
@@ -65,9 +65,6 @@ async function main(): Promise<void> {
 
   {
     console.log('[version]')
-
-    // Note: this fails on Cloudflare D1:
-    // `D1_ERROR: not authorized to use function: sqlite_version at offset 7: SQLITE_ERROR`
     const version = await engine.version()
     console.dir({ version }, { depth: null })
   }

--- a/libs/driver-adapters/src/factory.rs
+++ b/libs/driver-adapters/src/factory.rs
@@ -6,7 +6,8 @@ use std::sync::{
 use async_trait::async_trait;
 use quaint::{
     connector::{
-        AdapterProvider, DescribedQuery, ExternalConnector, ExternalConnectorFactory, IsolationLevel, Transaction,
+        AdapterName, AdapterProvider, DescribedQuery, ExternalConnector, ExternalConnectorFactory, IsolationLevel,
+        Transaction,
     },
     prelude::{
         ExternalConnectionInfo, Query as QuaintQuery, Queryable as QuaintQueryable, ResultSet, TransactionCapable,
@@ -44,6 +45,10 @@ pub fn adapter_factory_from_js(driver: JsObject) -> JsAdapterFactory {
 
 #[async_trait]
 impl ExternalConnectorFactory for JsAdapterFactory {
+    fn adapter_name(&self) -> quaint::connector::AdapterName {
+        self.inner.adapter_name()
+    }
+
     async fn connect(&self) -> quaint::Result<Arc<dyn ExternalConnector>> {
         self.connect()
             .await
@@ -88,7 +93,11 @@ impl Drop for JsQueryableDropGuard {
 
 #[async_trait]
 impl ExternalConnector for JsQueryableDropGuard {
-    fn provider(&self) -> quaint::connector::AdapterProvider {
+    fn adapter_name(&self) -> AdapterName {
+        self.inner.adapter_name()
+    }
+
+    fn provider(&self) -> AdapterProvider {
         self.inner.provider()
     }
 

--- a/libs/driver-adapters/src/proxy.rs
+++ b/libs/driver-adapters/src/proxy.rs
@@ -9,7 +9,7 @@ use crate::{
 
 use futures::Future;
 use prisma_metrics::gauge;
-use quaint::connector::{AdapterProvider, IsolationLevel};
+use quaint::connector::{AdapterName, AdapterProvider, IsolationLevel};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Proxy is a struct wrapping a javascript object that exhibits basic primitives for
@@ -24,7 +24,10 @@ pub(crate) struct CommonProxy {
     execute_raw: AdapterMethod<Query, u32>,
 
     /// Return the provider for this driver.
-    pub(crate) provider: String,
+    pub(crate) provider: AdapterProvider,
+
+    /// Return the adapter name for this driver.
+    pub(crate) adapter_name: AdapterName,
 }
 
 /// This is a JS proxy for accessing methods on the adapter factory.
@@ -37,6 +40,9 @@ pub(crate) struct AdapterFactoryProxy {
 
     /// Return the provider for this driver.
     pub(crate) provider: AdapterProvider,
+
+    /// Return the adapter name for this driver.
+    pub(crate) adapter_name: AdapterName,
 }
 
 /// This is a JS proxy for accessing the methods specific to top level
@@ -76,11 +82,16 @@ pub(crate) struct TransactionProxy {
 impl CommonProxy {
     pub fn new(object: &JsObject) -> JsResult<Self> {
         let provider: JsString = get_named_property(object, "provider")?;
+        let provider: AdapterProvider = to_rust_str(provider)?.parse().unwrap();
+
+        let adapter_name: JsString = get_named_property(object, "adapterName")?;
+        let adapter_name: AdapterName = to_rust_str(adapter_name)?.parse().unwrap();
 
         Ok(Self {
             query_raw: get_named_property(object, "queryRaw")?,
             execute_raw: get_named_property(object, "executeRaw")?,
-            provider: to_rust_str(provider)?,
+            provider,
+            adapter_name,
         })
     }
 
@@ -98,7 +109,11 @@ impl AdapterFactoryProxy {
         let provider: JsString = get_named_property(object, "provider")?;
         let provider: AdapterProvider = to_rust_str(provider)?.parse().unwrap();
 
+        let adapter_name: JsString = get_named_property(object, "adapterName")?;
+        let adapter_name: AdapterName = to_rust_str(adapter_name)?.parse().unwrap();
+
         Ok(Self {
+            adapter_name,
             connect: get_named_property(object, "connect")?,
             connect_to_shadow_db: get_optional_named_property(object, "connectToShadowDb")?,
             provider,
@@ -114,6 +129,10 @@ impl AdapterFactoryProxy {
             Some(method) => Some(UnsafeFuture(method.call_as_async(())).await),
             None => None,
         }
+    }
+
+    pub fn adapter_name(&self) -> AdapterName {
+        self.adapter_name
     }
 
     pub fn provider(&self) -> AdapterProvider {

--- a/libs/driver-adapters/src/queryable.rs
+++ b/libs/driver-adapters/src/queryable.rs
@@ -6,7 +6,7 @@ use super::conversion;
 use crate::send_future::UnsafeFuture;
 use async_trait::async_trait;
 use futures::Future;
-use quaint::connector::{DescribedQuery, ExternalConnectionInfo, ExternalConnector};
+use quaint::connector::{AdapterName, DescribedQuery, ExternalConnectionInfo, ExternalConnector};
 use quaint::{
     connector::{metrics, IsolationLevel, Transaction},
     prelude::{Query as QuaintQuery, Queryable as QuaintQueryable, ResultSet, TransactionCapable},
@@ -30,15 +30,18 @@ use tracing::{info_span, Instrument};
 pub(crate) struct JsBaseQueryable {
     pub(crate) proxy: CommonProxy,
     pub provider: AdapterProvider,
+    pub adapter_name: AdapterName,
     pub(crate) db_system_name: &'static str,
 }
 
 impl JsBaseQueryable {
     pub(crate) fn new(proxy: CommonProxy) -> Self {
-        let provider: AdapterProvider = proxy.provider.parse().unwrap();
+        let provider: AdapterProvider = proxy.provider;
+        let adapter_name = proxy.adapter_name.clone();
         let db_system_name = provider.db_system_name();
         Self {
             proxy,
+            adapter_name,
             provider,
             db_system_name,
         }
@@ -278,6 +281,10 @@ impl std::fmt::Debug for JsQueryable {
 
 #[async_trait]
 impl ExternalConnector for JsQueryable {
+    fn adapter_name(&self) -> AdapterName {
+        self.inner.adapter_name
+    }
+
     fn provider(&self) -> AdapterProvider {
         self.inner.provider
     }

--- a/schema-engine/connectors/sql-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/lib.rs
@@ -22,7 +22,7 @@ use enumflags2::BitFlags;
 use flavour::{SqlConnector, SqlDialect, UsingExternalShadowDb};
 use migration_pair::MigrationPair;
 use psl::{datamodel_connector::NativeTypeInstance, parser_database::ScalarType, SourceFile, ValidatedSchema};
-use quaint::connector::DescribedQuery;
+use quaint::connector::{AdapterName, DescribedQuery};
 use schema_connector::{migrations_directory::MigrationDirectory, *};
 use sql_doc_parser::{parse_sql_doc, sanitize_sql};
 use sql_migration::{DropUserDefinedType, DropView, SqlMigration, SqlMigrationStep};
@@ -177,6 +177,7 @@ impl SchemaDialect for SqlSchemaDialect {
 
 /// The top-level SQL migration connector.
 pub struct SqlSchemaConnector {
+    adapter_name: Option<AdapterName>,
     inner: Box<dyn SqlConnector + Send + Sync + 'static>,
     host: Arc<dyn ConnectorHost>,
 }
@@ -184,9 +185,6 @@ pub struct SqlSchemaConnector {
 impl SqlSchemaConnector {
     /// Initialise an external migration connector.
     pub async fn new_from_external(adapter: Arc<dyn quaint::connector::ExternalConnector>) -> ConnectorResult<Self> {
-        // TODO: store `adapter.adapter_name` in an `Option<String>` field on the connector.
-        // Use that to intercept calls to d1 (`@prisma/adapter-d1`, `@prisma/adapter-d1-http`),
-        // and change the behaviour of problematic methods, like `version()`.
         match adapter.provider() {
             #[cfg(all(feature = "postgresql", not(feature = "postgresql-native")))]
             quaint::connector::AdapterProvider::Postgres => Self::new_postgres_external(adapter).await,
@@ -202,7 +200,9 @@ impl SqlSchemaConnector {
     pub async fn new_postgres_external(
         adapter: Arc<dyn quaint::connector::ExternalConnector>,
     ) -> ConnectorResult<Self> {
+        let adapter_name = adapter.adapter_name();
         Ok(SqlSchemaConnector {
+            adapter_name: Some(adapter_name),
             inner: Box::new(flavour::PostgresConnector::new_external(adapter).await?),
             host: Arc::new(EmptyHost),
         })
@@ -211,7 +211,9 @@ impl SqlSchemaConnector {
     /// Initialize an external SQLite migration connector.
     #[cfg(all(feature = "sqlite", not(feature = "sqlite-native")))]
     pub async fn new_sqlite_external(adapter: Arc<dyn quaint::connector::ExternalConnector>) -> Self {
+        let adapter_name = adapter.adapter_name();
         SqlSchemaConnector {
+            adapter_name: Some(adapter_name),
             inner: Box::new(flavour::SqliteConnector::new_external(adapter)),
             host: Arc::new(EmptyHost),
         }
@@ -223,6 +225,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::PostgresConnector::new_postgres(params)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -232,6 +235,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::PostgresConnector::new_cockroach(params)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -244,6 +248,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::PostgresConnector::new_with_params(params)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -253,6 +258,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::SqliteConnector::new_with_params(params)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -262,6 +268,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::SqliteConnector::new_inmem(preview_features)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -271,6 +278,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::MysqlConnector::new_with_params(params)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -280,6 +288,7 @@ impl SqlSchemaConnector {
         Ok(SqlSchemaConnector {
             inner: Box::new(flavour::MssqlConnector::new_with_params(params)?),
             host: Arc::new(EmptyHost),
+            adapter_name: None,
         })
     }
 
@@ -381,10 +390,17 @@ impl SchemaConnector for SqlSchemaConnector {
 
     fn version(&mut self) -> BoxFuture<'_, ConnectorResult<String>> {
         Box::pin(async {
-            self.inner
-                .version()
-                .await
-                .map(|version| version.unwrap_or_else(|| "Database version information not available.".to_owned()))
+            match self.adapter_name {
+                // Cloudflare D1 doesn't allow querying the version.
+                // We thus return a hardcoded string to avoid the error
+                // `not authorized to use function: sqlite_version at offset`.
+                Some(AdapterName::D1(..)) => Ok("cf-d1".to_owned()),
+                _ => {
+                    self.inner.version().await.map(|version| {
+                        version.unwrap_or_else(|| "Database version information not available.".to_owned())
+                    })
+                }
+            }
         })
     }
 


### PR DESCRIPTION
This PR closes [ORM-381](https://linear.app/prisma-company/issue/ORM-831/add-rust-binding-to-adaptername-bypass-version-for-cloudflare-d1).

Background:
- Cloudflare D1 doesn't allow retrieving the version of sqlite it uses under the hood
- Attempting doing so with the same query we normally use for SQLite fails with an "unauthorized" error
- We thus need to bypass `.version()` calls in `sql-schema-connector` and return an hardcoded string in the Cloudflare D1 cases
- To do so, Prisma Engines need to be aware of our first-class Driver Adapters. We thus need to introduce the `AdapterName` enum, which binds to `.adapterName` in TypeScript's Driver Adapters.