### PR TITLE
feat(schema-engine-wasm): refine implementation based on TypeScript `SchemaEngineWasm`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4753,6 +4753,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "enumflags2",
+ "js-sys",
  "json-rpc-api",
  "psl",
  "quaint",

--- a/libs/driver-adapters/executor/src/demo-se.ts
+++ b/libs/driver-adapters/executor/src/demo-se.ts
@@ -100,8 +100,8 @@ async function main(): Promise<void> {
           }
         ],
       },
-      exitCode: undefined,
-      shadowDatabaseUrl: undefined,
+      exitCode: null,
+      shadowDatabaseUrl: null,
       script: true,
     })
     console.dir({ diffResult }, { depth: null })
@@ -121,7 +121,7 @@ async function main(): Promise<void> {
       baseDirectoryPath: process.cwd(),
       compositeTypeDepth: 0,
       force: false,
-      namespaces: undefined,
+      namespaces: null,
     })
     console.dir(introspectResult, { depth: null })
   }

--- a/libs/driver-adapters/executor/src/schema-engine-wasm-module.ts
+++ b/libs/driver-adapters/executor/src/schema-engine-wasm-module.ts
@@ -13,5 +13,5 @@ export type QueryLogCallback = (log: string) => void
 export async function initSchemaEngine(
   adapterFactory: ErrorCapturingSqlDriverAdapterFactory,
 ): Promise<SchemaEngine> {
-  return new SchemaEngine(adapterFactory)
+  return await SchemaEngine.new(adapterFactory)
 }

--- a/schema-engine/connectors/schema-connector/Cargo.toml
+++ b/schema-engine/connectors/schema-connector/Cargo.toml
@@ -34,6 +34,7 @@ user-facing-errors = { workspace = true, features = [
 chrono.workspace = true
 enumflags2.workspace = true
 json-rpc = { path = "../../json-rpc-api", package = "json-rpc-api" }
+js-sys.workspace = true
 sha2.workspace = true
 tracing.workspace = true
 tracing-error.workspace = true

--- a/schema-engine/json-rpc-api/src/types.rs
+++ b/schema-engine/json-rpc-api/src/types.rs
@@ -14,7 +14,7 @@ use tsify_next::Tsify;
 /// Information about a migration lockfile.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct MigrationLockfile {
     /// Relative path to the lockfile from base directory.
     /// E.g., `./migration_lock.toml`.
@@ -27,7 +27,7 @@ pub struct MigrationLockfile {
 /// A list of migration directories with related information.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct MigrationList {
     /// Absolute path to the base directory of Prisma migrations.
@@ -45,7 +45,7 @@ pub struct MigrationList {
 /// @deprecated
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct UrlContainer {
     /// The URL string.
     pub url: String,
@@ -54,7 +54,7 @@ pub struct UrlContainer {
 /// A container that holds the path and the content of a Prisma schema file.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct SchemaContainer {
     /// The content of the Prisma schema file.
     pub content: String,
@@ -66,7 +66,7 @@ pub struct SchemaContainer {
 /// A container that holds multiple Prisma schema files.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct SchemasContainer {
     /// List of schema files.
     pub files: Vec<SchemaContainer>,
@@ -75,7 +75,7 @@ pub struct SchemasContainer {
 /// A list of Prisma schema files with a config directory.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct SchemasWithConfigDir {
     /// A list of Prisma schema files.
@@ -89,7 +89,7 @@ pub struct SchemasWithConfigDir {
 /// connection string. See variants.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(tag = "tag")]
 pub enum DatasourceParam {
     /// Prisma schema as input
@@ -102,7 +102,7 @@ pub enum DatasourceParam {
 /// A supported source for a database schema to diff in the `diff` command.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(tag = "tag", rename_all = "camelCase")]
 pub enum DiffTarget {
     /// An empty schema.
@@ -131,7 +131,7 @@ pub enum DiffTarget {
 /// database migration history in relation to the migrations directory.
 #[derive(Debug, PartialEq, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(tag = "diagnostic", rename_all = "camelCase")]
 pub enum HistoryDiagnostic {
     /// There are migrations in the migrations directory that have not been
@@ -167,13 +167,13 @@ pub enum HistoryDiagnostic {
 /// Fields for the DatabaseIsBehind variant.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct DatabaseIsBehindFields {}
 
 /// The location of the live database to connect to.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(tag = "tag", rename_all = "camelCase")]
 pub enum DbExecuteDatasourceType {
     /// Prisma schema files and content to take the datasource URL from.
@@ -186,7 +186,7 @@ pub enum DbExecuteDatasourceType {
 /// A suggested action for the CLI `migrate dev` command.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(tag = "tag", rename_all = "camelCase")]
 pub enum DevAction {
     /// Reset the database.
@@ -199,7 +199,7 @@ pub enum DevAction {
 /// Reset action fields.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct DevActionReset {
     /// Why do we need to reset?
     pub reason: String,
@@ -212,7 +212,7 @@ pub struct DevActionReset {
 /// The input to the `applyMigrations` command.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct ApplyMigrationsInput {
     /// The list of migrations, already loaded from disk.
@@ -222,7 +222,7 @@ pub struct ApplyMigrationsInput {
 /// The output of the `applyMigrations` command.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct ApplyMigrationsOutput {
     /// The names of the migrations that were just applied. Empty if no migration was applied.
@@ -234,7 +234,7 @@ pub struct ApplyMigrationsOutput {
 /// The type of params for the `createDatabase` method.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct CreateDatabaseParams {
     /// The datasource parameter.
     pub datasource: DatasourceParam,
@@ -243,7 +243,7 @@ pub struct CreateDatabaseParams {
 /// The result for the `createDatabase` method.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateDatabaseResult {
     /// The name of the created database.
@@ -255,7 +255,7 @@ pub struct CreateDatabaseResult {
 /// The input to the `createMigration` command.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateMigrationInput {
     /// If true, always generate a migration, but do not apply.
@@ -274,7 +274,7 @@ pub struct CreateMigrationInput {
 /// The output of the `createMigration` command.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct CreateMigrationOutput {
     /// The active connector type used.
@@ -299,7 +299,7 @@ pub struct CreateMigrationOutput {
 /// The type of params accepted by dbExecute.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct DbExecuteParams {
     /// The location of the live database to connect to.
@@ -312,7 +312,7 @@ pub struct DbExecuteParams {
 /// The type of results returned by dbExecute.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct DbExecuteResult {}
 
 // Debug Panic
@@ -320,13 +320,13 @@ pub struct DbExecuteResult {}
 /// Request for debug panic.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct DebugPanicInput {}
 
 /// Response for debug panic.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct DebugPanicOutput {}
 
 // Dev Diagnostic
@@ -334,7 +334,7 @@ pub struct DebugPanicOutput {}
 /// The request type for `devDiagnostic`.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct DevDiagnosticInput {
     /// The list of migrations, already loaded from disk.
@@ -344,7 +344,7 @@ pub struct DevDiagnosticInput {
 /// The response type for `devDiagnostic`.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct DevDiagnosticOutput {
     /// The suggested course of action for the CLI.
     pub action: DevAction,
@@ -355,7 +355,7 @@ pub struct DevDiagnosticOutput {
 /// The request params for the `diagnoseMigrationHistory` method.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnoseMigrationHistoryInput {
     /// The list of migrations, already loaded from disk.
@@ -368,7 +368,7 @@ pub struct DiagnoseMigrationHistoryInput {
 /// The result type for `diagnoseMigrationHistory` responses.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnoseMigrationHistoryOutput {
     /// The names of the migrations for which the checksum of the script in the
@@ -393,7 +393,7 @@ pub struct DiagnoseMigrationHistoryOutput {
 /// The type of params for the `diff` method.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct DiffParams {
     /// The source of the schema to consider as a _starting point_.
@@ -424,7 +424,7 @@ pub struct DiffParams {
 /// The result type for the `diff` method.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct DiffResult {
     /// The exit code that the CLI should return.
@@ -442,7 +442,7 @@ pub struct DiffResult {
 /// Params type for the introspectSql method.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct IntrospectSqlParams {
     /// The database URL.
     pub url: String,
@@ -453,7 +453,7 @@ pub struct IntrospectSqlParams {
 /// Result type for the introspectSql method.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct IntrospectSqlResult {
     /// The introspected queries.
     pub queries: Vec<SqlQueryOutput>,
@@ -462,7 +462,7 @@ pub struct IntrospectSqlResult {
 /// Input for a single SQL query.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct SqlQueryInput {
     /// The name of the query.
     pub name: String,
@@ -473,7 +473,7 @@ pub struct SqlQueryInput {
 /// Output for a single SQL query.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct SqlQueryOutput {
     /// The name of the query.
@@ -491,7 +491,7 @@ pub struct SqlQueryOutput {
 /// Information about a SQL query parameter.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct SqlQueryParameterOutput {
     /// Parameter name.
     pub name: String,
@@ -506,7 +506,7 @@ pub struct SqlQueryParameterOutput {
 /// Information about a SQL query result column.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct SqlQueryColumnOutput {
     /// Column name.
     pub name: String,
@@ -521,7 +521,7 @@ pub struct SqlQueryColumnOutput {
 /// Introspect the database (db pull)
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct IntrospectParams {
     /// Prisma schema files.
@@ -539,7 +539,7 @@ pub struct IntrospectParams {
 /// Result type for the introspect method.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct IntrospectResult {
     /// The introspected schema.
     pub schema: SchemasContainer,
@@ -552,7 +552,7 @@ pub struct IntrospectResult {
 /// Information about a database view.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct IntrospectionView {
     /// The view definition.
     pub definition: String,
@@ -568,7 +568,7 @@ pub struct IntrospectionView {
 /// @deprecated
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct GetDatabaseVersionInput {
     /// The datasource parameter.
     pub datasource: DatasourceParam,
@@ -577,7 +577,7 @@ pub struct GetDatabaseVersionInput {
 /// Output for the getDatabaseVersion method.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 pub struct GetDatabaseVersionOutput {
     /// The database version.
     pub version: String,
@@ -597,7 +597,7 @@ pub struct GetDatabaseVersionOutput {
 /// with the migration history.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateDataLossInput {
     /// The list of migrations, already loaded from disk.
@@ -609,7 +609,7 @@ pub struct EvaluateDataLossInput {
 /// The output of the `evaluateDataLoss` command.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluateDataLossOutput {
     /// The number migration steps that would be generated. If this is empty, we
@@ -628,7 +628,7 @@ pub struct EvaluateDataLossOutput {
 /// A data loss warning or an unexecutable migration error, associated with the step that triggered it.
 #[derive(Debug, Serialize, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi, into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct MigrationFeedback {
     /// The human-readable message.
@@ -642,7 +642,7 @@ pub struct MigrationFeedback {
 /// Make sure the schema engine can connect to the database from the Prisma schema.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct EnsureConnectionValidityParams {
     /// The datasource parameter.
     pub datasource: DatasourceParam,
@@ -651,7 +651,7 @@ pub struct EnsureConnectionValidityParams {
 /// Result type for the ensureConnectionValidity method.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct EnsureConnectionValidityResult {}
 
 // Mark Migration Applied
@@ -667,7 +667,7 @@ pub struct EnsureConnectionValidityResult {}
 /// - If it is already applied, we return a user-facing error.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct MarkMigrationAppliedInput {
     /// The name of the migration to mark applied.
@@ -680,7 +680,7 @@ pub struct MarkMigrationAppliedInput {
 /// The output of the `markMigrationApplied` command.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct MarkMigrationAppliedOutput {}
 
 // Mark Migration Rolled Back
@@ -689,7 +689,7 @@ pub struct MarkMigrationAppliedOutput {}
 /// will still be there, but ignored for all purposes except as audit trail.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct MarkMigrationRolledBackInput {
     /// The name of the migration to mark rolled back.
@@ -699,7 +699,7 @@ pub struct MarkMigrationRolledBackInput {
 /// The output of the `markMigrationRolledBack` command.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct MarkMigrationRolledBackOutput {}
 
 // Reset
@@ -707,13 +707,13 @@ pub struct MarkMigrationRolledBackOutput {}
 /// The input to the `reset` command.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct ResetInput {}
 
 /// The output of the `reset` command.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 pub struct ResetOutput {}
 
 // Schema Push
@@ -721,7 +721,7 @@ pub struct ResetOutput {}
 /// Request params for the `schemaPush` method.
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(from_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct SchemaPushInput {
     /// Push the schema ignoring destructive change warnings.
     pub force: bool,
@@ -733,7 +733,7 @@ pub struct SchemaPushInput {
 /// Response result for the `schemaPush` method.
 #[derive(Debug, Serialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
-#[cfg_attr(target_arch = "wasm32", tsify(into_wasm_abi))]
+#[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, into_wasm_abi))]
 #[serde(rename_all = "camelCase")]
 pub struct SchemaPushOutput {
     /// How many migration steps were executed.

--- a/schema-engine/schema-engine-wasm/build.sh
+++ b/schema-engine/schema-engine-wasm/build.sh
@@ -76,7 +76,7 @@ build() {
 
     echo "ℹ️  Updating TypeScript definitions for \`schema_engine_bg.wasm\`"
     cp "$OUT_FOLDER/schema_engine.d.ts" "$OUT_FOLDER/schema_engine_bg.d.ts"
-    echo "\nexport const __wbindgen_start: () => void;" >> "$OUT_FOLDER/schema_engine_bg.d.ts"
+    printf "\nexport const __wbindgen_start: () => void;" >> "$OUT_FOLDER/schema_engine_bg.d.ts"
 
     if ! command -v wasm2wat &> /dev/null; then
         echo "Skipping wasm2wat, as it is not installed."

--- a/schema-engine/schema-engine-wasm/build.sh
+++ b/schema-engine/schema-engine-wasm/build.sh
@@ -74,6 +74,10 @@ build() {
     wasm-bindgen --target "$OUT_TARGET" --out-name schema_engine --out-dir "$OUT_FOLDER" "$IN_FILE"
     optimize "$OUT_FILE"
 
+    echo "ℹ️  Updating TypeScript definitions for \`schema_engine_bg.wasm\`"
+    cp "$OUT_FOLDER/schema_engine.d.ts" "$OUT_FOLDER/schema_engine_bg.d.ts"
+    echo "\nexport const __wbindgen_start: () => void;" >> "$OUT_FOLDER/schema_engine_bg.d.ts"
+
     if ! command -v wasm2wat &> /dev/null; then
         echo "Skipping wasm2wat, as it is not installed."
     else

--- a/schema-engine/schema-engine-wasm/package.json
+++ b/schema-engine/schema-engine-wasm/package.json
@@ -18,6 +18,11 @@
       "import": "./schema_engine.js",
       "require": "./schema_engine.js",
       "types": "./schema_engine.d.ts"
+    },
+    "./manual": {
+      "import": "./schema_engine_bg.js",
+      "require": "./schema_engine_bg.js",
+      "types": "./schema_engine_bg.d.ts"
     }
   },
   "types": "./schema_engine.d.ts"

--- a/schema-engine/schema-engine-wasm/src/wasm/engine.rs
+++ b/schema-engine/schema-engine-wasm/src/wasm/engine.rs
@@ -68,7 +68,8 @@ pub struct SchemaEngine {
 
 #[wasm_bindgen]
 impl SchemaEngine {
-    #[wasm_bindgen(constructor)]
+    // Note: we shouldn't mark this as a constructor, due to https://github.com/rustwasm/wasm-bindgen/issues/3976.
+    #[wasm_bindgen]
     pub async fn new(adapter: JsObject) -> Result<SchemaEngine, wasm_bindgen::JsError> {
         register_panic_hook();
 


### PR DESCRIPTION
This PR:
- fixes [ORM-832](https://linear.app/prisma-company/issue/ORM-832/fix-prismaschema-engine-wasm-rust-implementation)
- builds on top of https://github.com/prisma/prisma-engines/pull/5289 based on the findings https://github.com/prisma/prisma/pull/26753
- modifies type generation (using `tsify-next`) so that `T | undefined` is mapped to `T | null`, matching the existing TypeScript types in `prisma/prisma`
- fixes a potentially undefined behavior in `SchemaEngine`'s constructor (https://github.com/rustwasm/wasm-bindgen/issues/3976)
- allows `ConnectorError` to be mapped into a relatively detailed JS error
- create `schema_engine_bg.d.ts` type to ease dealing with bundling Wasm in `prisma/prisma`