### PR TITLE
feat: query compiler batching

### DIFF
--- a/query-compiler/query-compiler-wasm/src/compiler.rs
+++ b/query-compiler/query-compiler-wasm/src/compiler.rs
@@ -95,7 +95,7 @@ impl QueryCompiler {
         Ok(serde_json::to_string(&plan)?)
     }
 
-    #[wasm_bindgen]
+    #[wasm_bindgen(js_name = compileBatch)]
     pub fn compile_batch(&self, request: String) -> Result<BatchResponse, wasm_bindgen::JsError> {
         let request = RequestBody::try_from_str(&request, self.protocol)?;
         match request.into_doc(&self.schema)? {
@@ -134,6 +134,7 @@ pub enum BatchResponse {
     Multi {
         plans: Vec<Expression>,
     },
+    #[serde(rename_all = "camelCase")]
     Compacted {
         plan: Expression,
         arguments: Vec<HashMap<String, ArgumentValue>>,

--- a/query-compiler/query-compiler/src/lib.rs
+++ b/query-compiler/query-compiler/src/lib.rs
@@ -8,12 +8,12 @@ use quaint::{
     prelude::{ConnectionInfo, SqlFamily},
     visitor,
 };
-use query_core::{QueryGraphBuilderError, schema::QuerySchema};
+use query_core::{Operation, QueryGraphBuilderError, schema::QuerySchema};
 use sql_query_builder::{Context, SqlQueryBuilder};
 use thiserror::Error;
 pub use translate::{TranslateError, translate};
 
-use query_core::{QueryDocument, QueryGraphBuilder};
+use query_core::QueryGraphBuilder;
 
 #[derive(Debug, Error)]
 pub enum CompileError {
@@ -29,13 +29,9 @@ pub enum CompileError {
 
 pub fn compile(
     query_schema: &Arc<QuerySchema>,
-    query_doc: QueryDocument,
+    query: Operation,
     connection_info: &ConnectionInfo,
 ) -> Result<Expression, CompileError> {
-    let QueryDocument::Single(query) = query_doc else {
-        return Err(CompileError::UnsupportedRequest);
-    };
-
     let ctx = Context::new(connection_info, None);
     let (graph, _serializer) = QueryGraphBuilder::new(query_schema)
         .without_eager_default_evaluation()


### PR DESCRIPTION
[ORM-793](https://linear.app/prisma-company/issue/ORM-794/native-batching-support-in-qc)

This is a non-breaking change, but it's consumed on the client side via https://github.com/prisma/prisma/pull/26761. 

