### PR TITLE
fix(schema-engine): fix https://github.com/prisma/prisma/issues/26791

### DIFF
--- a/quaint/src/connector/external.rs
+++ b/quaint/src/connector/external.rs
@@ -16,6 +16,8 @@ pub enum AdapterD1 {
 /// The name of the adapter.
 /// We only want to keep track of first-class adapters maintained by Prisma, and among those,
 /// only the ones whose queries require special handling compared to the ones generated via `quaint`.
+///
+/// TODO: we could add here Neon as well, so we could exclude / expose Neon's auth tables in the future.
 pub enum AdapterName {
     D1(AdapterD1),
     Unknown,
@@ -116,6 +118,14 @@ pub trait ExternalConnector: TransactionCapable {
     async fn get_connection_info(&self) -> crate::Result<ExternalConnectionInfo>;
     async fn execute_script(&self, script: &str) -> crate::Result<()>;
     async fn dispose(&self) -> crate::Result<()>;
+
+    /// Returns a reference to self as an ExternalConnector.
+    fn as_external_connector(&self) -> Option<&dyn ExternalConnector>
+    where
+        Self: Sized,
+    {
+        Some(self)
+    }
 }
 
 #[async_trait]

--- a/quaint/src/connector/queryable.rs
+++ b/quaint/src/connector/queryable.rs
@@ -1,4 +1,4 @@
-use super::{DescribedQuery, IsolationLevel, ResultSet, Transaction};
+use super::{DescribedQuery, ExternalConnector, IsolationLevel, ResultSet, Transaction};
 use crate::ast::*;
 use async_trait::async_trait;
 
@@ -17,6 +17,11 @@ pub trait ToColumnNames {
 /// Represents a connection or a transaction that can be queried.
 #[async_trait]
 pub trait Queryable: Send + Sync {
+    /// Returns a reference to self as an ExternalConnector if available.
+    fn as_external_connector(&self) -> Option<&dyn ExternalConnector> {
+        None
+    }
+
     /// Execute the given query.
     async fn query(&self, q: Query<'_>) -> crate::Result<ResultSet>;
 

--- a/schema-engine/sql-schema-describer/src/sqlite.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite.rs
@@ -13,7 +13,7 @@ use quaint::{
     prelude::{Queryable, ResultRow},
 };
 use std::{
-    any::{type_name, Any},
+    any::type_name,
     borrow::Cow,
     collections::BTreeMap,
     convert::TryInto,
@@ -51,7 +51,7 @@ impl Connection for quaint::single::Quaint {
 }
 
 #[async_trait::async_trait]
-impl<Q: Queryable + Any + ?Sized> Connection for Arc<Q> {
+impl<Q: Queryable + ?Sized> Connection for Arc<Q> {
     async fn query_raw<'a>(
         &'a self,
         sql: &'a str,


### PR DESCRIPTION
This PR:
- closes [ORM-389](https://linear.app/prisma-company/issue/ORM-839/bug-cf-metadata-causes-error-with-prisma-migrate-diff-from-local-d1)
- fixes https://github.com/prisma/prisma/issues/26791, without forcing users to use the new `config.migrate.adapter` option with the D1 HTTP adapter
- opens the doors to knowing what kind of adapter we're dealing with in `sql-schema-describer`