### PR TITLE
fix(sql-schema-connector): don't acquire lock in LibSQL and Cloudflare D1

### DIFF
--- a/quaint/src/connector/external.rs
+++ b/quaint/src/connector/external.rs
@@ -20,6 +20,7 @@ pub enum AdapterD1 {
 /// TODO: we could add here Neon as well, so we could exclude / expose Neon's auth tables in the future.
 pub enum AdapterName {
     D1(AdapterD1),
+    LibSQL,
     Unknown,
 }
 
@@ -32,6 +33,7 @@ impl FromStr for AdapterName {
             match name {
                 "d1" => Ok(Self::D1(AdapterD1::Env)),
                 "d1-http" => Ok(Self::D1(AdapterD1::HTTP)),
+                "libsql" => Ok(Self::LibSQL),
                 _ => Ok(Self::Unknown),
             }
         } else {


### PR DESCRIPTION
Currently, when calling `acquire_lock()` in `sqlite` provider, we emit the following query:

```
PRAGMA main.locking_mode=EXCLUSIVE
```

This is incompatible with `@prisma/adapter-d1` and `@prisma/adapter-libsql`.

---

This PR:
- fixes it
- closes [ORM-841](https://linear.app/prisma-company/issue/ORM-841/prismaschema-engine-wasm-dont-set-locking-mode-in-libsql-d1)