### PR TITLE
feat(schema-engine-wasm): general improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4824,6 +4824,7 @@ name = "schema-engine-wasm"
 version = "0.1.0"
 dependencies = [
  "build-utils",
+ "crosstarget-utils",
  "driver-adapters",
  "js-sys",
  "json-rpc-api",
@@ -4833,7 +4834,9 @@ dependencies = [
  "serde",
  "sql-schema-connector",
  "tracing",
+ "tracing-error",
  "tracing-futures",
+ "tracing-subscriber",
  "tsify-next",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -5303,6 +5306,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "connection-string",
+ "crosstarget-utils",
  "datamodel-renderer",
  "either",
  "enumflags2",

--- a/libs/driver-adapters/executor/src/demo-se.ts
+++ b/libs/driver-adapters/executor/src/demo-se.ts
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
     }
 
     datasource db {
-      provider = "postgresql"
+      provider = "sqlite"
       url      = "${url}"
     }
 
@@ -86,7 +86,35 @@ async function main(): Promise<void> {
   }
 
   {
-    console.log('[diff]')
+    console.log('[reset]')
+    const result = await engine.reset()
+    console.dir({ result }, { depth: null })
+  }
+
+  {
+    console.log('[db push]')
+    const result = await engine.schemaPush({
+      schema: {
+        files: [
+          {
+            content: schema,
+            path: 'schema.prisma',
+          }
+        ],
+      },
+      force: false,
+    })
+    console.dir({ result }, { depth: null })
+  }
+
+  {
+    console.log('[reset]')
+    const result = await engine.reset()
+    console.dir({ result }, { depth: null })
+  }
+
+  {
+    console.log('[diff from empty to schemaDatamodel]')
     const diffResult = await engine.diff({
       from: {
         tag: 'empty',
@@ -136,7 +164,14 @@ async function initSE({
 }: InitSchemaEngineParams) {
   const adapterFactory = driverAdapterManager.factory()
   const errorCapturingAdapterFactory = bindSqlAdapterFactory(adapterFactory)
+
+  const debug = (log: string) => {
+    console.log('[debug]')
+    console.dir(JSON.parse(log), { depth: null })
+  }
+
   const engineInstance = await se.initSchemaEngine(
+    debug,
     errorCapturingAdapterFactory,
   )
 

--- a/libs/driver-adapters/executor/src/schema-engine-wasm-module.ts
+++ b/libs/driver-adapters/executor/src/schema-engine-wasm-module.ts
@@ -11,7 +11,8 @@ import { __dirname } from './utils'
 export type QueryLogCallback = (log: string) => void
 
 export async function initSchemaEngine(
+  debug: (log: string) => void,
   adapterFactory: ErrorCapturingSqlDriverAdapterFactory,
 ): Promise<SchemaEngine> {
-  return await SchemaEngine.new(adapterFactory)
+  return await SchemaEngine.new(debug, adapterFactory)
 }

--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -28,6 +28,7 @@ all-native = [
 ]
 
 [dependencies]
+crosstarget-utils.workspace = true
 psl.workspace = true
 quaint.workspace = true
 tokio = { workspace = true, features = ["macros", "sync", "io-util", "time"] }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -291,12 +291,12 @@ impl SqlConnector for PostgresConnector {
 
             // 72707369 is a unique number we chose to identify Migrate. It does not
             // have any meaning, but it should not be used by any other tool.
-            tokio::time::timeout(
+            crosstarget_utils::time::timeout(
                 ADVISORY_LOCK_TIMEOUT,
                 connection.raw_cmd("SELECT pg_advisory_lock(72707369)"),
             )
             .await
-            .map_err(|_elapsed| imp::timeout_error(params))?
+            .map_err(|_timeout_error| imp::timeout_error(params))?
             .map_err(imp::quaint_error_mapper(params))?;
 
             Ok(())

--- a/schema-engine/connectors/sql-schema-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_destructive_change_checker/destructive_check_plan.rs
@@ -3,11 +3,11 @@ use super::{
     unexecutable_step_check::UnexecutableStepCheck, warning_check::SqlMigrationWarningCheck,
 };
 use crate::flavour::SqlConnector;
+use crosstarget_utils::time::timeout;
 use schema_connector::{
     ConnectorError, ConnectorResult, DestructiveChangeDiagnostics, MigrationWarning, UnexecutableMigration,
 };
 use std::time::Duration;
-use tokio::time::{error::Elapsed, timeout};
 
 const DESTRUCTIVE_TIMEOUT_DURATION: Duration = Duration::from_secs(60);
 
@@ -61,7 +61,7 @@ impl DestructiveCheckPlan {
 
         // Ignore the timeout error, we will still return useful warnings.
         match timeout(DESTRUCTIVE_TIMEOUT_DURATION, inspection).await {
-            Ok(Ok(())) | Err(Elapsed { .. }) => (),
+            Ok(Ok(())) | Err(_) => (),
             Ok(Err(err)) => return Err(err),
         };
 

--- a/schema-engine/schema-engine-wasm/Cargo.toml
+++ b/schema-engine/schema-engine-wasm/Cargo.toml
@@ -18,10 +18,17 @@ sqlite = ["driver-adapters/sqlite", "psl/sqlite", "sql-schema-connector/sqlite",
 postgresql = ["driver-adapters/postgresql", "psl/postgresql", "sql-schema-connector/postgresql", "commands/postgresql"]
 
 [dependencies]
+crosstarget-utils.workspace = true
 psl.workspace = true
 quaint.workspace = true
 tracing.workspace = true
 tracing-futures.workspace = true
+tracing-subscriber = { workspace = true, features = [
+    "fmt",
+    "json",
+    "time",
+] }
+tracing-error.workspace = true
 sql-schema-connector = { workspace = true }
 json-rpc = { path = "../json-rpc-api", package = "json-rpc-api" }
 commands = { path = "../commands", package = "schema-commands" }

--- a/schema-engine/schema-engine-wasm/src/wasm.rs
+++ b/schema-engine/schema-engine-wasm/src/wasm.rs
@@ -1,1 +1,3 @@
 pub mod engine;
+mod logger;
+mod timings;

--- a/schema-engine/schema-engine-wasm/src/wasm/logger.rs
+++ b/schema-engine/schema-engine-wasm/src/wasm/logger.rs
@@ -1,0 +1,83 @@
+use super::timings::TimingsLayer;
+use js_sys::Function as JsFunction;
+use std::io::{self, Write};
+use tracing_error::ErrorLayer;
+use tracing_subscriber::{fmt, prelude::*};
+use wasm_bindgen::prelude::*;
+
+/// A custom writer that sends log output to a JavaScript callback.
+struct JsLogWriter {
+    callback: JsFunction,
+}
+
+unsafe impl Send for JsLogWriter {}
+unsafe impl Sync for JsLogWriter {}
+
+impl Write for JsLogWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        // Convert the log message from bytes to a UTF-8 string.
+        let s = std::str::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        // Call the JS callback with the log message.
+        let _ = self.callback.call1(&JsValue::NULL, &JsValue::from_str(s));
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A MakeWriter implementation that creates a new JsLogWriter.
+#[derive(Clone)]
+struct JsLogWriterMaker {
+    callback: JsFunction,
+}
+
+unsafe impl Send for JsLogWriterMaker {}
+unsafe impl Sync for JsLogWriterMaker {}
+
+impl JsLogWriterMaker {
+    pub fn new(callback: JsFunction) -> Self {
+        Self { callback }
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for JsLogWriterMaker {
+    type Writer = JsLogWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        JsLogWriter {
+            callback: self.callback.clone(),
+        }
+    }
+}
+
+#[wasm_bindgen]
+extern "C" {
+    #[wasm_bindgen(js_namespace = console)]
+    fn error(a: &str);
+}
+
+macro_rules! console_error {
+    ($($t:tt)*) => (error(&format_args!($($t)*).to_string()))
+}
+
+/// Initializes the global logger using the provided JavaScript callback for log output.
+pub fn init_logger(log_callback: JsFunction) {
+    let js_writer = JsLogWriterMaker::new(log_callback);
+
+    let subscriber = fmt::Subscriber::builder()
+        .json()
+        .without_time()
+        .with_writer(js_writer)
+        .finish()
+        .with(ErrorLayer::default())
+        .with(TimingsLayer);
+
+    tracing::subscriber::set_global_default(subscriber)
+        .map_err(|err| {
+            // Fallback: log to the browser console if initialization fails.
+            console_error!("[schema-engine-wasm] Error initializing the global logger: {}", err);
+        })
+        .ok();
+}

--- a/schema-engine/schema-engine-wasm/src/wasm/timings.rs
+++ b/schema-engine/schema-engine-wasm/src/wasm/timings.rs
@@ -1,0 +1,38 @@
+use crosstarget_utils::time::ElapsedTimeCounter;
+use tracing::Id as SpanId;
+
+/// Gather and display timings of tracing spans.
+#[derive(Default)]
+pub struct TimingsLayer;
+
+struct TimerTime(pub ElapsedTimeCounter, String);
+
+impl<S> tracing_subscriber::Layer<S> for TimingsLayer
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        attrs: &tracing::span::Attributes<'_>,
+        id: &SpanId,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let span_ctx = ctx.span(id).unwrap();
+        let mut extensions = span_ctx.extensions_mut();
+        let start = ElapsedTimeCounter::start();
+
+        extensions.insert(TimerTime(start, attrs.values().to_string()));
+    }
+
+    fn on_close(&self, id: SpanId, ctx: tracing_subscriber::layer::Context<'_, S>) {
+        let span_ctx = ctx.span(&id).unwrap();
+        let span_name = span_ctx.name();
+        let mut extensions = span_ctx.extensions_mut();
+        let TimerTime(start, values) = extensions.remove::<TimerTime>().unwrap();
+        let elapsed = start.elapsed_time();
+        tracing::debug!(
+            span_timing_μs = elapsed.as_micros() as u32,
+            "{span_name}{values}: Span closed. Elapsed: {elapsed:?}",
+        );
+    }
+}

--- a/schema-engine/sql-schema-describer/src/sqlite.rs
+++ b/schema-engine/sql-schema-describer/src/sqlite.rs
@@ -129,7 +129,7 @@ impl<'a> SqlSchemaDescriber<'a> {
         Ok(names)
     }
 
-    async fn get_table_names(
+    pub async fn get_table_names(
         &self,
         schema: &mut SqlSchema,
     ) -> DescriberResult<IndexMap<String, Either<TableId, ViewId>>> {


### PR DESCRIPTION
This PR:
- adds `debug` capabilities to `schema-engine-wasm`, making it forward `tracing` logs to a given JS callback
- fixes the underlying command of `prisma db push`, by avoiding using `Instant::now()` in wasm32 (it was still used by `tokio::time::timeout`)
- rewrite the `reset` command implementation, so that it works with `@prisma/adapter-libsql` and `@prisma/adapter-d1`