### PR TITLE
feat: driver adapter error mappings

### DIFF
--- a/libs/driver-adapters/src/error.rs
+++ b/libs/driver-adapters/src/error.rs
@@ -52,6 +52,41 @@ pub(crate) enum DriverAdapterError {
     InvalidIsolationLevel {
         level: String,
     },
+    LengthMismatch {
+        column: Option<String>,
+    },
+    UniqueConstraintViolation {
+        fields: Vec<String>,
+    },
+    NullConstraintViolation {
+        fields: Vec<String>,
+    },
+    ForeignKeyConstraintViolation {
+        constraint: DriverAdapterConstraint,
+    },
+    DatabaseDoesNotExist {
+        db: Option<String>,
+    },
+    DatabaseAlreadyExists {
+        db: Option<String>,
+    },
+    DatabaseAccessDenied {
+        db: Option<String>,
+    },
+    AuthenticationFailed {
+        user: Option<String>,
+    },
+    TransactionWriteConflict,
+
+    TableDoesNotExist {
+        table: Option<String>,
+    },
+    ColumnNotFound {
+        column: Option<String>,
+    },
+    TooManyConnections {
+        cause: String,
+    },
     #[cfg(feature = "postgresql")]
     #[serde(rename = "postgres")]
     Postgres(#[serde(with = "PostgresErrorDef")] PostgresError),
@@ -61,4 +96,12 @@ pub(crate) enum DriverAdapterError {
     #[cfg(feature = "sqlite")]
     #[serde(rename = "sqlite")]
     Sqlite(#[serde(with = "SqliteErrorDef")] SqliteError),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum DriverAdapterConstraint {
+    Fields(Vec<String>),
+    Index(String),
+    ForeignKey,
 }

--- a/query-engine/connectors/sql-query-connector/src/error.rs
+++ b/query-engine/connectors/sql-query-connector/src/error.rs
@@ -65,7 +65,11 @@ impl From<quaint::error::Error> for RawError {
     fn from(e: quaint::error::Error) -> Self {
         let default_value: RawError = Self::Database {
             code: e.original_code().map(ToString::to_string),
-            message: e.original_message().map(ToString::to_string),
+            message: Some(
+                e.original_message()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| e.to_string()),
+            ),
         };
 
         match e.kind() {


### PR DESCRIPTION
[ORM-522](https://linear.app/prisma-company/issue/ORM-522/migrate-database-error-mapping-from-rust-to-typescript)