### PR TITLE
chore: drop tests for mssql 2017 because it requires deprecated ubuntu version

### DIFF
--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -49,12 +49,12 @@ jobs:
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
       PRISMA_RELATION_LOAD_STRATEGY: ${{ matrix.relation_load_strategy }}
 
-    runs-on: "ubuntu-20.04"
-    # TODO: Replace with the following once `prisma@5.20.0` is released.
-    # runs-on: "ubuntu-${{ inputs.ubuntu }}"
+    runs-on: 'ubuntu-${{ inputs.ubuntu }}'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: 'ubuntu-${{ inputs.ubuntu }}'
       - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -124,9 +124,6 @@ jobs:
             version: "2022"
           - name: "mssql_2019"
             version: "2019"
-          - name: "mssql_2017"
-            version: "2017"
-            ubuntu: "20.04"
     uses: ./.github/workflows/test-query-engine-template.yml
     name: mssql ${{ matrix.database.version }}
     with:

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -63,10 +63,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        ubuntu:
+          - '24.04'
         database:
-          - name: mssql_2017
-            url: "sqlserver://localhost:1434;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
-            ubuntu: "20.04"
           - name: mssql_2019
             url: "sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED"
           - name: mssql_2022
@@ -109,12 +108,12 @@ jobs:
             is_vitess: true
             single_threaded: true
 
-    runs-on: "ubuntu-20.04"
-    # TODO: Replace with the following once `prisma@5.20.0` is released.
-    # runs-on: "ubuntu-${{ matrix.database.ubuntu || 'latest' }}"
+    runs-on: 'ubuntu-${{ matrix.ubuntu }}'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: 'ubuntu-${{ matrix.ubuntu }}'
       - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub


### PR DESCRIPTION
Added cache-key to the rust toolchain steps to avoid reusing cached stuff from the old ubuntu runs which caused e.g. OpenSSL issues.