### PR TITLE
test(ci): Reduce CI workload

### DIFF
--- a/.github/workflows/test-quaint.yml
+++ b/.github/workflows/test-quaint.yml
@@ -38,13 +38,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.features }}
 
       - name: Start Databases
-        run: docker compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose.yml up -d --wait
         working-directory: ./quaint
-
-      - name: Sleep for 20s
-        uses: juliangruber/sleep-action@v2
-        with:
-          time: 20s
 
       - name: Run tests
         run: cargo test ${{ matrix.features }}

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -20,27 +20,35 @@ concurrency:
 
 jobs:
   postgres:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '16')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
         database:
           - name: "postgres16"
             version: "16"
+            run_on_pr: true
           - name: "postgres15"
             version: "15"
+            run_on_pr: false
           - name: "postgres14"
             version: "14"
+            run_on_pr: false
           - name: "postgres13"
             version: "13"
+            run_on_pr: false
           - name: "postgres12"
             version: "12"
+            run_on_pr: false
           - name: "postgres11"
             version: "11"
+            run_on_pr: false
           - name: "postgres10"
             version: "10"
+            run_on_pr: false
           - name: "postgres9"
             version: "9"
+            run_on_pr: false
     uses: ./.github/workflows/test-query-engine-template.yml
     name: postgres ${{ matrix.database.version }}
     with:
@@ -50,24 +58,27 @@ jobs:
       single_threaded: true
 
   mysql:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '8')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: "mysql_5_6"
-            version: "5.6"
-            relation_load_strategy: '["query"]'
-          - name: "mysql_5_7"
-            version: "5.7"
-            relation_load_strategy: '["query"]'
           - name: "mysql_8"
             version: "8"
             relation_load_strategy: '["join", "query"]'
+            run_on_pr: true
+          - name: "mysql_5_7"
+            version: "5.7"
+            relation_load_strategy: '["query"]'
+            run_on_pr: false
+          - name: "mysql_5_6"
+            version: "5.6"
+            relation_load_strategy: '["query"]'
+            run_on_pr: false
           - name: "mysql_mariadb"
             version: "mariadb"
             relation_load_strategy: '["query"]'
-
+            run_on_pr: false
     uses: ./.github/workflows/test-query-engine-template.yml
     name: mysql ${{ matrix.database.version }}
     with:
@@ -78,7 +89,7 @@ jobs:
       single_threaded: true
 
   cockroachdb:
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
@@ -86,10 +97,13 @@ jobs:
           - name: "cockroach_23_1"
             connector: "cockroachdb"
             version: "23.1"
+            run_on_pr: false
           - name: "cockroach_22_2"
             version: "22.2"
+            run_on_pr: false
           - name: "cockroach_22_1_0"
             version: "22.1"
+            run_on_pr: false
     uses: ./.github/workflows/test-query-engine-template.yml
     name: cockroachdb ${{ matrix.database.version }}
     with:
@@ -98,18 +112,21 @@ jobs:
       connector: "cockroachdb"
 
   mongodb:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '5')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: "mongodb_4_2"
-            version: "4.2"
+          - name: "mongodb_5"
+            version: "5"
+            connector: "mongodb"
+            run_on_pr: true
           - name: "mongodb_4_4"
             version: "4.4"
-          - name: "mongodb_5"
-            connector: "mongodb"
-            version: "5"
+            run_on_pr: false
+          - name: "mongodb_4_2"
+            version: "4.2"
+            run_on_pr: false
     uses: ./.github/workflows/test-query-engine-template.yml
     name: mongodb ${{ matrix.database.version }}
     with:
@@ -120,15 +137,21 @@ jobs:
       relation_load_strategy: '["query"]'
 
   mssql:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '2022')
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
         database:
           - name: "mssql_2022"
             version: "2022"
+            run_on_pr: true
           - name: "mssql_2019"
             version: "2019"
+            run_on_pr: false
+          - name: "mssql_2017"
+            version: "2017"
+            ubuntu: "20.04"
+            run_on_pr: false
     uses: ./.github/workflows/test-query-engine-template.yml
     name: mssql ${{ matrix.database.version }}
     with:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   postgres:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '16')
     strategy:
       fail-fast: false
       matrix:
@@ -49,6 +50,7 @@ jobs:
       single_threaded: true
 
   mysql:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '8')
     strategy:
       fail-fast: false
       matrix:
@@ -76,6 +78,7 @@ jobs:
       single_threaded: true
 
   cockroachdb:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +98,7 @@ jobs:
       connector: "cockroachdb"
 
   mongodb:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '5')
     strategy:
       fail-fast: false
       matrix:
@@ -116,6 +120,7 @@ jobs:
       relation_load_strategy: '["query"]'
 
   mssql:
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.database.version == '2022')
     strategy:
       fail-fast: false
       matrix:

--- a/quaint/.github/workflows/test.yml
+++ b/quaint/.github/workflows/test.yml
@@ -80,12 +80,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.features }}
 
       - name: Start Databases
-        run: docker compose -f docker-compose.yml up -d
-
-      - name: Sleep for 20s
-        uses: juliangruber/sleep-action@v2
-        with:
-          time: 20s
+        run: docker compose -f docker-compose.yml up -d --wait
 
       - name: Run tests
         run: cargo test ${{ matrix.features }}


### PR DESCRIPTION
Goal: Make validating PRs faster by lowering CI workload and reducing delays due to tasks getting queued up.

This is achieved by:
- PR builds run tests only on the latest DB versions
- PR builds do not run tests on CocroachDB (mostly covered by PostgreSQL) and MariaDB (mostly covered my MySQL)
- Properly waiting on docker compose up instead of an ad-hoc 20s delay (reduces wall clock test time a bit)

The whole test matrix is executed on `main` branch pushes, therefore it does not affect the ability to bisect issues introduced by PRs merged.

Savings at the time of writing: Running 58 checks on PRs instead of 371.

[ORM-834](https://linear.app/prisma-company/issue/ORM-834/reduce-ci-workload)