### PR TITLE
fix: remove trailing `

### DIFF
--- a/libs/user-facing-errors/src/common.rs
+++ b/libs/user-facing-errors/src/common.rs
@@ -77,7 +77,7 @@ pub struct DatabaseOperationTimeout {
 #[derive(Debug, UserFacingError, Serialize)]
 #[user_facing(
     code = "P1009",
-    message = "Database `{database_name}` already exists on the database server`"
+    message = "Database `{database_name}` already exists on the database server"
 )]
 pub struct DatabaseAlreadyExists {
     /// Database name, append `database_schema_name` when applicable


### PR DESCRIPTION
there's a trailing ` in one of the messages