### PR TITLE
chore(qc-test-worker): integrate upstream changes

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -4,6 +4,7 @@ import { JsonProtocolQuery, QueryParams } from '../types/jsonRpc'
 import type { State } from './worker'
 import { debug } from '../utils'
 import {
+  noopTracingHelper,
   QueryInterpreter,
   type QueryInterpreterTransactionManager,
   type TransactionManager,
@@ -107,6 +108,7 @@ class QueryPipeline {
       onQuery: (event) => {
         this.logs.push(JSON.stringify(event))
       },
+      tracingHelper: noopTracingHelper,
     })
 
     return interpreter.run(queryPlan, queryable)

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -2,7 +2,7 @@ import {Schema as S} from '@effect/schema'
 import type {ConnectionInfo, SqlDriverAdapter} from '@prisma/driver-adapter-utils'
 import {DriverAdaptersManager} from '../driver-adapters-manager'
 import * as qc from '../query-compiler'
-import {TransactionManager, type TransactionOptions} from '@prisma/client-engine-runtime'
+import {noopTracingHelper, TransactionManager, type TransactionOptions} from '@prisma/client-engine-runtime'
 import {parentPort} from 'worker_threads'
 import {
     CommitTxParams,
@@ -167,6 +167,7 @@ async function initializeSchema(
             timeout: 500,
             isolationLevel: 'SERIALIZABLE'
         } satisfies TransactionOptions,
+        tracingHelper: noopTracingHelper,
     })
 
     state = {


### PR DESCRIPTION
Adjust the code for the breaking change in
`@prisma/client-engine-runtime`: `TransactionManager` and `QueryInterpreter` now require a `TracingHelper` to be passed via constructor options.

Ref: https://github.com/prisma/prisma/pull/26861

/prisma-branch push-utxwmprulvon