### PR TITLE
test(ci): Split test matrix

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ dir = "target/nextest"
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }
 # * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
-retries = { backoff = "fixed", count = 5, delay = "1s", jitter = true }
+retries = { backoff = "fixed", count = 2, delay = "20s", jitter = true }
 
 # The number of threads to run tests with. Supported values are either an integer or
 # the string "num-cpus". Can be overridden through the `--test-threads` option.
@@ -71,7 +71,10 @@ fail-fast = false
 # which will cause slow tests to be terminated after the specified number of
 # periods have passed.
 # Example: slow-timeout = { period = "60s", terminate-after = 2 }
-slow-timeout = { period = "60s" }
+slow-timeout = { period = "30s", terminate-after = 6 }
+
+# Hard timeout for test cases (must be greater than slow-timeout period times terminate-after)
+test-timeout = "185s"
 
 # Treat a test as leaky if after the process is shut down, standard output and standard error
 # aren't closed within this duration.

--- a/.github/workflows/test-compilation-template.yml
+++ b/.github/workflows/test-compilation-template.yml
@@ -1,5 +1,3 @@
-run-name: '${{ inputs.crate }} on ${{ inputs.os }}'
-
 on:
   workflow_call:
     inputs:
@@ -12,7 +10,7 @@ on:
 
 jobs:
   test-crate-compilation:
-    name: '${{ inputs.crate }} on ${{ inputs.os }}'
+    name: 'compile ${{ inputs.crate }} @ ${{ inputs.os }}'
     runs-on: ${{ inputs.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-compilation-template.yml
+++ b/.github/workflows/test-compilation-template.yml
@@ -1,0 +1,35 @@
+run-name: '${{ inputs.crate }} on ${{ inputs.os }}'
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        type: string
+        required: true
+      crate:
+        type: string
+        required: true
+
+jobs:
+  test-crate-compilation:
+    name: '${{ inputs.crate }} on ${{ inputs.os }}'
+    runs-on: ${{ inputs.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: compile ${{ inputs.crate }}
+        shell: bash
+        env:
+          CRATE: ${{ inputs.crate }}
+        run: cargo build --release -p "$CRATE"
+
+      - name: 'Check that Cargo.lock did not change'
+        run: 'git diff --exit-code'

--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -1,8 +1,9 @@
-name: 'All crates: compilation'
+name: 'All crates'
 on:
   pull_request:
     paths-ignore:
       - '!.github/workflows/test-compilation.yml'
+      - '!.github/workflows/test-compilation-template.yml'
       - '.github/**'
       - '.buildkite/**'
       - '*.md'
@@ -14,44 +15,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-crate-compilation:
-    name: '${{ matrix.crate }} on ${{ matrix.os }}'
+  compilation:
     strategy:
       fail-fast: false
       matrix:
         os:
           - ubuntu-latest
           - windows-latest
+        crate:
+          - schema-engine-cli
+          - prisma-fmt
+          - query-engine
+          - query-engine-node-api
+
+    uses: ./.github/workflows/test-compilation-template.yml
+    with:
+      os: ${{ matrix.os }}
+      crate: ${{ matrix.crate }}
+
+  compilation-push:
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
           - macos-13
         crate:
           - schema-engine-cli
           - prisma-fmt
           - query-engine
           - query-engine-node-api
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: compile ${{ matrix.crate }}
-        shell: bash
-        env:
-          CRATE: ${{ matrix.crate }}
-        run: cargo build --release -p "$CRATE"
-
-      - name: 'Check that Cargo.lock did not change'
-        run: 'git diff --exit-code'
-
-  test-react-native-compilation:
-    name: React Native
-    uses: ./.github/workflows/build-engines-react-native-template.yml
+    uses: ./.github/workflows/test-compilation-template.yml
     with:
-      commit: ${{ github.sha }}
-      uploadArtifacts: false
+      os: ${{ matrix.os }}
+      crate: ${{ matrix.crate }}

--- a/.github/workflows/test-driver-adapters-template.yml
+++ b/.github/workflows/test-driver-adapters-template.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           # using head ref rather than merge branch to get original commit message
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: 'Setup Node.js'
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-query-compiler-template.yml
+++ b/.github/workflows/test-query-compiler-template.yml
@@ -1,3 +1,4 @@
+name: 'QC: integration tests'
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/test-query-compiler-template.yml
+++ b/.github/workflows/test-query-compiler-template.yml
@@ -1,4 +1,3 @@
-name: 'QC: integration tests'
 on:
   workflow_call:
     inputs:
@@ -47,6 +46,7 @@ jobs:
         with:
           # using head ref rather than merge branch to get original commit message
           ref: ${{ github.event.pull_request.head.sha }}
+
       - name: 'Setup Node.js'
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test-query-engine-black-box.yml
+++ b/.github/workflows/test-query-engine-black-box.yml
@@ -41,6 +41,7 @@ jobs:
       TEST_RUNNER: 'direct'
       TEST_CONNECTOR: ${{ matrix.database.connector }}
       TEST_CONNECTOR_VERSION: ${{ matrix.database.version }}
+      WORKSPACE_ROOT: ${{ github.workspace }}
 
     runs-on: ubuntu-latest
     steps:
@@ -67,10 +68,10 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo build --package query-engine
+      - run: cargo build --package query-engine
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo test --package black-box-tests -- --test-threads=1
+      - run: cargo test --package black-box-tests -- --test-threads=1
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -45,6 +45,7 @@ jobs:
       TEST_CONNECTOR_VERSION: ${{ inputs.version }}
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
       PRISMA_RELATION_LOAD_STRATEGY: ${{ matrix.relation_load_strategy }}
+      WORKSPACE_ROOT: ${{ github.workspace }}
 
     runs-on: 'ubuntu-${{ inputs.ubuntu }}'
     steps:
@@ -75,12 +76,12 @@ jobs:
       - name: 'Start ${{ inputs.name }} (${{ matrix.engine_protocol }})'
         run: make start-${{ inputs.name }}
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
+      - run: cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
         if: ${{ inputs.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
 
-      - run: export WORKSPACE_ROOT=$(pwd) && cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=8
+      - run: cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=8
         if: ${{ !inputs.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -1,5 +1,3 @@
-name: 'QE: integration template'
-run-name: ${{ inputs.connector }}
 on:
   workflow_call:
     inputs:
@@ -51,9 +49,11 @@ jobs:
     runs-on: 'ubuntu-${{ inputs.ubuntu }}'
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: 'ubuntu-${{ inputs.ubuntu }}'
+
       - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -20,37 +20,42 @@ concurrency:
 
 jobs:
   postgres:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
         database:
           - name: 'postgres16'
             version: '16'
-            run_on_pr: true
+    name: ${{ matrix.database.name }}
+    uses: ./.github/workflows/test-query-engine-template.yml
+    with:
+      name: ${{ matrix.database.name }}
+      version: ${{ matrix.database.version }}
+      connector: 'postgres'
+      single_threaded: true
+
+  postgres-push:
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
           - name: 'postgres15'
             version: '15'
-            run_on_pr: false
           - name: 'postgres14'
             version: '14'
-            run_on_pr: false
           - name: 'postgres13'
             version: '13'
-            run_on_pr: false
           - name: 'postgres12'
             version: '12'
-            run_on_pr: false
           - name: 'postgres11'
             version: '11'
-            run_on_pr: false
           - name: 'postgres10'
             version: '10'
-            run_on_pr: false
           - name: 'postgres9'
             version: '9'
-            run_on_pr: false
+    name: ${{ matrix.database.name }}
     uses: ./.github/workflows/test-query-engine-template.yml
-    name: postgres ${{ matrix.database.version }}
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
@@ -58,7 +63,6 @@ jobs:
       single_threaded: true
 
   mysql:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
@@ -66,21 +70,8 @@ jobs:
           - name: 'mysql_8'
             version: '8'
             relation_load_strategy: '["join", "query"]'
-            run_on_pr: true
-          - name: 'mysql_5_7'
-            version: '5.7'
-            relation_load_strategy: '["query"]'
-            run_on_pr: false
-          - name: 'mysql_5_6'
-            version: '5.6'
-            relation_load_strategy: '["query"]'
-            run_on_pr: false
-          - name: 'mysql_mariadb'
-            version: 'mariadb'
-            relation_load_strategy: '["query"]'
-            run_on_pr: false
+    name: ${{ matrix.database.name }}
     uses: ./.github/workflows/test-query-engine-template.yml
-    name: mysql ${{ matrix.database.version }}
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
@@ -88,31 +79,50 @@ jobs:
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
       single_threaded: true
 
-  cockroachdb:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
+  mysql-push:
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
+          - name: 'mysql_5_7'
+            version: '5.7'
+            relation_load_strategy: '["query"]'
+          - name: 'mysql_5_6'
+            version: '5.6'
+            relation_load_strategy: '["query"]'
+          - name: 'mysql_mariadb'
+            version: 'mariadb'
+            relation_load_strategy: '["query"]'
+    name: ${{ matrix.database.name }}
+    uses: ./.github/workflows/test-query-engine-template.yml
+    with:
+      name: ${{ matrix.database.name }}
+      version: ${{ matrix.database.version }}
+      connector: 'mysql'
+      relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
+      single_threaded: true
+
+  cockroachdb-push:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
         database:
           - name: 'cockroach_23_1'
-            connector: 'cockroachdb'
             version: '23.1'
-            run_on_pr: false
           - name: 'cockroach_22_2'
             version: '22.2'
-            run_on_pr: false
           - name: 'cockroach_22_1_0'
             version: '22.1'
-            run_on_pr: false
+    name: ${{ matrix.database.name }}
     uses: ./.github/workflows/test-query-engine-template.yml
-    name: cockroachdb ${{ matrix.database.version }}
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       connector: 'cockroachdb'
 
   mongodb:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
@@ -120,15 +130,27 @@ jobs:
           - name: 'mongodb_5'
             version: '5'
             connector: 'mongodb'
-            run_on_pr: true
+    name: ${{ matrix.database.name }}
+    uses: ./.github/workflows/test-query-engine-template.yml
+    with:
+      name: ${{ matrix.database.name }}
+      version: ${{ matrix.database.version }}
+      single_threaded: true
+      connector: 'mongodb'
+      relation_load_strategy: '["query"]'
+
+  mongodb-push:
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
           - name: 'mongodb_4_4'
             version: '4.4'
-            run_on_pr: false
           - name: 'mongodb_4_2'
             version: '4.2'
-            run_on_pr: false
+    name: ${{ matrix.database.name }}
     uses: ./.github/workflows/test-query-engine-template.yml
-    name: mongodb ${{ matrix.database.version }}
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
@@ -137,23 +159,36 @@ jobs:
       relation_load_strategy: '["query"]'
 
   mssql:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && matrix.run_on_pr)
     strategy:
       fail-fast: false
       matrix:
         database:
           - name: 'mssql_2022'
             version: '2022'
-            run_on_pr: true
+            ubuntu: '24.04'
+    name: ${{ matrix.database.name }}
+    uses: ./.github/workflows/test-query-engine-template.yml
+    with:
+      name: ${{ matrix.database.name }}
+      version: ${{ matrix.database.version }}
+      ubuntu: ${{ matrix.database.ubuntu }}
+      connector: 'sqlserver'
+      relation_load_strategy: '["query"]'
+
+  mssql-push:
+    if: github.event_name == 'push'
+    strategy:
+      fail-fast: false
+      matrix:
+        database:
           - name: 'mssql_2019'
             version: '2019'
-            run_on_pr: false
+            ubuntu: '24.04'
           - name: 'mssql_2017'
             version: '2017'
             ubuntu: '20.04'
-            run_on_pr: false
+    name: ${{ matrix.database.name }}
     uses: ./.github/workflows/test-query-engine-template.yml
-    name: mssql ${{ matrix.database.version }}
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
@@ -162,8 +197,8 @@ jobs:
       relation_load_strategy: '["query"]'
 
   sqlite:
-    uses: ./.github/workflows/test-query-engine-template.yml
     name: sqlite
+    uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: 'sqlite'
       version: 3

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -26,7 +26,7 @@ jobs:
         database:
           - name: 'postgres16'
             version: '16'
-    name: ${{ matrix.database.name }}
+    name: 'Postgres v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -54,7 +54,7 @@ jobs:
             version: '10'
           - name: 'postgres9'
             version: '9'
-    name: ${{ matrix.database.name }}
+    name: 'Postgres Old v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -70,7 +70,7 @@ jobs:
           - name: 'mysql_8'
             version: '8'
             relation_load_strategy: '["join", "query"]'
-    name: ${{ matrix.database.name }}
+    name: 'MySQL v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -94,7 +94,7 @@ jobs:
           - name: 'mysql_mariadb'
             version: 'mariadb'
             relation_load_strategy: '["query"]'
-    name: ${{ matrix.database.name }}
+    name: 'MySQL Old v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -115,7 +115,7 @@ jobs:
             version: '22.2'
           - name: 'cockroach_22_1_0'
             version: '22.1'
-    name: ${{ matrix.database.name }}
+    name: 'CockroachDB v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -130,7 +130,7 @@ jobs:
           - name: 'mongodb_5'
             version: '5'
             connector: 'mongodb'
-    name: ${{ matrix.database.name }}
+    name: 'MongoDB v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -149,7 +149,7 @@ jobs:
             version: '4.4'
           - name: 'mongodb_4_2'
             version: '4.2'
-    name: ${{ matrix.database.name }}
+    name: 'MongoDB Old v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -166,7 +166,7 @@ jobs:
           - name: 'mssql_2022'
             version: '2022'
             ubuntu: '24.04'
-    name: ${{ matrix.database.name }}
+    name: 'MSSQL v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}
@@ -184,10 +184,7 @@ jobs:
           - name: 'mssql_2019'
             version: '2019'
             ubuntu: '24.04'
-          - name: 'mssql_2017'
-            version: '2017'
-            ubuntu: '20.04'
-    name: ${{ matrix.database.name }}
+    name: 'MSSQL Old v${{ matrix.database.version}}'
     uses: ./.github/workflows/test-query-engine-template.yml
     with:
       name: ${{ matrix.database.name }}

--- a/.github/workflows/test-schema-engine-linux-template.yml
+++ b/.github/workflows/test-schema-engine-linux-template.yml
@@ -1,0 +1,135 @@
+on:
+  workflow_call:
+    inputs:
+      database_name:
+        required: true
+        type: string
+      database_url:
+        required: true
+        type: string
+      ubuntu:
+        required: true
+        type: string
+      is_vitess:
+        required: false
+        type: boolean
+        default: false
+      single_threaded:
+        required: false
+        type: boolean
+        default: false
+      shadow_database_url:
+        required: false
+        type: string
+
+jobs:
+  tests:
+    name: ${{ inputs.database_name }}
+    runs-on: ubuntu-${{ inputs.ubuntu }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: ubuntu-${{ inputs.ubuntu }}
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        continue-on-error: true
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.5.0
+        with:
+          key: docker-${{ inputs.database_name }}-${{ hashFiles('docker-compose.yaml') }}
+
+      #
+      # Multithreaded tests
+      #
+      - name: 'Start ${{ inputs.database_name }}'
+        run: make start-${{ inputs.database_name }}
+
+      - run: cargo nextest run -p sql-introspection-tests
+        if: ${{ !inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+
+      - run: cargo nextest run -p sql-schema-describer --features all-native
+        if: ${{ !inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+
+      - run: cargo nextest run -p sql-migration-tests
+        if: ${{ !inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+
+      - run: cargo nextest run -p schema-engine-cli
+        if: ${{ !inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+
+      #
+      # Vitess tests
+      #
+      - run: cargo nextest run -p sql-introspection-tests --test-threads=1
+        if: ${{ inputs.is_vitess }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+          TEST_SHADOW_DATABASE_URL: ${{ inputs.shadow_database_url }}
+
+      - run: cargo nextest run -p sql-migration-tests --test-threads=1
+        if: ${{ inputs.is_vitess }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+          TEST_SHADOW_DATABASE_URL: ${{ inputs.shadow_database_url }}
+          RUST_LOG: debug
+
+      - run: cargo nextest run -p schema-engine-cli --test-threads=1
+        if: ${{ inputs.is_vitess }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+          TEST_SHADOW_DATABASE_URL: ${{ inputs.shadow_database_url }}
+
+      #
+      # Single threaded tests (excluding Vitess)
+      #
+      - run: cargo nextest run -p sql-schema-describer --features all-native --test-threads=1
+        if: ${{ !inputs.is_vitess && inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+
+      - run: cargo nextest run -p sql-introspection-tests --test-threads=1
+        if: ${{ !inputs.is_vitess && inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+
+      - run: cargo nextest run -p sql-migration-tests --test-threads=1
+        if: ${{ !inputs.is_vitess && inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}
+          RUST_LOG: debug
+
+      - run: cargo nextest run -p schema-engine-cli --test-threads=1
+        if: ${{ !inputs.is_vitess && inputs.single_threaded }}
+        env:
+          CLICOLOR_FORCE: 1
+          TEST_DATABASE_URL: ${{ inputs.database_url }}

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -1,4 +1,4 @@
-name: 'SE: integration tests'
+name: 'SE'
 on:
   push:
     branches:
@@ -7,6 +7,7 @@ on:
     paths-ignore:
       - '.github/**'
       - '!.github/workflows/test-schema-engine.yml'
+      - '!.github/workflows/test-schema-engine-linux-template.yml'
       - '.buildkite/**'
       - '*.md'
       - 'LICENSE'
@@ -20,17 +21,18 @@ concurrency:
 
 jobs:
   test-mongodb-schema-connector:
-    name: '${{ matrix.database.name }}'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
         database:
-          - name: 'mongodb42'
-            url: 'mongodb://prisma:prisma@localhost:27016/?authSource=admin&retryWrites=true'
-          - name: 'mongodb44'
-            url: 'mongodb://prisma:prisma@localhost:27017/?authSource=admin&retryWrites=true'
           - name: 'mongodb5'
             url: 'mongodb://prisma:prisma@localhost:27018/?authSource=admin&retryWrites=true'
+          - name: 'mongodb44'
+            url: 'mongodb://prisma:prisma@localhost:27017/?authSource=admin&retryWrites=true'
+          - name: 'mongodb42'
+            url: 'mongodb://prisma:prisma@localhost:27016/?authSource=admin&retryWrites=true'
+    name: '${{ matrix.database.name }}'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,8 +60,29 @@ jobs:
           TEST_DATABASE_URL: ${{ matrix.database.url }}
 
   test-linux:
-    name: '${{ matrix.database.name }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        ubuntu:
+          - '24.04'
+        database:
+          - name: mssql_2022
+            url: 'sqlserver://localhost:1435;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED'
+          - name: mysql_8
+            url: 'mysql://root:prisma@localhost:3307'
+          - name: postgres16
+            url: 'postgresql://postgres:prisma@localhost:5439'
+          - name: sqlite
+            url: sqlite
+    name: '${{ matrix.database.name }} on Linux'
+    uses: ./.github/workflows/test-schema-engine-linux-template.yml
+    with:
+      ubuntu: ${{ matrix.ubuntu }}
+      database_name: ${{ matrix.database.name }}
+      database_url: ${{ matrix.database.url }}
 
+  test-linux-push:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -68,14 +91,10 @@ jobs:
         database:
           - name: mssql_2019
             url: 'sqlserver://localhost:1433;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED'
-          - name: mssql_2022
-            url: 'sqlserver://localhost:1435;database=master;user=SA;password=<YourStrong@Passw0rd>;trustServerCertificate=true;socket_timeout=60;isolationLevel=READ UNCOMMITTED'
           - name: mysql_5_6
             url: 'mysql://root:prisma@localhost:3309'
           - name: mysql_5_7
             url: 'mysql://root:prisma@localhost:3306'
-          - name: mysql_8
-            url: 'mysql://root:prisma@localhost:3307'
           - name: mysql_mariadb
             url: 'mysql://root:prisma@localhost:3308'
           - name: postgres9
@@ -92,131 +111,33 @@ jobs:
             url: 'postgresql://postgres:prisma@localhost:5437'
           - name: postgres15
             url: 'postgresql://postgres:prisma@localhost:5438'
-          - name: postgres16
-            url: 'postgresql://postgres:prisma@localhost:5439'
           - name: cockroach_23_1
             url: 'postgresql://prisma@localhost:26260'
           - name: cockroach_22_2
             url: 'postgresql://prisma@localhost:26259'
           - name: cockroach_22_1_0
             url: 'postgresql://prisma@localhost:26257'
-          - name: sqlite
-            url: sqlite
           - name: vitess_8_0
             url: 'mysql://root:prisma@localhost:33807/test'
             shadow_database_url: 'mysql://root:prisma@localhost:33808/shadow'
             is_vitess: true
             single_threaded: true
-
-    runs-on: 'ubuntu-${{ matrix.ubuntu }}'
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache-key: 'ubuntu-${{ matrix.ubuntu }}'
-      - uses: taiki-e/install-action@nextest
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        continue-on-error: true
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        if: "${{ env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != '' }}"
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ matrix.database.name }}-${{hashFiles('docker-compose.yaml')}}
-
-      - name: 'Start ${{ matrix.database.name }}'
-        run: make start-${{ matrix.database.name }}
-
-      - run: cargo nextest run -p sql-introspection-tests
-        if: ${{ !matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-
-      - run: cargo nextest run -p sql-schema-describer --features all-native
-        if: ${{ !matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-
-      - run: cargo nextest run -p sql-migration-tests
-        if: ${{ !matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-
-      - run: cargo nextest run -p schema-engine-cli
-        if: ${{ !matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-
-      #
-      # Vitess tests
-      #
-      - run: cargo nextest run -p sql-introspection-tests --test-threads=1
-        if: ${{ matrix.database.is_vitess }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-          TEST_SHADOW_DATABASE_URL: ${{ matrix.database.shadow_database_url }}
-
-      - run: cargo nextest run -p sql-migration-tests --test-threads=1
-        if: ${{ matrix.database.is_vitess }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-          TEST_SHADOW_DATABASE_URL: ${{ matrix.database.shadow_database_url }}
-          RUST_LOG: debug
-
-      - run: cargo nextest run -p schema-engine-cli --test-threads=1
-        if: ${{ matrix.database.is_vitess }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-          TEST_SHADOW_DATABASE_URL: ${{ matrix.database.shadow_database_url }}
-
-      #
-      # Single threaded tests (excluding Vitess)
-      #
-      - run: cargo nextest run -p sql-schema-describer --features all-native --test-threads=1
-        if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-
-      - run: cargo nextest run -p sql-introspection-tests --test-threads=1
-        if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-
-      - run: cargo nextest run -p sql-migration-tests --test-threads=1
-        if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
-          RUST_LOG: debug
-
-      - run: cargo nextest run -p schema-engine-cli --test-threads=1
-        if: ${{ !matrix.database.is_vitess && matrix.database.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-          TEST_DATABASE_URL: ${{ matrix.database.url }}
+    name: '${{ matrix.database.name }} on Linux'
+    uses: ./.github/workflows/test-schema-engine-linux-template.yml
+    with:
+      ubuntu: ${{ matrix.ubuntu }}
+      database_name: ${{ matrix.database.name }}
+      database_url: ${{ matrix.database.url }}
+      shadow_database_url: ${{ matrix.database.shadow_database_url }}
+      is_vitess: ${{ matrix.database.is_vitess }}
+      single_threaded: ${{ matrix.database.single_threaded }}
 
   test-windows:
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
-        db:
+        database:
           - name: 'mysql-lts'
             url: 'mysql://root@localhost:3306?connect_timeout=20&socket_timeout=60'
           - name: 'mariadb'
@@ -227,9 +148,7 @@ jobs:
           - windows-latest
 
     runs-on: ${{ matrix.os }}
-
-    name: '${{ matrix.db.name }} on Windows'
-
+    name: '${{ matrix.database.name }} on Windows'
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -243,17 +162,17 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Install ${{ matrix.db.name }}
+      - name: Install ${{ matrix.database.name }}
         run: |
           iwr -useb 'https://raw.githubusercontent.com/scoopinstaller/install/master/install.ps1' -outfile 'install.ps1'
           .\install.ps1 -RunAsAdmin
 
           scoop install sudo
-          scoop install ${{ matrix.db.name }}
+          scoop install ${{ matrix.database.name }}
           sudo mysqld --install
           sudo sc start MySQL
 
       - name: Run tests
         run: cargo nextest run -p sql-migration-tests
         env:
-          TEST_DATABASE_URL: ${{ matrix.db.url }}
+          TEST_DATABASE_URL: ${{ matrix.database.url }}

--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ Run `cargo test` in the repository root.
 
 ### Testing driver adapters
 
-Please refer to the [Testing driver adapters](./query-engine/connector-test-kit-rs/README.md#testing-driver-adapters) section in the connector-test-kit-rs README.
+Please refer to the [Testing driver adapters](./query-engine/connector-test-kit-rs/README.md) section in the connector-test-kit-rs README.
 
 **ℹ️ Important note on developing features that require changes to the both the query engine, and driver adapters code**
 
-As explained in [Testing driver adapters](./query-engine/connector-test-kit-rs/README.md#testing-driver-adapters), running `DRIVER_ADAPTER=$adapter make qe-test`
+As explained in [Testing driver adapters](./query-engine/connector-test-kit-rs/README.md), running `DRIVER_ADAPTER=$adapter make qe-test`
 will ensure you have prisma checked out in your filesystem in the same directory as prisma-engines. This is needed because the driver adapters code is symlinked in prisma-engines.
 
 When working on a feature or bugfix spanning adapters code and query-engine code, you will need to open sibling PRs in `prisma/prisma` and `prisma/prisma-engines` respectively.

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/logs.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/logs.rs
@@ -6,7 +6,7 @@ use query_engine_tests::*;
         MongoDb,
         Vitess("planetscale.js.wasm"),
         Postgres("neon.js.wasm", "pg.js.wasm"),
-        Sqlite("libsql.js.wasm", "cfd1", "react-native")
+        Sqlite("libsql.js.wasm", "cfd1", "react-native", "better-sqlite3")
     )
 )]
 mod logs {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/metrics.rs
@@ -5,7 +5,7 @@ use query_engine_tests::test_suite;
     exclude(
         Vitess("planetscale.js.wasm"),
         Postgres("neon.js.wasm", "pg.js.wasm"),
-        Sqlite("libsql.js.wasm", "cfd1", "react-native")
+        Sqlite("libsql.js.wasm", "cfd1", "react-native", "better-sqlite3")
     )
 )]
 mod metrics {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15204.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_15204.rs
@@ -24,7 +24,11 @@ mod conversion_error {
         schema.to_owned()
     }
 
-    #[connector_test(schema(schema_int), only(Sqlite), exclude(Sqlite("libsql.js.wasm")))]
+    #[connector_test(
+        schema(schema_int),
+        only(Sqlite),
+        exclude(Sqlite("libsql.js.wasm", "better-sqlite3"))
+    )]
     async fn convert_to_int_sqlite_quaint(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 
@@ -52,7 +56,11 @@ mod conversion_error {
         Ok(())
     }
 
-    #[connector_test(schema(schema_bigint), only(Sqlite), exclude(Sqlite("libsql.js.wasm")))]
+    #[connector_test(
+        schema(schema_bigint),
+        only(Sqlite),
+        exclude(Sqlite("libsql.js.wasm", "better-sqlite3"))
+    )]
     async fn convert_to_bigint_sqlite_quaint(runner: Runner) -> TestResult<()> {
         create_test_data(&runner).await?;
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/json.rs
@@ -214,7 +214,7 @@ mod json {
         exclude(
             Vitess("planetscale.js.wasm"),
             Postgres("neon.js.wasm", "pg.js.wasm"),
-            Sqlite("libsql.js.wasm", "cfd1"),
+            Sqlite("libsql.js.wasm", "cfd1", "better-sqlite3"),
             MySQL(5.6)
         )
     )]

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/raw/sql/errors.rs
@@ -36,7 +36,10 @@ mod raw_errors {
 
     #[connector_test(
         only(Postgres, Sqlite),
-        exclude(Postgres("neon.js.wasm", "pg.js.wasm"), Sqlite("libsql.js.wasm", "cfd1"))
+        exclude(
+            Postgres("neon.js.wasm", "pg.js.wasm"),
+            Sqlite("libsql.js.wasm", "cfd1", "better-sqlite3")
+        )
     )]
     async fn invalid_parameter_count(runner: Runner) -> TestResult<()> {
         assert_error!(

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -23,7 +23,7 @@ pub(crate) use vitess::*;
 use crate::{datamodel_rendering::DatamodelRenderer, BoxFuture, TestConfig, TestError, CONFIG};
 use psl::datamodel_connector::ConnectorCapabilities;
 use quaint::prelude::SqlFamily;
-use std::{convert::TryFrom, fmt};
+use std::{convert::TryFrom, fmt, fs};
 
 pub trait ConnectorTagInterface {
     fn raw_execute<'a>(&'a self, query: &'a str, connection_url: &'a str) -> BoxFuture<'a, Result<(), TestError>>;
@@ -174,6 +174,8 @@ pub(crate) fn connection_string(
                 .unwrap_or_else(|_| ".".to_owned())
                 .trim_end_matches('/')
                 .to_owned();
+
+            fs::create_dir_all(format!("{workspace_root}/db")).ok();
 
             format!("file://{workspace_root}/db/{database}.db")
         }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -177,7 +177,7 @@ pub(crate) fn connection_string(
 
             fs::create_dir_all(format!("{workspace_root}/db")).ok();
 
-            format!("file://{workspace_root}/db/{database}.db")
+            format!("file:{workspace_root}/db/{database}.db")
         }
         ConnectorVersion::CockroachDb(v) => {
             // Use the same database and schema name for CockroachDB - unfortunately CockroachDB


### PR DESCRIPTION
- Extracted the SE test steps into its own workflow template.
- Split the QE and SE test matrices to have quick PR validation and a complete one on `main` push.
- Not compiling on Mac during PR validation, only on `main` push.
- The latest version of the most common databases are always tested.
- Older database versions and rare database variants tested only on `push`.
- Reduced test case timeout of 3 minutes, showing SLOW log after 30 seconds.
- Reduced test case retries to maximum of 2. (Later we should remove all retries.)
- Properly defined `WORKSPACE_ROOT` environment variable for all QE tests.
- Fixed the SQLite test URL to `file:PATH` instead of `file://PATH`
- Minor fix to the README (unrelated)

This way the CI progress is cleaner on GitHub's UI, properly grouping all skipped tests and showing with the skipped icon. The cost is a bit of redundancy in the workflow definition.

[ORM-834](https://linear.app/prisma-company/issue/ORM-834/reduce-ci-workload)