### PR TITLE
test(speed): Running SQLite tests on ramdisk

### DIFF
--- a/.github/workflows/test-driver-adapters-template.yml
+++ b/.github/workflows/test-driver-adapters-template.yml
@@ -31,6 +31,7 @@ jobs:
       SIMPLE_TEST_MODE: '1'
       QUERY_BATCH_SIZE: '10'
       WASM_BUILD_PROFILE: 'profiling' # Include debug info for proper backtraces
+      RAMDISK: '/mnt/ramdisk'
       WORKSPACE_ROOT: ${{ github.workspace }}
 
     runs-on: ubuntu-latest
@@ -39,6 +40,12 @@ jobs:
         with:
           # using head ref rather than merge branch to get original commit message
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Create ramdisk
+        run: |
+          sudo mkdir ${{ env.RAMDISK }}
+          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
+          echo "Ramdisk (2GB): /mnt/ramdisk"
 
       - name: 'Setup Node.js'
         uses: actions/setup-node@v4

--- a/.github/workflows/test-query-compiler-template.yml
+++ b/.github/workflows/test-query-compiler-template.yml
@@ -37,6 +37,7 @@ jobs:
       SIMPLE_TEST_MODE: '1'
       QUERY_BATCH_SIZE: '10'
       WASM_BUILD_PROFILE: 'profiling' # Include debug info for proper backtraces
+      RAMDISK: '/mnt/ramdisk'
       WORKSPACE_ROOT: ${{ github.workspace }}
       IGNORED_TESTS: ${{ inputs.ignored_tests_list }}
       SHOULD_FAIL_TESTS: ${{ inputs.should_fail_tests_list }}
@@ -47,6 +48,12 @@ jobs:
         with:
           # using head ref rather than merge branch to get original commit message
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Create ramdisk
+        run: |
+          sudo mkdir ${{ env.RAMDISK }}
+          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
+          echo "Ramdisk (2GB): /mnt/ramdisk"
 
       - name: 'Setup Node.js'
         uses: actions/setup-node@v4

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -46,10 +46,17 @@ jobs:
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
       PRISMA_RELATION_LOAD_STRATEGY: ${{ matrix.relation_load_strategy }}
       WORKSPACE_ROOT: ${{ github.workspace }}
+      RAMDISK: '/mnt/ramdisk'
 
     runs-on: 'ubuntu-${{ inputs.ubuntu }}'
     steps:
       - uses: actions/checkout@v4
+
+      - name: Create ramdisk
+        run: |
+          sudo mkdir ${{ env.RAMDISK }}
+          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
+          echo "Ramdisk (2GB): /mnt/ramdisk"
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/test-schema-engine-linux-template.yml
+++ b/.github/workflows/test-schema-engine-linux-template.yml
@@ -26,22 +26,13 @@ jobs:
   tests:
     name: ${{ inputs.database_name }}
     runs-on: ubuntu-${{ inputs.ubuntu }}
-
-    env:
-      RAMDISK: '/mnt/ramdisk'
-
     steps:
       - uses: actions/checkout@v4
-
-      - name: Create ramdisk
-        run: |
-          sudo mkdir ${{ env.RAMDISK }}
-          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
-          echo "Ramdisk (2GB): /mnt/ramdisk"
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: ubuntu-${{ inputs.ubuntu }}
+
       - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub

--- a/.github/workflows/test-schema-engine-linux-template.yml
+++ b/.github/workflows/test-schema-engine-linux-template.yml
@@ -26,13 +26,22 @@ jobs:
   tests:
     name: ${{ inputs.database_name }}
     runs-on: ubuntu-${{ inputs.ubuntu }}
+
+    env:
+      RAMDISK: '/mnt/ramdisk'
+
     steps:
       - uses: actions/checkout@v4
+
+      - name: Create ramdisk
+        run: |
+          sudo mkdir ${{ env.RAMDISK }}
+          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
+          echo "Ramdisk (2GB): /mnt/ramdisk"
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: ubuntu-${{ inputs.ubuntu }}
-
       - uses: taiki-e/install-action@nextest
 
       - name: Login to Docker Hub

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -176,7 +176,7 @@ pub(crate) fn connection_string(
                 .trim_end_matches('/')
                 .to_owned();
 
-            let db_dir = format!("{}/db", working_dir);
+            let db_dir = format!("{working_dir}/db");
             fs::create_dir_all(&db_dir).ok();
 
             format!("file:{db_dir}/{database}.db")

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -170,7 +170,8 @@ pub(crate) fn connection_string(
             None => unreachable!("A versioned connector must have a concrete version to run."),
         },
         ConnectorVersion::Sqlite(_) => {
-            let workspace_root = std::env::var("WORKSPACE_ROOT")
+            let workspace_root = std::env::var("RAMDISK")
+                .or_else(|_| std::env::var("WORKSPACE_ROOT"))
                 .unwrap_or_else(|_| ".".to_owned())
                 .trim_end_matches('/')
                 .to_owned();

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -170,15 +170,16 @@ pub(crate) fn connection_string(
             None => unreachable!("A versioned connector must have a concrete version to run."),
         },
         ConnectorVersion::Sqlite(_) => {
-            let workspace_root = std::env::var("RAMDISK")
+            let working_dir = std::env::var("RAMDISK")
                 .or_else(|_| std::env::var("WORKSPACE_ROOT"))
                 .unwrap_or_else(|_| ".".to_owned())
                 .trim_end_matches('/')
                 .to_owned();
 
-            fs::create_dir_all(format!("{workspace_root}/db")).ok();
+            let db_dir = format!("{}/db", working_dir);
+            fs::create_dir_all(&db_dir).ok();
 
-            format!("file:{workspace_root}/db/{database}.db")
+            format!("file:{db_dir}/{database}.db")
         }
         ConnectorVersion::CockroachDb(v) => {
             // Use the same database and schema name for CockroachDB - unfortunately CockroachDB


### PR DESCRIPTION
- Introduced optional `RAMDISK` environment variable (it can be used for local development as well)
- Mounting `/tmp/ramdisk` to tmpfs with up to 2GB capacity
- Using `RAMDISK` (if defined) to run the SQLite tests

**Remarks**
- Not using a `:memory:` database, so the resulting database files can still be inspected in local development. It may be improved on later, to use `:memory:` only in CI, but not locally. But that would result in more code...
- Introduced while working on [ORM-877](https://linear.app/prisma-company/issue/ORM-877/qe-test-conflicts) to improve the efficiency of testing local changes to the `prisma-engines` code base.