### PR TITLE
test(ci): Fix test timeouts and concurrency issues on main

### DIFF
--- a/.config/nextest.cockroachdb.toml
+++ b/.config/nextest.cockroachdb.toml
@@ -1,0 +1,88 @@
+[store]
+# The directory under the workspace root at which nextest-related files are
+# written. Profile-specific storage is currently written to dir/<profile-name>.
+dir = "target/nextest"
+
+# This section defines the default nextest profile. Custom profiles are layered
+# on top of the default profile.
+[profile.default]
+# "retries" defines the number of times a test should be retried. If set to a
+# non-zero value, tests that succeed on a subsequent attempt will be marked as
+# flaky. Can be overridden through the `--retries` option.
+# Examples
+# * retries = 3
+# * retries = { backoff = "fixed", count = 2, delay = "1s" }
+# * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
+retries = { backoff = "fixed", count = 2, delay = "1s", jitter = false }
+
+# The number of threads to run tests with. Supported values are either an integer or
+# the string "num-cpus". Can be overridden through the `--test-threads` option.
+test-threads = "num-cpus"
+
+# The number of threads required for each test. This is generally used in overrides to
+# mark certain tests as heavier than others. However, it can also be set as a global parameter.
+threads-required = 1
+
+# Show these test statuses in the output.
+#
+# The possible values this can take are:
+# * none: no output
+# * fail: show failed (including exec-failed) tests
+# * retry: show flaky and retried tests
+# * slow: show slow tests
+# * pass: show passed tests
+# * skip: show skipped tests (most useful for CI)
+# * all: all of the above
+#
+# Each value includes all the values above it; for example, "slow" includes
+# failed and retried tests.
+#
+# Can be overridden through the `--status-level` flag.
+status-level = "pass"
+
+# Similar to status-level, show these test statuses at the end of the run.
+final-status-level = "flaky"
+
+# "failure-output" defines when standard output and standard error for failing tests are produced.
+# Accepted values are
+# * "immediate": output failures as soon as they happen
+# * "final": output failures at the end of the test run
+# * "immediate-final": output failures as soon as they happen and at the end of
+#   the test run; combination of "immediate" and "final"
+# * "never": don't output failures at all
+#
+# For large test suites and CI it is generally useful to use "immediate-final".
+#
+# Can be overridden through the `--failure-output` option.
+failure-output = "immediate-final"
+
+# "success-output" controls production of standard output and standard error on success. This should
+# generally be set to "never".
+success-output = "never"
+
+# Cancel the test run on the first failure. For CI runs, consider setting this
+# to false.
+fail-fast = false
+
+# Treat a test that takes longer than the configured 'period' as slow, and print a message.
+# See <https://nexte.st/book/slow-tests> for more information.
+#
+# Optional: specify the parameter 'terminate-after' with a non-zero integer,
+# which will cause slow tests to be terminated after the specified number of
+# periods have passed.
+# Example: slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "30s", terminate-after = 20 }
+
+# Treat a test as leaky if after the process is shut down, standard output and standard error
+# aren't closed within this duration.
+#
+# This usually happens in case of a test that creates a child process and lets it inherit those
+# handles, but doesn't clean the child process up (especially when it fails).
+#
+# See <https://nexte.st/book/leaky-tests> for more information.
+leak-timeout = "100ms"
+
+# This profile is activated if MIRI_SYSROOT is set.
+[profile.default-miri]
+# Miri tests take up a lot of memory, so only run 1 test at a time by default.
+test-threads = 1

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -24,6 +24,8 @@ jobs:
   rust-query-engine-tests:
     name: '${{ matrix.engine_protocol }} ${{ matrix.relation_load_strategy }} ${{ matrix.partition }}'
 
+    timeout-minutes: 60
+
     strategy:
       fail-fast: false
       matrix:
@@ -82,6 +84,16 @@ jobs:
 
       - name: 'Start ${{ inputs.name }} (${{ matrix.engine_protocol }})'
         run: make start-${{ inputs.name }}
+
+      - name: Use custom Nextest config if it exists
+        run: |
+          CUSTOM_NEXTEST_CONFIG=".config/nextest.$TEST_CONNECTOR.toml"
+          if [[ -e "$CUSTOM_NEXTEST_CONFIG" ]]; then
+            echo "Using custom Nextest config: $CUSTOM_NEXTEST_CONFIG"
+            mv -f "$CUSTOM_NEXTEST_CONFIG" .config/nextest.toml
+          else
+            echo 'Using common Nextest config: .config/nextest.toml'
+          fi
 
       - run: cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
         if: ${{ inputs.single_threaded }}

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -13,9 +13,9 @@ on:
       ubuntu:
         type: string
         default: 'latest'
-      single_threaded:
-        type: boolean
-        default: false
+      threads:
+        type: number
+        default: 1
       relation_load_strategy:
         type: string
         default: '["join", "query"]'
@@ -95,12 +95,6 @@ jobs:
             echo 'Using common Nextest config: .config/nextest.toml'
           fi
 
-      - run: cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=1
-        if: ${{ inputs.single_threaded }}
-        env:
-          CLICOLOR_FORCE: 1
-
-      - run: cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=8
-        if: ${{ !inputs.single_threaded }}
+      - run: cargo nextest run -p query-engine-tests --partition hash:${{ matrix.partition }} --test-threads=${{ inputs.threads }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -35,7 +35,7 @@ jobs:
       single_threaded: false
 
   postgres-push:
-    if: github.event_name == 'push'
+#    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,7 @@ jobs:
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
 
   mysql-push:
-    if: github.event_name == 'push'
+#    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -104,7 +104,7 @@ jobs:
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
 
   cockroachdb-push:
-    if: github.event_name == 'push'
+#    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -136,12 +136,13 @@ jobs:
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
+      # MongoDB tests MUST run single threaded
+      single_threaded: true
       connector: 'mongodb'
-      single_threaded: false
       relation_load_strategy: '["query"]'
 
   mongodb-push:
-    if: github.event_name == 'push'
+#    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -155,8 +156,9 @@ jobs:
     with:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
+      # MongoDB tests MUST run single threaded
+      single_threaded: true
       connector: 'mongodb'
-      single_threaded: false
       relation_load_strategy: '["query"]'
 
   mssql:
@@ -178,7 +180,7 @@ jobs:
       relation_load_strategy: '["query"]'
 
   mssql-push:
-    if: github.event_name == 'push'
+#    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -35,7 +35,7 @@ jobs:
       threads: 8
 
   postgres-push:
-#    if: github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -80,7 +80,7 @@ jobs:
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
 
   mysql-push:
-#    if: github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -107,7 +107,7 @@ jobs:
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
 
   cockroachdb-push:
-#    if: github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +145,7 @@ jobs:
       relation_load_strategy: '["query"]'
 
   mongodb-push:
-#    if: github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -183,7 +183,7 @@ jobs:
       relation_load_strategy: '["query"]'
 
   mssql-push:
-#    if: github.event_name == 'push'
+    if: github.event_name == 'push'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -32,7 +32,7 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       connector: 'postgres'
-      single_threaded: false
+      threads: 8
 
   postgres-push:
 #    if: github.event_name == 'push'
@@ -60,7 +60,7 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       connector: 'postgres'
-      single_threaded: false
+      threads: 8
 
   mysql:
     strategy:
@@ -76,7 +76,7 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       connector: 'mysql'
-      single_threaded: false
+      threads: 8
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
 
   mysql-push:
@@ -100,7 +100,10 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       connector: 'mysql'
-      single_threaded: false
+      # Reason for single threaded test: `test_itx_concurrent_updates_single_thread`
+      # This test fails with: `Query core error: Error in connector: Error creating a database connection. (Error in the underlying connector)`
+      # It does NOT happen on MySQL 8, only on the older versions.
+      threads: 1
       relation_load_strategy: ${{ matrix.database.relation_load_strategy }}
 
   cockroachdb-push:
@@ -121,7 +124,7 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       connector: 'cockroachdb'
-      single_threaded: false
+      threads: 4
 
   mongodb:
     strategy:
@@ -137,7 +140,7 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       # MongoDB tests MUST run single threaded
-      single_threaded: true
+      threads: 1
       connector: 'mongodb'
       relation_load_strategy: '["query"]'
 
@@ -157,7 +160,7 @@ jobs:
       name: ${{ matrix.database.name }}
       version: ${{ matrix.database.version }}
       # MongoDB tests MUST run single threaded
-      single_threaded: true
+      threads: 1
       connector: 'mongodb'
       relation_load_strategy: '["query"]'
 
@@ -176,7 +179,7 @@ jobs:
       version: ${{ matrix.database.version }}
       ubuntu: ${{ matrix.database.ubuntu }}
       connector: 'sqlserver'
-      single_threaded: false
+      threads: 8
       relation_load_strategy: '["query"]'
 
   mssql-push:
@@ -195,7 +198,7 @@ jobs:
       version: ${{ matrix.database.version }}
       ubuntu: ${{ matrix.database.ubuntu }}
       connector: 'sqlserver'
-      single_threaded: false
+      threads: 8
       relation_load_strategy: '["query"]'
 
   sqlite:
@@ -205,7 +208,7 @@ jobs:
       name: 'sqlite'
       version: 3
       connector: 'sqlite'
-      single_threaded: false
+      threads: 8
       relation_load_strategy: '["query"]'
 
   driver_adapters:

--- a/.github/workflows/test-schema-engine-linux-template.yml
+++ b/.github/workflows/test-schema-engine-linux-template.yml
@@ -57,25 +57,25 @@ jobs:
       - name: 'Start ${{ inputs.database_name }}'
         run: make start-${{ inputs.database_name }}
 
-      - run: cargo nextest run -p sql-introspection-tests
+      - run: cargo nextest run -p sql-introspection-tests --test-threads=8
         if: ${{ !inputs.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ inputs.database_url }}
 
-      - run: cargo nextest run -p sql-schema-describer --features all-native
+      - run: cargo nextest run -p sql-schema-describer --features all-native --test-threads=8
         if: ${{ !inputs.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ inputs.database_url }}
 
-      - run: cargo nextest run -p sql-migration-tests
+      - run: cargo nextest run -p sql-migration-tests --test-threads=8
         if: ${{ !inputs.single_threaded }}
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ inputs.database_url }}
 
-      - run: cargo nextest run -p schema-engine-cli
+      - run: cargo nextest run -p schema-engine-cli --test-threads=8
         if: ${{ !inputs.single_threaded }}
         env:
           CLICOLOR_FORCE: 1

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -54,7 +54,8 @@ jobs:
       - name: 'Start ${{ matrix.database.name }}'
         run: make start-${{ matrix.database.name }}-single
 
-      - run: cargo nextest run -p mongodb-schema-connector
+      # MongoDB tests MUST run single threaded
+      - run: cargo nextest run -p mongodb-schema-connector --test-threads=1
         env:
           CLICOLOR_FORCE: 1
           TEST_DATABASE_URL: ${{ matrix.database.url }}
@@ -173,6 +174,6 @@ jobs:
           sudo sc start MySQL
 
       - name: Run tests
-        run: cargo nextest run -p sql-migration-tests
+        run: cargo nextest run -p sql-migration-tests --test-threads=8
         env:
           TEST_DATABASE_URL: ${{ matrix.database.url }}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_create.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod connect_inside_create {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_connect_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod connect_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_create.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_create.rs
@@ -1,7 +1,7 @@
 use query_engine_tests::*;
 
 // TODO(dom): All failings except one (only a couple of tests is failing per test)
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod create_inside_create {
     use query_engine_tests::{run_query, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_create_inside_update.rs
@@ -2,7 +2,7 @@ use query_engine_tests::*;
 
 //TODO: which tests to keep and which ones to delete???? Some do not really test the compound unique functionality
 // TODO(dom): All failing except one
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod create_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod delete_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_inside_upsert.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod delete_inside_upsert {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_many_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_delete_many_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod delete_many_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod disconnect_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_disconnect_inside_upsert.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod disconnect_inside_upsert {
     use query_engine_tests::{assert_error, run_query, run_query_json};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_set_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_set_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod set_inside_update {
     use query_engine_tests::{run_query, run_query_json, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_update_many_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_update_many_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 // update_many_inside_update
 mod um_inside_update {
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams, Runner, TestResult};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_upsert_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/already_converted/nested_upsert_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod upsert_inside_update {
     use query_engine_tests::{run_query, run_query_json};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/combining_different_nested_mutations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/combining_different_nested_mutations.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod many_nested_muts {
     use query_engine_tests::{run_query, DatamodelWithParams};
     use query_test_macros::relation_link_test;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/nested_mutations/not_using_schema_base/nested_update_inside_update.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod update_inside_update {
     use indoc::indoc;
     use query_engine_tests::{assert_error, run_query, run_query_json, DatamodelWithParams};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many_relations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many_relations.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod delete_many_rels {
     use indoc::indoc;
     use query_engine_tests::{run_query, Runner};

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_mutation_relations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_mutation_relations.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite]
+#[test_suite(exclude(CockroachDb))]
 mod delete_mutation_relations {
     use indoc::indoc;
     use query_engine_tests::{run_query, Runner};

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/connector_test.rs
@@ -1,14 +1,10 @@
 use super::*;
-use crate::ensure_db_names::UniqueTestDatabaseNames;
+use crate::ensure_db_names::UNIQUE_TEST_DATABASE_NAMES;
 use darling::{ast::NestedMeta, FromMeta};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
 use quote::quote;
-use std::sync::{Arc, LazyLock};
 use syn::{parse_macro_input, ItemFn};
-
-static UNIQUE_TEST_DATABASE_NAMES: LazyLock<Arc<UniqueTestDatabaseNames>> =
-    LazyLock::new(|| Arc::new(UniqueTestDatabaseNames::new()));
 
 pub fn connector_test_impl(attr: TokenStream, input: TokenStream) -> TokenStream {
     let attributes_meta = match NestedMeta::parse_meta_list(attr.into()) {

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/ensure_db_names.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/ensure_db_names.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::sync::Mutex;
+use std::sync::{Arc, LazyLock, Mutex};
 
 // Ensures unique test database names.
 // Reusing the same name more than once causes random test failures, retries and overall flakiness.
@@ -50,3 +50,6 @@ impl UniqueTestDatabaseNames {
         }
     }
 }
+
+pub static UNIQUE_TEST_DATABASE_NAMES: LazyLock<Arc<UniqueTestDatabaseNames>> =
+    LazyLock::new(|| Arc::new(UniqueTestDatabaseNames::new()));

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/relation_link_test.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::ensure_db_names::UNIQUE_TEST_DATABASE_NAMES;
 use darling::{ast::NestedMeta, FromMeta};
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
@@ -55,6 +56,9 @@ pub fn relation_link_test_impl(attr: TokenStream, input: TokenStream) -> TokenSt
     let test_name = test_fn_ident.to_string();
     let suite_name = args.suite.expect("A test must have a test suite.");
     let required_capabilities = &args.capabilities.idents;
+
+    let test_database_name = format!("{suite_name}_{test_name}_#");
+    UNIQUE_TEST_DATABASE_NAMES.ensure_unique(&test_database_name, &suite_name, &test_name);
 
     let ts = quote! {
         #[test]


### PR DESCRIPTION
CI test fixes:
- Test database name collision detection for the relational link tests. (No collisions found.)
- Excluded all relational link tests on CockroachDB, they run way too slow on that database. `*`
- Increased the CockroachDB test case timeout to 10 minutes, some nested operation test cases need it.

Made the number of test runner threads explicit everywhere:
- MySQL versions below 8 and MariaDB run out of connections if tested on more than 1 thread due to this test case: `test_itx_concurrent_updates_single_thread` - We may want to fix this later by running this test case in a separate job.
- CockroachDB does not appear to handle concurrency efficiently, therefore we run on less threads.
- MongoDB tests must run single threaded.

A full test run of 331 successful test jobs takes about 22 minutes wall clock time. This will run each time a PR is merged on the `main` branch (`push` operation). PR test runs are smaller with about 120 test jobs and should complete a bit faster (will be measured) and consuming less resources.

`*` In the last test run it was discovered that `#[test_suite(exclude(CockroachDb))]` is not actually effective, they continue to run. This will need to be addressed later. Not fixing it in this PR to avoid further scope creep.