### PR TITLE
fix(ci): use correct Prettier args to check formatting on CI

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -43,4 +43,4 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '22'
-      - run: npx prettier@3 --write '**/*.ts'
+      - run: npx prettier@3 --check '**/*.ts'


### PR DESCRIPTION
A fixup to https://github.com/prisma/prisma-engines/pull/5339.

It should've been `--check` instead of `--write`.