### PR TITLE
fix: fix compiler result serialization

### DIFF
--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -24,10 +24,6 @@ impl ValidationError {
     pub fn message(&self) -> &str {
         &self.message
     }
-
-    pub fn meta(&self) -> Option<&serde_json::Value> {
-        self.meta.as_ref()
-    }
 }
 
 impl fmt::Display for ValidationError {

--- a/query-compiler/query-compiler-wasm/src/compiler.rs
+++ b/query-compiler/query-compiler-wasm/src/compiler.rs
@@ -129,7 +129,7 @@ impl QueryCompiler {
 
 #[derive(Serialize, Tsify)]
 #[serde(tag = "type", rename_all = "camelCase")]
-#[tsify(into_wasm_abi)]
+#[tsify(into_wasm_abi, hashmap_as_object)]
 pub enum BatchResponse {
     Multi {
         plans: Vec<Expression>,
@@ -145,7 +145,7 @@ pub enum BatchResponse {
 }
 
 #[derive(Serialize, Tsify)]
-#[tsify(into_wasm_abi)]
+#[tsify(into_wasm_abi, hashmap_as_object)]
 pub struct JsCompileError {
     message: String,
     code: Option<String>,
@@ -171,7 +171,7 @@ impl From<CompileError> for JsCompileError {
             )) => JsCompileError {
                 message: error.message().into(),
                 code: Some(error.kind().code().into()),
-                meta: error.meta().cloned(),
+                meta: serde_json::to_value(&error).ok(),
             },
             _ => JsCompileError {
                 message: value.to_string(),


### PR DESCRIPTION
Fixes some serialization issues in the compiler:
- some types are wastefully serialized as Maps and then in some cases converted back to objects on the client or miss the conversion entirely and end up having the wrong type
- we shouldn't be using the `meta` field from `ValidationError`, the client side actually expects the format returned from serializing the `ValidationError` directly (the meta object is flattened into  `ValidationError`), see https://github.com/prisma/prisma/blob/ff1909d2b3161bde2bcc8816fb1650105996256c/packages/client/src/runtime/RequestHandler.ts#L340

/prisma-branch feat/surface-compile-errors