### PR TITLE
fix(qc): Fix interactive transactions (QC)

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-runner.ts
+++ b/libs/driver-adapters/executor/src/qc-test-runner.ts
@@ -11,7 +11,7 @@ import type { Message } from './qc-test-worker/worker'
 
 async function main(): Promise<void> {
   const env = S.decodeUnknownSync(Env)(process.env)
-  console.log('[env]', env)
+  // console.log('[env]', env)
 
   const iface = readline.createInterface({
     input: process.stdin,

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -51,9 +51,9 @@ class QueryPipeline {
 
       const results = transaction
         ? await this.executeTransactionalBatch(
-          batch,
-          parseIsolationLevel(transaction.isolationLevel),
-        )
+            batch,
+            parseIsolationLevel(transaction.isolationLevel),
+          )
         : await this.executeIndependentBatch(batch)
 
       debug('🟢 Batch query results: ', results)
@@ -131,9 +131,9 @@ class QueryPipeline {
     // workaround needed due to raw SQL tests being written against unserialized results
     const interpreter = isPlainRawQuery(queryPlan)
       ? new QueryInterpreter({
-        ...interpreterOpts,
-        serializer: serializeRawQueryResult,
-      })
+          ...interpreterOpts,
+          serializer: serializeRawQueryResult,
+        })
       : QueryInterpreter.forSql(interpreterOpts)
 
     return interpreter.run(queryPlan, queryable)

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -51,9 +51,9 @@ class QueryPipeline {
 
       const results = transaction
         ? await this.executeTransactionalBatch(
-            batch,
-            parseIsolationLevel(transaction.isolationLevel),
-          )
+          batch,
+          parseIsolationLevel(transaction.isolationLevel),
+        )
         : await this.executeIndependentBatch(batch)
 
       debug('🟢 Batch query results: ', results)
@@ -65,7 +65,7 @@ class QueryPipeline {
       })
     } else {
       const queryable = txId
-        ? this.transactionManager.getTransaction({ id: txId }, query.action)
+        ? this.transactionManager.getTransaction({ id: txId }, 'query')
         : this.driverAdapter
 
       if (!queryable) {
@@ -131,9 +131,9 @@ class QueryPipeline {
     // workaround needed due to raw SQL tests being written against unserialized results
     const interpreter = isPlainRawQuery(queryPlan)
       ? new QueryInterpreter({
-          ...interpreterOpts,
-          serializer: serializeRawQueryResult,
-        })
+        ...interpreterOpts,
+        serializer: serializeRawQueryResult,
+      })
       : QueryInterpreter.forSql(interpreterOpts)
 
     return interpreter.run(queryPlan, queryable)
@@ -159,7 +159,7 @@ class QueryPipeline {
 
     const transaction = this.transactionManager.getTransaction(
       txInfo,
-      'batch transaction query',
+      'batch query',
     )
 
     try {

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-transaction.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-transaction.ts
@@ -32,7 +32,7 @@ export function parseIsolationLevel(
       // We don't validate the isolation level on the RPC schema level because some tests
       // rely on sending invalid isolation levels to test error handling, and those invalid
       // levels must be forwarded to the query engine as-is in `testd-qe.ts`.
-      throw new Error(`Unknown isolation level: ${level}`)
+      throw new Error(`Invalid isolation level \`${level}\``)
   }
 }
 

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -123,6 +123,8 @@ parentPort.on('message', async (rawMsg: unknown) => {
     response = {}
   }
 
+  debug('worker response:', JSON.stringify(response))
+
   msg.responsePort.postMessage(response)
 })
 

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -107,12 +107,8 @@ parentPort.on('message', async (rawMsg: unknown) => {
   try {
     response = await dispatchMessage(msg)
   } catch (error) {
-    if (!(error instanceof Error)) {
-      // TODO: we should have a nicer mapping for driver adapter errors
-      error = new Error(JSON.stringify(error))
-    }
-    msg.responsePort.postMessage(error)
-    return
+    // TODO: we should have a nicer mapping for driver adapter errors
+    response = error instanceof Error ? error : new Error(JSON.stringify(error))
   }
 
   // The Rust side expects `TransactionEndResponse::Ok(Empty)`,

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -115,6 +115,14 @@ parentPort.on('message', async (rawMsg: unknown) => {
     return
   }
 
+  // The Rust side expects `TransactionEndResponse::Ok(Empty)`,
+  // where `Empty` is `struct Empty {}` as an empty response.
+  // Without this conversion the test cases don't receive the
+  // response at all, rendering them frozen.
+  if (response === undefined) {
+    response = {}
+  }
+
   msg.responsePort.postMessage(response)
 })
 
@@ -197,10 +205,7 @@ type InitQueryCompilerParams = {
   schema: string
 }
 
-async function initQueryCompiler({
-  driverAdapterManager,
-  schema,
-}: InitQueryCompilerParams) {
+async function initQueryCompiler({ driverAdapterManager, schema }: InitQueryCompilerParams) {
   const adapter = await driverAdapterManager.connect()
 
   let connectionInfo: ConnectionInfo = {}

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -203,7 +203,10 @@ type InitQueryCompilerParams = {
   schema: string
 }
 
-async function initQueryCompiler({ driverAdapterManager, schema }: InitQueryCompilerParams) {
+async function initQueryCompiler({
+  driverAdapterManager,
+  schema,
+}: InitQueryCompilerParams) {
   const adapter = await driverAdapterManager.connect()
 
   let connectionInfo: ConnectionInfo = {}

--- a/query-compiler/query-engine-tests-todo/libsql/fail
+++ b/query-compiler/query-engine-tests-todo/libsql/fail
@@ -1,6 +1,15 @@
 new::cursor::bigint_cursor::bigint_id_must_work
 new::disconnect::disconnect_security::must_honor_connect_scope_m2m
 new::disconnect::disconnect_security::must_honor_connect_scope_one2m
+new::interactive_tx::interactive_tx::batch_queries_failure
+new::interactive_tx::interactive_tx::batch_queries_rollback
+new::interactive_tx::interactive_tx::batch_queries_success
+new::interactive_tx::interactive_tx::commit_after_rollback
+new::interactive_tx::interactive_tx::double_commit
+new::interactive_tx::interactive_tx::double_rollback
+new::interactive_tx::interactive_tx::rollback_after_commit
+new::interactive_tx::interactive_tx::tx_expiration_cycle
+new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
 new::native_upsert::native_upsert::should_not_if_has_nested_select
 new::native_upsert::native_upsert::should_not_if_missing_update
 new::native_upsert::native_upsert::should_not_use_if_where_and_create_different

--- a/query-compiler/query-engine-tests-todo/libsql/skip
+++ b/query-compiler/query-engine-tests-todo/libsql/skip
@@ -2,24 +2,9 @@
 new::regressions::prisma_12572::prisma_12572::all_generated_timestamps_are_the_same
 
 # Timeout at 90 seconds
-new::interactive_tx::interactive_tx::basic_commit_workflow
-new::interactive_tx::interactive_tx::basic_rollback_workflow
-new::interactive_tx::interactive_tx::commit_after_rollback
-new::interactive_tx::interactive_tx::double_commit
-new::interactive_tx::interactive_tx::double_rollback
-new::interactive_tx::interactive_tx::no_auto_rollback
-new::interactive_tx::interactive_tx::rollback_after_commit
-new::interactive_tx::itx_isolation::basic_serializable
-new::interactive_tx::itx_isolation::casing_doesnt_matter
 new::regressions::prisma_engines_4286::sqlite::close_tx_on_error
 
 # Very slow, mostly failing, maybe flaky
-new::interactive_tx::interactive_tx::batch_queries_failure
-new::interactive_tx::interactive_tx::batch_queries_rollback
-new::interactive_tx::interactive_tx::batch_queries_success
-new::interactive_tx::interactive_tx::tx_expiration_cycle
-new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
-new::interactive_tx::itx_isolation::invalid_isolation
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::p1_c1_connect_by_id
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::p1_c1_connect_by_id_already_in_rel
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::p1_c1_connect_by_id_and_filters

--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -70,8 +70,6 @@ new::ref_actions::on_update::set_null::one2one_opt::update_parent_recurse_set_nu
 new::ref_actions::on_update::set_null::one2one_opt::upsert_parent
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_multi_thread
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_single_thread
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_13158::prisma_1358::insert_mixed_int_float_array_in_execute_raw

--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -1,6 +1,16 @@
 new::cursor::bigint_cursor::bigint_id_must_work
 new::disconnect::disconnect_security::must_honor_connect_scope_m2m
 new::disconnect::disconnect_security::must_honor_connect_scope_one2m
+new::interactive_tx::interactive_tx::batch_queries_failure
+new::interactive_tx::interactive_tx::batch_queries_rollback
+new::interactive_tx::interactive_tx::batch_queries_success
+new::interactive_tx::interactive_tx::commit_after_rollback
+new::interactive_tx::interactive_tx::double_commit
+new::interactive_tx::interactive_tx::double_rollback
+new::interactive_tx::interactive_tx::raw_queries
+new::interactive_tx::interactive_tx::rollback_after_commit
+new::interactive_tx::interactive_tx::tx_expiration_cycle
+new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
 new::multi_schema::multi_schema::create_and_get_many_to_many_relations
 new::multi_schema::multi_schema::implicit_m2m_simple
 new::native_upsert::native_upsert::should_not_if_has_nested_select
@@ -70,6 +80,8 @@ new::ref_actions::on_update::set_null::one2one_opt::update_parent_recurse_set_nu
 new::ref_actions::on_update::set_null::one2one_opt::upsert_parent
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
+new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_multi_thread
+new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_single_thread
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_13158::prisma_1358::insert_mixed_int_float_array_in_execute_raw

--- a/query-compiler/query-engine-tests-todo/pg/skip
+++ b/query-compiler/query-engine-tests-todo/pg/skip
@@ -11,28 +11,8 @@ writes::data_types::datetime::datetime::datetime::ms_in_date_after_1970
 writes::data_types::datetime::datetime::datetime::ms_in_date_before_1970
 
 # Timeout at 90 seconds
-new::interactive_tx::interactive_tx::basic_commit_workflow
-new::interactive_tx::interactive_tx::basic_rollback_workflow
-new::interactive_tx::interactive_tx::batch_queries_rollback
-new::interactive_tx::interactive_tx::batch_queries_success
-new::interactive_tx::interactive_tx::commit_after_rollback
-new::interactive_tx::interactive_tx::double_commit
-new::interactive_tx::interactive_tx::double_rollback
-new::interactive_tx::interactive_tx::multiple_tx
-new::interactive_tx::interactive_tx::no_auto_rollback
-new::interactive_tx::interactive_tx::rollback_after_commit
-new::interactive_tx::interactive_tx::write_conflict
-new::interactive_tx::itx_isolation::basic_serializable
-new::interactive_tx::itx_isolation::casing_doesnt_matter
-new::interactive_tx::itx_isolation::high_concurrency
-new::interactive_tx::itx_isolation::spacing_doesnt_matter
 
 # Very slow, mostly failing, maybe flaky
-new::interactive_tx::interactive_tx::batch_queries_failure
-new::interactive_tx::interactive_tx::raw_queries
-new::interactive_tx::interactive_tx::tx_expiration_cycle
-new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
-new::interactive_tx::itx_isolation::invalid_isolation
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::p1_c1_connect_by_id
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::p1_c1_connect_by_id_already_in_rel
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::p1_c1_connect_by_id_and_filters


### PR DESCRIPTION
- Disabled console logging which caused RPC errors during test execution
- Fixed frozen RPC by converting empty (`undefined`) RPC responses to an empty object (`{}`)
- Fixed `invalid_isolation`
- Fixed double transaction rollback error message
- Logging worker error response as well
- Updated `skip` and `fail` lists

Fixes [ORM-785](https://linear.app/prisma-company/issue/ORM-785/fix-interactive-transaction-tests)

/prisma-branch fix/itx