### PR TITLE
fix(quaint): use `NoOpCache` with pgbouncer

### DIFF
--- a/quaint/src/pooled/manager.rs
+++ b/quaint/src/pooled/manager.rs
@@ -139,8 +139,12 @@ impl Manager for QuaintManager {
                 tls_manager,
                 is_tracing_enabled: false,
             } => {
-                use crate::connector::PostgreSqlWithDefaultCache;
-                Ok(Box::new(PostgreSqlWithDefaultCache::new(url.clone(), tls_manager).await?) as Self::Connection)
+                use crate::connector::{PostgreSqlWithDefaultCache, PostgreSqlWithNoCache};
+                Ok(if url.query_params.pg_bouncer {
+                    Box::new(PostgreSqlWithNoCache::new(url.clone(), tls_manager).await?) as Self::Connection
+                } else {
+                    Box::new(PostgreSqlWithDefaultCache::new(url.clone(), tls_manager).await?) as Self::Connection
+                })
             }
 
             #[cfg(feature = "postgresql-native")]
@@ -149,8 +153,12 @@ impl Manager for QuaintManager {
                 tls_manager,
                 is_tracing_enabled: true,
             } => {
-                use crate::connector::PostgreSqlWithTracingCache;
-                Ok(Box::new(PostgreSqlWithTracingCache::new(url.clone(), tls_manager).await?) as Self::Connection)
+                use crate::connector::{PostgreSqlWithNoCache, PostgreSqlWithTracingCache};
+                Ok(if url.query_params.pg_bouncer {
+                    Box::new(PostgreSqlWithNoCache::new(url.clone(), tls_manager).await?) as Self::Connection
+                } else {
+                    Box::new(PostgreSqlWithTracingCache::new(url.clone(), tls_manager).await?) as Self::Connection
+                })
             }
 
             #[cfg(feature = "mssql-native")]


### PR DESCRIPTION
When `pgbouncer=true` is enabled, use `NoOpCache` instead of LRU cache of size 0. This avoids problems that `TracingLruCache` has with transaction mode in `pgbouncer`.

This fixes the specific scenario that the reporter complains about, but it's not a proper fix for the root cause. If `pgbouncer=true` is omitted, the client still hangs every time it happens not to run into the 42P05 error (which is about half the time for me). Even though it's not a supported use case, it must not hang either, and doing that is still a bug.

Ref: https://github.com/prisma/prisma/issues/26537