### PR TITLE
fix(test): Fix the RPC used in QC tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,7 +13,7 @@ dir = "target/nextest"
 # * retries = 3
 # * retries = { backoff = "fixed", count = 2, delay = "1s" }
 # * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
-retries = { backoff = "fixed", count = 2, delay = "1s", jitter = false }
+retries = { backoff = "fixed", count = 0, delay = "1s", jitter = false }
 
 # The number of threads to run tests with. Supported values are either an integer or
 # the string "num-cpus". Can be overridden through the `--test-threads` option.
@@ -71,7 +71,7 @@ fail-fast = false
 # which will cause slow tests to be terminated after the specified number of
 # periods have passed.
 # Example: slow-timeout = { period = "60s", terminate-after = 2 }
-slow-timeout = { period = "30s", terminate-after = 10 }
+slow-timeout = { period = "10s", terminate-after = 10 }
 
 # Treat a test as leaky if after the process is shut down, standard output and standard error
 # aren't closed within this duration.

--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -51,9 +51,9 @@ class QueryPipeline {
 
       const results = transaction
         ? await this.executeTransactionalBatch(
-            batch,
-            parseIsolationLevel(transaction.isolationLevel),
-          )
+          batch,
+          parseIsolationLevel(transaction.isolationLevel),
+        )
         : await this.executeIndependentBatch(batch)
 
       debug('🟢 Batch query results: ', results)
@@ -131,9 +131,9 @@ class QueryPipeline {
     // workaround needed due to raw SQL tests being written against unserialized results
     const interpreter = isPlainRawQuery(queryPlan)
       ? new QueryInterpreter({
-          ...interpreterOpts,
-          serializer: serializeRawQueryResult,
-        })
+        ...interpreterOpts,
+        serializer: serializeRawQueryResult,
+      })
       : QueryInterpreter.forSql(interpreterOpts)
 
     return interpreter.run(queryPlan, queryable)

--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -80,8 +80,6 @@ new::ref_actions::on_update::set_null::one2one_opt::update_parent_recurse_set_nu
 new::ref_actions::on_update::set_null::one2one_opt::upsert_parent
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_multi_thread
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_single_thread
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_13158::prisma_1358::insert_mixed_int_float_array_in_execute_raw

--- a/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/Cargo.toml
@@ -20,7 +20,7 @@ async-trait.workspace = true
 nom.workspace = true
 itertools.workspace = true
 regex.workspace = true
-serde.workspace = true
+serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 tracing-futures.workspace = true
 tracing-subscriber.workspace = true

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/js.rs
@@ -10,5 +10,20 @@ pub(crate) async fn executor_process_request<T: DeserializeOwned>(
     method: &str,
     params: serde_json::Value,
 ) -> Result<T, Box<dyn std::error::Error + Send + Sync>> {
-    EXTERNAL_PROCESS.request(method, params).await
+    match EXTERNAL_PROCESS.request::<T>(method, params).await {
+        Response::None => panic!("Missing result value"),
+        Response::Ok(value) => Ok(value),
+        Response::Err(error) => Err(error),
+    }
+}
+
+pub(crate) async fn executor_process_request_no_return(
+    method: &str,
+    params: serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    match EXTERNAL_PROCESS.request::<()>(method, params).await {
+        Response::None => Ok(()),
+        Response::Ok(_) => panic!("There should be no result value"),
+        Response::Err(error) => Err(error),
+    }
 }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/lib.rs
@@ -50,7 +50,7 @@ pub static ENGINE_PROTOCOL: LazyLock<String> =
 async fn teardown_project(datamodel: &str, db_schemas: &[&str], schema_id: Option<usize>) -> TestResult<()> {
     if let Some(schema_id) = schema_id {
         let params = serde_json::json!({ "schemaId": schema_id });
-        executor_process_request::<serde_json::Value>("teardown", params).await?;
+        executor_process_request_no_return("teardown", params).await?;
     }
 
     Ok(qe_setup::teardown(datamodel, db_schemas).await?)


### PR DESCRIPTION
- Cleaner RPC API to properly represent the `None`, `Result` and `Error` responses
- Fixes conflict of JSON serialization via RPC from TS to Rust modules by using `null` instead of `{}` to represent no return value

The code is currently broken. I think we need a simpler solution here.
