### PR TITLE
fix(schema-engine-wasm): allow constructing multiple instances

### DIFF
--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -16,7 +16,7 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::{mpsc, Mutex};
-use tracing_futures::Instrument;
+use tracing_futures::{Instrument, WithSubscriber};
 
 /// The container for the state of the schema engine. It can contain one or more connectors
 /// corresponding to a database to be reached or that we are already connected to.
@@ -118,11 +118,14 @@ impl EngineState {
 
                 connector.set_host(self.host.clone());
                 let (erased_sender, mut erased_receiver) = mpsc::channel::<ErasedConnectorRequest>(12);
-                tokio::spawn(async move {
-                    while let Some(req) = erased_receiver.recv().await {
-                        req(connector.as_mut()).await;
+                tokio::spawn(
+                    async move {
+                        while let Some(req) = erased_receiver.recv().await {
+                            req(connector.as_mut()).await;
+                        }
                     }
-                });
+                    .with_current_subscriber(),
+                );
                 match erased_sender.send(erased).await {
                     Ok(()) => (),
                     Err(_) => return Err(ConnectorError::from_msg("erased sender send error".to_owned())),
@@ -157,11 +160,14 @@ impl EngineState {
                 connector.set_host(self.host.clone());
 
                 let (erased_sender, mut erased_receiver) = mpsc::channel::<ErasedConnectorRequest>(12);
-                tokio::spawn(async move {
-                    while let Some(req) = erased_receiver.recv().await {
-                        req(connector.as_mut()).await;
+                tokio::spawn(
+                    async move {
+                        while let Some(req) = erased_receiver.recv().await {
+                            req(connector.as_mut()).await;
+                        }
                     }
-                });
+                    .with_current_subscriber(),
+                );
                 match erased_sender.send(erased).await {
                     Ok(()) => (),
                     Err(_) => return Err(ConnectorError::from_msg("erased sender send error".to_owned())),


### PR DESCRIPTION
`SchemaEngine` WASM constructor fails when invoked multiple times because it attempts to set the default tracing subscriber. Even if it worked, it would mean that only one instance at a time could use logs, and all logs would be sent to the last created instance.

This commit changes `schema-engine-wasm` to instrument the futures with local subscribers instead of setting the global one.