### PR TITLE
test(clustering): Clustering of test errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ package-lock.json
 # Folder with GraphViz representation of query graphs.
 .query_graphs
 query-compiler/query-compiler/tests/graphs/*.dot
+
+# Python
+*.pyo
+*.pyc
+__pycache__
+.venv

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,4 @@
+# Utility scripts
+
+This folder contains scripts useful for the development of the Prisma ORM,
+but not part of the distribution.

--- a/utils/test-error-clustering/README.md
+++ b/utils/test-error-clustering/README.md
@@ -1,0 +1,73 @@
+# Clustering test errors
+
+## Dependencies
+
+Tested on Python 3.12.3. 
+
+```shell
+pip install -r requirements.txt
+```
+
+## Gathering test output
+
+Prepare the test environment specific to your target. For example:
+```shell
+make dev-sqlite
+```
+
+Run the Query Engine tests using Nextest to produce `libtest-json` output.
+It is an experimental feature of Nextest at the time of writing, which needs
+to be enabled by the `NEXTEST_EXPERIMENTAL_LIBTEST_JSON` environment variable.
+
+Nextest will generate data on its `stdout` in JSONL format, e.g. one JSON
+object each line. Each object includes the result of a test case and its
+captured `stdout` and `stderr` in case the test failed.
+
+```shell
+export NEXTEST_EXPERIMENTAL_LIBTEST_JSON=1
+cargo nextest run \
+  --test-threads=1 \
+  --package query-engine-tests \
+  --message-format libtest-json \
+  >"test.jsonl" 2>"test.log"
+```
+
+The above command will run one test at a time, which may take very long.
+
+You can parallelize the tests with `--test-threads=8`
+
+Running the tests in parallel may fail with `XFAIL` or `EXECFAIL` errors.
+In this case run multiple processes instead, then concatenate the resulting
+JSONL files. With `SHARD` 1..8: `--test-thread=1 --partition hash:"$SHARD/8"`
+
+## Clustering the test failures
+
+```shell
+python cluster.py test.jsonl
+```
+
+The script will write these files into the same folder as the input file is in:
+
+- `test.jsonl.md`: Markdown formatted clustering with representative test output
+- `test.jsonl.png`: Cluster visualization, mainly useful for debugging
+- `test.jsonl.fail`: List of failed test cases, useful to update a known failure list
+
+The `fail` list is sorted and contains each failed test only once (unique).
+
+If there are no failed tests, empty `md` and `fail` files will be written. If there
+are less than 3 test failures, then no actual clustering will happen and no PNG
+will be produced, but the output will still contain all the failed tests.
+
+## Remarks
+
+The goal is not to have perfect clustering, but has good enough automated
+clustering to be able to target the most frequent issues first. Is it recommended
+to re-run all tests and repeat the clustering after fixing a few issues.
+
+The same test may show up in multiple clusters, if it fails with different errors
+due to failed retries. In order to avoid confusion and to speed up testing it is
+recommended to set `retries = 0` in `.config/nextest.toml` to disable retries.
+
+The script has some hardcoded heuristics to determine the `perplexity` parameter 
+of the t-SNE algorithm used. It may need to be changed/tuned in the future if
+the clustering is not good enough.

--- a/utils/test-error-clustering/cluster
+++ b/utils/test-error-clustering/cluster
@@ -14,6 +14,7 @@ if ! [ -d "$VENV_DIR" ]; then
 
   pushd "$SCRIPT_DIR"
   python3 -m venv .venv
+  # shellcheck source=/dev/null
   . "$VENV_DIR/bin/activate"
   pip3 install -r "$SCRIPT_DIR/requirements.txt"
   popd
@@ -22,5 +23,6 @@ if ! [ -d "$VENV_DIR" ]; then
   echo ''
 fi
 
+# shellcheck source=/dev/null
 . "$VENV_DIR/bin/activate"
 python3 "$SCRIPT_DIR/cluster.py" "$@"

--- a/utils/test-error-clustering/cluster
+++ b/utils/test-error-clustering/cluster
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname "$0")
+VENV_DIR="$SCRIPT_DIR/.venv"
+
+if ! [ -d "$VENV_DIR" ]; then
+  echo 'Installing dependencies into a Python virtual environment (venv):'
+
+  if ! which python3; then
+    echo 'This script requires a recent version of Python 3 (tested with 3.12.3)'
+    exit 1
+  fi
+
+  pushd "$SCRIPT_DIR"
+  python3 -m venv .venv
+  . "$VENV_DIR/bin/activate"
+  pip3 install -r "$SCRIPT_DIR/requirements.txt"
+  popd
+
+  echo 'Done installing dependencies.'
+  echo ''
+fi
+
+. "$VENV_DIR/bin/activate"
+python3 "$SCRIPT_DIR/cluster.py" "$@"

--- a/utils/test-error-clustering/cluster
+++ b/utils/test-error-clustering/cluster
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR=$(dirname "$0")

--- a/utils/test-error-clustering/cluster.py
+++ b/utils/test-error-clustering/cluster.py
@@ -1,0 +1,205 @@
+import sys
+import json
+import re
+from collections import defaultdict, Counter
+from dataclasses import dataclass
+from math import ceil, sqrt
+from typing import List, Dict, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.manifold import TSNE
+from sklearn.cluster import DBSCAN
+
+
+@dataclass
+class ClusteringOptions:
+    representative_output_count: int = 1  # How many representative outputs to show per cluster
+    dbscan_epsilon: float = 3.0  # Higher value produces less clusters
+    log_cleaned_stdout: bool = False  # Helps debugging the cleanup method
+    plot_clusters: bool = True
+
+
+@dataclass
+class TestResult:
+    name: str
+    output: str
+    clean_output: str
+
+
+class TestFailureClustering:
+    def __init__(self, options: ClusteringOptions):
+        self.options = options
+        self.tests: List[TestResult] = []
+        self.clusters: Dict[int, list[TestResult]] = defaultdict(list)
+
+    def clean_test_output(self, text: str) -> str:
+        """Cleans dynamic parts like timestamps, IDs, file paths from the test output"""
+        text = re.sub(r'\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}', '<TIMESTAMP>', text)  # Timestamps
+        text = re.sub(r'\d{4}-\d{2}-\d{2}', '<DATE>', text)  # Timestamps
+        text = re.sub(r'\d{2}:\d{2}:\d{2}', '<TIME>', text)  # Timestamps
+        text = re.sub(r'/[\w/.-]+', '<PATH>', text)  # Unix file paths
+        text = re.sub(r'\\[\w\\.-]+', '<PATH>', text)  # Windows file paths
+        text = re.sub(r'[0-9a-fA-F\-]{36}', '<UID>', text)  # UIDs
+        text = re.sub(r'[0-9a-fA-F]{4,}', '<HEX>', text)  # Hex numbers, addresses
+        text = re.sub(r':\d+', ':<LINE>', text)  # Line numbers
+        text = re.sub(r'\d{2,}', '<DEC>', text)  # Decimal numbers
+        text = re.sub(r'[+\-]?\d+\.\d+', '<FLOAT>', text)  # Floating point numbers
+        text = re.sub(r'={3,}', '===', text)  # Separators
+        text = re.sub(r'\*{3,}', '***', text)  # Separators
+        text = re.sub(r'-{3,}', '---', text)  # Separators
+        text = re.sub(r'[ \t]{2,}', ' ', text)  # Repeated spaces and tabs, but not newlines
+        text = re.sub(r'\n{2,}', '\n', text)  # Repeated newlines
+        return text.strip()
+
+    def run(self, jsonl_path: str):
+        self.read_test_results(jsonl_path)
+
+        plot_path = f'{jsonl_path}.png' if self.options.plot_clusters else None
+        self.cluster_test_results(plot_path)
+
+        md_path = f'{jsonl_path}.md'
+        self.write_markdown(md_path)
+
+        fail_path = f'{jsonl_path}.fail'
+        self.write_failed_tests(fail_path)
+
+    def read_test_results(self, jsonl_path: str):
+        with open(jsonl_path, 'r', encoding='utf-8') as f:
+            for line in f:
+                line = line.strip()
+                if not line.startswith('{') or not line.endswith('}'):
+                    continue
+
+                try:
+                    obj = json.loads(line)
+                except json.decoder.JSONDecodeError:
+                    continue
+
+                if obj.get('event') != 'failed':
+                    continue
+
+                name = obj.get('name')
+                if not name:
+                    continue
+
+                stdout = obj.get('stdout')
+                if not stdout:
+                    continue
+
+                name = name.split('$')[-1].split('#')[0]
+                cleaned_stdout = self.clean_test_output(stdout)
+
+                self.tests.append(TestResult(
+                    name=name,
+                    output=stdout,
+                    clean_output=cleaned_stdout,
+                ))
+
+    def cluster_test_results(self, plot_path: Optional[str] = None):
+        self.clusters.clear()
+
+        count = len(self.tests)
+        if count < 3:
+            for i, test in enumerate(self.tests):
+                self.clusters[1 + i].append(test)
+            return
+
+        # Vectorize the test outputs based on term frequencies
+        vectorizer = TfidfVectorizer(max_features=8192)
+        vectors = vectorizer.fit_transform(test.clean_output for test in self.tests)
+
+        # Reduce to 2 dimensions using t-SNE
+        tsne = TSNE(n_components=2, random_state=42, perplexity=int(ceil(sqrt(count))))
+        reduced = tsne.fit_transform(vectors.toarray())
+
+        # Cluster using DBSCAN
+        dbscan = DBSCAN(eps=self.options.dbscan_epsilon, min_samples=2)
+        labels = dbscan.fit_predict(reduced)
+
+        # Organize tests by clusters
+        for label, test in zip(labels, self.tests):
+            if label < 0:
+                # Ignore noisy sample (see the doc of dbscan.fit_predict)
+                continue
+            self.clusters[label].append(test)
+
+        # Plot the clusters
+        self.plot_clusters(plot_path, reduced, labels)
+
+    def plot_clusters(self, plot_path: Optional[str], reduced: np.ndarray, labels: np.ndarray):
+        if not plot_path:
+            return
+
+        plt.figure(figsize=(12, 8))
+        for label in set(labels):
+            if label < 0:
+                continue
+            mask = labels == label
+            plt.scatter(reduced[mask, 0], reduced[mask, 1], label=f"Cluster {label}", alpha=0.6)
+
+        plt.title("Test error clustering (t-SNE + DBSCAN)")
+        plt.savefig(plot_path)
+
+    def write_markdown(self, md_path: str):
+        # Iterate the clusters in decreasing order of test counts
+        sorted_clusters = sorted(self.clusters.items(), key=lambda x: len(x[1]), reverse=True)
+        with open(md_path, 'w', encoding='utf-8') as f:
+            for cluster_no, (cluster_id, tests) in enumerate(sorted_clusters, 1):
+
+                # Format the cluster as Markdown
+                print(f"# Cluster {cluster_no} ({len(tests)} tests)", file=f)
+                print(file=f)
+                for name in sorted(test.name for test in tests):
+                    print(f'- {name}', file=f)
+                print(file=f)
+
+                if self.options.representative_output_count < 1:
+                    continue
+
+                # Find the most common test output inside the cluster
+                frequencies = Counter(t.clean_output for t in tests)
+                top_n = [doc for doc, _ in frequencies.most_common(self.options.representative_output_count)]
+                original_outputs = {t.clean_output: t.output for t in tests}
+
+                # Provide the top N representative log outputs as collapsed blocks
+                for i, cleaned_doc in enumerate(top_n):
+                    print('<details>', file=f)
+                    print('<summary>', file=f)
+                    print(f"Representative output {1 + i}", file=f)
+                    print('</summary>', file=f)
+                    print(file=f)
+                    print('```js', file=f)
+                    print(original_outputs[cleaned_doc].replace('```', '`~`~`'), file=f)
+                    print('```', file=f)
+                    print(file=f)
+                    if self.options.log_cleaned_stdout:
+                        print(f'### Cleaned', file=f)
+                        print('```js', file=f)
+                        print(cleaned_doc.replace('```', '`~`~`'), file=f)
+                        print('```', file=f)
+                        print(file=f)
+                    print('</details>', file=f)
+                    print(file=f)
+                print(file=f)
+
+    def write_failed_tests(self, fail_path):
+        with open(fail_path, 'w') as f:
+            for name in sorted(set(test.name for test in self.tests)):
+                print(name, file=f)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} <test-results.jsonl>')
+        sys.exit(1)
+    jsonl_path = sys.argv[1]
+
+    options = ClusteringOptions()
+    clustering = TestFailureClustering(options)
+    clustering.run(jsonl_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/test-error-clustering/requirements.txt
+++ b/utils/test-error-clustering/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib~=3.10.1
+numpy~=2.2.5
+scikit-learn~=1.6.1


### PR DESCRIPTION
Clustering of test error output:
- Test output (log) cleanup and normalization.
- Embedding based on the frequency of log lines.
- Reduction to 2 or 3 dimensions using t-SNE (no practical difference in clustering quality).
- Clustering using DBSCAN (many clusters contain overlapping points, they show up as single dots on the plot).
- Render per-cluster insights in Markdown format.
- Render cluster visualization as PNG (for debugging).
- Write a `fail` list, so it can be used directly to update the Query Compiler tests after making fixes.

We need to repeat the clustering of test failures many times while working on the Query Compiler, therefore it is worth to have a dedicated tool for this.

This tool is intended for local test runs in development. It is not integrated into CI, since in general we expect no, or only a few test failures there.

There is no support to update the `skip` list, also no handling of timing out tests. They can be found in the test log by searching for `SLOW`, therefore they are out of scope here. Fix the timeout first, so they pass or fail. If they fail, then they can be handled by clustering. The same applies for the skipped flaky test cases.

Better quality clustering could be achieved by using a transformer model for the embedding, but that would need to run on a GPU to achieve a usable performance.

Former manual clustering: [ORM-862](https://linear.app/prisma-company/issue/ORM-862/cluster-failing-qc-tests)