### PR TITLE
feat: remove obsolete `deno` preview feature

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -152,8 +152,7 @@ impl<'a> FeatureMapWithProvider<'a> {
         // Generator preview features (alphabetically sorted)
         let feature_map: FeatureMap = FeatureMap {
             active: enumflags2::make_bitflags!(PreviewFeature::{
-                Deno
-                 | DriverAdapters
+                 DriverAdapters
                  | Metrics
                  | MultiSchema
                  | NativeDistinct
@@ -193,6 +192,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                 | ConnectOrCreate
                 | CreateMany
                 | DataProxy
+                | Deno
                 | Distinct
                 | ExtendedIndexes
                 | ExtendedWhereUnique

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -256,7 +256,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, queryCompiler, relationJoins, strictUndefinedChecks, views[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, queryCompiler, relationJoins, strictUndefinedChecks, views[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client-js"

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
@@ -14,7 +14,7 @@ model Blog {
   title   String
   @@fulltext([content, title])
 }
-// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: deno, driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, queryCompiler, relationJoins, strictUndefinedChecks, views[0m
+// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: driverAdapters, metrics, multiSchema, nativeDistinct, postgresqlExtensions, queryCompiler, relationJoins, strictUndefinedChecks, views[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client-js"


### PR DESCRIPTION
Remove obsolete preview feature for Deno Deploy 1.x.

Deno (both CLI and Deploy) work with Prisma Client with any preview features, and the new ESM client generator makes the support first class.

Ref: https://linear.app/prisma-company/issue/ORM-679/get-rid-of-prismaclientdeno-and-previewfeatures-=-deno