### PR TITLE
fix: scalar and composite fields should respect ignored status

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -29,6 +29,7 @@ mod prisma_22007;
 mod prisma_22298;
 mod prisma_22971;
 mod prisma_24072;
+mod prisma_25290;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_25290.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_25290.rs
@@ -1,0 +1,54 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), only(Postgres, CockroachDb, Sqlite))]
+mod prisma_25290 {
+    fn schema() -> String {
+        indoc! {
+            r#"
+            model User {
+                id     Int    @id
+                email  String @unique
+                name   String?
+                secret String? @ignore // This field should be ignored in query results
+            }
+            "#
+        }
+        .to_string()
+    }
+
+    // Test for issue #25290: Attempting a createManyAndReturn with an ignored field
+    // should result in a GraphQL validation error. Prior to this issue the engine would panic
+    // https://github.com/prisma/prisma/issues/25290
+    #[connector_test]
+    async fn cm_selecting_ignored_field_errors(runner: Runner) -> TestResult<()> {
+        let result = runner
+            .query(
+                r#"
+                mutation {
+                  createManyUserAndReturn(data: [
+                    { id: 1, email: "alice@prisma.io", name: "Alice" },
+                    { id: 2, email: "bob@prisma.io", name: "Bob" }
+                  ]) {
+                    id
+                    email
+                    name
+                    secret
+                  }
+                }
+                "#,
+            )
+            .await?;
+
+        result.assert_failure(2009, None);
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn cm_does_not_return_ignored_fields(runner: Runner) -> TestResult<()> {
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"mutation { createManyUserAndReturn(data: [{ id: 3, email: "charlie@prisma.io", name: "Charlie" }]) { id }}"#),
+          @r###"{"data":{"createManyUserAndReturn":[{"id":3}]}}"###
+        );
+        Ok(())
+    }
+}

--- a/query-engine/query-structure/src/fields.rs
+++ b/query-engine/query-structure/src/fields.rs
@@ -40,10 +40,11 @@ impl<'a> Fields<'a> {
             .walk(self.model.id)
             .scalar_fields()
             .filter(|sf| {
-                !matches!(
-                    sf.scalar_field_type(),
-                    ScalarFieldType::CompositeType(_) | ScalarFieldType::Unsupported(_)
-                )
+                !sf.is_ignored()
+                    && !matches!(
+                        sf.scalar_field_type(),
+                        ScalarFieldType::CompositeType(_) | ScalarFieldType::Unsupported(_)
+                    )
             })
             .map(|rf| self.model.dm.clone().zip(ScalarFieldId::InModel(rf.id)))
     }
@@ -62,7 +63,7 @@ impl<'a> Fields<'a> {
             .dm
             .walk(self.model.id)
             .scalar_fields()
-            .filter(|sf| sf.scalar_field_type().as_composite_type().is_some())
+            .filter(|sf| sf.scalar_field_type().as_composite_type().is_some() && !sf.is_ignored())
             .map(|sf| self.model.dm.clone().zip(CompositeFieldId::InModel(sf.id)))
             .collect()
     }


### PR DESCRIPTION
Fix for [this](https://github.com/prisma/prisma/issues/25290) issue.

`createManyAndReturn` with `@ignore`'d fields was crashing on [this](https://github.com/prisma/prisma-engines/blob/b5aa5ebfc30fd6ed747ca6fdf505d5c45a3204a1/query-engine/core/src/response_ir/internal.rs#L560) line. This PR makes the behavior for `scalar` and `composite` in line with that of `all` and `relation`.

Let me know if there is anything I can do to help get this merged or anything I need to change about my PR!

Fixes: https://github.com/prisma/prisma/issues/25290