### PR TITLE
refactor: introduce specialized diff result data dependency edges

### DIFF
--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -125,6 +125,8 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 }
                 // TODO: implement data dependencies and if/else
                 QueryGraphDependency::DataDependency(_) => todo!(),
+                QueryGraphDependency::DiffLeftDataDependency(_) => todo!(),
+                QueryGraphDependency::DiffRightDataDependency(_) => todo!(),
                 QueryGraphDependency::Then => todo!(),
                 QueryGraphDependency::Else => todo!(),
             };

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -366,6 +366,14 @@ impl Expressionista {
 
                                         QueryGraphDependency::DataDependency(f) => Ok(f(node, binding)?),
 
+                                        QueryGraphDependency::DiffLeftDataDependency(f) => {
+                                            Ok(f(node, &binding.as_diff_result()?.left)?)
+                                        }
+
+                                        QueryGraphDependency::DiffRightDataDependency(f) => {
+                                            Ok(f(node, &binding.as_diff_result()?.right)?)
+                                        }
+
                                         _ => unreachable!(),
                                     };
 
@@ -392,11 +400,10 @@ impl Expressionista {
         parent_edges
             .into_iter()
             .filter_map(|edge| match graph.pluck_edge(&edge) {
-                x @ QueryGraphDependency::DataDependency(_) => {
-                    let parent_binding_name = graph.edge_source(&edge).id();
-                    Some((parent_binding_name, x))
-                }
-                x @ QueryGraphDependency::ProjectedDataDependency(_, _, _) => {
+                x @ (QueryGraphDependency::DataDependency(_)
+                | QueryGraphDependency::ProjectedDataDependency(_, _, _)
+                | QueryGraphDependency::DiffLeftDataDependency(_)
+                | QueryGraphDependency::DiffRightDataDependency(_)) => {
                     let parent_binding_name = graph.edge_source(&edge).id();
                     Some((parent_binding_name, x))
                 }

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -118,6 +118,8 @@ impl Display for QueryGraphDependency {
                         .collect::<Vec<_>>()
                 )
             }
+            Self::DiffLeftDataDependency(_) => write!(f, "DiffLeftResult"),
+            Self::DiffRightDataDependency(_) => write!(f, "DiffRightResult"),
             Self::Then => write!(f, "Then"),
             Self::Else => write!(f, "Else"),
         }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -135,6 +135,9 @@ pub(crate) type ProjectedDataDependencyFn =
 pub(crate) type DataDependencyFn =
     Box<dyn FnOnce(Node, &ExpressionResult) -> QueryGraphBuilderResult<Node> + Send + Sync + 'static>;
 
+pub(crate) type DiffDataDependencyFn =
+    Box<dyn FnOnce(Node, &[SelectionResult]) -> QueryGraphBuilderResult<Node> + Send + Sync + 'static>;
+
 /// Stored on the edges of the QueryGraph, a QueryGraphDependency contains information on how children are connected to their parents,
 /// expressing for example the need for additional information from the parent to be able to execute at runtime.
 pub enum QueryGraphDependency {
@@ -154,6 +157,14 @@ pub enum QueryGraphDependency {
     /// To achieve that, the query graph is post-processed in the `finalize` and reloads are injected at points where a selection is not fulfilled.
     /// See `insert_reloads` for more information.
     ProjectedDataDependency(FieldSelection, ProjectedDataDependencyFn, Option<DataExpectation>), // [Composites] todo rename
+
+    /// Specialized version of `DataDependency` that accepts the the difference
+    /// between the left and right side of a parent diff operation.
+    DiffLeftDataDependency(DiffDataDependencyFn),
+
+    /// Specialized version of `DataDependency` that accepts the the difference
+    /// between the right and left side of a parent diff operation.
+    DiffRightDataDependency(DiffDataDependencyFn),
 
     /// Only valid in the context of a `If` control flow node.
     Then,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -976,9 +976,8 @@ fn one_to_one_inlined_child(
         graph.create_edge(
             &diff_node,
             &if_node,
-            QueryGraphDependency::DataDependency(Box::new(move |if_node, result| {
-                let diff_result = result.as_diff_result().unwrap();
-                let should_disconnect = !diff_result.left.is_empty();
+            QueryGraphDependency::DiffLeftDataDependency(Box::new(move |if_node, diff_left_result| {
+                let should_disconnect = !diff_left_result.is_empty();
 
                 if let Node::Flow(Flow::If(_)) = if_node {
                     Ok(Node::Flow(Flow::If(Box::new(move || should_disconnect))))


### PR DESCRIPTION
Part of https://linear.app/prisma-company/issue/ORM-907/implement-computation-nodes.

We can't introspect what a data dependency function does inside query compiler, so the generic `DataDependency` edge type must go, and what exactly we extract from the parent node must be statically defined by the edge type.

This PR introduces two new edge types to extract the left-to-right and right-to-left parts of the parent diff node.

There are two more `DataDependency` instances left in the codebase, one also related to diffs but in a different way. They both depend on refactoring the `If` nodes and on @jacek-prisma's validation refactoring PR and will be tackled separately.