### PR TITLE
refactor: introduce `DiffLeftToRight` and `DiffRightToLeft` nodes

### DIFF
--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -134,8 +134,6 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 }
                 // TODO: implement data dependencies and if/else
                 QueryGraphDependency::DataDependency(_) => todo!(),
-                QueryGraphDependency::DiffLeftDataDependency(_) => todo!(),
-                QueryGraphDependency::DiffRightDataDependency(_) => todo!(),
                 QueryGraphDependency::Then => todo!(),
                 QueryGraphDependency::Else => todo!(),
             };

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -19,31 +19,8 @@ pub enum ExpressionResult {
     /// A fixed result returned in the query graph.
     FixedResult(Vec<SelectionResult>),
 
-    /// A result from a computation in the query graph.
-    Computation(ComputationResult),
-
     /// An empty result
     Empty,
-}
-
-#[derive(Debug, Clone)]
-pub enum ComputationResult {
-    Diff(DiffResult),
-}
-
-/// Diff of two identifier vectors A and B:
-/// `left` contains all elements that are in A but not in B.
-/// `right` contains all elements that are in B but not in A.
-#[derive(Debug, Clone)]
-pub struct DiffResult {
-    pub left: Vec<SelectionResult>,
-    pub right: Vec<SelectionResult>,
-}
-
-impl DiffResult {
-    pub fn is_empty(&self) -> bool {
-        self.left.is_empty() && self.right.is_empty()
-    }
 }
 
 impl ExpressionResult {
@@ -111,17 +88,6 @@ impl ExpressionResult {
 
         converted.ok_or_else(|| {
             InterpreterError::InterpretationError("Unable to convert result into a query result".to_owned(), None)
-        })
-    }
-
-    pub fn as_diff_result(&self) -> InterpretationResult<&DiffResult> {
-        let converted = match self {
-            Self::Computation(ComputationResult::Diff(ref d)) => Some(d),
-            _ => None,
-        };
-
-        converted.ok_or_else(|| {
-            InterpreterError::InterpretationError("Unable to convert result into a computation result".to_owned(), None)
         })
     }
 }

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -64,7 +64,8 @@ impl Display for Flow {
 impl Display for Computation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Diff(_) => write!(f, "Diff"),
+            Self::DiffLeftToRight(_) => write!(f, "DiffLeftToRight"),
+            Self::DiffRightToLeft(_) => write!(f, "DiffRightToLeft"),
         }
     }
 }
@@ -128,8 +129,6 @@ impl Display for QueryGraphDependency {
                         .collect::<Vec<_>>()
                 )
             }
-            Self::DiffLeftDataDependency(_) => write!(f, "DiffLeftResult"),
-            Self::DiffRightDataDependency(_) => write!(f, "DiffRightResult"),
             Self::Then => write!(f, "Then"),
             Self::Else => write!(f, "Else"),
         }

--- a/query-engine/core/src/query_graph_builder/inputs.rs
+++ b/query-engine/core/src/query_graph_builder/inputs.rs
@@ -1,6 +1,6 @@
 use query_structure::SelectionResult;
 
-use crate::{Node, NodeInputField, Query, WriteQuery};
+use crate::{Computation, Node, NodeInputField, Query, WriteQuery};
 
 #[derive(Debug)]
 pub(crate) struct UpdateRecordFilterInput;
@@ -24,6 +24,36 @@ impl NodeInputField<Vec<SelectionResult>> for UpdateManyRecordsFilterInput {
             ur.record_filter.selectors.get_or_insert_default()
         } else {
             panic!("UpdateManyRecordsFilterInput can only be used with UpdateManyRecords node")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct LeftSideDiffInput;
+
+impl NodeInputField<Vec<SelectionResult>> for LeftSideDiffInput {
+    fn node_input_field<'a>(&self, node: &'a mut Node) -> &'a mut Vec<SelectionResult> {
+        if let Node::Computation(Computation::DiffLeftToRight(diff_node) | Computation::DiffRightToLeft(diff_node)) =
+            node
+        {
+            &mut diff_node.left
+        } else {
+            panic!("LeftSideDiffInput can only be used with DiffLeftToRight or DiffRightToLeft node")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct RightSideDiffInput;
+
+impl NodeInputField<Vec<SelectionResult>> for RightSideDiffInput {
+    fn node_input_field<'a>(&self, node: &'a mut Node) -> &'a mut Vec<SelectionResult> {
+        if let Node::Computation(Computation::DiffLeftToRight(diff_node) | Computation::DiffRightToLeft(diff_node)) =
+            node
+        {
+            &mut diff_node.right
+        } else {
+            panic!("RightSideDiffInput can only be used with DiffLeftToRight or DiffRightToLeft node")
         }
     }
 }


### PR DESCRIPTION
Replace `Diff` nodes that compute both diffs at the same time and the specialized edges that extract one of the fields from the result of the diff node with separate `DiffLeftToRight` and `DiffRightToLeft` nodes and `ProjectedDataSinkDependency` edges.

It can be simplifed even further back to a single `Diff` node type but unidirectional and using the new abstractions (it just requires rewiring the query graphs a little bit more), which can be done in a follow up PR.

Part of ORM-907