### PR TITLE
feat: show sink and input types in rendered query graphs

### DIFF
--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -118,10 +118,10 @@ impl Display for QueryGraphDependency {
                         .collect::<Vec<_>>()
                 )
             }
-            Self::ProjectedDataSinkDependency(selection, _, _) => {
+            Self::ProjectedDataSinkDependency(selection, sink, _) => {
                 write!(
                     f,
-                    "ProjectedDataSinkDependency ({:?})",
+                    "ProjectedDataSinkDependency({sink:?}) {:?}",
                     selection
                         .selections()
                         .map(|f| format!("{}.{}", f.container().name(), f.prisma_name()))

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -175,13 +175,14 @@ pub enum QueryGraphDependency {
     Else,
 }
 
+#[derive(Debug)]
 pub enum DataSink {
     AllRows(&'static dyn NodeInputField<Vec<SelectionResult>>),
     SingleRow(&'static dyn NodeInputField<SelectionResult>),
     SingleRowArray(&'static dyn NodeInputField<Vec<SelectionResult>>),
 }
 
-pub trait NodeInputField<R>: Send + Sync {
+pub trait NodeInputField<R>: Send + Sync + std::fmt::Debug {
     fn node_input_field<'a>(&self, node: &'a mut Node) -> &'a mut R;
 }
 


### PR DESCRIPTION
Makes debugging easier, especially when the downstream node has multiple inputs.