### PR TITLE
refactor: make `If` nodes declarative

### DIFF
--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -325,6 +325,7 @@ where
                                 .text("rowCountNeq")
                                 .append(self.softline())
                                 .append(self.text(count.to_string())),
+                            DataRule::Never => self.text("never"),
                         };
                         self.softline().append(rendered_rule).append(self.line())
                     }),

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -221,7 +221,7 @@ impl Expressionista {
         graph.mark_visited(node);
 
         match graph.node_content(node).unwrap() {
-            Node::Flow(Flow::If(_)) => Self::translate_if_node(graph, node, parent_edges),
+            Node::Flow(Flow::If { .. }) => Self::translate_if_node(graph, node, parent_edges),
             Node::Flow(Flow::Return(_)) => Self::translate_return_node(graph, node, parent_edges),
             _ => unreachable!(),
         }
@@ -265,9 +265,9 @@ impl Expressionista {
         let into_expr = Box::new(move |node: Node| {
             let flow: Flow = node.try_into()?;
 
-            if let Flow::If(cond_fn) = flow {
+            if let Flow::If { rule, data } = flow {
                 let if_expr = Expression::If {
-                    func: cond_fn,
+                    func: Box::new(move || rule.matches_data(&data)),
                     then: vec![then_expr],
                     else_: else_expr,
                 };

--- a/query-engine/core/src/query_graph/formatters.rs
+++ b/query-engine/core/src/query_graph/formatters.rs
@@ -55,8 +55,8 @@ fn stringify_nodes(graph: &QueryGraph, nodes: Vec<NodeRef>, seen_nodes: &mut Vec
 impl Display for Flow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::If(_) => write!(f, "(If (condition func)"),
-            Self::Return(_) => write!(f, "(return results)"),
+            Self::If { rule, .. } => write!(f, "If {rule:?}"),
+            Self::Return(_) => write!(f, "Return"),
         }
     }
 }

--- a/query-engine/core/src/query_graph_builder/inputs.rs
+++ b/query-engine/core/src/query_graph_builder/inputs.rs
@@ -1,6 +1,6 @@
 use query_structure::SelectionResult;
 
-use crate::{Computation, Node, NodeInputField, Query, WriteQuery};
+use crate::{Computation, Flow, Node, NodeInputField, Query, WriteQuery};
 
 #[derive(Debug)]
 pub(crate) struct UpdateRecordFilterInput;
@@ -54,6 +54,19 @@ impl NodeInputField<Vec<SelectionResult>> for RightSideDiffInput {
             &mut diff_node.right
         } else {
             panic!("RightSideDiffInput can only be used with DiffLeftToRight or DiffRightToLeft node")
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct IfInput;
+
+impl NodeInputField<Vec<SelectionResult>> for IfInput {
+    fn node_input_field<'a>(&self, node: &'a mut Node) -> &'a mut Vec<SelectionResult> {
+        if let Node::Flow(Flow::If { data, .. }) = node {
+            data
+        } else {
+            panic!("IfInput can only be used with If node")
         }
     }
 }


### PR DESCRIPTION
Remove functions from the `Flow::If` nodes in the query graph and replace them with declarative `DataRule`s.

Part of https://linear.app/prisma-company/issue/ORM-906/implement-flow-nodes