### PR TITLE
feat(schema-engine): use new format for local PPg URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5392,6 +5392,7 @@ dependencies = [
 name = "sql-schema-connector"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "connection-string",
  "crosstarget-utils",

--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -44,6 +44,7 @@ datamodel-renderer.workspace = true
 sql-ddl.workspace = true
 user-facing-errors = { workspace = true, features = ["sql"] }
 
+base64.workspace = true
 chrono.workspace = true
 connection-string.workspace = true
 enumflags2.workspace = true

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connection_string.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connection_string.rs
@@ -1,0 +1,26 @@
+use schema_connector::{ConnectorError, ConnectorResult};
+use url::Url;
+
+pub fn parse(connection_string: &str) -> ConnectorResult<Url> {
+    let mut url = connection_string.parse().map_err(ConnectorError::url_parse_error)?;
+    disable_postgres_statement_cache(&mut url);
+    Ok(url)
+}
+
+fn disable_postgres_statement_cache(url: &mut Url) {
+    let params: Vec<(_, _)> = url.query_pairs().map(|(k, v)| (k.to_string(), v.to_string())).collect();
+
+    url.query_pairs_mut().clear();
+
+    for (k, v) in params {
+        if k == "statement_cache_size" {
+            url.query_pairs_mut().append_pair("statement_cache_size", "0");
+        } else {
+            url.query_pairs_mut().append_pair(&k, &v);
+        }
+    }
+
+    if !url.query_pairs().any(|(k, _)| k == "statement_cache_size") {
+        url.query_pairs_mut().append_pair("statement_cache_size", "0");
+    }
+}


### PR DESCRIPTION
Local PPg will now pass the connection string to the underlying PostgreSQL database encoded inside the `api_key` parameter.