### PR TITLE
fix(quaint): support disabling `socket_timeout` explicitly for postgres

### DIFF
--- a/quaint/src/connector/postgres/url.rs
+++ b/quaint/src/connector/postgres/url.rs
@@ -354,7 +354,12 @@ impl PostgresNativeUrl {
                     let as_int = v
                         .parse()
                         .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
-                    socket_timeout = Some(Duration::from_secs(as_int));
+
+                    if as_int == 0 {
+                        socket_timeout = None;
+                    } else {
+                        socket_timeout = Some(Duration::from_secs(as_int));
+                    }
                 }
                 "connect_timeout" => {
                     let as_int = v


### PR DESCRIPTION
Make it consistent with other timeouts.

See https://prisma-company.slack.com/archives/C08QF717GR3/p1746788393463209?thread_ts=1746749746.083559&cid=C08QF717GR3