### PR TITLE
feat(schema-engine): use BASE64_URL_SAFE_NO_PAD to decode local base64url encoded PPG API keys.

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -5,7 +5,6 @@ mod renderer;
 mod schema_calculator;
 mod schema_differ;
 
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::prelude::*;
 use connector as imp;
 use destructive_change_checker::PostgresDestructiveChangeCheckerFlavour;

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -5,6 +5,7 @@ mod renderer;
 mod schema_calculator;
 mod schema_differ;
 
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::prelude::*;
 use connector as imp;
 use destructive_change_checker::PostgresDestructiveChangeCheckerFlavour;
@@ -61,7 +62,7 @@ struct PpgParams<'a> {
     ///
     /// In remote Prisma Postgres URLs, this parameter is used to authenticate the connection.
     ///
-    /// In local Prisma Postgres URLs, this parameter is a base64-encoded JSON
+    /// In local Prisma Postgres URLs, this parameter is a base64url-encoded JSON
     /// object that contains data necessary for local PPg emulation. Schema
     /// engine decodes it to extract the connection string to the underlying
     /// PostgreSQL database to perform migrations.
@@ -132,7 +133,7 @@ impl MigratePostgresUrl {
                 let params = PpgParams::parse_from(&url)?;
                 let api_key_param = params.api_key()?;
 
-                let api_key_json = BASE64_STANDARD
+                let api_key_json = URL_SAFE_NO_PAD
                     .decode(api_key_param)
                     .map_err(ConnectorError::url_parse_error)?;
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -132,7 +132,7 @@ impl MigratePostgresUrl {
                 let params = PpgParams::parse_from(&url)?;
                 let api_key_param = params.api_key()?;
 
-                let api_key_json = URL_SAFE_NO_PAD
+                let api_key_json = BASE64_URL_SAFE_NO_PAD
                     .decode(api_key_param)
                     .map_err(ConnectorError::url_parse_error)?;
 


### PR DESCRIPTION
Hey :wave:

part of STR-8

The API keys in local Prisma Postgres URLs are now encoded using URL-safe base64 encoding. 

e.g.

```
prisma+postgres://localhost:5433/?api_key=eyJkYXRhYmFzZVVybCI6InBvc3RncmVzOi8vcG9zdGdyZXM6cG9zdGdyZXNAbG9jYWxob3N0OjU0MzIvcG9zdGdyZXM_Y29ubmVjdGlvbl9saW1pdD0xJmNvbm5lY3RfdGltZW91dD0wJm1heF9pZGxlX2Nvbm5lY3Rpb25fbGlmZXRpbWU9MCZwb29sX3RpbWVvdXQ9MCZzb2NrZXRfdGltZW91dD0wJnNzbG1vZGU9ZGlzYWJsZSJ9
```


This PR replaces basic base64 decoder with `BASE64_URL_SAFE_NO_PAD`. This ensures that the keys are properly decoded.
