### PR TITLE
fix: avoid decimal precision loss

### DIFF
--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -209,7 +209,6 @@ raw::sql::errors::raw_errors::list_param_for_scalar_column_should_not_panic_pg_j
 raw::sql::scalar_list::scalar_list::null_native_type_lists
 raw::sql::scalar_list::scalar_list::null_scalar_lists
 raw::sql::typed_output::typed_output::all_scalars_pg
-writes::data_types::decimal::decimal::using_decimal_field
 writes::data_types::native_types::postgres::postgres::native_date
 writes::data_types::native_types::postgres::postgres::native_other_types
 writes::ids::byoid::byoid::nested_upsert_should_work_1

--- a/query-engine/query-builders/sql-query-builder/src/convert.rs
+++ b/query-engine/query-builders/sql-query-builder/src/convert.rs
@@ -47,6 +47,7 @@ pub(crate) fn quaint_value_to_prisma_value(value: quaint::Value<'_>, family: Sql
             PrismaValue::List(a.into_iter().map(|v| quaint_value_to_prisma_value(v, family)).collect())
         }
         quaint::ValueType::Array(None) => PrismaValue::Null,
+        quaint::ValueType::Numeric(Some(bd)) if !family.is_sqlite() => PrismaValue::String(bd.to_string()),
         quaint::ValueType::Numeric(Some(bd)) => PrismaValue::Float(bd),
         quaint::ValueType::Numeric(None) => PrismaValue::Null,
         quaint::ValueType::Json(Some(j)) => PrismaValue::Json(j.to_string()),


### PR DESCRIPTION
Fixes decimal precision loss (emulates what we do in query engine: https://github.com/prisma/prisma-engines/blob/45903b6952ef4ccd708820b6e9ea5b4e338f8913/libs/driver-adapters/src/conversion/postgres.rs#L19)