### PR TITLE
fix(ci): create an isolated ramdisk

### DIFF
--- a/.github/workflows/include/setup-ramdisk/action.yml
+++ b/.github/workflows/include/setup-ramdisk/action.yml
@@ -1,0 +1,19 @@
+name: Setup ramdisk
+description: Sets up ramdisk to improve test performance
+inputs:
+  mount-path:
+    description: Mount path in the filesystem
+
+runs:
+  using: composite
+  steps:
+    - name: Create ramdisk
+      shell: bash
+      run: |
+        if [ -d "${{ inputs.mount-path }}" ]; then
+          echo "${{ inputs.mount-path }} exists, skipping"
+        else
+          sudo mkdir ${{ inputs.mount-path }}
+          sudo mount -t tmpfs -o size=2G tmpfs "${{ inputs.mount-path }}"
+          echo "Ramdisk (2GB): ${{ inputs.mount-path }}"
+        fi

--- a/.github/workflows/test-driver-adapters-template.yml
+++ b/.github/workflows/test-driver-adapters-template.yml
@@ -31,7 +31,7 @@ jobs:
       SIMPLE_TEST_MODE: '1'
       QUERY_BATCH_SIZE: '10'
       WASM_BUILD_PROFILE: 'profiling' # Include debug info for proper backtraces
-      RAMDISK: '/mnt/ramdisk'
+      RAMDISK: '/mnt/prisma-test-ramdisk'
       WORKSPACE_ROOT: ${{ github.workspace }}
 
     runs-on: ubuntu-latest
@@ -42,10 +42,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Create ramdisk
-        run: |
-          sudo mkdir ${{ env.RAMDISK }}
-          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
-          echo "Ramdisk (2GB): /mnt/ramdisk"
+        uses: ./.github/workflows/include/setup-ramdisk
+        with:
+          mount-path: ${{ env.RAMDISK }}
 
       - name: 'Setup Node.js'
         uses: actions/setup-node@v4

--- a/.github/workflows/test-query-compiler-template.yml
+++ b/.github/workflows/test-query-compiler-template.yml
@@ -37,7 +37,7 @@ jobs:
       SIMPLE_TEST_MODE: '1'
       QUERY_BATCH_SIZE: '10'
       WASM_BUILD_PROFILE: 'profiling' # Include debug info for proper backtraces
-      RAMDISK: '/mnt/ramdisk'
+      RAMDISK: '/mnt/prisma-test-ramdisk'
       WORKSPACE_ROOT: ${{ github.workspace }}
       IGNORED_TESTS: ${{ inputs.ignored_tests_list }}
       SHOULD_FAIL_TESTS: ${{ inputs.should_fail_tests_list }}
@@ -50,10 +50,9 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Create ramdisk
-        run: |
-          sudo mkdir ${{ env.RAMDISK }}
-          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
-          echo "Ramdisk (2GB): /mnt/ramdisk"
+        uses: ./.github/workflows/include/setup-ramdisk
+        with:
+          mount-path: ${{ env.RAMDISK }}
 
       - name: 'Setup Node.js'
         uses: actions/setup-node@v4

--- a/.github/workflows/test-query-compiler.yml
+++ b/.github/workflows/test-query-compiler.yml
@@ -5,9 +5,9 @@ on:
       - main
   pull_request:
     paths-ignore:
+      - '.github/**'
       - '!.github/workflows/test-query-compiler.yml'
       - '!.github/workflows/test-query-compiler-template.yml'
-      - '.github/**'
       - '.buildkite/**'
       - '*.md'
       - 'LICENSE'

--- a/.github/workflows/test-query-engine-template.yml
+++ b/.github/workflows/test-query-engine-template.yml
@@ -48,17 +48,16 @@ jobs:
       PRISMA_ENGINE_PROTOCOL: ${{ matrix.engine_protocol }}
       PRISMA_RELATION_LOAD_STRATEGY: ${{ matrix.relation_load_strategy }}
       WORKSPACE_ROOT: ${{ github.workspace }}
-      RAMDISK: '/mnt/ramdisk'
+      RAMDISK: '/mnt/prisma-test-ramdisk'
 
     runs-on: 'ubuntu-${{ inputs.ubuntu }}'
     steps:
       - uses: actions/checkout@v4
 
       - name: Create ramdisk
-        run: |
-          sudo mkdir ${{ env.RAMDISK }}
-          sudo mount -t tmpfs -o size=2G tmpfs /mnt/ramdisk
-          echo "Ramdisk (2GB): /mnt/ramdisk"
+        uses: ./.github/workflows/include/setup-ramdisk
+        with:
+          mount-path: ${{ env.RAMDISK }}
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:

--- a/.github/workflows/test-query-engine.yml
+++ b/.github/workflows/test-query-engine.yml
@@ -8,6 +8,7 @@ on:
       - '.github/**'
       - '!.github/workflows/test-query-engine.yml'
       - '!.github/workflows/test-query-engine-template.yml'
+      - '!.github/workflows/test-driver-adapters-template.yml'
       - '!.github/workflows/include/rust-wasm-setup/action.yml'
       - '.buildkite/**'
       - '*.md'


### PR DESCRIPTION
CI is now suddenly failing with the following error:

```
mkdir: cannot create directory ‘/mnt/ramdisk’: File exists
```

Creating the ramdisk in a different location leads to the same error but
in a fewer number of jobs, so not only there's an existing ramdisk
mounted at `/mnt/ramdisk`, but also the filesystem seems to be reused
between different jobs.

This commit changes the ramdisk location to `/mnt/prisma-test-ramdisk`
and makes sure we only create it if it doesn't exist.