### PR TITLE
fix: use read_id_infallible for one-to-one connect-or-create

### DIFF
--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail
@@ -44,8 +44,6 @@ writes::nested_mutations::already_converted::nested_connect_inside_create::conne
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::pm_to_c1_rel_fail_filter_dont_match
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2m_connect_or_create
-writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_update_if_no_child_connected_yet
-writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_upsert_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one_req_2m_connect_or_create
 writes::top_level_mutations::create_many::create_many::basic_create_many_autoincrement
 writes::top_level_mutations::create_many::create_many::create_many_by_shape

--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail
@@ -47,8 +47,6 @@ writes::nested_mutations::not_using_schema_base::nested_connect_or_create::conne
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_update_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_upsert_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one_req_2m_connect_or_create
-writes::regressions::prisma_11731::connect_or_create::one2one_inlined_child
-writes::regressions::prisma_11731::connect_or_create::one2one_inlined_parent
 writes::top_level_mutations::create_many::create_many::basic_create_many_autoincrement
 writes::top_level_mutations::create_many::create_many::create_many_by_shape
 writes::top_level_mutations::create_many_and_return::create_many_and_return::basic_create_many_autoincrement

--- a/query-compiler/query-engine-tests-todo/libsql/fail
+++ b/query-compiler/query-engine-tests-todo/libsql/fail
@@ -48,8 +48,6 @@ writes::nested_mutations::already_converted::nested_connect_inside_create::conne
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::pm_to_c1_rel_fail_filter_dont_match
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2m_connect_or_create
-writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_update_if_no_child_connected_yet
-writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_upsert_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one_req_2m_connect_or_create
 writes::top_level_mutations::create_many::create_many::basic_create_many_autoincrement
 writes::top_level_mutations::create_many::create_many::create_many_by_shape

--- a/query-compiler/query-engine-tests-todo/libsql/fail
+++ b/query-compiler/query-engine-tests-todo/libsql/fail
@@ -51,8 +51,6 @@ writes::nested_mutations::not_using_schema_base::nested_connect_or_create::conne
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_update_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_upsert_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one_req_2m_connect_or_create
-writes::regressions::prisma_11731::connect_or_create::one2one_inlined_child
-writes::regressions::prisma_11731::connect_or_create::one2one_inlined_parent
 writes::top_level_mutations::create_many::create_many::basic_create_many_autoincrement
 writes::top_level_mutations::create_many::create_many::create_many_by_shape
 writes::top_level_mutations::create_many_and_return::create_many_and_return::basic_create_many_autoincrement

--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -65,8 +65,6 @@ writes::nested_mutations::already_converted::nested_connect_inside_create::conne
 writes::nested_mutations::already_converted::nested_connect_inside_create::connect_inside_create::pm_to_c1_rel_fail_filter_dont_match
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2m_connect_or_create
-writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_update_if_no_child_connected_yet
-writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_upsert_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one_req_2m_connect_or_create
 writes::top_level_mutations::create_list::create_list::create_not_accept_null_in_set
 writes::top_level_mutations::create_many_and_return::create_many_and_return::create_many_11_inline_rel_read_works

--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -68,8 +68,6 @@ writes::nested_mutations::not_using_schema_base::nested_connect_or_create::conne
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_update_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one2one_upsert_if_no_child_connected_yet
 writes::nested_mutations::not_using_schema_base::nested_connect_or_create::connect_or_create::one_req_2m_connect_or_create
-writes::regressions::prisma_11731::connect_or_create::one2one_inlined_child
-writes::regressions::prisma_11731::connect_or_create::one2one_inlined_parent
 writes::top_level_mutations::create_list::create_list::create_not_accept_null_in_set
 writes::top_level_mutations::create_many_and_return::create_many_and_return::create_many_11_inline_rel_read_works
 writes::top_level_mutations::create_many_and_return::create_many_and_return::create_many_1m_inline_rel_read_works

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -539,7 +539,7 @@ fn one_to_one_inlined_parent(
     let parent_link = parent_relation_field.linking_fields();
     let child_link = parent_relation_field.related_field().linking_fields();
 
-    let read_node = graph.create_node(utils::read_ids_infallible(
+    let read_node = graph.create_node(utils::read_id_infallible(
         child_model.clone(),
         child_link.clone(),
         filter,
@@ -741,7 +741,7 @@ fn one_to_one_inlined_child(
     let child_link = parent_relation_field.related_field().linking_fields();
     let child_relation_field = parent_relation_field.related_field();
 
-    let read_new_child_node = graph.create_node(utils::read_ids_infallible(
+    let read_new_child_node = graph.create_node(utils::read_id_infallible(
         child_model.clone(),
         child_link.clone(),
         filter,


### PR DESCRIPTION
[ORM-956](https://linear.app/prisma-company/issue/ORM-956/fix-array-being-passed-instead-of-scalar)