### PR TITLE
fix: use leaf nodes as the default result rather than root

### DIFF
--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -9,7 +9,7 @@ use query_structure::{AggregationSelection, FieldSelection, PrismaValueType, Sel
 use std::collections::HashMap;
 
 pub fn map_result_structure(graph: &QueryGraph) -> Option<ResultNode> {
-    for idx in graph.result_nodes().chain(graph.root_nodes()) {
+    for idx in graph.result_nodes().chain(graph.leaf_nodes()) {
         let node = graph.node_content(&idx);
         if let Some(Node::Query(query)) = node {
             return map_query(query);

--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail
@@ -5,12 +5,6 @@ new::interactive_tx::interactive_tx::double_rollback
 new::interactive_tx::interactive_tx::rollback_after_commit
 new::interactive_tx::interactive_tx::tx_expiration_cycle
 new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
-new::ref_actions::on_update::cascade::one2one_opt::update_parent_cascade
-new::ref_actions::on_update::cascade::one2one_req::update_parent_cascade
-new::ref_actions::on_update::restrict::one2many_opt::update_parent
-new::ref_actions::on_update::restrict::one2many_req::update_parent
-new::ref_actions::on_update::set_null::one2many_opt::update_many_parent
-new::ref_actions::on_update::set_null::one2one_opt::update_many_parent
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::prisma_12572::prisma_12572::all_generated_timestamps_are_the_same
 new::regressions::prisma_22971::prisma_22971::test_22971

--- a/query-compiler/query-engine-tests-todo/libsql/fail
+++ b/query-compiler/query-engine-tests-todo/libsql/fail
@@ -7,12 +7,6 @@ new::interactive_tx::interactive_tx::double_rollback
 new::interactive_tx::interactive_tx::rollback_after_commit
 new::interactive_tx::interactive_tx::tx_expiration_cycle
 new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
-new::ref_actions::on_update::cascade::one2one_opt::update_parent_cascade
-new::ref_actions::on_update::cascade::one2one_req::update_parent_cascade
-new::ref_actions::on_update::restrict::one2many_opt::update_parent
-new::ref_actions::on_update::restrict::one2many_req::update_parent
-new::ref_actions::on_update::set_null::one2many_opt::update_many_parent
-new::ref_actions::on_update::set_null::one2one_opt::update_many_parent
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::prisma_12572::prisma_12572::all_generated_timestamps_are_the_same
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_js

--- a/query-compiler/query-engine-tests-todo/pg/fail
+++ b/query-compiler/query-engine-tests-todo/pg/fail
@@ -8,12 +8,6 @@ new::interactive_tx::interactive_tx::rollback_after_commit
 new::interactive_tx::interactive_tx::tx_expiration_cycle
 new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
 new::occ::occ::occ_update_many_test
-new::ref_actions::on_update::cascade::one2one_opt::update_parent_cascade
-new::ref_actions::on_update::cascade::one2one_req::update_parent_cascade
-new::ref_actions::on_update::restrict::one2many_opt::update_parent
-new::ref_actions::on_update::restrict::one2many_req::update_parent
-new::ref_actions::on_update::set_null::one2many_opt::update_many_parent
-new::ref_actions::on_update::set_null::one2one_opt::update_many_parent
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
 new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_multi_thread

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -412,6 +412,18 @@ impl QueryGraph {
         })
     }
 
+    /// Returns all leaf nodes of the graph.
+    /// A leaf node is defined by having no outgoing edges.
+    pub fn leaf_nodes(&self) -> impl Iterator<Item = NodeRef> + '_ {
+        self.graph.node_indices().filter_map(|node_ix| {
+            self.graph
+                .edges_directed(node_ix, Direction::Outgoing)
+                .next()
+                .is_none()
+                .then_some(NodeRef { node_ix })
+        })
+    }
+
     /// Creates a node with content `t` and adds it to the graph.
     /// Returns a `NodeRef` to the newly added node.
     pub(crate) fn create_node<T>(&mut self, t: T) -> NodeRef


### PR DESCRIPTION
[ORM-962](https://linear.app/prisma-company/issue/ORM-962/datamapper-error-in-referential-actions-tests)

I think this defaulting isn't great in the first place, but it makes more sense to look at leaves for results rather than the roots.