### PR TITLE
fix(qc-test-runner): fix a bunch of iTX issues in the test runner

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker.ts
@@ -177,11 +177,10 @@ async function initializeSchema(
 
   const transactionManager = new TransactionManager({
     driverAdapter: adapter,
-    // Transaction timeouts matching `TransactionManager.test.ts` in the `prisma` repo
+    // Transaction timeouts matching those used by the Prisma Client
     transactionOptions: {
-      maxWait: 200,
-      timeout: 500,
-      isolationLevel: 'SERIALIZABLE',
+      maxWait: 2000,
+      timeout: 5000,
     } satisfies TransactionOptions,
     tracingHelper: noopTracingHelper,
   })

--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
@@ -1,10 +1,4 @@
 new::interactive_tx::interactive_tx::batch_queries_failure
-new::interactive_tx::interactive_tx::commit_after_rollback
-new::interactive_tx::interactive_tx::double_commit
-new::interactive_tx::interactive_tx::double_rollback
-new::interactive_tx::interactive_tx::rollback_after_commit
-new::interactive_tx::interactive_tx::tx_expiration_cycle
-new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
@@ -14,8 +8,6 @@ queries::batching::select_one_singular::singular_batch::repro_16548
 queries::batching::select_one_singular::singular_batch::two_success_one_fail
 queries::batching::transactional_batch::transactional::batch_request_idx
 queries::batching::transactional_batch::transactional::invalid_isolation_level
-queries::batching::transactional_batch::transactional::one_query
-queries::batching::transactional_batch::transactional::one_success_one_fail
 queries::chunking::chunking::order_by_aggregation_should_fail
 queries::data_types::enum_type::enum_type::read_one_invalid_sqlite
 queries::data_types::json::json::dollar_type_in_json_protocol

--- a/query-compiler/query-engine-tests-todo/libsql/fail/query
+++ b/query-compiler/query-engine-tests-todo/libsql/fail/query
@@ -1,12 +1,4 @@
 new::interactive_tx::interactive_tx::batch_queries_failure
-new::interactive_tx::interactive_tx::batch_queries_rollback
-new::interactive_tx::interactive_tx::batch_queries_success
-new::interactive_tx::interactive_tx::commit_after_rollback
-new::interactive_tx::interactive_tx::double_commit
-new::interactive_tx::interactive_tx::double_rollback
-new::interactive_tx::interactive_tx::rollback_after_commit
-new::interactive_tx::interactive_tx::tx_expiration_cycle
-new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_js
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_js
@@ -18,8 +10,6 @@ queries::batching::select_one_singular::singular_batch::repro_16548
 queries::batching::select_one_singular::singular_batch::two_success_one_fail
 queries::batching::transactional_batch::transactional::batch_request_idx
 queries::batching::transactional_batch::transactional::invalid_isolation_level
-queries::batching::transactional_batch::transactional::one_query
-queries::batching::transactional_batch::transactional::one_success_one_fail
 queries::chunking::chunking::order_by_aggregation_should_fail
 queries::data_types::enum_type::enum_type::read_one_invalid_sqlite
 queries::data_types::json::json::dollar_type_in_json_protocol

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -1,17 +1,5 @@
-new::interactive_tx::interactive_tx::batch_queries_failure
-new::interactive_tx::interactive_tx::batch_queries_rollback
-new::interactive_tx::interactive_tx::batch_queries_success
-new::interactive_tx::interactive_tx::commit_after_rollback
-new::interactive_tx::interactive_tx::double_commit
-new::interactive_tx::interactive_tx::double_rollback
-new::interactive_tx::interactive_tx::rollback_after_commit
-new::interactive_tx::interactive_tx::tx_expiration_cycle
-new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
-new::occ::occ::occ_update_many_test
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_multi_thread
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_single_thread
 new::regressions::prisma_13089::prisma_13097::filtering_with_dollar_values
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
@@ -46,8 +34,6 @@ queries::batching::select_one_singular::singular_batch::repro_16548
 queries::batching::select_one_singular::singular_batch::two_success_one_fail
 queries::batching::transactional_batch::transactional::batch_request_idx
 queries::batching::transactional_batch::transactional::invalid_isolation_level
-queries::batching::transactional_batch::transactional::one_query
-queries::batching::transactional_batch::transactional::one_success_one_fail
 queries::chunking::chunking::order_by_aggregation_should_fail
 queries::chunking::chunking::order_by_relevance_should_fail
 queries::data_types::bytes::bytes::issue_687::common_types

--- a/query-compiler/query-engine-tests-todo/pg/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg/fail/query
@@ -1,17 +1,5 @@
-new::interactive_tx::interactive_tx::batch_queries_failure
-new::interactive_tx::interactive_tx::batch_queries_rollback
-new::interactive_tx::interactive_tx::batch_queries_success
-new::interactive_tx::interactive_tx::commit_after_rollback
-new::interactive_tx::interactive_tx::double_commit
-new::interactive_tx::interactive_tx::double_rollback
-new::interactive_tx::interactive_tx::rollback_after_commit
-new::interactive_tx::interactive_tx::tx_expiration_cycle
-new::interactive_tx::interactive_tx::tx_expiration_failure_cycle
-new::occ::occ::occ_update_many_test
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_multi_thread
-new::regressions::prisma_11750::prisma_11750::test_itx_concurrent_updates_single_thread
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_22971::prisma_22971::test_22971
@@ -22,8 +10,6 @@ queries::batching::select_one_singular::singular_batch::repro_16548
 queries::batching::select_one_singular::singular_batch::two_success_one_fail
 queries::batching::transactional_batch::transactional::batch_request_idx
 queries::batching::transactional_batch::transactional::invalid_isolation_level
-queries::batching::transactional_batch::transactional::one_query
-queries::batching::transactional_batch::transactional::one_success_one_fail
 queries::chunking::chunking::order_by_aggregation_should_fail
 queries::chunking::chunking::order_by_relevance_should_fail
 queries::data_types::json::json::dollar_type_in_json_protocol

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/interactive_tx.rs
@@ -182,7 +182,7 @@ mod interactive_tx {
         runner.clear_active_tx();
 
         insta::assert_snapshot!(
-          run_query!(&runner, "query { findManyTestModel { id }}"),
+          run_query!(&runner, "query { findManyTestModel(orderBy: { id: asc }) { id }}"),
             @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2},{"id":3}]}}"###
         );
 


### PR DESCRIPTION
- Handle transaction manager errors in `worker-transaction.ts` and return them as part of the response like QE does.

- Similarly, handle user facing errors in batch requests and return them appropriately. Previously only errors in non-batch queries were handled. Unfortunately we can't pull this logic to the very top to ensure any and all user facing errors are caught because the expected format of errors in response is different for different methods.

- Align the transaction defaults with Prisma Client and make them less aggressive. This fixes some test flakiness that happens when running the tests locally with `cargo test` without retries (those weren't a problem on CI because the retries configured for `cargo nextest` mitigated this problem).

- Fix running non-transactional batches from within an interactive transaction. Previously they would be executed on the wrong connection.

- Add an `orderBy` argument to the final select in `new::interactive_tx::interactive_tx::batch_queries_success`. We don't have compacting a batch implemented, and we run non-transactional batches concurrently and not sequentially in `qc-test-runner`. Since we don't guarantee any particular execution order for non-transactional batches (and neither does the database guarantee that the selection order would match the insertion order, it just usually happens to work in practice), the result that the test was failing with was equally correct.

Closes: https://linear.app/prisma-company/issue/ORM-893/fix-remaining-interactive-transaction-tests
Closes: https://linear.app/prisma-company/issue/ORM-961/transaction-failed-due-to-a-write-conflict-in-occ-update-many-test
Closes: https://github.com/prisma/prisma-engines/pull/5326