### PR TITLE
fix: update bot token secret name

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -328,6 +328,6 @@ jobs:
           repository: prisma/engines-wrapper
           event-type: publish-engines
           client-payload: '{ "commit": "${{ github.sha }}", "branch": "${{ github.head_ref || github.ref_name }}" }'
-          token: ${{ secrets.PRISMA_BOT_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN_PRISMA_ENGINES_WRAPPER_BUILD }}
       - name: Cleanup local directories
         run: rm -rf engines-artifacts engines-artifacts-for-r2 engines-artifacts-for-s3


### PR DESCRIPTION
There seem to be some confusion around the github bot tokens used in this repository. This PR aligns the naming of the remaining token to be very specific and clear.

This token is a fine grained access token living in the `prismabots` account and granting access to github actions of the `prisma/engines-wrapper` repo

Once that token has been approved by Github Admins and this PR is merged we can delete the following two secrets from github actions for this repo as they seem unused:
- `BOT_TOKEN_PRISMA_ENGINES_BUILD`
- `PRISMA_BOT_TOKEN`
