### PR TITLE
fix: add delete validation

### DIFF
--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -288,6 +288,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                         RowSink::SingleRow(field) => {
                             *field.node_input_field(&mut node) = SelectionResult::new(fields);
                         }
+                        RowSink::Discard => {}
                     }
                 }
 

--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
@@ -10,6 +10,3 @@ queries::data_types::json::json::nested_dollar_type_in_json_protocol
 queries::filters::self_relation_regression::sr_regression::all_categories
 raw::sql::typed_output::typed_output::all_scalars_sqlite
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
-writes::top_level_mutations::delete::delete::delete_fails_if_filter_dont_match
-writes::top_level_mutations::delete::delete::should_fail_non_exist_id
-writes::top_level_mutations::delete::delete::should_fail_non_existent_value_non_id_uniq_field

--- a/query-compiler/query-engine-tests-todo/libsql/fail/query
+++ b/query-compiler/query-engine-tests-todo/libsql/fail/query
@@ -12,6 +12,3 @@ queries::data_types::json::json::nested_dollar_type_in_json_protocol
 queries::filters::self_relation_regression::sr_regression::all_categories
 raw::sql::typed_output::typed_output::all_scalars_sqlite
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
-writes::top_level_mutations::delete::delete::delete_fails_if_filter_dont_match
-writes::top_level_mutations::delete::delete::should_fail_non_exist_id
-writes::top_level_mutations::delete::delete::should_fail_non_existent_value_non_id_uniq_field

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -60,6 +60,3 @@ writes::data_types::native_types::postgres::postgres::native_other_types
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
 writes::top_level_mutations::create_list::create_list::create_not_accept_null_in_set
 writes::top_level_mutations::default_value::default_value::remapped_enum_field
-writes::top_level_mutations::delete::delete::delete_fails_if_filter_dont_match
-writes::top_level_mutations::delete::delete::should_fail_non_exist_id
-writes::top_level_mutations::delete::delete::should_fail_non_existent_value_non_id_uniq_field

--- a/query-compiler/query-engine-tests-todo/pg/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg/fail/query
@@ -24,6 +24,3 @@ writes::data_types::native_types::postgres::postgres::native_other_types
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent
 writes::top_level_mutations::create_list::create_list::create_not_accept_null_in_set
 writes::top_level_mutations::default_value::default_value::remapped_enum_field
-writes::top_level_mutations::delete::delete::delete_fails_if_filter_dont_match
-writes::top_level_mutations::delete::delete::should_fail_non_exist_id
-writes::top_level_mutations::delete::delete::should_fail_non_existent_value_non_id_uniq_field

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -399,6 +399,7 @@ impl Expressionista {
                                                         );
                                                         *field.node_input_field(&mut node) = vec![row];
                                                     }
+                                                    RowSink::Discard => {}
                                                 }
                                                 node
                                             }),

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -180,6 +180,7 @@ pub enum RowSink {
     AllRows(&'static dyn NodeInputField<Vec<SelectionResult>>),
     SingleRow(&'static dyn NodeInputField<SelectionResult>),
     SingleRowArray(&'static dyn NodeInputField<Vec<SelectionResult>>),
+    Discard,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
[ORM-953](https://linear.app/prisma-company/issue/ORM-953/validation-for-deleteone)

Adds validation to the query graph. I didn't remove the hardcoded check in the query interpreter because the function is currently hardcoded to return a `SingleRow` so it has to basically do the same validation before this check even happens. I don't think it's worth refactoring the query interpreter at this point so I left that as is.