### PR TITLE
refactor(qc): use `OsStr::display` instead of unwrapping `OsStr::to_str`

### DIFF
--- a/query-compiler/query-compiler/tests/queries.rs
+++ b/query-compiler/query-compiler/tests/queries.rs
@@ -11,7 +11,7 @@ use std::{fs, process::Command, sync::Arc};
 #[test]
 fn queries() {
     insta::glob!("data/*.json", |path| {
-        let test_name = path.file_name().unwrap().to_str().unwrap();
+        let test_name = path.file_name().unwrap().display();
         println!("running: {test_name}");
 
         let schema_string = include_str!("data/schema.prisma");


### PR DESCRIPTION
Change `file_name().unwrap().to_str().unwrap()` to `file_name().unwrap().display()` in `query-compiler/tests/queries.rs`.