### PR TITLE
fix(qe): make sure we always drop the server future

### DIFF
--- a/query-engine/query-engine/Cargo.toml
+++ b/query-engine/query-engine/Cargo.toml
@@ -8,7 +8,7 @@ sql = ["sql-connector", "sql-connector/all-native"]
 vendored-openssl = ["sql-connector/vendored-openssl"]
 
 [dependencies]
-tokio.workspace = true
+tokio = { workspace = true, features = ["signal"] }
 anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true


### PR DESCRIPTION
Make sure we always exit with unwinding the stack and running the destructors. This is important to make sure we close the database connections and not leave them open until they time out.

- Handle SIGINT and SIGTERM signals.
- Don't force exit in the panic hook before unwinding.

See https://prisma-company.slack.com/archives/C058VM009HT/p1748447180998219

Closes: https://linear.app/prisma-company/issue/ORM-1014/handle-sigterm-in-query-engine-binary-to-properly-close-connections