### PR TITLE
fix: use db field names before data mapping

### DIFF
--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -456,7 +456,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                             Binding::new(
                                 binding::projected_dependency(source, field),
                                 Expression::MapField {
-                                    field: field.prisma_name().into_owned(),
+                                    field: field.db_name().into(),
                                     records: Expression::Get {
                                         name: binding::node_result(source),
                                     }

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -150,7 +150,7 @@ pub(super) fn add_inmemory_join(
         .map(|sf| Binding {
             name: binding::join_parent_field(&sf),
             expr: Expression::MapField {
-                field: sf.name().to_owned(),
+                field: sf.db_name().into(),
                 records: Box::new(Expression::Get {
                     name: binding::join_parent(),
                 }),
@@ -190,7 +190,7 @@ pub(super) fn add_inmemory_join(
                 is_relation_unique: join.is_relation_unique,
                 on: left_scalars
                     .into_iter()
-                    .map(|sf| sf.name().to_owned())
+                    .map(|sf| sf.db_name().into())
                     .zip(join.into_fields())
                     .collect(),
                 parent_field: parent_field_name,
@@ -347,7 +347,7 @@ fn build_read_one2m_query(
                 .related_field()
                 .left_scalars()
                 .iter()
-                .map(|sf| sf.name().to_owned())
+                .map(|sf| sf.db_name().into())
                 .collect(),
             is_relation_unique: !field.arity().is_list(),
         },

--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -34,7 +34,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                 .collect::<BTreeMap<_, _>>();
 
             if let Some(last_insert_id_field) = last_insert_id_field {
-                initializers.insert(last_insert_id_field.name().into(), FieldInitializer::LastInsertId);
+                initializers.insert(last_insert_id_field.db_name().into(), FieldInitializer::LastInsertId);
             }
 
             if let Some(defaults_query) = &select_defaults {
@@ -42,7 +42,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                 // select query, since they can a part of the primary identifier.
                 for (field, placeholder) in &defaults_query.field_placeholders {
                     let value = FieldInitializer::Value(PrismaValue::Placeholder(placeholder.clone()));
-                    initializers.insert(field.name().into(), value);
+                    initializers.insert(field.db_name().into(), value);
                 }
             }
 

--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -30,7 +30,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
 
             let mut initializers = merge_values
                 .into_iter()
-                .map(|(field, value)| (field.prisma_name().into_owned(), FieldInitializer::Value(value)))
+                .map(|(field, value)| (field.db_name().into(), FieldInitializer::Value(value)))
                 .collect::<BTreeMap<_, _>>();
 
             if let Some(last_insert_id_field) = last_insert_id_field {
@@ -70,7 +70,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                     Binding::new(
                         ph.name,
                         Expression::MapField {
-                            field: field.name().into(),
+                            field: field.db_name().into(),
                             records: get_defaults.into(),
                         },
                     )
@@ -184,7 +184,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                 .expect("should have exactly one selector")
                 .pairs
                 .iter()
-                .map(|(field, val)| (field.prisma_name().into_owned(), FieldInitializer::Value(val.clone())))
+                .map(|(field, val)| (field.db_name().into(), FieldInitializer::Value(val.clone())))
                 .collect();
 
             // Keep track of the operations that are applied to the primary identifier fields.
@@ -194,7 +194,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                 .selections()
                 .filter_map(|field| {
                     Some((
-                        field.prisma_name().into_owned(),
+                        field.db_name().into(),
                         FieldOperation::try_from(args.get_field_value(&field.db_name())?.as_scalar()?.clone())
                             .expect("arg value should be convertible to FieldOperation"),
                     ))

--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
@@ -1,6 +1,5 @@
 new::interactive_tx::interactive_tx::batch_queries_failure
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
-new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/d1/fail/query
+++ b/query-compiler/query-engine-tests-todo/d1/fail/query
@@ -1,6 +1,5 @@
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_quaint
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_quaint
-new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::reproductions::issue_23743

--- a/query-compiler/query-engine-tests-todo/libsql/fail/query
+++ b/query-compiler/query-engine-tests-todo/libsql/fail/query
@@ -2,7 +2,6 @@ new::interactive_tx::interactive_tx::batch_queries_failure
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_js
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_js
-new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -4,7 +4,6 @@ new::regressions::prisma_13089::prisma_13097::filtering_with_dollar_values
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_15177::prisma_15177::repro
-new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -4,6 +4,7 @@ new::regressions::prisma_13089::prisma_13097::filtering_with_dollar_values
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_15177::prisma_15177::repro
+new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/pg/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg/fail/query
@@ -2,7 +2,6 @@ new::regressions::max_integer::max_integer::unfitted_int_should_fail
 new::regressions::max_integer::max_integer::unfitted_int_should_fail_pg_js
 new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
 new::regressions::prisma_13097::prisma_13097::group_by_enum_array
-new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/planetscale/fail/query
+++ b/query-compiler/query-engine-tests-todo/planetscale/fail/query
@@ -1,5 +1,4 @@
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
-new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 new::relation_load_strategy::relation_load_strategy::test_create_subquery_join
 new::relation_load_strategy::relation_load_strategy::test_delete_subquery_join

--- a/query-compiler/query-engine-tests-todo/planetscale/fail/query
+++ b/query-compiler/query-engine-tests-todo/planetscale/fail/query
@@ -1,5 +1,4 @@
 new::regressions::max_integer::max_integer::unfitted_int_should_fail
-new::regressions::prisma_15177::prisma_15177::repro
 new::regressions::prisma_22971::prisma_22971::test_22971
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 new::relation_load_strategy::relation_load_strategy::test_create_subquery_join


### PR DESCRIPTION
we're using prisma names when referring to fields before data mapping happens, we should be using db names everywhere