### PR TITLE
feat: use shard-aware identifiers in queries

### DIFF
--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -201,10 +201,10 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                 .map(|(field, val)| (field.db_name().into(), FieldInitializer::Value(val.clone())))
                 .collect();
 
-            // Keep track of the operations that are applied to the primary identifier fields.
+            // Keep track of the operations that are applied to the primary identifier or shard key fields.
             // They need to be applied in-memory to the record we intend to return.
             let operations = model
-                .primary_identifier()
+                .shard_aware_primary_identifier()
                 .selections()
                 .filter_map(|field| {
                     Some((

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/query_engine_tests.rs
@@ -7,4 +7,5 @@
 mod new;
 mod queries;
 mod raw;
+mod sharding;
 mod writes;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/basic.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/basic.rs
@@ -1,0 +1,632 @@
+use query_engine_tests::*;
+
+#[test_suite(only(MySql))]
+mod basic_shard_key {
+    use indoc::indoc;
+
+    fn single_shard_key_schema() -> String {
+        let schema = indoc! {
+            r#"
+            model User {
+              id       String @id @default(uuid())
+              email    String @unique
+              name     String
+              region   String @shardKey
+              posts    Post[]
+            }
+
+            model Post {
+              id       String @id @default(uuid())
+              title    String
+              content  String
+              userId   String
+              region   String @shardKey
+              user     User   @relation(fields: [userId], references: [id])
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    fn composite_shard_key_schema() -> String {
+        let schema = indoc! {
+            r#"
+            model Order {
+              id         String @id @default(uuid())
+              customerId String
+              productId  String
+              quantity   Int
+              region     String
+              tenantId   String
+
+              @@shardKey([region, tenantId])
+            }
+
+            model Product {
+              id       String @id @default(uuid())
+              name     String
+              price    Decimal
+              region   String
+              category String
+
+              @@shardKey([region, category])
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    fn mixed_key_schema() -> String {
+        let schema = indoc! {
+            r#"
+            model Document {
+              id       String @id @default(uuid())
+              title    String
+              content  String
+              shardKey String @shardKey
+            }
+
+            model CompoundPrimary {
+              userId   String
+              gameId   String
+              score    Int
+              region   String
+
+              @@id([userId, gameId])
+              @@shardKey([region])
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn create_record_with_single_shard_key(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "test@example.com"
+                    name: "Test User"
+                    region: "us-east-1"
+                }) {
+                    id
+                    email
+                    name
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createOneUser":{"id":"user-1","email":"test@example.com","name":"Test User","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn find_unique_with_shard_key(runner: Runner) -> TestResult<()> {
+        // First create a record
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "test@example.com"
+                    name: "Test User"
+                    region: "us-east-1"
+                }) {
+                    id
+                }
+            }"#
+        );
+
+        // Find by primary key only (should work but might be cross-shard)
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueUser(where: { id: "user-1" }) {
+                    id
+                    email
+                    name
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findUniqueUser":{"id":"user-1","email":"test@example.com","name":"Test User","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn find_unique_with_email_unique_index(runner: Runner) -> TestResult<()> {
+        // First create a record
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "test@example.com"
+                    name: "Test User"
+                    region: "us-east-1"
+                }) {
+                    id
+                }
+            }"#
+        );
+
+        // Find by unique email field
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueUser(where: { email: "test@example.com" }) {
+                    id
+                    email
+                    name
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findUniqueUser":{"id":"user-1","email":"test@example.com","name":"Test User","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn update_record_with_shard_key(runner: Runner) -> TestResult<()> {
+        // First create a record
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "test@example.com"
+                    name: "Test User"
+                    region: "us-east-1"
+                }) {
+                    id
+                }
+            }"#
+        );
+
+        // Update the record
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                updateOneUser(
+                    where: { id: "user-1" }
+                    data: { name: "Updated User" }
+                ) {
+                    id
+                    email
+                    name
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"updateOneUser":{"id":"user-1","email":"test@example.com","name":"Updated User","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn delete_record_with_shard_key(runner: Runner) -> TestResult<()> {
+        // First create a record
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "test@example.com"
+                    name: "Test User"
+                    region: "us-east-1"
+                }) {
+                    id
+                }
+            }"#
+        );
+
+        // Delete the record
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteOneUser(where: { id: "user-1" }) {
+                    id
+                    email
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"deleteOneUser":{"id":"user-1","email":"test@example.com","region":"us-east-1"}}}"###
+        );
+
+        // Verify it's deleted
+        let verify_result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueUser(where: { id: "user-1" }) {
+                    id
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            verify_result,
+            @r###"{"data":{"findUniqueUser":null}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(composite_shard_key_schema))]
+    async fn create_record_with_composite_shard_key(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneOrder(data: {
+                    id: "order-1"
+                    customerId: "customer-1"
+                    productId: "product-1"
+                    quantity: 5
+                    region: "us-west-2"
+                    tenantId: "tenant-a"
+                }) {
+                    id
+                    customerId
+                    productId
+                    quantity
+                    region
+                    tenantId
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createOneOrder":{"id":"order-1","customerId":"customer-1","productId":"product-1","quantity":5,"region":"us-west-2","tenantId":"tenant-a"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(composite_shard_key_schema))]
+    async fn update_record_with_composite_shard_key(runner: Runner) -> TestResult<()> {
+        // First create a record
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneOrder(data: {
+                    id: "order-1"
+                    customerId: "customer-1"
+                    productId: "product-1"
+                    quantity: 5
+                    region: "us-west-2"
+                    tenantId: "tenant-a"
+                }) {
+                    id
+                }
+            }"#
+        );
+
+        // Update the record
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                updateOneOrder(
+                    where: { id: "order-1" }
+                    data: { quantity: 10 }
+                ) {
+                    id
+                    customerId
+                    productId
+                    quantity
+                    region
+                    tenantId
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"updateOneOrder":{"id":"order-1","customerId":"customer-1","productId":"product-1","quantity":10,"region":"us-west-2","tenantId":"tenant-a"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(mixed_key_schema))]
+    async fn create_compound_primary_shard_key(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneCompoundPrimary(data: {
+                    userId: "user-1"
+                    gameId: "game-1"
+                    score: 1000
+                    region: "eu-central-1"
+                }) {
+                    userId
+                    gameId
+                    score
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createOneCompoundPrimary":{"userId":"user-1","gameId":"game-1","score":1000,"region":"eu-central-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(mixed_key_schema))]
+    async fn find_compound_primary_shard_key(runner: Runner) -> TestResult<()> {
+        // First create a record
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCompoundPrimary(data: {
+                    userId: "user-1"
+                    gameId: "game-1"
+                    score: 1000
+                    region: "eu-central-1"
+                }) {
+                    userId
+                    gameId
+                }
+            }"#
+        );
+
+        // Find by compound primary key
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueCompoundPrimary(where: {
+                    userId_gameId: { userId: "user-1", gameId: "game-1" }
+                }) {
+                    userId
+                    gameId
+                    score
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findUniqueCompoundPrimary":{"userId":"user-1","gameId":"game-1","score":1000,"region":"eu-central-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn create_many_with_shard_key(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createManyUser(data: [
+                    {
+                        id: "user-1"
+                        email: "user1@example.com"
+                        name: "User One"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "user-2"
+                        email: "user2@example.com"
+                        name: "User Two"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "user-3"
+                        email: "user3@example.com"
+                        name: "User Three"
+                        region: "us-east-1"
+                    }
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createManyUser":{"count":3}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn find_many_with_shard_key_filter(runner: Runner) -> TestResult<()> {
+        // First create test data
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyUser(data: [
+                    {
+                        id: "user-1"
+                        email: "user1@example.com"
+                        name: "User One"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "user-2"
+                        email: "user2@example.com"
+                        name: "User Two"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "user-3"
+                        email: "user3@example.com"
+                        name: "User Three"
+                        region: "us-east-1"
+                    }
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        // Find users by shard key - this should be efficient as it targets a specific shard
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(where: { region: "us-east-1" }) {
+                    id
+                    email
+                    name
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findManyUser":[{"id":"user-1","email":"user1@example.com","name":"User One","region":"us-east-1"},{"id":"user-3","email":"user3@example.com","name":"User Three","region":"us-east-1"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn update_many_with_shard_key_filter(runner: Runner) -> TestResult<()> {
+        // First create test data
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyUser(data: [
+                    {
+                        id: "user-1"
+                        email: "user1@example.com"
+                        name: "User One"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "user-2"
+                        email: "user2@example.com"
+                        name: "User Two"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "user-3"
+                        email: "user3@example.com"
+                        name: "User Three"
+                        region: "us-east-1"
+                    }
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        // Update users in a specific region
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                updateManyUser(
+                    where: { region: "us-east-1" }
+                    data: { name: "Updated User" }
+                ) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"updateManyUser":{"count":2}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(single_shard_key_schema))]
+    async fn delete_many_with_shard_key_filter(runner: Runner) -> TestResult<()> {
+        // First create test data
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyUser(data: [
+                    {
+                        id: "user-1"
+                        email: "user1@example.com"
+                        name: "User One"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "user-2"
+                        email: "user2@example.com"
+                        name: "User Two"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "user-3"
+                        email: "user3@example.com"
+                        name: "User Three"
+                        region: "us-east-1"
+                    }
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        // Delete users in a specific region
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteManyUser(where: { region: "us-east-1" }) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"deleteManyUser":{"count":2}}}"###
+        );
+
+        // Verify only one user remains
+        let verify_result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser {
+                    id
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            verify_result,
+            @r###"{"data":{"findManyUser":[{"id":"user-2","region":"us-west-2"}]}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/complex_queries.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/complex_queries.rs
@@ -1,0 +1,956 @@
+use query_engine_tests::*;
+
+#[test_suite(only(MySql))]
+mod shard_complex {
+    use indoc::indoc;
+
+    fn complex_schema() -> String {
+        let schema = indoc! {
+            r#"
+            model User {
+              id          String @id @default(uuid())
+              email       String @unique
+              username    String @unique
+              firstName   String
+              lastName    String
+              age         Int?
+              isActive    Boolean  @default(true)
+              region      String   @shardKey
+              score       Int      @default(0)
+              balance     Decimal  @default(0.00)
+              createdAt   DateTime @default(now())
+              updatedAt   DateTime @updatedAt
+              posts       Post[]
+              comments    Comment[]
+              profile     UserProfile?
+
+              @@index([region, score])
+              @@index([region, createdAt])
+            }
+
+            model UserProfile {
+              id          String @id @default(uuid())
+              userId      String @unique
+              bio         String?
+              website     String?
+              avatar      String?
+              country     String
+              city        String
+              region      String @shardKey
+              user        User   @relation(fields: [userId], references: [id])
+            }
+
+            model Post {
+              id          String   @id @default(uuid())
+              title       String
+              content     String
+              authorId    String
+              published   Boolean  @default(false)
+              viewCount   Int      @default(0)
+              likes       Int      @default(0)
+              category    PostCategory
+              region      String   @shardKey
+              publishedAt DateTime?
+              createdAt   DateTime @default(now())
+              updatedAt   DateTime @updatedAt
+              author      User     @relation(fields: [authorId], references: [id])
+              comments    Comment[]
+              tags        PostTag[]
+
+              @@index([region, category])
+              @@index([region, publishedAt])
+              @@index([region, likes])
+            }
+
+            model Comment {
+              id        String   @id @default(uuid())
+              content   String
+              authorId  String
+              postId    String
+              region    String   @shardKey
+              createdAt DateTime @default(now())
+              updatedAt DateTime @updatedAt
+              author    User     @relation(fields: [authorId], references: [id])
+              post      Post     @relation(fields: [postId], references: [id])
+
+              @@index([region, postId])
+              @@index([region, authorId])
+            }
+
+            model Tag {
+              id    String @id @default(uuid())
+              name  String @unique
+              color String @default("black")
+              posts PostTag[]
+            }
+
+            model PostTag {
+              id     String @id @default(uuid())
+              postId String
+              tagId  String
+              region String @shardKey
+              post   Post   @relation(fields: [postId], references: [id])
+              tag    Tag    @relation(fields: [tagId], references: [id])
+
+              @@unique([postId, tagId])
+              @@index([region, tagId])
+            }
+
+            model Analytics {
+              id          String @id @default(uuid())
+              eventType   String
+              userId      String?
+              postId      String?
+              value       Int
+              metadata    Json?
+              region      String
+              department  String
+              timestamp   DateTime @default(now())
+
+              @@shardKey([region, department])
+              @@index([region, department, eventType])
+              @@index([region, department, timestamp])
+            }
+
+            enum PostCategory {
+              TECH
+              BUSINESS
+              HEALTH
+              ENTERTAINMENT
+              SPORTS
+              SCIENCE
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    // Setup test data helper
+    async fn setup_test_data(runner: &Runner) -> TestResult<()> {
+        // Create users across different regions
+        run_query!(
+            runner,
+            r#"mutation {
+                createManyUser(data: [
+                    {
+                        id: "user-1"
+                        email: "john@example.com"
+                        username: "john_doe"
+                        firstName: "John"
+                        lastName: "Doe"
+                        age: 25
+                        region: "us-east-1"
+                        score: 100
+                        balance: 500.00
+                    },
+                    {
+                        id: "user-2"
+                        email: "jane@example.com"
+                        username: "jane_smith"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        age: 30
+                        region: "us-west-2"
+                        score: 200
+                        balance: 750.50
+                    },
+                    {
+                        id: "user-3"
+                        email: "bob@example.com"
+                        username: "bob_johnson"
+                        firstName: "Bob"
+                        lastName: "Johnson"
+                        age: 35
+                        region: "us-east-1"
+                        score: 150
+                        balance: 1000.75
+                    },
+                    {
+                        id: "user-4"
+                        email: "alice@example.com"
+                        username: "alice_wilson"
+                        firstName: "Alice"
+                        lastName: "Wilson"
+                        age: 28
+                        region: "eu-west-1"
+                        score: 300
+                        balance: 2000.00
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Create posts
+        run_query!(
+            runner,
+            r#"mutation {
+                createManyPost(data: [
+                    {
+                        id: "post-1"
+                        title: "Tech Innovation"
+                        content: "Latest in tech..."
+                        authorId: "user-1"
+                        published: true
+                        viewCount: 100
+                        likes: 25
+                        category: TECH
+                        region: "us-east-1"
+                        publishedAt: "2024-01-01T00:00:00Z"
+                    },
+                    {
+                        id: "post-2"
+                        title: "Business Trends"
+                        content: "Market analysis..."
+                        authorId: "user-2"
+                        published: true
+                        viewCount: 200
+                        likes: 50
+                        category: BUSINESS
+                        region: "us-west-2"
+                        publishedAt: "2024-01-02T00:00:00Z"
+                    },
+                    {
+                        id: "post-3"
+                        title: "Health Tips"
+                        content: "Stay healthy..."
+                        authorId: "user-3"
+                        published: false
+                        viewCount: 50
+                        likes: 10
+                        category: HEALTH
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "post-4"
+                        title: "Entertainment News"
+                        content: "Latest movies..."
+                        authorId: "user-4"
+                        published: true
+                        viewCount: 300
+                        likes: 75
+                        category: ENTERTAINMENT
+                        region: "eu-west-1"
+                        publishedAt: "2024-01-03T00:00:00Z"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Create analytics data
+        run_query!(
+            runner,
+            r#"mutation {
+                createManyAnalytics(data: [
+                    {
+                        id: "analytics-1"
+                        eventType: "page_view"
+                        userId: "user-1"
+                        postId: "post-1"
+                        value: 1
+                        region: "us-east-1"
+                        department: "marketing"
+                    },
+                    {
+                        id: "analytics-2"
+                        eventType: "click"
+                        userId: "user-2"
+                        value: 5
+                        region: "us-west-2"
+                        department: "sales"
+                    },
+                    {
+                        id: "analytics-3"
+                        eventType: "conversion"
+                        userId: "user-3"
+                        value: 100
+                        region: "us-east-1"
+                        department: "marketing"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        Ok(())
+    }
+
+    // Complex Filtering Tests
+
+    #[connector_test(schema(complex_schema))]
+    async fn complex_where_conditions(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Complex query with multiple conditions including shard key
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(where: {
+                    region: "us-east-1",
+                    age: { gte: 25 },
+                    score: { gte: 100 },
+                    isActive: true
+                }) {
+                    id
+                    firstName
+                    age
+                    score
+                    region
+                }
+            }"#
+        );
+
+        assert!(result.contains("user-1"));
+        assert!(result.contains("user-3"));
+        assert!(!result.contains("user-2")); // Different region
+        assert!(!result.contains("user-4")); // Different region
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-1","firstName":"John","age":25,"score":100,"region":"us-east-1"},{"id":"user-3","firstName":"Bob","age":35,"score":150,"region":"us-east-1"}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn or_conditions_across_shards(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // OR condition that spans multiple shards
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(where: {
+                    OR: [
+                        {
+                            AND: [
+                                { region: "us-east-1" },
+                                { score: { gte: 150 } }
+                            ]
+                        },
+                        {
+                            AND: [
+                                { region: "eu-west-1" },
+                                { score: { gte: 250 } }
+                            ]
+                        }
+                    ]
+                }) {
+                    id
+                    firstName
+                    score
+                    region
+                }
+            }"#
+        );
+
+        assert!(result.contains("user-3")); // us-east-1 with score 150
+        assert!(result.contains("user-4")); // eu-west-1 with score 300
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-4","firstName":"Alice","score":300,"region":"eu-west-1"},{"id":"user-3","firstName":"Bob","score":150,"region":"us-east-1"}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn in_filter_with_shard_key(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // IN filter targeting specific shards
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(where: {
+                    region: { in: ["us-east-1", "eu-west-1"] }
+                    score: { in: [100, 300] }
+                }) {
+                    id
+                    firstName
+                    score
+                    region
+                }
+            }"#
+        );
+
+        assert!(result.contains("user-1")); // us-east-1, score 100
+        assert!(result.contains("user-4")); // eu-west-1, score 300
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-4","firstName":"Alice","score":300,"region":"eu-west-1"},{"id":"user-1","firstName":"John","score":100,"region":"us-east-1"}]}}"#);
+
+        Ok(())
+    }
+
+    // Ordering and Pagination Tests
+
+    #[connector_test(schema(complex_schema))]
+    async fn orderby_with_shard_key_pagination(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Order by score within a shard with pagination
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(
+                    where: { region: "us-east-1" }
+                    orderBy: { score: desc }
+                    take: 1
+                    skip: 0
+                ) {
+                    id
+                    firstName
+                    score
+                    region
+                }
+            }"#
+        );
+
+        // Highest score in us-east-1
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-3","firstName":"Bob","score":150,"region":"us-east-1"}]}}"#);
+
+        // Second page
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(
+                    where: { region: "us-east-1" }
+                    orderBy: { score: desc }
+                    take: 1
+                    skip: 1
+                ) {
+                    id
+                    firstName
+                    score
+                    region
+                }
+            }"#
+        );
+
+        // Second highest score in us-east-1
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-1","firstName":"John","score":100,"region":"us-east-1"}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn complex_orderby_multiple_fields(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Complex ordering by multiple fields
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyPost(
+                    where: { region: "us-east-1" }
+                    orderBy: [
+                        { published: desc },
+                        { likes: desc },
+                        { createdAt: desc }
+                    ]
+                ) {
+                    id
+                    title
+                    published
+                    likes
+                    region
+                }
+            }"#
+        );
+
+        // Should order published posts first, then by likes descending
+        insta::assert_snapshot!(
+            result,
+            @r#"{"data":{"findManyPost":[{"id":"post-1","title":"Tech Innovation","published":true,"likes":25,"region":"us-east-1"},{"id":"post-3","title":"Health Tips","published":false,"likes":10,"region":"us-east-1"}]}}"#
+        );
+
+        Ok(())
+    }
+
+    // Aggregation Tests
+
+    #[connector_test(schema(complex_schema))]
+    async fn aggregate_by_shard_key(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Count users by region
+        let result = run_query!(
+            &runner,
+            r#"query {
+                aggregateUser(where: { region: "us-east-1" }) {
+                    _count {
+                        _all
+                        id
+                    }
+                    _avg {
+                        age
+                        score
+                        balance
+                    }
+                    _sum {
+                        score
+                        balance
+                    }
+                    _max {
+                        age
+                        score
+                    }
+                    _min {
+                        age
+                        score
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"aggregateUser":{"_count":{"_all":2,"id":2},"_avg":{"age":30,"score":125,"balance":"750.375"},"_sum":{"score":250,"balance":"1500.75"},"_max":{"age":35,"score":150},"_min":{"age":25,"score":100}}}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn group_by_with_shard_key(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Group analytics by region and department (composite shard key)
+        let result = run_query!(
+            &runner,
+            r#"query {
+                groupByAnalytics(
+                    by: [region, department, eventType]
+                ) {
+                    region
+                    department
+                    eventType
+                    _count {
+                        _all
+                        value
+                    }
+                    _sum {
+                        value
+                    }
+                    _avg {
+                        value
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"groupByAnalytics":[{"region":"us-east-1","department":"marketing","eventType":"conversion","_count":{"_all":1,"value":1},"_sum":{"value":100},"_avg":{"value":100}},{"region":"us-east-1","department":"marketing","eventType":"page_view","_count":{"_all":1,"value":1},"_sum":{"value":1},"_avg":{"value":1}},{"region":"us-west-2","department":"sales","eventType":"click","_count":{"_all":1,"value":1},"_sum":{"value":5},"_avg":{"value":5}}]}}"#);
+
+        Ok(())
+    }
+
+    // Relation and Join Tests
+
+    #[connector_test(schema(complex_schema))]
+    async fn nested_shard_filtering(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Find users with their posts, filtering by shard key at multiple levels
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(
+                    where: { region: "us-east-1" }
+                ) {
+                    id
+                    firstName
+                    region
+                    posts(
+                        where: {
+                            region: "us-east-1"
+                            published: true
+                        }
+                        orderBy: { likes: desc }
+                    ) {
+                        id
+                        title
+                        likes
+                        region
+                    }
+                }
+            }"#
+        );
+
+        assert!(result.contains("user-1"));
+        assert!(result.contains("user-3"));
+        assert!(result.contains("post-1")); // Published post by user-1
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-1","firstName":"John","region":"us-east-1","posts":[{"id":"post-1","title":"Tech Innovation","likes":25,"region":"us-east-1"}]},{"id":"user-3","firstName":"Bob","region":"us-east-1","posts":[]}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn complex_nested_relations_cross_shard(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Create comments across shards
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyComment(data: [
+                    {
+                        id: "comment-1"
+                        content: "Great post!"
+                        authorId: "user-2"
+                        postId: "post-1"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "comment-2"
+                        content: "Interesting perspective"
+                        authorId: "user-1"
+                        postId: "post-2"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Query posts with comments from different shards
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyPost(
+                    where: { published: true }
+                ) {
+                    id
+                    title
+                    region
+                    author {
+                        id
+                        firstName
+                        region
+                    }
+                    comments {
+                        id
+                        content
+                        region
+                        author {
+                            firstName
+                            region
+                        }
+                    }
+                }
+            }"#
+        );
+
+        assert!(result.contains("comment-1"));
+        assert!(result.contains("comment-2"));
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyPost":[{"id":"post-1","title":"Tech Innovation","region":"us-east-1","author":{"id":"user-1","firstName":"John","region":"us-east-1"},"comments":[{"id":"comment-1","content":"Great post!","region":"us-west-2","author":{"firstName":"Jane","region":"us-west-2"}}]},{"id":"post-2","title":"Business Trends","region":"us-west-2","author":{"id":"user-2","firstName":"Jane","region":"us-west-2"},"comments":[{"id":"comment-2","content":"Interesting perspective","region":"us-east-1","author":{"firstName":"John","region":"us-east-1"}}]},{"id":"post-4","title":"Entertainment News","region":"eu-west-1","author":{"id":"user-4","firstName":"Alice","region":"eu-west-1"},"comments":[]}]}}"#);
+
+        Ok(())
+    }
+
+    // Complex Filtering with Relations
+
+    #[connector_test(schema(complex_schema))]
+    async fn filter_by_related_model_shard_key(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Find posts where the author is in a specific region
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyPost(where: {
+                    author: {
+                        region: "us-east-1"
+                        score: { gte: 100 }
+                    }
+                    published: true
+                }) {
+                    id
+                    title
+                    region
+                    author {
+                        firstName
+                        region
+                        score
+                    }
+                }
+            }"#
+        );
+
+        assert!(result.contains("post-1")); // By user-1 in us-east-1
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyPost":[{"id":"post-1","title":"Tech Innovation","region":"us-east-1","author":{"firstName":"John","region":"us-east-1","score":100}}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn some_none_filters_with_shard_keys(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Find users who have some posts in a specific region
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(where: {
+                    posts: {
+                        some: {
+                            region: "us-east-1"
+                            published: true
+                        }
+                    }
+                }) {
+                    id
+                    firstName
+                    region
+                    posts(where: { region: "us-east-1" }) {
+                        id
+                        title
+                        region
+                    }
+                }
+            }"#
+        );
+
+        assert!(result.contains("user-1")); // Has published post in us-east-1
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-1","firstName":"John","region":"us-east-1","posts":[{"id":"post-1","title":"Tech Innovation","region":"us-east-1"}]}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn shard_aware_bulk_operations(runner: Runner) -> TestResult<()> {
+        let mut users_data = Vec::new();
+        let mut posts_data = Vec::new();
+
+        for i in 1..=50 {
+            let region = match i % 3 {
+                0 => "us-east-1",
+                1 => "us-west-2",
+                _ => "eu-west-1",
+            };
+
+            users_data.push(format!(
+                r#"{{
+                    id: "bulk-user-{i}"
+                    email: "user{i}@example.com"
+                    username: "user{i}"
+                    firstName: "User"
+                    lastName: "{i}"
+                    region: "{region}"
+                    score: {}
+                }}"#,
+                i * 10
+            ));
+
+            posts_data.push(format!(
+                r#"{{
+                    id: "bulk-post-{i}"
+                    title: "Post {i}"
+                    content: "Content for post {i}"
+                    authorId: "bulk-user-{i}"
+                    region: "{region}"
+                    category: TECH
+                    published: true
+                    likes: {}
+                }}"#,
+                i * 2
+            ));
+        }
+
+        // Bulk create users
+        let create_users_query = format!(
+            r#"mutation {{
+                createManyUser(data: [{}]) {{
+                    count
+                }}
+            }}"#,
+            users_data.join(",")
+        );
+
+        let user_result = run_query!(&runner, &create_users_query);
+        insta::assert_snapshot!(user_result, @r#"{"data":{"createManyUser":{"count":50}}}"#);
+
+        // Bulk create posts
+        let create_posts_query = format!(
+            r#"mutation {{
+                createManyPost(data: [{}]) {{
+                    count
+                }}
+            }}"#,
+            posts_data.join(",")
+        );
+
+        let post_result = run_query!(&runner, &create_posts_query);
+        insta::assert_snapshot!(post_result, @r#"{"data":{"createManyPost":{"count":50}}}"#);
+
+        let query_result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(
+                    where: { region: "us-east-1" }
+                    orderBy: { score: desc }
+                    take: 10
+                ) {
+                    id
+                    score
+                    region
+                    posts(
+                        where: { region: "us-east-1" }
+                        orderBy: { likes: desc }
+                        take: 3
+                    ) {
+                        id
+                        likes
+                        region
+                    }
+                }
+            }"#
+        );
+
+        // Should return users only from us-east-1 shard
+        assert!(query_result.contains("us-east-1"));
+        assert!(!query_result.contains("us-west-2"));
+        assert!(!query_result.contains("eu-west-1"));
+
+        Ok(())
+    }
+
+    // Batch Operations
+
+    #[connector_test(schema(complex_schema))]
+    async fn batch_operations_within_shard(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Batch update users within the same shard
+        let update_result = run_query!(
+            &runner,
+            r#"mutation {
+                updateManyUser(
+                    where: {
+                        region: "us-east-1"
+                        age: { gte: 30 }
+                    }
+                    data: {
+                        score: { increment: 50 }
+                        isActive: false
+                    }
+                ) {
+                    count
+                }
+            }"#
+        );
+
+        // Only user-3 matches
+        insta::assert_snapshot!(update_result, @r#"{"data":{"updateManyUser":{"count":1}}}"#);
+
+        // Verify the update
+        let verify_result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueUser(where: { id: "user-3" }) {
+                    score
+                    isActive
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(verify_result, @r#"{"data":{"findUniqueUser":{"score":200,"isActive":false,"region":"us-east-1"}}}"#);
+
+        Ok(())
+    }
+
+    // Edge Cases and Complex Scenarios
+
+    #[connector_test(schema(complex_schema))]
+    async fn mixed_shard_and_non_shard_operations(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Query that mixes shard-aware and cross-shard operations
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(
+                    where: {
+                        OR: [
+                            { region: "us-east-1" },
+                            { email: { contains: "jane" } }
+                        ]
+                    }
+                    orderBy: { createdAt: desc }
+                ) {
+                    id
+                    firstName
+                    email
+                    region
+                    posts(
+                        where: { published: true }
+                        orderBy: { publishedAt: desc }
+                    ) {
+                        id
+                        title
+                        publishedAt
+                        region
+                    }
+                }
+            }"#
+        );
+
+        // Should include users from us-east-1 and Jane from us-west-2
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-1","firstName":"John","email":"john@example.com","region":"us-east-1","posts":[{"id":"post-1","title":"Tech Innovation","publishedAt":"2024-01-01T00:00:00.000Z","region":"us-east-1"}]},{"id":"user-2","firstName":"Jane","email":"jane@example.com","region":"us-west-2","posts":[{"id":"post-2","title":"Business Trends","publishedAt":"2024-01-02T00:00:00.000Z","region":"us-west-2"}]},{"id":"user-3","firstName":"Bob","email":"bob@example.com","region":"us-east-1","posts":[]}]}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(complex_schema))]
+    async fn deeply_nested_relations(runner: Runner) -> TestResult<()> {
+        setup_test_data(&runner).await?;
+
+        // Create deeply nested data
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUserProfile(data: {
+                    id: "profile-1"
+                    userId: "user-1"
+                    bio: "Software Engineer"
+                    country: "USA"
+                    city: "New York"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Query with deep nesting across potential shard boundaries
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyUser(
+                    where: { region: "us-east-1" }
+                ) {
+                    id
+                    firstName
+                    region
+                    profile {
+                        bio
+                        country
+                        region
+                    }
+                    posts(
+                        where: { published: true }
+                    ) {
+                        id
+                        title
+                        region
+                        comments {
+                            content
+                            region
+                            author {
+                                firstName
+                                region
+                            }
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findManyUser":[{"id":"user-1","firstName":"John","region":"us-east-1","profile":{"bio":"Software Engineer","country":"USA","region":"us-east-1"},"posts":[{"id":"post-1","title":"Tech Innovation","region":"us-east-1","comments":[]}]},{"id":"user-3","firstName":"Bob","region":"us-east-1","profile":null,"posts":[]}]}}"#);
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/crud_operations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/crud_operations.rs
@@ -1,0 +1,917 @@
+use query_engine_tests::*;
+
+#[test_suite(only(MySql))]
+mod shard_crud {
+    use indoc::indoc;
+
+    fn crud_schema() -> String {
+        let schema = indoc! {
+            r#"
+            model Customer {
+              id          String @id @default(uuid())
+              email       String @unique
+              firstName   String
+              lastName    String
+              region      String @shardKey
+              createdAt   DateTime @default(now())
+              updatedAt   DateTime @updatedAt
+              orders      Order[]
+              profile     CustomerProfile?
+            }
+
+            model CustomerProfile {
+              id          String @id @default(uuid())
+              customerId  String @unique
+              bio         String?
+              avatar      String?
+              region      String @shardKey
+              customer    Customer @relation(fields: [customerId], references: [id])
+            }
+
+            model Order {
+              id          String @id @default(uuid())
+              orderNumber String @unique
+              customerId  String
+              totalAmount Decimal
+              status      OrderStatus @default(PENDING)
+              region      String @shardKey
+              orderDate   DateTime @default(now())
+              customer    Customer @relation(fields: [customerId], references: [id])
+              items       OrderItem[]
+            }
+
+            model OrderItem {
+              id          String @id @default(uuid())
+              orderId     String
+              productName String
+              quantity    Int
+              price       Decimal
+              region      String @shardKey
+              order       Order @relation(fields: [orderId], references: [id])
+            }
+
+            model Product {
+              id          String @id @default(uuid())
+              sku         String @unique
+              name        String
+              description String?
+              price       Decimal
+              category    String
+              region      String
+
+              @@shardKey([region, category])
+            }
+
+            enum OrderStatus {
+              PENDING
+              CONFIRMED
+              SHIPPED
+              DELIVERED
+              CANCELLED
+            }
+            "#
+        };
+
+        schema.to_owned()
+    }
+
+    // CREATE Operations Tests
+
+    #[connector_test(schema(crud_schema))]
+    async fn create_one_customer(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john.doe@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                }) {
+                    id
+                    email
+                    firstName
+                    lastName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"createOneCustomer":{"id":"customer-1","email":"john.doe@example.com","firstName":"John","lastName":"Doe","region":"us-east-1"}}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn create_many_customers(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createManyCustomer(data: [
+                    {
+                        id: "customer-1"
+                        email: "john@example.com"
+                        firstName: "John"
+                        lastName: "Doe"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "customer-2"
+                        email: "jane@example.com"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "customer-3"
+                        email: "bob@example.com"
+                        firstName: "Bob"
+                        lastName: "Johnson"
+                        region: "us-east-1"
+                    }
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createManyCustomer":{"count":3}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn create_customer_with_nested_profile(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                    profile: {
+                        create: {
+                            id: "profile-1"
+                            bio: "Software Engineer"
+                            avatar: "avatar.jpg"
+                            region: "us-east-1"
+                        }
+                    }
+                }) {
+                    id
+                    email
+                    region
+                    profile {
+                        id
+                        bio
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"createOneCustomer":{"id":"customer-1","email":"john@example.com","region":"us-east-1","profile":{"id":"profile-1","bio":"Software Engineer","region":"us-east-1"}}}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn create_composite_shard_key_product(runner: Runner) -> TestResult<()> {
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneProduct(data: {
+                    id: "product-1"
+                    sku: "SKU-001"
+                    name: "Laptop"
+                    description: "High-performance laptop"
+                    price: 999.99
+                    category: "electronics"
+                    region: "us-east-1"
+                }) {
+                    id
+                    sku
+                    name
+                    category
+                    region
+                    price
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createOneProduct":{"id":"product-1","sku":"SKU-001","name":"Laptop","category":"electronics","region":"us-east-1","price":"999.99"}}}"###
+        );
+
+        Ok(())
+    }
+
+    // READ Operations Tests
+
+    #[connector_test(schema(crud_schema))]
+    async fn find_unique_customer_by_id(runner: Runner) -> TestResult<()> {
+        // Setup: Create customer
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Test: Find by ID (this will use shard-aware primary identifier)
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueCustomer(where: { id: "customer-1" }) {
+                    id
+                    email
+                    firstName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findUniqueCustomer":{"id":"customer-1","email":"john@example.com","firstName":"John","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn find_unique_customer_by_email(runner: Runner) -> TestResult<()> {
+        // Setup: Create customer
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Test: Find by unique email
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueCustomer(where: { email: "john@example.com" }) {
+                    id
+                    email
+                    firstName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findUniqueCustomer":{"id":"customer-1","email":"john@example.com","firstName":"John","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn find_many_customers_by_shard_key(runner: Runner) -> TestResult<()> {
+        // Setup: Create customers in different regions
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyCustomer(data: [
+                    {
+                        id: "customer-1"
+                        email: "john@example.com"
+                        firstName: "John"
+                        lastName: "Doe"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "customer-2"
+                        email: "jane@example.com"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "customer-3"
+                        email: "bob@example.com"
+                        firstName: "Bob"
+                        lastName: "Johnson"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Test: Find customers by shard key (should be efficient single-shard query)
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findManyCustomer(where: { region: "us-east-1" }) {
+                    id
+                    firstName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"findManyCustomer":[{"id":"customer-1","firstName":"John","region":"us-east-1"},{"id":"customer-3","firstName":"Bob","region":"us-east-1"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn find_first_customer_with_shard_filter(runner: Runner) -> TestResult<()> {
+        // Setup: Create customers
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyCustomer(data: [
+                    {
+                        id: "customer-1"
+                        email: "john@example.com"
+                        firstName: "John"
+                        lastName: "Doe"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "customer-2"
+                        email: "jane@example.com"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Test: Find first customer in region
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findFirstCustomer(where: { region: "us-east-1" }) {
+                    id
+                    firstName
+                    region
+                }
+            }"#
+        );
+
+        // Should return one of the customers in us-east-1
+        insta::assert_snapshot!(result, @r#"{"data":{"findFirstCustomer":{"id":"customer-1","firstName":"John","region":"us-east-1"}}}"#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn find_customer_with_nested_relations(runner: Runner) -> TestResult<()> {
+        // Setup: Create customer with profile and orders
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                    profile: {
+                        create: {
+                            id: "profile-1"
+                            bio: "Software Engineer"
+                            region: "us-east-1"
+                        }
+                    }
+                    orders: {
+                        create: [
+                            {
+                                id: "order-1"
+                                orderNumber: "ORD-001"
+                                totalAmount: 100.50
+                                region: "us-east-1"
+                            },
+                            {
+                                id: "order-2"
+                                orderNumber: "ORD-002"
+                                totalAmount: 250.75
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                }) { id }
+            }"#
+        );
+
+        // Test: Find customer with all relations
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueCustomer(where: { id: "customer-1" }) {
+                    id
+                    firstName
+                    region
+                    profile {
+                        id
+                        bio
+                        region
+                    }
+                    orders {
+                        id
+                        orderNumber
+                        totalAmount
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findUniqueCustomer":{"id":"customer-1","firstName":"John","region":"us-east-1","profile":{"id":"profile-1","bio":"Software Engineer","region":"us-east-1"},"orders":[{"id":"order-1","orderNumber":"ORD-001","totalAmount":"100.5","region":"us-east-1"},{"id":"order-2","orderNumber":"ORD-002","totalAmount":"250.75","region":"us-east-1"}]}}}"#);
+
+        Ok(())
+    }
+
+    // UPDATE Operations Tests
+
+    #[connector_test(schema(crud_schema))]
+    async fn update_one_customer(runner: Runner) -> TestResult<()> {
+        // Setup: Create customer
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Test: Update customer (should use shard-aware primary identifier)
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                updateOneCustomer(
+                    where: { id: "customer-1" }
+                    data: {
+                        firstName: "Johnny"
+                        lastName: "Updated"
+                    }
+                ) {
+                    id
+                    firstName
+                    lastName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"updateOneCustomer":{"id":"customer-1","firstName":"Johnny","lastName":"Updated","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn update_many_customers_by_shard(runner: Runner) -> TestResult<()> {
+        // Setup: Create customers in different regions
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyCustomer(data: [
+                    {
+                        id: "customer-1"
+                        email: "john@example.com"
+                        firstName: "John"
+                        lastName: "Doe"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "customer-2"
+                        email: "jane@example.com"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "customer-3"
+                        email: "bob@example.com"
+                        firstName: "Bob"
+                        lastName: "Johnson"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Test: Update all customers in a specific region
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                updateManyCustomer(
+                    where: { region: "us-east-1" }
+                    data: { lastName: "UpdatedInEast" }
+                ) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"updateManyCustomer":{"count":2}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn upsert_customer_create(runner: Runner) -> TestResult<()> {
+        // Test: Upsert that creates a new record
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                upsertOneCustomer(
+                    where: { email: "new@example.com" }
+                    create: {
+                        id: "customer-1"
+                        email: "new@example.com"
+                        firstName: "New"
+                        lastName: "Customer"
+                        region: "us-east-1"
+                    }
+                    update: {
+                        firstName: "Updated"
+                    }
+                ) {
+                    id
+                    email
+                    firstName
+                    lastName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"upsertOneCustomer":{"id":"customer-1","email":"new@example.com","firstName":"New","lastName":"Customer","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn upsert_customer_update(runner: Runner) -> TestResult<()> {
+        // Setup: Create existing customer
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "existing@example.com"
+                    firstName: "Existing"
+                    lastName: "Customer"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Test: Upsert that updates existing record
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                upsertOneCustomer(
+                    where: { email: "existing@example.com" }
+                    create: {
+                        id: "customer-new"
+                        email: "existing@example.com"
+                        firstName: "Should Not Create"
+                        lastName: "Should Not Create"
+                        region: "us-west-2"
+                    }
+                    update: {
+                        firstName: "Updated"
+                        lastName: "Existing"
+                    }
+                ) {
+                    id
+                    email
+                    firstName
+                    lastName
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"upsertOneCustomer":{"id":"customer-1","email":"existing@example.com","firstName":"Updated","lastName":"Existing","region":"us-east-1"}}}"###
+        );
+
+        Ok(())
+    }
+
+    // DELETE Operations Tests
+
+    #[connector_test(schema(crud_schema))]
+    async fn delete_one_customer(runner: Runner) -> TestResult<()> {
+        // Setup: Create customer
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Test: Delete customer (should use shard-aware primary identifier)
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteOneCustomer(where: { id: "customer-1" }) {
+                    id
+                    email
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"deleteOneCustomer":{"id":"customer-1","email":"john@example.com","region":"us-east-1"}}}"###
+        );
+
+        // Verify deletion
+        let verify_result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueCustomer(where: { id: "customer-1" }) {
+                    id
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            verify_result,
+            @r###"{"data":{"findUniqueCustomer":null}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn delete_many_customers_by_shard(runner: Runner) -> TestResult<()> {
+        // Setup: Create customers in different regions
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyCustomer(data: [
+                    {
+                        id: "customer-1"
+                        email: "john@example.com"
+                        firstName: "John"
+                        lastName: "Doe"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "customer-2"
+                        email: "jane@example.com"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "customer-3"
+                        email: "bob@example.com"
+                        firstName: "Bob"
+                        lastName: "Johnson"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Test: Delete all customers in a specific region
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteManyCustomer(where: { region: "us-east-1" }) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"deleteManyCustomer":{"count":2}}}"###
+        );
+
+        // Verify only one customer remains
+        let verify_result = run_query!(
+            &runner,
+            r#"query {
+                findManyCustomer {
+                    id
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            verify_result,
+            @r###"{"data":{"findManyCustomer":[{"id":"customer-2","region":"us-west-2"}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(crud_schema))]
+    async fn delete_customer_with_cascade_relations(runner: Runner) -> TestResult<()> {
+        // Setup: Create customer with profile and orders
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneCustomer(data: {
+                    id: "customer-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                    orders: {
+                        create: [
+                            {
+                                id: "order-1"
+                                orderNumber: "ORD-001"
+                                totalAmount: 100.50
+                                region: "us-east-1"
+                                items: {
+                                    create: [
+                                        {
+                                            id: "item-1"
+                                            productName: "Laptop"
+                                            quantity: 1
+                                            price: 100.50
+                                            region: "us-east-1"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }) { id }
+            }"#
+        );
+
+        // First delete related items
+        run_query!(
+            &runner,
+            r#"mutation {
+                deleteManyOrderItem(where: {
+                    order: { customerId: "customer-1" }
+                }) {
+                    count
+                }
+            }"#
+        );
+
+        // Then delete orders
+        run_query!(
+            &runner,
+            r#"mutation {
+                deleteManyOrder(where: { customerId: "customer-1" }) {
+                    count
+                }
+            }"#
+        );
+
+        // Finally delete customer
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteOneCustomer(where: { id: "customer-1" }) {
+                    id
+                    email
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"deleteOneCustomer":{"id":"customer-1","email":"john@example.com"}}}"###
+        );
+
+        Ok(())
+    }
+
+    // Complex Operations with Composite Shard Keys
+
+    #[connector_test(schema(crud_schema))]
+    async fn composite_shard_key_product_ops(runner: Runner) -> TestResult<()> {
+        // Create product with composite shard key
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneProduct(data: {
+                    id: "product-1"
+                    sku: "SKU-001"
+                    name: "Laptop"
+                    description: "High-performance laptop"
+                    price: 999.99
+                    category: "electronics"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Update product
+        let update_result = run_query!(
+            &runner,
+            r#"mutation {
+                updateOneProduct(
+                    where: { id: "product-1" }
+                    data: {
+                        name: "Gaming Laptop"
+                        price: 1299.99
+                    }
+                ) {
+                    id
+                    name
+                    price
+                    category
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            update_result,
+            @r###"{"data":{"updateOneProduct":{"id":"product-1","name":"Gaming Laptop","price":"1299.99","category":"electronics","region":"us-east-1"}}}"###
+        );
+
+        // Find by composite shard key fields
+        let find_result = run_query!(
+            &runner,
+            r#"query {
+                findManyProduct(where: {
+                    region: "us-east-1"
+                    category: "electronics"
+                }) {
+                    id
+                    name
+                    category
+                    region
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(find_result, @r#"{"data":{"findManyProduct":[{"id":"product-1","name":"Gaming Laptop","category":"electronics","region":"us-east-1"}]}}"#);
+
+        // Delete product
+        let delete_result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteOneProduct(where: { id: "product-1" }) {
+                    id
+                    name
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            delete_result,
+            @r###"{"data":{"deleteOneProduct":{"id":"product-1","name":"Gaming Laptop"}}}"###
+        );
+
+        Ok(())
+    }
+}

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/mod.rs
@@ -1,0 +1,4 @@
+mod basic;
+mod complex_queries;
+mod crud_operations;
+mod relations;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/relations.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/sharding/relations.rs
@@ -1,0 +1,1684 @@
+use query_engine_tests::*;
+
+/// Tests complex relational queries with `@shardKey` and `relationMode = "prisma"`.
+#[test_suite(only(MySql), relation_mode = "prisma")]
+mod relations_shard_key {
+    use indoc::indoc;
+    use query_engine_tests::{run_query, Runner};
+
+    fn relations_schema() -> String {
+        let schema = indoc! {
+            r##"
+            // One-to-One Relations
+            model User {
+              id               String       @id @default(uuid())
+              email            String       @unique
+              firstName        String
+              lastName         String
+              region           String       @shardKey
+              profile          UserProfile?
+              posts            Post[]
+              authoredComments Comment[]    @relation("AuthorComments")
+              receivedComments Comment[]    @relation("PostOwnerComments")
+            }
+
+            model UserProfile {
+              id        String  @id @default(uuid())
+              userId    String  @unique
+              bio       String?
+              website   String?
+              avatarUrl String?
+              region    String  @shardKey
+              user      User    @relation(fields: [userId], references: [id])
+            }
+
+            // One-to-Many Relations
+            model Post {
+              id        String    @id @default(uuid())
+              title     String
+              content   String
+              published Boolean   @default(false)
+              authorId  String
+              region    String    @shardKey
+              author    User      @relation(fields: [authorId], references: [id])
+              comments  Comment[]
+              postTags  PostTag[]
+            }
+
+            model Comment {
+              id        String @id @default(uuid())
+              content   String
+              authorId  String
+              postId    String
+              region    String @shardKey
+              author    User   @relation("AuthorComments", fields: [authorId], references: [id])
+              post      Post   @relation(fields: [postId], references: [id], map: "Comment_post_fkey")
+              postOwner User   @relation("PostOwnerComments", fields: [postId], references: [id], map: "Comment_postOwner_fkey")
+            }
+
+            // Explicit Many-to-Many Relations
+            model Tag {
+              id       String    @id @default(uuid())
+              name     String    @unique
+              color    String    @default("000000")
+              postTags PostTag[]
+            }
+
+            model PostTag {
+              id     String @id @default(uuid())
+              postId String
+              tagId  String
+              region String @shardKey
+              post   Post   @relation(fields: [postId], references: [id])
+              tag    Tag    @relation(fields: [tagId], references: [id])
+
+              @@unique([postId, tagId])
+            }
+
+            // Cross-Shard Relations
+            model Organization {
+              id          String       @id @default(uuid())
+              name        String
+              region      String       @shardKey
+              departments Department[]
+              employees   Employee[]
+            }
+
+            model Department {
+              id             String       @id @default(uuid())
+              name           String
+              organizationId String
+              region         String       @shardKey
+              organization   Organization @relation(fields: [organizationId], references: [id])
+              employees      Employee[]
+            }
+
+            model Employee {
+              id             String       @id @default(uuid())
+              firstName      String
+              lastName       String
+              email          String       @unique
+              organizationId String
+              departmentId   String?
+              region         String       @shardKey
+              organization   Organization @relation(fields: [organizationId], references: [id])
+              department     Department?  @relation(fields: [departmentId], references: [id])
+            }
+
+            // Composite Shard Key Relations
+            model Tenant {
+              id       String    @id @default(uuid())
+              name     String
+              region   String
+              tier     String
+              projects Project[]
+
+              @@shardKey([region, tier])
+            }
+
+            model Project {
+              id       String @id @default(uuid())
+              name     String
+              tenantId String
+              region   String
+              category String
+              tenant   Tenant @relation(fields: [tenantId], references: [id])
+              tasks    Task[]
+
+              @@shardKey([region, category])
+            }
+
+            model Task {
+              id        String  @id @default(uuid())
+              title     String
+              completed Boolean @default(false)
+              projectId String
+              region    String
+              priority  String
+              project   Project @relation(fields: [projectId], references: [id])
+
+              @@shardKey([region, priority])
+            }
+            "##
+        };
+
+        schema.to_owned()
+    }
+
+    // Setup helper for test data
+    async fn setup_relation_test_data(runner: &Runner) -> TestResult<()> {
+        // Create users
+        run_query!(
+            runner,
+            r#"mutation {
+                createManyUser(data: [
+                    {
+                        id: "user-1"
+                        email: "john@example.com"
+                        firstName: "John"
+                        lastName: "Doe"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "user-2"
+                        email: "jane@example.com"
+                        firstName: "Jane"
+                        lastName: "Smith"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "user-3"
+                        email: "bob@example.com"
+                        firstName: "Bob"
+                        lastName: "Johnson"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Create tags
+        run_query!(
+            runner,
+            r##"mutation {
+                createManyTag(data: [
+                    {
+                        id: "tag-1"
+                        name: "technology"
+                        color: "#0066CC"
+                    },
+                    {
+                        id: "tag-2"
+                        name: "business"
+                        color: "#CC6600"
+                    },
+                    {
+                        id: "tag-3"
+                        name: "science"
+                        color: "#00CC66"
+                    }
+                ]) { count }
+            }"##
+        );
+
+        Ok(())
+    }
+
+    // One-to-One Relation Tests
+
+    #[connector_test(schema(relations_schema))]
+    async fn create_one_to_one_relation_same_shard(runner: Runner) -> TestResult<()> {
+        // Create user with profile in the same shard
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                    profile: {
+                        create: {
+                            id: "profile-1"
+                            bio: "Software Engineer"
+                            website: "https://johndoe.dev"
+                            region: "us-east-1"
+                        }
+                    }
+                }) {
+                    id
+                    firstName
+                    region
+                    profile {
+                        id
+                        bio
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createOneUser":{"id":"user-1","firstName":"John","region":"us-east-1","profile":{"id":"profile-1","bio":"Software Engineer","region":"us-east-1"}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn create_one_to_one_relation_different_shards(runner: Runner) -> TestResult<()> {
+        // Create user
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Create profile in different shard
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createOneUserProfile(data: {
+                    id: "profile-1"
+                    userId: "user-1"
+                    bio: "Software Engineer"
+                    region: "us-west-2"
+                }) {
+                    id
+                    bio
+                    region
+                    user {
+                        firstName
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createOneUserProfile":{"id":"profile-1","bio":"Software Engineer","region":"us-west-2","user":{"firstName":"John","region":"us-east-1"}}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn query_one_to_one_with_include(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create profile
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUserProfile(data: {
+                    id: "profile-1"
+                    userId: "user-1"
+                    bio: "Software Engineer"
+                    website: "https://johndoe.dev"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Query user with profile
+        let result = run_query!(
+            &runner,
+            r#"query {
+                findUniqueUser(where: { id: "user-1" }) {
+                    id
+                    firstName
+                    region
+                    profile {
+                        bio
+                        website
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"findUniqueUser":{"id":"user-1","firstName":"John","region":"us-east-1","profile":{"bio":"Software Engineer","website":"https://johndoe.dev","region":"us-east-1"}}}}"#);
+
+        Ok(())
+    }
+
+    // One-to-Many Relation Tests
+
+    #[connector_test(schema(relations_schema))]
+    async fn create_one_to_many_relation_same_shard(runner: Runner) -> TestResult<()> {
+        // Create user with posts in the same shard
+        let result = run_query_pretty!(
+            &runner,
+            r#"mutation {
+                createOneUser(data: {
+                    id: "user-1"
+                    email: "john@example.com"
+                    firstName: "John"
+                    lastName: "Doe"
+                    region: "us-east-1"
+                    posts: {
+                        create: [
+                            {
+                                id: "post-1"
+                                title: "First Post"
+                                content: "Hello World"
+                                region: "us-east-1"
+                            },
+                            {
+                                id: "post-2"
+                                title: "Second Post"
+                                content: "Another post"
+                                published: true
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                }) {
+                    id
+                    firstName
+                    region
+                    posts {
+                        id
+                        title
+                        published
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "createOneUser": {
+              "id": "user-1",
+              "firstName": "John",
+              "region": "us-east-1",
+              "posts": [
+                {
+                  "id": "post-1",
+                  "title": "First Post",
+                  "published": false,
+                  "region": "us-east-1"
+                },
+                {
+                  "id": "post-2",
+                  "title": "Second Post",
+                  "published": true,
+                  "region": "us-east-1"
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn create_posts_across_different_shards(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create posts for user-1 in different shards
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyPost(data: [
+                    {
+                        id: "post-1"
+                        title: "East Coast Post"
+                        content: "Content from east"
+                        authorId: "user-1"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "post-2"
+                        title: "West Coast Post"
+                        content: "Content from west"
+                        authorId: "user-1"
+                        region: "us-west-2"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Query user with posts from all shards
+        let result = run_query_pretty!(
+            &runner,
+            r#"query {
+                findUniqueUser(where: { id: "user-1" }) {
+                    id
+                    firstName
+                    region
+                    posts {
+                        id
+                        title
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "findUniqueUser": {
+              "id": "user-1",
+              "firstName": "John",
+              "region": "us-east-1",
+              "posts": [
+                {
+                  "id": "post-1",
+                  "title": "East Coast Post",
+                  "region": "us-east-1"
+                },
+                {
+                  "id": "post-2",
+                  "title": "West Coast Post",
+                  "region": "us-west-2"
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn nested_create_with_comments(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create post with comments
+        let result = run_query_pretty!(
+            &runner,
+            r#"mutation {
+                createOnePost(data: {
+                    id: "post-1"
+                    title: "Discussion Post"
+                    content: "Let's discuss this topic"
+                    authorId: "user-1"
+                    published: true
+                    region: "us-east-1"
+                    comments: {
+                        create: [
+                            {
+                                id: "comment-1"
+                                content: "Great post!"
+                                authorId: "user-2"
+                                region: "us-west-2"
+                            },
+                            {
+                                id: "comment-2"
+                                content: "I agree!"
+                                authorId: "user-3"
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                }) {
+                    id
+                    title
+                    region
+                    comments {
+                        id
+                        content
+                        region
+                        author {
+                            firstName
+                            region
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "createOnePost": {
+              "id": "post-1",
+              "title": "Discussion Post",
+              "region": "us-east-1",
+              "comments": [
+                {
+                  "id": "comment-1",
+                  "content": "Great post!",
+                  "region": "us-west-2",
+                  "author": {
+                    "firstName": "Jane",
+                    "region": "us-west-2"
+                  }
+                },
+                {
+                  "id": "comment-2",
+                  "content": "I agree!",
+                  "region": "us-east-1",
+                  "author": {
+                    "firstName": "Bob",
+                    "region": "us-east-1"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    // Many-to-Many Relation Tests
+
+    #[connector_test(schema(relations_schema))]
+    async fn create_explicit_many_to_many_relation(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create post
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOnePost(data: {
+                    id: "post-1"
+                    title: "Tech Article"
+                    content: "Latest in technology"
+                    authorId: "user-1"
+                    region: "us-east-1"
+                }) { id }
+            }"#
+        );
+
+        // Connect tags to post via junction table
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                createManyPostTag(data: [
+                    {
+                        id: "posttag-1"
+                        postId: "post-1"
+                        tagId: "tag-1"
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "posttag-2"
+                        postId: "post-1"
+                        tagId: "tag-3"
+                        region: "us-east-1"
+                    }
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"createManyPostTag":{"count":2}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn query_explicit_many_to_many_relations(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create post with tags
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOnePost(data: {
+                    id: "post-1"
+                    title: "Business Tech Article"
+                    content: "Intersection of business and technology"
+                    authorId: "user-1"
+                    region: "us-east-1"
+                    postTags: {
+                        create: [
+                            {
+                                id: "posttag-1"
+                                tagId: "tag-1"
+                                region: "us-east-1"
+                            },
+                            {
+                                id: "posttag-2"
+                                tagId: "tag-2"
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                }) { id }
+            }"#
+        );
+
+        // Query post with tags
+        let result = run_query_pretty!(
+            &runner,
+            r#"query {
+                findUniquePost(where: { id: "post-1" }) {
+                    id
+                    title
+                    region
+                    postTags {
+                        region
+                        tag {
+                            name
+                            color
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r##"
+        {
+          "data": {
+            "findUniquePost": {
+              "id": "post-1",
+              "title": "Business Tech Article",
+              "region": "us-east-1",
+              "postTags": [
+                {
+                  "region": "us-east-1",
+                  "tag": {
+                    "name": "technology",
+                    "color": "#0066CC"
+                  }
+                },
+                {
+                  "region": "us-east-1",
+                  "tag": {
+                    "name": "business",
+                    "color": "#CC6600"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "##);
+
+        Ok(())
+    }
+
+    // Connect/Disconnect Operations
+
+    #[connector_test(schema(relations_schema))]
+    async fn connect_existing_relations(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Connect user-1 to a new profile
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                updateOneUser(
+                    where: { id: "user-1" }
+                    data: {
+                        profile: {
+                            create: {
+                                id: "profile-new"
+                                bio: "Full Stack Developer"
+                                region: "us-east-1"
+                            }
+                        }
+                    }
+                ) {
+                    id
+                    profile {
+                        bio
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"updateOneUser":{"id":"user-1","profile":{"bio":"Full Stack Developer","region":"us-east-1"}}}}"#);
+
+        // Connect a new profile to user-2
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneUserProfile(data: {
+                    id: "profile-1"
+                    userId: "user-2"
+                    bio: "Data Scientist"
+                    region: "us-west-2"
+                }) { id }
+            }"#
+        );
+
+        // This will fail because user-2 already has a profile, and the old one can't be
+        // disconnected without deleting it.
+        assert_error!(
+            &runner,
+            r#"mutation {
+                updateOneUser(
+                    where: { id: "user-2" },
+                    data: {
+                        profile: {
+                            create: {
+                                id: "profile-2-new"
+                                bio: "Full Stack Developer"
+                                region: "us-west-2"
+                            }
+                        }
+                    }
+                ) {
+                    id
+                    profile { id }
+                }
+            }"#,
+            2014
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn disconnect_relations(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create user with profile
+        insta::assert_snapshot!(
+            run_query!(
+                &runner,
+                r#"mutation {
+                    createOneUser(data: {
+                        id: "user-disconnect"
+                        email: "disconnect@example.com"
+                        firstName: "Disconnect"
+                        lastName: "Test"
+                        region: "us-east-1"
+                        profile: {
+                            create: {
+                                id: "profile-disconnect"
+                                bio: "To be disconnected"
+                                region: "us-east-1"
+                            }
+                        }
+                    }) {
+                        id
+                        profile {
+                            id
+                            bio
+                        }
+                    }
+                }"#
+            ),
+            @r#"{"data":{"createOneUser":{"id":"user-disconnect","profile":{"id":"profile-disconnect","bio":"To be disconnected"}}}}"#
+        );
+
+        // Connect profile to another user.
+        insta::assert_snapshot!(
+            run_query!(
+                &runner,
+                r#"mutation {
+                    updateOneUser(
+                        where: { id: "user-1" }
+                        data: {
+                            profile: {
+                                connect: { id: "profile-disconnect" }
+                            }
+                        }
+                    ) {
+                        id
+                        profile {
+                            bio
+                        }
+                    }
+                }"#
+            ),
+            @r#"{"data":{"updateOneUser":{"id":"user-1","profile":{"bio":"To be disconnected"}}}}"#
+        );
+
+        // Verify it has been disconnected from the previous user
+        insta::assert_snapshot!(
+            run_query!(
+                &runner,
+                r#"query {
+                    findUniqueUser(where: { id: "user-disconnect" }) {
+                        id
+                        profile {
+                            id
+                        }
+                    }
+                }"#
+            ),
+            @r#"{"data":{"findUniqueUser":{"id":"user-disconnect","profile":null}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn query_cross_shard_organization_structure(runner: Runner) -> TestResult<()> {
+        // Setup from previous test
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOneOrganization(data: {
+                    id: "org-1"
+                    name: "TechCorp"
+                    region: "us-east-1"
+                    departments: {
+                        create: [
+                            {
+                                id: "dept-1"
+                                name: "Engineering"
+                                region: "us-east-1"
+                            },
+                            {
+                                id: "dept-2"
+                                name: "Sales"
+                                region: "us-west-2"
+                            }
+                        ]
+                    }
+                    employees: {
+                        create: [
+                            {
+                                id: "emp-1"
+                                firstName: "Alice"
+                                lastName: "Engineer"
+                                email: "alice@techcorp.com"
+                                departmentId: "dept-1"
+                                region: "us-east-1"
+                            },
+                            {
+                                id: "emp-2"
+                                firstName: "Bob"
+                                lastName: "Sales"
+                                email: "bob@techcorp.com"
+                                departmentId: "dept-2"
+                                region: "us-west-2"
+                            }
+                        ]
+                    }
+                }) { id }
+            }"#
+        );
+
+        // Query organization with all related data across shards
+        let result = run_query_pretty!(
+            &runner,
+            r#"query {
+                findUniqueOrganization(where: { id: "org-1" }) {
+                    id
+                    name
+                    region
+                    departments {
+                        id
+                        name
+                        region
+                        employees {
+                            firstName
+                            lastName
+                            region
+                        }
+                    }
+                    employees {
+                        id
+                        firstName
+                        region
+                        department {
+                            name
+                            region
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "findUniqueOrganization": {
+              "id": "org-1",
+              "name": "TechCorp",
+              "region": "us-east-1",
+              "departments": [
+                {
+                  "id": "dept-1",
+                  "name": "Engineering",
+                  "region": "us-east-1",
+                  "employees": [
+                    {
+                      "firstName": "Alice",
+                      "lastName": "Engineer",
+                      "region": "us-east-1"
+                    }
+                  ]
+                },
+                {
+                  "id": "dept-2",
+                  "name": "Sales",
+                  "region": "us-west-2",
+                  "employees": [
+                    {
+                      "firstName": "Bob",
+                      "lastName": "Sales",
+                      "region": "us-west-2"
+                    }
+                  ]
+                }
+              ],
+              "employees": [
+                {
+                  "id": "emp-1",
+                  "firstName": "Alice",
+                  "region": "us-east-1",
+                  "department": {
+                    "name": "Engineering",
+                    "region": "us-east-1"
+                  }
+                },
+                {
+                  "id": "emp-2",
+                  "firstName": "Bob",
+                  "region": "us-west-2",
+                  "department": {
+                    "name": "Sales",
+                    "region": "us-west-2"
+                  }
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    // Composite Shard Key Relations
+
+    #[connector_test(schema(relations_schema))]
+    async fn composite_shard_key_relations(runner: Runner) -> TestResult<()> {
+        // Create tenant with composite shard key
+        let result = run_query_pretty!(
+            &runner,
+            r#"mutation {
+                createOneTenant(data: {
+                    id: "tenant-1"
+                    name: "Enterprise Customer"
+                    region: "us-east-1"
+                    tier: "premium"
+                    projects: {
+                        create: [
+                            {
+                                id: "project-1"
+                                name: "Web Platform"
+                                region: "us-east-1"
+                                category: "web"
+                                tasks: {
+                                    create: [
+                                        {
+                                            id: "task-1"
+                                            title: "Setup Database"
+                                            region: "us-east-1"
+                                            priority: "high"
+                                        },
+                                        {
+                                            id: "task-2"
+                                            title: "Design UI"
+                                            region: "us-east-1"
+                                            priority: "medium"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                id: "project-2"
+                                name: "Mobile App"
+                                region: "us-east-1"
+                                category: "mobile"
+                                tasks: {
+                                    create: [
+                                        {
+                                            id: "task-3"
+                                            title: "Setup CI/CD"
+                                            region: "us-east-1"
+                                            priority: "high"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    }
+                }) {
+                    id
+                    name
+                    region
+                    tier
+                    projects {
+                        id
+                        name
+                        category
+                        region
+                        tasks {
+                            title
+                            priority
+                            region
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "createOneTenant": {
+              "id": "tenant-1",
+              "name": "Enterprise Customer",
+              "region": "us-east-1",
+              "tier": "premium",
+              "projects": [
+                {
+                  "id": "project-1",
+                  "name": "Web Platform",
+                  "category": "web",
+                  "region": "us-east-1",
+                  "tasks": [
+                    {
+                      "title": "Setup Database",
+                      "priority": "high",
+                      "region": "us-east-1"
+                    },
+                    {
+                      "title": "Design UI",
+                      "priority": "medium",
+                      "region": "us-east-1"
+                    }
+                  ]
+                },
+                {
+                  "id": "project-2",
+                  "name": "Mobile App",
+                  "category": "mobile",
+                  "region": "us-east-1",
+                  "tasks": [
+                    {
+                      "title": "Setup CI/CD",
+                      "priority": "high",
+                      "region": "us-east-1"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn query_composite_shard_hierarchy(runner: Runner) -> TestResult<()> {
+        // Setup hierarchical data with composite shard keys
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyTenant(data: [
+                    {
+                        id: "tenant-1"
+                        name: "StartupCorp"
+                        region: "us-west-2"
+                        tier: "basic"
+                    },
+                    {
+                        id: "tenant-2"
+                        name: "EnterpriseCorp"
+                        region: "us-east-1"
+                        tier: "premium"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyProject(data: [
+                    {
+                        id: "project-1"
+                        name: "Quick Website"
+                        tenantId: "tenant-1"
+                        region: "us-west-2"
+                        category: "web"
+                    },
+                    {
+                        id: "project-2"
+                        name: "Enterprise Platform"
+                        tenantId: "tenant-2"
+                        region: "us-east-1"
+                        category: "platform"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyTask(data: [
+                    {
+                        id: "task-1"
+                        title: "Create Landing Page"
+                        projectId: "project-1"
+                        region: "us-west-2"
+                        priority: "low"
+                    },
+                    {
+                        id: "task-2"
+                        title: "Implement Authentication"
+                        projectId: "project-2"
+                        region: "us-east-1"
+                        priority: "critical"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Query across the hierarchy with composite shard keys
+        let result = run_query_pretty!(
+            &runner,
+            r#"query {
+                findManyTenant(
+                    where: {
+                        region: "us-east-1"
+                        tier: "premium"
+                    }
+                ) {
+                    id
+                    name
+                    region
+                    tier
+                    projects(
+                        where: {
+                            region: "us-east-1"
+                        }
+                    ) {
+                        name
+                        category
+                        region
+                        tasks(
+                            where: {
+                                region: "us-east-1"
+                                priority: "critical"
+                            }
+                        ) {
+                            title
+                            priority
+                            region
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "findManyTenant": [
+              {
+                "id": "tenant-2",
+                "name": "EnterpriseCorp",
+                "region": "us-east-1",
+                "tier": "premium",
+                "projects": [
+                  {
+                    "name": "Enterprise Platform",
+                    "category": "platform",
+                    "region": "us-east-1",
+                    "tasks": [
+                      {
+                        "title": "Implement Authentication",
+                        "priority": "critical",
+                        "region": "us-east-1"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn delete_relations_across_shards(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create nested structure
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOnePost(data: {
+                    id: "post-cascade"
+                    title: "Post to be deleted"
+                    content: "This will cascade"
+                    authorId: "user-1"
+                    region: "us-east-1"
+                    comments: {
+                        create: [
+                            {
+                                id: "comment-cascade-1"
+                                content: "First comment"
+                                authorId: "user-2"
+                                region: "us-west-2"
+                            },
+                            {
+                                id: "comment-cascade-2"
+                                content: "Second comment"
+                                authorId: "user-3"
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                    postTags: {
+                        create: [
+                            {
+                                id: "posttag-cascade"
+                                tagId: "tag-1"
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                }) { id }
+            }"#
+        );
+
+        // Try to delete the post
+        assert_error!(
+            &runner,
+            r#"mutation {
+                deleteOnePost(where: { id: "post-cascade" }) {
+                    id
+                    title
+                }
+            }"#,
+            2014
+        );
+
+        // Delete related data
+        run_query!(
+            &runner,
+            r#"mutation {
+                deleteManyComment(where: { postId: "post-cascade" }) {
+                    count
+                }
+            }"#
+        );
+        run_query!(
+            &runner,
+            r#"mutation {
+                deleteManyPostTag(where: { postId: "post-cascade" }) {
+                    count
+                }
+            }"#
+        );
+
+        // Then delete the post
+        let result = run_query!(
+            &runner,
+            r#"mutation {
+                deleteOnePost(where: { id: "post-cascade" }) {
+                    id
+                    title
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"deleteOnePost":{"id":"post-cascade","title":"Post to be deleted"}}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn relation_filters_across_shards(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create posts and comments across shards
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyPost(data: [
+                    {
+                        id: "filter-post-1"
+                        title: "Popular Post"
+                        content: "This will have many comments"
+                        authorId: "user-1"
+                        published: true
+                        region: "us-east-1"
+                    },
+                    {
+                        id: "filter-post-2"
+                        title: "Unpopular Post"
+                        content: "This will have no comments"
+                        authorId: "user-2"
+                        published: true
+                        region: "us-west-2"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        run_query!(
+            &runner,
+            r#"mutation {
+                createManyComment(data: [
+                    {
+                        id: "filter-comment-1"
+                        content: "Great post!"
+                        authorId: "user-2"
+                        postId: "filter-post-1"
+                        region: "us-west-2"
+                    },
+                    {
+                        id: "filter-comment-2"
+                        content: "Amazing content!"
+                        authorId: "user-3"
+                        postId: "filter-post-1"
+                        region: "us-east-1"
+                    }
+                ]) { count }
+            }"#
+        );
+
+        // Find posts that have comments (some relation filter)
+        let result = run_query_pretty!(
+            &runner,
+            r#"query {
+                findManyPost(
+                    where: {
+                        comments: {
+                            some: {
+                                content: { contains: "Great" }
+                            }
+                        }
+                    }
+                ) {
+                    id
+                    title
+                    region
+                    comments {
+                        content
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "findManyPost": [
+              {
+                "id": "filter-post-1",
+                "title": "Popular Post",
+                "region": "us-east-1",
+                "comments": [
+                  {
+                    "content": "Great post!",
+                    "region": "us-west-2"
+                  },
+                  {
+                    "content": "Amazing content!",
+                    "region": "us-east-1"
+                  }
+                ]
+              }
+            ]
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn nested_writes_across_shards(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOnePost(data: {
+                    id: "post-1"
+                    authorId: "user-1"
+                    title: "Initial Post"
+                    content: "Initial post content"
+                    region: "us-east-1"
+                    comments: {
+                        create: [
+                            {
+                                id: "comment-1"
+                                content: "Great post!"
+                                authorId: "user-2"
+                                region: "us-east-1"
+                            }
+                        ]
+                    }
+                }) {
+                    id
+                }
+            }"#
+        );
+
+        // Complex nested write operation
+        let result = run_query_pretty!(
+            &runner,
+            r#"mutation {
+                updateOneUser(
+                    where: { id: "user-1" }
+                    data: {
+                        posts: {
+                            create: [
+                                {
+                                    id: "nested-post-1"
+                                    title: "Nested Created Post"
+                                    content: "Created via nested write"
+                                    region: "us-east-1"
+                                    comments: {
+                                        create: [
+                                            {
+                                                id: "nested-comment-1"
+                                                content: "Deeply nested comment"
+                                                authorId: "user-2"
+                                                region: "us-west-2"
+                                            }
+                                        ]
+                                    }
+                                }
+                            ]
+                            update: {
+                                where: { id: "post-1" }
+                                data: { title: "Updated via nested write" }
+                            }
+                        }
+                        profile: {
+                            upsert: {
+                                create: {
+                                    id: "upserted-profile"
+                                    bio: "Created via upsert"
+                                    region: "us-east-1"
+                                }
+                                update: {
+                                    bio: "Updated via upsert"
+                                }
+                            }
+                        }
+                    }
+                ) {
+                    id
+                    posts {
+                        id
+                        title
+                        region
+                        comments {
+                            content
+                            region
+                        }
+                    }
+                    profile {
+                        bio
+                        region
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "updateOneUser": {
+              "id": "user-1",
+              "posts": [
+                {
+                  "id": "nested-post-1",
+                  "title": "Nested Created Post",
+                  "region": "us-east-1",
+                  "comments": [
+                    {
+                      "content": "Deeply nested comment",
+                      "region": "us-west-2"
+                    }
+                  ]
+                },
+                {
+                  "id": "post-1",
+                  "title": "Updated via nested write",
+                  "region": "us-east-1",
+                  "comments": [
+                    {
+                      "content": "Great post!",
+                      "region": "us-east-1"
+                    }
+                  ]
+                }
+              ],
+              "profile": {
+                "bio": "Created via upsert",
+                "region": "us-east-1"
+              }
+            }
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+
+    #[connector_test(schema(relations_schema))]
+    async fn relation_count_and_aggregates(runner: Runner) -> TestResult<()> {
+        setup_relation_test_data(&runner).await?;
+
+        // Create posts with different numbers of comments
+        run_query!(
+            &runner,
+            r#"mutation {
+                createOnePost(data: {
+                    id: "count-post-1"
+                    title: "Post with Many Comments"
+                    content: "Popular post"
+                    authorId: "user-1"
+                    region: "us-east-1"
+                    comments: {
+                        create: [
+                            {
+                                id: "count-comment-1"
+                                content: "First comment"
+                                authorId: "user-2"
+                                region: "us-west-2"
+                            },
+                            {
+                                id: "count-comment-2"
+                                content: "Second comment"
+                                authorId: "user-3"
+                                region: "us-east-1"
+                            },
+                            {
+                                id: "count-comment-3"
+                                content: "Third comment"
+                                authorId: "user-2"
+                                region: "us-west-2"
+                            }
+                        ]
+                    }
+                }) { id }
+            }"#
+        );
+
+        // Query with relation counts
+        let result = run_query_pretty!(
+            &runner,
+            r#"query {
+                findManyUser {
+                    id
+                    firstName
+                    region
+                    _count {
+                        posts
+                        authoredComments
+                    }
+                    posts {
+                        id
+                        title
+                        _count {
+                            comments
+                        }
+                    }
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"
+        {
+          "data": {
+            "findManyUser": [
+              {
+                "id": "user-1",
+                "firstName": "John",
+                "region": "us-east-1",
+                "_count": {
+                  "posts": 1,
+                  "authoredComments": 0
+                },
+                "posts": [
+                  {
+                    "id": "count-post-1",
+                    "title": "Post with Many Comments",
+                    "_count": {
+                      "comments": 3
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "user-2",
+                "firstName": "Jane",
+                "region": "us-west-2",
+                "_count": {
+                  "posts": 0,
+                  "authoredComments": 2
+                },
+                "posts": []
+              },
+              {
+                "id": "user-3",
+                "firstName": "Bob",
+                "region": "us-east-1",
+                "_count": {
+                  "posts": 0,
+                  "authoredComments": 1
+                },
+                "posts": []
+              }
+            ]
+          }
+        }
+        "#);
+
+        Ok(())
+    }
+}

--- a/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/update.rs
@@ -60,14 +60,14 @@ pub(crate) async fn update_one_without_selection(
 
         let record = ids.into_iter().next().map(|id| SingleRecord {
             record: Record::from(id),
-            field_names: model.primary_identifier().db_names().collect_vec(),
+            field_names: model.shard_aware_primary_identifier().db_names().collect_vec(),
         });
 
         return Ok(record);
     }
 
     // Pick the primary identifiers args from the WriteArgs if there are any.
-    let id_args = pick_args(&model.primary_identifier().into(), &args);
+    let id_args = pick_args(&model.shard_aware_primary_identifier().into(), &args);
     // Perform the update and return the ids on which we've applied the update.
     // Note: We are _not_ getting back the ids from the update. Either we got some ids passed from the parent operation or we perform a read _before_ doing the update.
     let filter = record_filter.filter.clone();
@@ -83,7 +83,7 @@ pub(crate) async fn update_one_without_selection(
 
     let record = merged_ids.into_iter().next().map(|id| SingleRecord {
         record: Record::from(id),
-        field_names: model.primary_identifier().db_names().collect(),
+        field_names: model.shard_aware_primary_identifier().db_names().collect(),
     });
 
     Ok(record)

--- a/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
+++ b/query-engine/connectors/sql-query-connector/src/database/operations/write.rs
@@ -51,7 +51,7 @@ pub(crate) async fn create_record(
     selected_fields: FieldSelection,
     ctx: &Context<'_>,
 ) -> crate::Result<SingleRecord> {
-    let id_field: FieldSelection = model.primary_identifier();
+    let id_field: FieldSelection = model.shard_aware_primary_identifier();
 
     let returned_id = if sql_family.is_mysql() {
         generate_id(conn, &id_field, &args, ctx)

--- a/query-engine/connectors/sql-query-connector/src/query_ext.rs
+++ b/query-engine/connectors/sql-query-connector/src/query_ext.rs
@@ -105,7 +105,7 @@ impl<Q: Queryable + ?Sized> QueryExt for Q {
         filter: Filter,
         ctx: &Context<'_>,
     ) -> crate::Result<Vec<SelectionResult>> {
-        let model_id: ModelProjection = model.primary_identifier().into();
+        let model_id: ModelProjection = model.shard_aware_primary_identifier().into();
         let id_cols: Vec<Column<'static>> = model_id.as_columns(ctx).collect();
         let condition = FilterBuilder::without_top_level_joins().visit_filter(filter, ctx);
 

--- a/query-engine/core/src/interpreter/interpreter_impl.rs
+++ b/query-engine/core/src/interpreter/interpreter_impl.rs
@@ -7,7 +7,7 @@ use crate::{Query, QueryResult};
 use connector::ConnectionLike;
 use futures::future::BoxFuture;
 use query_structure::prelude::*;
-use std::{collections::HashMap, fmt};
+use std::{collections::HashMap, fmt, slice};
 use telemetry::TraceParent;
 use tracing::Instrument;
 
@@ -46,7 +46,9 @@ impl ExpressionResult {
         let converted = match self {
             Self::Query(ref result) => match result {
                 QueryResult::Id(id) => match id {
-                    Some(id) if field_selection.matches(id) => Some(vec![id.clone()]),
+                    Some(id) if field_selection.matches(id) => {
+                        Some(id.clone().split_into(slice::from_ref(field_selection)))
+                    }
                     None => Some(vec![]),
                     Some(id) => {
                         trace!(

--- a/query-engine/core/src/interpreter/query_interpreters/write.rs
+++ b/query-engine/core/src/interpreter/query_interpreters/write.rs
@@ -198,7 +198,7 @@ async fn update_one(
         }
         UpdateRecord::WithoutSelection(_) => {
             let res = res
-                .map(|record| record.extract_selection_result(&q.model().primary_identifier()))
+                .map(|record| record.extract_selection_result(&q.model().shard_aware_primary_identifier()))
                 .transpose()?;
 
             Ok(QueryResult::Id(res))

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -97,7 +97,7 @@ impl WriteQuery {
             }
             Self::UpdateRecord(UpdateRecord::WithSelection(ur)) => Some(&ur.selected_fields),
             Self::UpdateRecord(UpdateRecord::WithoutSelection(_)) => {
-                return Some(Cow::Owned(self.model().primary_identifier()))
+                return Some(Cow::Owned(self.model().shard_aware_primary_identifier()))
             }
             Self::DeleteRecord(DeleteRecord { selected_fields, .. }) => selected_fields.as_ref().map(|sf| &sf.fields),
             Self::UpdateManyRecords(UpdateManyRecords { selected_fields, .. }) => {

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -950,7 +950,7 @@ impl QueryGraph {
 
             // Create reload node and connect it to the `node`.
             let model = query.model();
-            let primary_model_id = model.primary_identifier();
+            let primary_model_id = model.shard_aware_primary_identifier();
 
             let read_query = ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
                 name: "reload".into(),

--- a/query-engine/core/src/query_graph_builder/read/utils.rs
+++ b/query-engine/core/src/query_graph_builder/read/utils.rs
@@ -28,7 +28,7 @@ pub fn collect_selected_fields(
     model: &Model,
     query_schema: &QuerySchema,
 ) -> QueryGraphBuilderResult<FieldSelection> {
-    let model_id = model.primary_identifier();
+    let model_id = model.shard_aware_primary_identifier();
     let selected_fields = pairs_to_selections(model, from_pairs, query_schema)?;
 
     let selection = FieldSelection::new(selected_fields);
@@ -45,7 +45,7 @@ pub fn collect_selected_fields(
 /// Creates a `FieldSelection` from a query selection, which contains only scalar fields.
 /// Automatically adds model IDs to the selected fields as well.
 pub fn collect_selected_scalars(from_pairs: &[FieldPair<'_>], model: &Model) -> FieldSelection {
-    let model_id = model.primary_identifier();
+    let model_id = model.shard_aware_primary_identifier();
     let selected_fields = pairs_to_scalar_selections(model, from_pairs);
     let selection = FieldSelection::new(selected_fields);
 

--- a/query-engine/core/src/query_graph_builder/write/connect.rs
+++ b/query-engine/core/src/query_graph_builder/write/connect.rs
@@ -42,8 +42,8 @@ pub(crate) fn connect_records_node(
 ) -> QueryGraphBuilderResult<NodeRef> {
     assert!(parent_relation_field.relation().is_many_to_many());
 
-    let parent_model_id = parent_relation_field.model().primary_identifier();
-    let child_model_id = parent_relation_field.related_model().primary_identifier();
+    let parent_model_id = parent_relation_field.model().shard_aware_primary_identifier();
+    let child_model_id = parent_relation_field.related_model().shard_aware_primary_identifier();
 
     let connect = WriteQuery::ConnectRecords(ConnectRecords {
         parent_id: None,

--- a/query-engine/core/src/query_graph_builder/write/create.rs
+++ b/query-engine/core/src/query_graph_builder/write/create.rs
@@ -40,7 +40,7 @@ pub(crate) fn create_record(
             &create_node,
             &read_node,
             QueryGraphDependency::ProjectedDataDependency(
-                model.primary_identifier(),
+                model.shard_aware_primary_identifier(),
                 Box::new(move |mut read_node, mut parent_ids| {
                     let parent_id = parent_ids.pop().expect("parent id should be present");
 
@@ -136,7 +136,7 @@ pub(crate) fn create_record_node_from_args(
     args: WriteArgs,
     nested: Vec<(Zipper<RelationFieldId>, ParsedInputMap<'_>)>,
 ) -> QueryGraphBuilderResult<NodeRef> {
-    let selected_fields = model.primary_identifier();
+    let selected_fields = model.shard_aware_primary_identifier();
     let selection_order = selected_fields.db_names().collect();
 
     let cr = CreateRecord {

--- a/query-engine/core/src/query_graph_builder/write/delete.rs
+++ b/query-engine/core/src/query_graph_builder/write/delete.rs
@@ -53,7 +53,7 @@ pub(crate) fn delete_record(
             &delete_node,
             &check_node,
             QueryGraphDependency::ProjectedDataSinkDependency(
-                model.primary_identifier(),
+                model.shard_aware_primary_identifier(),
                 RowSink::Discard,
                 Some(DataExpectation::non_empty_rows(
                     MissingRecord::builder().operation(DataOperation::Delete).build(),
@@ -95,7 +95,7 @@ pub(crate) fn delete_record(
             // NOTE: We do not actually use primary identifier returned from `read_node`, this edge
             // is just checking if any records matched the filter.
             QueryGraphDependency::ProjectedDataDependency(
-                model.primary_identifier(),
+                model.shard_aware_primary_identifier(),
                 Box::new(|delete_node, _| Ok(delete_node)),
                 Some(DataExpectation::non_empty_rows(
                     MissingRecord::builder().operation(DataOperation::Delete).build(),
@@ -124,7 +124,7 @@ pub fn delete_many_records(
 
     let limit = validate_limit(field.arguments.lookup(args::LIMIT))?;
 
-    let model_id = model.primary_identifier();
+    let model_id = model.shard_aware_primary_identifier();
     let record_filter = filter.clone().into();
     let delete_many = WriteQuery::DeleteManyRecords(DeleteManyRecords {
         model: model.clone(),

--- a/query-engine/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-engine/core/src/query_graph_builder/write/disconnect.rs
@@ -40,8 +40,8 @@ pub(crate) fn disconnect_records_node(
 ) -> QueryGraphBuilderResult<NodeRef> {
     assert!(parent_relation_field.relation().is_many_to_many());
 
-    let parent_model_id = parent_relation_field.model().primary_identifier();
-    let child_model_id = parent_relation_field.related_model().primary_identifier();
+    let parent_model_id = parent_relation_field.model().shard_aware_primary_identifier();
+    let child_model_id = parent_relation_field.related_model().shard_aware_primary_identifier();
 
     let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
         parent_id: None,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -79,7 +79,11 @@ fn handle_many_to_many(
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let expected_connects = filter.size();
-    let child_read_query = utils::read_ids_infallible(child_model.clone(), child_model.primary_identifier(), filter);
+    let child_read_query = utils::read_ids_infallible(
+        child_model.clone(),
+        child_model.shard_aware_primary_identifier(),
+        filter,
+    );
     let child_node = graph.create_node(child_read_query);
 
     graph.create_edge(&parent_node, &child_node, QueryGraphDependency::ExecutionOrder)?;
@@ -407,7 +411,10 @@ fn handle_one_to_one_parent_update(
 
         let parent_linking_fields = parent_relation_field.linking_fields();
         let child_linking_fields = parent_relation_field.related_field().linking_fields();
-        let child_model_identifier = parent_relation_field.related_field().model().primary_identifier();
+        let child_model_identifier = parent_relation_field
+            .related_field()
+            .model()
+            .shard_aware_primary_identifier();
 
         graph.create_edge(
             &read_new_child_node,
@@ -494,7 +501,7 @@ fn handle_one_to_one_parent_update(
             ),
         )?;
 
-        let parent_model_identifier = parent_relation_field.model().primary_identifier();
+        let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
         graph.create_edge(
             &idempotent_check_node,
             &update_parent_node,
@@ -593,7 +600,10 @@ fn handle_one_to_one_parent_create(
 
         let parent_linking_fields = parent_relation_field.linking_fields();
         let child_linking_fields = parent_relation_field.related_field().linking_fields();
-        let child_model_identifier = parent_relation_field.related_field().model().primary_identifier();
+        let child_model_identifier = parent_relation_field
+            .related_field()
+            .model()
+            .shard_aware_primary_identifier();
 
         graph.create_edge(
             &read_new_child_node,

--- a/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -108,7 +108,7 @@ fn handle_many_to_many(
         let filter = extract_unique_filter(where_map, child_model)?;
         let read_node = graph.create_node(utils::read_id_infallible(
             child_model.clone(),
-            child_model.primary_identifier(),
+            child_model.shard_aware_primary_identifier(),
             filter,
         ));
 
@@ -126,7 +126,7 @@ fn handle_many_to_many(
             &read_node,
             &if_node,
             QueryGraphDependency::ProjectedDataSinkDependency(
-                child_model.primary_identifier(),
+                child_model.shard_aware_primary_identifier(),
                 RowSink::AllRows(&IfInput),
                 None,
             ),
@@ -279,7 +279,7 @@ fn one_to_many_inlined_child(
             &read_node,
             &if_node,
             QueryGraphDependency::ProjectedDataSinkDependency(
-                child_model.primary_identifier(),
+                child_model.shard_aware_primary_identifier(),
                 RowSink::AllRows(&IfInput),
                 None,
             ),
@@ -417,7 +417,7 @@ fn one_to_many_inlined_parent(
         &read_node,
         &if_node,
         QueryGraphDependency::ProjectedDataSinkDependency(
-            child_model.primary_identifier(),
+            child_model.shard_aware_primary_identifier(),
             RowSink::AllRows(&IfInput),
             None,
         ),
@@ -557,7 +557,7 @@ fn one_to_one_inlined_parent(
         &read_node,
         &if_node,
         QueryGraphDependency::ProjectedDataSinkDependency(
-            child_model.primary_identifier(),
+            child_model.shard_aware_primary_identifier(),
             RowSink::AllRows(&IfInput),
             None,
         ),
@@ -618,7 +618,7 @@ fn one_to_one_inlined_parent(
             &parent_node,
             &update_parent_node,
             QueryGraphDependency::ProjectedDataDependency(
-                parent_model.primary_identifier(),
+                parent_model.shard_aware_primary_identifier(),
                 Box::new(move |mut update_parent_node, mut parent_ids| {
                     let parent_id = parent_ids.pop().expect("parent id should be present");
 
@@ -736,7 +736,7 @@ fn one_to_one_inlined_child(
     create_data: ParsedInputMap<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    let child_model_identifier = child_model.primary_identifier();
+    let child_model_identifier = child_model.shard_aware_primary_identifier();
     let parent_link = parent_relation_field.linking_fields();
     let child_link = parent_relation_field.related_field().linking_fields();
     let child_relation_field = parent_relation_field.related_field();
@@ -758,7 +758,7 @@ fn one_to_one_inlined_child(
         &read_new_child_node,
         &if_node,
         QueryGraphDependency::ProjectedDataSinkDependency(
-            child_model.primary_identifier(),
+            child_model.shard_aware_primary_identifier(),
             RowSink::AllRows(&IfInput),
             None,
         ),

--- a/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -60,7 +60,7 @@ pub fn nested_create(
     if should_use_bulk_create {
         // Create all child records in a single query.
         let selected_fields = if relation.is_many_to_many() {
-            let selected_fields = child_model.primary_identifier();
+            let selected_fields = child_model.shard_aware_primary_identifier();
             let selection_order = selected_fields.db_names().collect();
             Some(CreateManyRecordsFields {
                 fields: selected_fields,
@@ -547,7 +547,7 @@ fn handle_one_to_one(
             &parent_node,
             &update_node,
             QueryGraphDependency::ProjectedDataDependency(
-                parent_relation_field.model().primary_identifier(),
+                parent_relation_field.model().shard_aware_primary_identifier(),
                 Box::new(move |mut update_node, mut parent_ids| {
                     let parent_id = parent_ids.pop().expect("parent id should be present");
 

--- a/query-engine/core/src/query_graph_builder/write/nested/delete_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/delete_nested.rs
@@ -27,7 +27,7 @@ pub fn nested_delete(
     value: ParsedInputValue<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
+    let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
     if parent_relation_field.is_list() {
         let filters: Vec<Filter> = utils::coerce_vec(value)
@@ -140,7 +140,7 @@ pub fn nested_delete_many(
     value: ParsedInputValue<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
+    let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
     for value in utils::coerce_vec(value) {
         let as_map: ParsedInputMap<'_> = value.try_into()?;

--- a/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -168,7 +168,7 @@ fn handle_one_to_x(
         if parent_relation_field.is_inlined_on_enclosing_model() {
             // Inlined on parent
             let parent_model = parent_relation_field.model();
-            let extractor_model_id = parent_model.primary_identifier();
+            let extractor_model_id = parent_model.shard_aware_primary_identifier();
             let null_record_id = SelectionResult::from(&parent_relation_field.linking_fields());
             // If the relation is inlined on the parent and a filter is applied on the child then update is done on the parent table.
             // Therefore, the filter applied on the child needs to be converted to a "relational" filter so that the connector renders the adequate SQL to join the Child table.
@@ -182,7 +182,7 @@ fn handle_one_to_x(
         } else {
             // Inlined on child
             let child_model = child_relation_field.model();
-            let extractor_model_id = child_model.primary_identifier();
+            let extractor_model_id = child_model.shard_aware_primary_identifier();
             let null_record_id = SelectionResult::from(&child_relation_field.linking_fields());
 
             (

--- a/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -91,9 +91,9 @@ fn handle_many_to_many(
     parent_relation_field: &RelationFieldRef,
     filter: Filter,
 ) -> QueryGraphBuilderResult<()> {
-    let parent_model_identifier = parent_relation_field.model().primary_identifier();
+    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
     let child_model = parent_relation_field.related_model();
-    let child_model_identifier = child_model.primary_identifier();
+    let child_model_identifier = child_model.shard_aware_primary_identifier();
     let read_old_node =
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
 
@@ -219,7 +219,7 @@ fn handle_one_to_many(
     parent_relation_field: &RelationFieldRef,
     filter: Filter,
 ) -> QueryGraphBuilderResult<()> {
-    let child_model_identifier = parent_relation_field.related_model().primary_identifier();
+    let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
     let child_link = parent_relation_field.related_field().linking_fields();
     let parent_link = parent_relation_field.linking_fields();
     let empty_child_link = SelectionResult::from(&child_link);

--- a/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -90,7 +90,7 @@ pub fn nested_update(
             utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter.clone())?;
 
         let update_node = update::update_record_node(graph, query_schema, filter, child_model.clone(), data_map, None)?;
-        let child_model_identifier = parent_relation_field.related_model().primary_identifier();
+        let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
         graph.create_edge(
             &find_child_records_node,
@@ -128,7 +128,7 @@ pub fn nested_update_many(
         let data_value = map.swap_remove(args::DATA).unwrap();
         let data_map: ParsedInputMap<'_> = data_value.try_into()?;
         let where_map: ParsedInputMap<'_> = where_arg.try_into()?;
-        let child_model_identifier = parent_relation_field.related_model().primary_identifier();
+        let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
         let filter = extract_filter(where_map, child_model)?;
 

--- a/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-engine/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -102,7 +102,7 @@ pub fn nested_upsert(
     value: ParsedInputValue<'_>,
 ) -> QueryGraphBuilderResult<()> {
     let child_model = parent_relation_field.related_model();
-    let child_model_identifier = child_model.primary_identifier();
+    let child_model_identifier = child_model.shard_aware_primary_identifier();
 
     for value in coerce_vec(value) {
         let parent_link = parent_relation_field.linking_fields();
@@ -211,7 +211,7 @@ pub fn nested_upsert(
             connect::connect_records_node(graph, &parent_node, &create_node, parent_relation_field, 1)?;
         } else if parent_relation_field.is_inlined_on_enclosing_model() {
             let parent_model = parent_relation_field.model();
-            let parent_model_id = parent_model.primary_identifier();
+            let parent_model_id = parent_model.shard_aware_primary_identifier();
             let update_node = utils::update_records_node_placeholder(graph, filter, parent_model.clone());
 
             // Edge to retrieve the finder

--- a/query-engine/core/src/query_graph_builder/write/upsert.rs
+++ b/query-engine/core/src/query_graph_builder/write/upsert.rs
@@ -96,7 +96,7 @@ pub(crate) fn upsert_record(
 
     graph.flag_transactional();
 
-    let model_id = model.primary_identifier();
+    let model_id = model.shard_aware_primary_identifier();
 
     let read_parent_records = utils::read_ids_infallible(model.clone(), model_id.clone(), filter.clone());
     let read_parent_records_node = graph.create_node(read_parent_records);

--- a/query-engine/query-builders/sql-query-builder/src/lib.rs
+++ b/query-engine/query-builders/sql-query-builder/src/lib.rs
@@ -216,7 +216,7 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
         mut args: WriteArgs,
         selected_fields: &FieldSelection,
     ) -> Result<CreateRecord, Box<dyn std::error::Error + Send + Sync>> {
-        let id_selection = model.primary_identifier();
+        let id_selection = model.shard_aware_primary_identifier();
 
         let (select_defaults, last_insert_id_field, merge_values) = if self.context.sql_family().is_mysql() {
             let (field_placeholders, query): (Vec<_>, Select<'static>) =

--- a/query-engine/query-builders/sql-query-builder/src/limit.rs
+++ b/query-engine/query-builders/sql-query-builder/src/limit.rs
@@ -10,7 +10,7 @@ pub fn wrap_with_limit_subquery_if_needed<'a>(
 ) -> ConditionTree<'a> {
     if let Some(limit) = limit {
         let columns = model
-            .primary_identifier()
+            .shard_aware_primary_identifier()
             .as_scalar_fields()
             .expect("primary identifier must contain scalar fields")
             .into_iter()

--- a/query-engine/query-builders/sql-query-builder/src/write.rs
+++ b/query-engine/query-builders/sql-query-builder/src/write.rs
@@ -215,7 +215,7 @@ pub fn chunk_update_with_ids(
     filter_condition: ConditionTree<'static>,
     ctx: &Context<'_>,
 ) -> Vec<Query<'static>> {
-    let columns: Vec<_> = ModelProjection::from(model.primary_identifier())
+    let columns: Vec<_> = ModelProjection::from(model.shard_aware_primary_identifier())
         .as_columns(ctx)
         .collect();
 
@@ -307,7 +307,7 @@ pub fn delete_many_from_ids_and_filter(
     limit: Option<usize>,
     ctx: &Context<'_>,
 ) -> Vec<Query<'static>> {
-    let columns: Vec<_> = ModelProjection::from(model.primary_identifier())
+    let columns: Vec<_> = ModelProjection::from(model.shard_aware_primary_identifier())
         .as_columns(ctx)
         .collect();
 

--- a/query-engine/query-structure/src/field_selection.rs
+++ b/query-engine/query-structure/src/field_selection.rs
@@ -177,7 +177,8 @@ impl FieldSelection {
 
     /// Checks if a given `SelectionResult` belongs to this `FieldSelection`.
     pub fn matches(&self, result: &SelectionResult) -> bool {
-        result.pairs.iter().all(|(rt, _)| self.selections.contains(rt))
+        self.selections()
+            .all(|sf| result.pairs().any(|(result_field, _)| result_field == sf))
     }
 
     /// Merges all given `FieldSelection` a set union of all.


### PR DESCRIPTION
First pass of the `@shardKey` support in QE/QC implementation.

There still are some cases that can be made more optimal if we add a way to specify the relationship between the `@shardKey` attributes between different models in the schema if all related records are stored in the same shard. 

Closes: https://linear.app/prisma-company/issue/ORM-1032/make-queries-that-use-primary-identifier-shard-aware