### PR TITLE
fix(query-builders): never skip writes when partitioning

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/create_many.rs
@@ -473,6 +473,58 @@ mod create_many {
 
         Ok(())
     }
+
+    fn schema_8() -> String {
+        indoc! {
+            r#"
+                model TestModel {
+                    #id(id, Int, @id)
+                    field1  Int
+                    field2  Int
+                    field3  Int
+                    field4  Int
+                    field5  Int
+                    field6  Int
+                    field7  Int
+                    field8  Int
+                    field9  Int
+                    field10 Int
+                    field11 Int
+                    field12 Int
+                }
+            "#
+        }
+        .to_owned()
+    }
+
+    #[connector_test(schema(schema_8))]
+    async fn create_many_with_many_fields(runner: Runner) -> TestResult<()> {
+        const FIELDS_IN_TEST_MODEL: usize = 12;
+
+        if let Some(max_bind_values) = runner.max_bind_values() {
+            if !runner.connector_version().is_wasm() {
+                assert!(max_bind_values < FIELDS_IN_TEST_MODEL, "When QUERY_BATCH_SIZE is set, its value must be less than {FIELDS_IN_TEST_MODEL}, otherwise the test will not be testing what it's supposed to; instead got {max_bind_values}. Either update this test, or the QUERY_BATCH_SIZE env var value in .envrc and GitHub Actions pipelines");
+            }
+        }
+
+        let result = run_query!(
+            runner,
+            r#"mutation {
+                createManyTestModel(data: [
+                    { id: 1, field1: 1, field2: 2, field3: 3, field4: 4, field5: 5, field6: 6, field7: 7, field8: 8, field9: 9, field10: 10, field11: 11, field12: 12 },
+                    { id: 2, field1: 1, field2: 2, field3: 3, field4: 4, field5: 5, field6: 6, field7: 7, field8: 8, field9: 9, field10: 10, field11: 11, field12: 12 },
+                    { id: 3, field1: 1, field2: 2, field3: 3, field4: 4, field5: 5, field6: 6, field7: 7, field8: 8, field9: 9, field10: 10, field11: 11, field12: 12 },
+                    { id: 4, field1: 1, field2: 2, field3: 3, field4: 4, field5: 5, field6: 6, field7: 7, field8: 8, field9: 9, field10: 10, field11: 11, field12: 12 },
+                ]) {
+                    count
+                }
+            }"#
+        );
+
+        insta::assert_snapshot!(result, @r#"{"data":{"createManyTestModel":{"count":4}}}"#);
+
+        Ok(())
+    }
 }
 
 #[test_suite(schema(json_opt), exclude(MySql(5.6)), capabilities(CreateMany, Json))]

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -319,7 +319,7 @@ impl ConnectorVersion {
     /// Determines if the connector uses a driver adapter implemented in Wasm.
     /// Do not delete! This is used because the `#[cfg(target_arch = "wasm32")]` conditional compilation
     /// directive doesn't work in the test runner.
-    fn is_wasm(&self) -> bool {
+    pub fn is_wasm(&self) -> bool {
         matches!(
             self,
             Self::Postgres(Some(PostgresVersion::PgJsWasm))


### PR DESCRIPTION
The partitioning logic had a bug: if any write query contained more parameters than than `max_bind_values`, the entire write was skipped. It's rather unlikely for this to happen in practice, but it was easily possible in our tests, because we set `QUERY_BATCH_SIZE` to 10 in tests in order to test partitioning and chunking.

This change ensures that we never skip writes when partitioning and put the writes which are too large into their own separate batches (and let them fail on the database level if they genuinely exceed the real parameter limit of the database). An alternative would've been to panic or return an error ourselves (and raise the `QUERY_BATCH_SIZE` in tests and update the tests which depend on it) but this seems preferable to me.