### PR TITLE
feat(qe): allow connecting to vitess without database name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "mysql_async"
 version = "0.31.3"
-source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#0d40d0d2c332fc97512bff81e82e62002f03c224"
+source = "git+https://github.com/prisma/mysql_async?branch=vendored-openssl#c4c841c9d03e361df7377264a075335a823534ee"
 dependencies = [
  "bytes",
  "crossbeam",

--- a/libs/driver-adapters/src/types.rs
+++ b/libs/driver-adapters/src/types.rs
@@ -27,34 +27,30 @@ pub(crate) struct JsConnectionInfo {
 
 impl JsConnectionInfo {
     pub fn into_external_connection_info(self, provider: &AdapterProvider) -> ExternalConnectionInfo {
-        let schema_name = self.get_schema_name(provider);
-        let sql_family = SqlFamily::from(provider);
-
         ExternalConnectionInfo::new(
-            sql_family,
-            schema_name.to_owned(),
+            SqlFamily::from(provider),
+            self.schema_name(provider).map(ToOwned::to_owned),
             self.max_bind_values.map(|v| v as usize),
             self.supports_relation_joins,
         )
     }
 
-    fn get_schema_name(&self, provider: &AdapterProvider) -> &str {
-        match self.schema_name.as_ref() {
-            Some(name) => name,
-            None => self.default_schema_name(provider),
-        }
+    fn schema_name(&self, provider: &AdapterProvider) -> Option<&str> {
+        self.schema_name
+            .as_deref()
+            .or_else(|| self.default_schema_name(provider))
     }
 
-    fn default_schema_name(&self, provider: &AdapterProvider) -> &str {
+    fn default_schema_name(&self, provider: &AdapterProvider) -> Option<&str> {
         match provider {
             #[cfg(feature = "mysql")]
-            AdapterProvider::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
+            AdapterProvider::Mysql => None,
             #[cfg(feature = "postgresql")]
-            AdapterProvider::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
+            AdapterProvider::Postgres => Some(quaint::connector::DEFAULT_POSTGRES_SCHEMA),
             #[cfg(feature = "sqlite")]
-            AdapterProvider::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
+            AdapterProvider::Sqlite => Some(quaint::connector::DEFAULT_SQLITE_DATABASE),
             #[cfg(feature = "mssql")]
-            AdapterProvider::SqlServer => quaint::connector::DEFAULT_MSSQL_SCHEMA,
+            AdapterProvider::SqlServer => Some(quaint::connector::DEFAULT_MSSQL_SCHEMA),
         }
     }
 }

--- a/quaint/src/connector/external.rs
+++ b/quaint/src/connector/external.rs
@@ -114,7 +114,7 @@ impl From<&AdapterProvider> for SqlFamily {
 pub struct ExternalConnectionInfo {
     // TODO: `sql_family` doesn't exist in TypeScript's `ConnectionInfo` type.
     pub sql_family: SqlFamily,
-    pub schema_name: String,
+    pub schema_name: Option<String>,
     pub max_bind_values: Option<usize>,
     pub supports_relation_joins: bool,
 }
@@ -122,7 +122,7 @@ pub struct ExternalConnectionInfo {
 impl ExternalConnectionInfo {
     pub fn new(
         sql_family: SqlFamily,
-        schema_name: String,
+        schema_name: Option<String>,
         max_bind_values: Option<usize>,
         supports_relation_joins: bool,
     ) -> Self {

--- a/quaint/src/connector/mysql/native/mod.rs
+++ b/quaint/src/connector/mysql/native/mod.rs
@@ -43,7 +43,7 @@ impl MysqlUrl {
             .stmt_cache_size(Some(0))
             .user(Some(self.username()))
             .pass(self.password())
-            .db_name(Some(self.dbname()));
+            .db_name(self.dbname());
 
         match self.socket() {
             Some(ref socket) => {
@@ -323,7 +323,13 @@ impl Queryable for Mysql {
     async fn version(&self) -> crate::Result<Option<String>> {
         let guard = self.conn.lock().await;
         let (major, minor, patch) = guard.server_version();
-        let flavour = if guard.is_mariadb() { "MariaDB" } else { "MySQL" };
+        let flavour = if guard.is_mariadb() {
+            "MariaDB"
+        } else if guard.is_vitess() {
+            "Vitess"
+        } else {
+            "MySQL"
+        };
         drop(guard);
 
         Ok(Some(format!("{major}.{minor}.{patch}-{flavour}")))

--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -63,12 +63,14 @@ impl MysqlUrl {
         }
     }
 
-    /// Name of the database connected. Defaults to `mysql`.
-    pub fn dbname(&self) -> &str {
-        match self.url.path_segments() {
-            Some(mut segments) => segments.next().unwrap_or(super::defaults::DEFAULT_MYSQL_DB),
-            None => super::defaults::DEFAULT_MYSQL_DB,
-        }
+    /// Name of the database connected.
+    pub fn dbname(&self) -> Option<&str> {
+        self.url.path_segments().and_then(|mut s| s.next())
+    }
+
+    /// Name of the database in the URL, or the default database if not set.
+    pub fn dbname_or_default(&self) -> &str {
+        self.dbname().unwrap_or(super::defaults::DEFAULT_MYSQL_DB)
     }
 
     /// The database host. If `socket` and `host` are not set, defaults to `localhost`.
@@ -343,14 +345,14 @@ mod tests {
     #[test]
     fn should_parse_socket_url() {
         let url = MysqlUrl::new(Url::parse("mysql://root@localhost/dbname?socket=(/tmp/mysql.sock)").unwrap()).unwrap();
-        assert_eq!("dbname", url.dbname());
+        assert_eq!(Some("dbname"), url.dbname());
         assert_eq!(&Some(String::from("/tmp/mysql.sock")), url.socket());
     }
 
     #[test]
     fn should_parse_socket_url_as_host() {
         let url = MysqlUrl::new(Url::parse("mysql://root@localhost/dbname?socket=(/tmp/mysql.sock)").unwrap()).unwrap();
-        assert_eq!("dbname", url.dbname());
+        assert_eq!(Some("dbname"), url.dbname());
         assert_eq!(&String::from("/tmp/mysql.sock"), url.host());
     }
 

--- a/query-compiler/query-compiler-playground/src/main.rs
+++ b/query-compiler/query-compiler-playground/src/main.rs
@@ -22,7 +22,7 @@ pub fn main() -> anyhow::Result<()> {
 
     let connection_info = ConnectionInfo::External(ExternalConnectionInfo::new(
         SqlFamily::Postgres,
-        "public".to_owned(),
+        Some("public".to_owned()),
         None,
         true,
     ));

--- a/query-compiler/query-compiler-wasm/src/params.rs
+++ b/query-compiler/query-compiler-wasm/src/params.rs
@@ -15,34 +15,30 @@ pub struct JsConnectionInfo {
 
 impl JsConnectionInfo {
     pub fn into_external_connection_info(self, provider: AdapterProvider) -> ExternalConnectionInfo {
-        let schema_name = self.get_schema_name(provider);
-        let sql_family = SqlFamily::from(provider);
-
         ExternalConnectionInfo::new(
-            sql_family,
-            schema_name.to_owned(),
+            SqlFamily::from(provider),
+            self.schema_name(provider).map(ToOwned::to_owned),
             self.max_bind_values.map(|v| v as usize),
             self.supports_relation_joins,
         )
     }
 
-    fn get_schema_name(&self, provider: AdapterProvider) -> &str {
-        match self.schema_name.as_ref() {
-            Some(name) => name,
-            None => self.default_schema_name(provider),
-        }
+    fn schema_name(&self, provider: AdapterProvider) -> Option<&str> {
+        self.schema_name
+            .as_deref()
+            .or_else(|| self.default_schema_name(provider))
     }
 
-    fn default_schema_name(&self, provider: AdapterProvider) -> &str {
+    fn default_schema_name(&self, provider: AdapterProvider) -> Option<&str> {
         match provider {
             #[cfg(feature = "mysql")]
-            AdapterProvider::Mysql => quaint::connector::DEFAULT_MYSQL_DB,
+            AdapterProvider::Mysql => None,
             #[cfg(feature = "postgresql")]
-            AdapterProvider::Postgres => quaint::connector::DEFAULT_POSTGRES_SCHEMA,
+            AdapterProvider::Postgres => Some(quaint::connector::DEFAULT_POSTGRES_SCHEMA),
             #[cfg(feature = "sqlite")]
-            AdapterProvider::Sqlite => quaint::connector::DEFAULT_SQLITE_DATABASE,
+            AdapterProvider::Sqlite => Some(quaint::connector::DEFAULT_SQLITE_DATABASE),
             #[cfg(feature = "mssql")]
-            AdapterProvider::SqlServer => quaint::connector::DEFAULT_MSSQL_SCHEMA,
+            AdapterProvider::SqlServer => Some(quaint::connector::DEFAULT_MSSQL_SCHEMA),
         }
     }
 }

--- a/query-compiler/query-compiler/tests/queries.rs
+++ b/query-compiler/query-compiler/tests/queries.rs
@@ -24,7 +24,7 @@ fn queries() {
 
         let connection_info = ConnectionInfo::External(ExternalConnectionInfo::new(
             SqlFamily::Postgres,
-            "public".to_owned(),
+            Some("public".to_owned()),
             None,
             true,
         ));

--- a/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
@@ -29,14 +29,17 @@ pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[
 
         conn.raw_cmd(&format!(
             "DROP SCHEMA IF EXISTS {}",
-            conn.connection_info().schema_name()
+            conn.connection_info().schema_name().unwrap()
         ))
         .await
         .unwrap();
 
-        conn.raw_cmd(&format!("CREATE SCHEMA {}", conn.connection_info().schema_name(),))
-            .await
-            .unwrap();
+        conn.raw_cmd(&format!(
+            "CREATE SCHEMA {}",
+            conn.connection_info().schema_name().unwrap()
+        ))
+        .await
+        .unwrap();
     }
 
     let params = ConnectorParams::new(url, Default::default(), None);

--- a/query-engine/query-builders/sql-query-builder/src/context.rs
+++ b/query-engine/query-builders/sql-query-builder/src/context.rs
@@ -37,7 +37,7 @@ impl<'a> Context<'a> {
         self.traceparent
     }
 
-    pub(crate) fn schema_name(&self) -> &str {
+    pub(crate) fn schema_name(&self) -> Option<&str> {
         self.connection_info.schema_name()
     }
 

--- a/query-engine/query-builders/sql-query-builder/src/model_extensions/relation.rs
+++ b/query-engine/query-builders/sql-query-builder/src/model_extensions/relation.rs
@@ -73,10 +73,10 @@ impl AsTable for Relation {
             // table, so MSSQL can convert the `INSERT .. ON CONFLICT IGNORE` into
             // a `MERGE` statement.
             walkers::RefinedRelationWalker::ImplicitManyToMany(ref m) => {
-                let model_a = m.model_a();
-                let prefix = model_a.schema_name().unwrap_or_else(|| ctx.schema_name()).to_owned();
-                let table: Table = (prefix, m.table_name().to_string()).into();
-
+                let mut table = Table::from(m.table_name().to_string());
+                if let Some(prefix) = m.model_a().schema_name().or_else(|| ctx.schema_name()) {
+                    table = table.database(prefix.to_owned());
+                };
                 table.add_unique_index(vec![Column::from("A"), Column::from("B")])
             }
             walkers::RefinedRelationWalker::Inline(ref m) => {

--- a/query-engine/query-builders/sql-query-builder/src/model_extensions/scalar_field.rs
+++ b/query-engine/query-builders/sql-query-builder/src/model_extensions/scalar_field.rs
@@ -25,11 +25,7 @@ impl ScalarFieldExt for ScalarField {
             (PrismaValue::Enum(e), TypeIdentifier::Enum(enum_id)) => {
                 let enum_walker = self.dm.clone().zip(enum_id);
                 let enum_name = enum_walker.db_name().to_owned();
-                let schema_name = enum_walker
-                    .schema_name()
-                    .map(ToOwned::to_owned)
-                    .or(Some(ctx.schema_name().to_owned()));
-
+                let schema_name = enum_walker.schema_name().or(ctx.schema_name()).map(ToOwned::to_owned);
                 Value::enum_variant_with_name(e, EnumName::new(enum_name, schema_name))
             }
             (PrismaValue::List(vals), TypeIdentifier::Enum(enum_id)) => {
@@ -41,10 +37,7 @@ impl ScalarFieldExt for ScalarField {
                     .collect();
 
                 let enum_name = enum_walker.db_name().to_owned();
-                let schema_name = enum_walker
-                    .schema_name()
-                    .map(ToOwned::to_owned)
-                    .or(Some(ctx.schema_name().to_owned()));
+                let schema_name = enum_walker.schema_name().or(ctx.schema_name()).map(ToOwned::to_owned);
 
                 Value::enum_array_with_name(variants, EnumName::new(enum_name, schema_name))
             }
@@ -64,11 +57,7 @@ impl ScalarFieldExt for ScalarField {
                 TypeIdentifier::Enum(enum_id) => {
                     let enum_walker = self.dm.clone().zip(enum_id);
                     let enum_name = enum_walker.db_name().to_owned();
-                    let schema_name = enum_walker
-                        .schema_name()
-                        .map(ToOwned::to_owned)
-                        .or(Some(ctx.schema_name().to_owned()));
-
+                    let schema_name = enum_walker.schema_name().or(ctx.schema_name()).map(ToOwned::to_owned);
                     ValueType::Enum(None, Some(EnumName::new(enum_name, schema_name))).into_value()
                 }
                 TypeIdentifier::Json => Value::null_json(),

--- a/query-engine/query-builders/sql-query-builder/src/model_extensions/table.rs
+++ b/query-engine/query-builders/sql-query-builder/src/model_extensions/table.rs
@@ -6,10 +6,16 @@ pub(crate) fn db_name_with_schema(model: &Model, ctx: &Context<'_>) -> Table<'st
     let schema_prefix = model
         .walker()
         .schema_name()
-        .map(ToOwned::to_owned)
-        .unwrap_or_else(|| ctx.schema_name().to_owned());
+        .or(ctx.schema_name())
+        .map(ToOwned::to_owned);
+
     let model_db_name = model.db_name().to_owned();
-    (schema_prefix, model_db_name).into()
+
+    if let Some(schema_prefix) = schema_prefix {
+        (schema_prefix, model_db_name).into()
+    } else {
+        model_db_name.into()
+    }
 }
 
 pub trait AsTable {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/connector/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/connector/native/mod.rs
@@ -70,7 +70,7 @@ impl Connection {
         }
 
         let mut schema = sql_schema_describer::mysql::SqlSchemaDescriber::new(&self.0, describer_circumstances)
-            .describe(&[params.url.dbname()])
+            .describe(&[params.url.dbname_or_default()])
             .await
             .map_err(|err| match err.into_kind() {
                 DescriberErrorKind::QuaintError(err) => quaint_err(&params.url)(err),

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/wasm/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/wasm/mod.rs
@@ -29,7 +29,10 @@ impl State {
             .get_connection_info()
             .await
             .map_err(|err| ConnectorError::from_source(err, "failed to get connection info"))?;
-        let schema_name = info.schema_name.to_owned();
+
+        let schema_name = info
+            .schema_name
+            .unwrap_or_else(|| quaint::connector::DEFAULT_POSTGRES_SCHEMA.to_owned());
 
         let connection = Connection { adapter };
         let circumstances = super::setup_connection(&connection, &Params, provider, &schema_name).await?;

--- a/schema-engine/sql-introspection-tests/src/test_api.rs
+++ b/schema-engine/sql-introspection-tests/src/test_api.rs
@@ -301,7 +301,7 @@ impl TestApi {
     }
 
     pub fn schema_name(&self) -> &str {
-        self.database.connection_info().schema_name()
+        self.database.connection_info().schema_name().unwrap()
     }
 
     pub fn barrel(&self) -> BarrelMigrationExecutor {

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -307,7 +307,7 @@ pub struct EngineTestApi {
 impl EngineTestApi {
     /// Plan an `applyMigrations` command
     pub fn apply_migrations<'a>(&'a mut self, migrations_directory: &'a TempDir) -> ApplyMigrations<'a> {
-        let mut namespaces = vec![self.connection_info.schema_name().to_string()];
+        let mut namespaces = vec![self.connection_info.schema_name().unwrap().to_string()];
 
         for namespace in self.namespaces {
             namespaces.push(namespace.to_string());
@@ -362,7 +362,7 @@ impl EngineTestApi {
 
     /// The schema name of the current connected database.
     pub fn schema_name(&self) -> &str {
-        self.connection_info.schema_name()
+        self.connection_info.schema_name().unwrap()
     }
 
     /// Execute a raw SQL command and expect it to succeed.

--- a/schema-engine/sql-schema-describer/tests/test_api/mod.rs
+++ b/schema-engine/sql-schema-describer/tests/test_api/mod.rs
@@ -136,7 +136,7 @@ impl TestApi {
     }
 
     pub(crate) fn schema_name(&self) -> &str {
-        self.database.connection_info().schema_name()
+        self.database.connection_info().schema_name().unwrap()
     }
 
     #[track_caller]


### PR DESCRIPTION
Allow connecting to Vitess in QE and QC without specifying the database name to allow Vitess to route the queries to the correct keyspace/database automatically.

When the database isn't specified in the connection string and the server is Vitess, the generated queries do not include the database name prefix:
```
prisma:query SELECT `User`.`id`, `User`.`email`, `User`.`status` FROM `User` WHERE 1=1
[]
```

In schema engine (regardless of using Vitess), as well when connecting to raw MySQL or MariaDB in QE/QC, we currently preserve the old behaviour (using `mysql` database by default).

Closes: https://linear.app/prisma-company/issue/ORM-1046/allow-connecting-without-specifying-the-db-name-in-url