### PR TITLE
fix: fix incorrect coercion

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/mod.rs
@@ -30,6 +30,7 @@ mod prisma_22298;
 mod prisma_22971;
 mod prisma_24072;
 mod prisma_25290;
+mod prisma_27452;
 mod prisma_5952;
 mod prisma_6173;
 mod prisma_7010;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_27452.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_27452.rs
@@ -1,0 +1,124 @@
+use query_engine_tests::*;
+
+#[test_suite(schema(schema), exclude(MongoDb, SqlServer))]
+mod prisma_27452 {
+    fn schema() -> String {
+        indoc! {
+            r#"
+            model User {
+              id    String  @id @default(cuid())
+
+              posts        Post[]
+              comments     Comment[]
+              commentLikes CommentLike[]
+            }
+
+            model Post {
+              id    String @id @default(cuid())
+
+              user         User          @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+              ownerId      String
+              comments     Comment[]
+              commentLikes CommentLike[]
+
+              @@unique([id, ownerId])
+            }
+
+            model Comment {
+              id      String @id @default(cuid())
+
+              post         Post          @relation(fields: [postId], references: [id], onDelete: Cascade)
+              postId       String
+              user         User          @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+              ownerId      String
+              commentLikes CommentLike[]
+            }
+
+            model CommentLike {
+              id Int @id @default(autoincrement())
+
+              user     User      @relation(fields: [ownerId], references: [id], onDelete: Cascade)
+              ownerId  String
+              post     Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+              postId   String
+              comments Comment[]
+
+              @@unique([postId, ownerId])
+            }
+            "#
+        }
+        .to_string()
+    }
+
+    #[connector_test]
+    async fn comment_like_upsert_with_nested_comments(runner: Runner) -> TestResult<()> {
+        let user_id = "1";
+        let post_id = "1";
+        let comment1_id = "1";
+        let comment2_id = "2";
+
+        runner
+            .query(&format!(
+                r#"
+                mutation {{
+                  createOneUser(data: {{
+                    id: "{user_id}"
+                    posts: {{
+                      createMany: {{
+                        data: [{{ id: "{post_id}" }}]
+                      }}
+                    }}
+                    comments: {{
+                      createMany: {{
+                        data: [
+                          {{ id: "{comment1_id}", postId: "{post_id}" }},
+                          {{ id: "{comment2_id}", postId: "{post_id}" }}
+                        ]
+                      }}
+                    }}
+                  }}) {{
+                    id
+                  }}
+                }}
+                "#,
+            ))
+            .await?;
+
+        let result = runner
+            .query(&format!(
+                r#"
+                mutation {{
+                  upsertOneCommentLike(
+                    where: {{
+                      postId_ownerId: {{ postId: "{post_id}", ownerId: "{user_id}" }}
+                    }}
+                    create: {{
+                      postId: "{post_id}"
+                      ownerId: "{user_id}"
+                      comments: {{
+                        connect: [{{ id: "{comment1_id}" }}]
+                      }}
+                    }}
+                    update: {{
+                      comments: {{
+                        set: [{{ id: "{comment2_id}" }}]
+                      }}
+                    }}
+                  ) {{
+                    comments {{
+                      id
+                    }}
+                  }}
+                }}
+                "#,
+            ))
+            .await?;
+
+        insta::assert_snapshot!(
+            result,
+            @r###"{"data":{"upsertOneCommentLike":{"comments":[{"id":"1"}]}}}"###
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This is a pretty confusing behavior, but our choice of fields for `add_condition` doesn't actually affect the final m2m filter being generated, because it uses the linking table which isn't represented in `query_ast`, so this change does not change the actual filter. It only fixes a bug that occurs when we attempt to coerce the value being filtered against the column it's meant to filter. When we filter against an m2m table, for the coercion to work correctly we need to use `parent_field.linking_fields()`.

[ORM-1124](https://linear.app/prisma-company/issue/ORM-1124/fix-conversion-failure-on-upsert-update-relationship)

Fixes https://github.com/prisma/prisma/issues/27452