### PR TITLE
fix(qc): allow overlapping relation fields and scalar DB names

### DIFF
--- a/query-compiler/query-compiler/src/binding.rs
+++ b/query-compiler/query-compiler/src/binding.rs
@@ -1,12 +1,13 @@
 use std::borrow::Cow;
 
 use query_core::NodeRef;
-use query_structure::{ScalarField, SelectedField};
+use query_structure::{RelationField, ScalarField, SelectedField};
 
 const JOIN_PARENT: &str = "@parent";
 const DEFAULTS: &str = "@defaults";
 const GENERATED: &str = "@generated";
 const SELECTOR: &str = "@selector";
+const NESTED: &str = "@nested";
 
 const FIELD_SEPARATOR: &str = "$";
 
@@ -36,4 +37,8 @@ pub fn generated(row_idx: usize, field_name: &str) -> Cow<'static, str> {
 
 pub fn selector(field: &SelectedField) -> Cow<'static, str> {
     format!("{SELECTOR}{FIELD_SEPARATOR}{}", field.prisma_name()).into()
+}
+
+pub fn nested_relation_field(field: &RelationField) -> String {
+    format!("{NESTED}{FIELD_SEPARATOR}{}", field.name())
 }

--- a/query-compiler/query-compiler/src/binding.rs
+++ b/query-compiler/query-compiler/src/binding.rs
@@ -39,6 +39,10 @@ pub fn selector(field: &SelectedField) -> Cow<'static, str> {
     format!("{SELECTOR}{FIELD_SEPARATOR}{}", field.prisma_name()).into()
 }
 
-pub fn nested_relation_field(field: &RelationField) -> String {
-    format!("{NESTED}{FIELD_SEPARATOR}{}", field.name())
+pub fn nested_relation_field(field: &RelationField) -> Cow<'static, str> {
+    nested_relation_field_by_name(field.name())
+}
+
+pub fn nested_relation_field_by_name(field_name: &str) -> Cow<'static, str> {
+    format!("{NESTED}{FIELD_SEPARATOR}{}", field_name).into()
 }

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -198,7 +198,7 @@ pub(super) fn add_inmemory_join(
                     .map(|sf| sf.db_name().into())
                     .zip(join.into_fields())
                     .collect(),
-                parent_field: prefixed_parent_field_name,
+                parent_field: prefixed_parent_field_name.into_owned(),
             })
         })
         .try_collect()?;

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -170,7 +170,7 @@ pub(super) fn add_inmemory_join(
             _ => None,
         })
         .map(|rrq| -> TranslateResult<JoinExpression> {
-            let parent_field_name = rrq.parent_field.name().to_owned();
+            let prefixed_parent_field_name = binding::nested_relation_field(&rrq.parent_field);
             let left_scalars = rrq.parent_field.left_scalars();
             let links = left_scalars
                 .iter()
@@ -198,7 +198,7 @@ pub(super) fn add_inmemory_join(
                     .map(|sf| sf.db_name().into())
                     .zip(join.into_fields())
                     .collect(),
-                parent_field: parent_field_name,
+                parent_field: prefixed_parent_field_name,
             })
         })
         .try_collect()?;

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-custom.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-custom.json.snap
@@ -4,22 +4,22 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/aggregate-custom.json
 ---
 dataMap {
-    _count: {
+    _count (from _count): {
         _all: Int (_all)
     }
-    _sum: {
+    _sum (from _sum): {
         float: Float (db_float)
         int: Int (db_int)
     }
-    _avg: {
+    _avg (from _avg): {
         float: Float (db_float)
         int: Float (db_int)
     }
-    _min: {
+    _min (from _min): {
         float: Float (db_float)
         int: Int (db_int)
     }
-    _max: {
+    _max (from _max): {
         float: Float (db_float)
         int: Int (db_int)
     }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-join-lateral.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-join-lateral.json.snap
@@ -5,7 +5,7 @@ input_file: query-compiler/query-compiler/tests/data/aggregate-join-lateral.json
 ---
 dataMap {
     email: String (email)
-    _count: {
+    _count (from _count): {
         activations: Int (activations)
     }
 }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-join.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-join.json.snap
@@ -5,8 +5,8 @@ input_file: query-compiler/query-compiler/tests/data/aggregate-join.json
 ---
 dataMap {
     email: String (email)
-    _count: {
-        activations (flattened): Int (_aggr_count_activations)
+    _count (inlined): {
+        activations: Int (_aggr_count_activations)
     }
 }
 query «SELECT "public"."User"."id", "public"."User"."email",

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate.json.snap
@@ -4,7 +4,7 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/aggregate.json
 ---
 dataMap {
-    _count: {
+    _count (from _count): {
         id: Int (id)
         email: Int (email)
         role: Int (role)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
@@ -8,7 +8,7 @@ transaction
        id: Int (id)
        email: String (email)
        role: Enum<Role> (role)
-       posts: {
+       posts (from @nested$posts): {
            id: Int (id)
            title: String (title)
            userId: Int (userId)
@@ -66,6 +66,6 @@ transaction
                                     "public"."Post" WHERE
                                     "public"."Post"."userId" = $1 OFFSET $2»
                              params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
              in get 4
       in get 4

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -8,7 +8,7 @@ transaction
        id: Int (id)
        email: String (email)
        role: Enum<Role> (role)
-       posts: {
+       posts (from @nested$posts): {
            id: Int (id)
            title: String (title)
            userId: Int (userId)
@@ -60,6 +60,6 @@ transaction
                                     "public"."Post" WHERE
                                     "public"."Post"."userId" = $1 OFFSET $2»
                              params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
              in get 3
       in get 3

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
@@ -8,7 +8,7 @@ transaction
        id: Int (id)
        title: String (title)
        userId: Int (userId)
-       user: {
+       user (from @nested$user): {
            id: Int (id)
            email: String (email)
            role: Enum<Role> (role)
@@ -70,7 +70,7 @@ transaction
                                                      "public"."User"."id" = $1
                                                      OFFSET $2»
                                               params [var(@parent$userId as Int),
-                                                      const(BigInt(0))]) on unique left.(userId) = right.(id) as user
+                                                      const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user
                               in get 6
                        in get 6
              in get 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -8,12 +8,12 @@ transaction
        id: Int (id)
        title: String (title)
        userId: Int (userId)
-       user: {
+       user (from @nested$user): {
            id: Int (id)
            email: String (email)
            role: Enum<Role> (role)
        }
-       categories: {
+       categories (from @nested$categories): {
            id: Int (id)
            name: String (name)
        }
@@ -112,7 +112,7 @@ transaction
                                                      "public"."User"."id" = $1
                                                      OFFSET $2»
                                               params [var(@parent$userId as Int),
-                                                      const(BigInt(0))]) on unique left.(userId) = right.(id) as user,
+                                                      const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user,
                                              (query «SELECT "t1"."id",
                                                      "t1"."name", "t0"."B" AS
                                                      "CategoryToPost@Post" FROM
@@ -121,7 +121,7 @@ transaction
                                                      "public"."Category" AS "t1"
                                                      ON "t0"."A" = "t1"."id"
                                                      WHERE "t0"."B" = $1»
-                                              params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as categories
+                                              params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
                               in get 11
                        in get 11
              in get 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -8,12 +8,12 @@ transaction
        id: Int (id)
        title: String (title)
        userId: Int (userId)
-       user: {
+       user (from @nested$user): {
            id: Int (id)
            email: String (email)
            role: Enum<Role> (role)
        }
-       categories: {
+       categories (from @nested$categories): {
            id: Int (id)
            name: String (name)
        }
@@ -97,7 +97,7 @@ transaction
                                               "public"."User"."id" = $1 OFFSET
                                               $2»
                                        params [var(@parent$userId as Int),
-                                               const(BigInt(0))]) on unique left.(userId) = right.(id) as user,
+                                               const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user,
                                       (query «SELECT "t1"."id", "t1"."name",
                                               "t0"."B" AS "CategoryToPost@Post"
                                               FROM "public"."_CategoryToPost" AS
@@ -105,7 +105,7 @@ transaction
                                               "public"."Category" AS "t1" ON
                                               "t0"."A" = "t1"."id" WHERE
                                               "t0"."B" = $1»
-                                       params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as categories
+                                       params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
                        in get 7
                 in get 7
       in get 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create-with-composite-id.json.snap
@@ -7,7 +7,7 @@ transaction
    dataMap {
        a: Int (a)
        b: Int (b)
-       children: {
+       children (from @nested$children): {
            id: Int (id)
            parentA: Int (parentA)
            parentB: Int (parentB)
@@ -63,6 +63,6 @@ transaction
                                      var(@parent$b as Int),
                                      const(BigInt(0))]) on left.(a,
                                                                  b) = right.(parentA,
-                                                                             parentB) as children
+                                                                             parentB) as @nested$children
              in get 2
       in get 2

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
@@ -8,7 +8,7 @@ transaction
        id: Int (id)
        email: String (email)
        role: Enum<Role> (role)
-       posts: {
+       posts (from @nested$posts): {
            id: Int (id)
            title: String (title)
            userId: Int (userId)
@@ -55,6 +55,6 @@ transaction
                                     "public"."Post" WHERE
                                     "public"."Post"."userId" = $1 OFFSET $2»
                              params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
              in get 2
       in get 2

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
@@ -4,7 +4,7 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/group-by.json
 ---
 dataMap {
-    _count: {
+    _count (from _count): {
         id: Int (id)
         title: Int (title)
         userId: Int (userId)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
@@ -7,7 +7,7 @@ dataMap {
     id: Int (id)
     title: String (title)
     userId: Int (userId)
-    categories: {
+    categories (from @nested$categories): {
         id: Int (id)
         name: String (name)
     }
@@ -24,4 +24,4 @@ in let @parent$id = mapField id (get @parent)
                    "CategoryToPost@Post" FROM "public"."_CategoryToPost" AS "t0"
                    INNER JOIN "public"."Category" AS "t1" ON "t0"."A" =
                    "t1"."id" WHERE "t0"."B" = $1»
-            params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as categories
+            params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o-lateral.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o-lateral.json.snap
@@ -7,7 +7,7 @@ dataMap {
     issued: Date (issued)
     secret: String (secret)
     done: Boolean (done)
-    user: {
+    user (from user): {
         id: Int (id)
         email: String (email)
     }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o.json.snap
@@ -7,7 +7,7 @@ dataMap {
     issued: Date (issued)
     secret: String (secret)
     done: Boolean (done)
-    user: {
+    user (from @nested$user): {
         id: Int (id)
         email: String (email)
     }
@@ -24,4 +24,4 @@ in let @parent$userId = mapField userId (get @parent)
       with (query «SELECT "public"."User"."id", "public"."User"."email" FROM
                    "public"."User" WHERE "public"."User"."id" IN [$1] OFFSET $2»
             params [var(@parent$userId as Int),
-                    const(BigInt(0))]) on unique left.(userId) = right.(id) as user
+                    const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-m2m.json.snap
@@ -7,7 +7,7 @@ dataMap {
     id: Int (id)
     title: String (title)
     userId: Int (userId)
-    categories: {
+    categories (from @nested$categories): {
         id: Int (id)
         name: String (name)
     }
@@ -22,4 +22,4 @@ in let @parent$id = mapField id (get @parent)
                    "CategoryToPost@Post" FROM "public"."_CategoryToPost" AS "t0"
                    INNER JOIN "public"."Category" AS "t1" ON "t0"."A" =
                    "t1"."id" WHERE "t0"."B" IN [$1]»
-            params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as categories
+            params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-one2m.json.snap
@@ -7,7 +7,7 @@ dataMap {
     id: Int (id)
     title: String (title)
     userId: Int (userId)
-    user: {
+    user (from @nested$user): {
         id: Int (id)
         email: String (email)
         role: Enum<Role> (role)
@@ -29,4 +29,4 @@ in let @parent$userId = mapField userId (get @parent)
                    "public"."User"."role"::text FROM "public"."User" WHERE
                    "public"."User"."id" IN [$1] OFFSET $2»
             params [var(@parent$userId as Int),
-                    const(BigInt(0))]) on unique left.(userId) = right.(id) as user
+                    const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m-lateral.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m-lateral.json.snap
@@ -6,7 +6,7 @@ input_file: query-compiler/query-compiler/tests/data/query-o2m-lateral.json
 dataMap {
     id: Int (id)
     email: String (email)
-    activations: {
+    activations (from activations): {
         issued: Date (issued)
         secret: String (secret)
         done: Boolean (done)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m.json.snap
@@ -6,7 +6,7 @@ input_file: query-compiler/query-compiler/tests/data/query-o2m.json
 dataMap {
     id: Int (id)
     email: String (email)
-    activations: {
+    activations (from @nested$activations): {
         issued: Date (issued)
         secret: String (secret)
         done: Boolean (done)
@@ -23,4 +23,4 @@ in let @parent$id = mapField id (get @parent)
                    "public"."Activation"."userId" FROM "public"."Activation"
                    WHERE "public"."Activation"."userId" IN [$1] OFFSET $2»
             params [var(@parent$id as Int),
-                    const(BigInt(0))]) on left.(id) = right.(userId) as activations
+                    const(BigInt(0))]) on left.(id) = right.(userId) as @nested$activations

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m-pagination.json.snap
@@ -7,7 +7,7 @@ dataMap {
     id: Int (id)
     title: String (title)
     userId: Int (userId)
-    categories: {
+    categories (from @nested$categories): {
         id: Int (id)
         name: String (name)
     }
@@ -26,4 +26,4 @@ in let @parent$id = mapField id (get @parent)
                    "CategoryToPost@Post" FROM "public"."_CategoryToPost" AS "t0"
                    INNER JOIN "public"."Category" AS "t1" ON "t0"."A" =
                    "t1"."id" WHERE "t0"."B" IN [$1] ORDER BY "t1"."id" ASC»
-            params [var(@parent$id as Int)])) on left.(id) = right.(CategoryToPost@Post) as categories
+            params [var(@parent$id as Int)])) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
@@ -7,7 +7,7 @@ dataMap {
     id: Int (id)
     title: String (title)
     userId: Int (userId)
-    user: {
+    user (from @nested$user): {
         id: Int (id)
         email: String (email)
         role: Enum<Role> (role)
@@ -31,4 +31,4 @@ in let @parent$userId = mapField userId (get @parent)
                    "public"."User"."role"::text FROM "public"."User" WHERE
                    "public"."User"."id" = $1 OFFSET $2»
             params [var(@parent$userId as Int),
-                    const(BigInt(0))]) on unique left.(userId) = right.(id) as user
+                    const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -8,7 +8,7 @@ transaction
        id: Int (id)
        email: String (email)
        role: Enum<Role> (role)
-       posts: {
+       posts (from @nested$posts): {
            id: Int (id)
            title: String (title)
            userId: Int (userId)
@@ -58,6 +58,6 @@ transaction
                                     "public"."Post" WHERE
                                     "public"."Post"."userId" = $1 OFFSET $2»
                              params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
              in get 3
       in get 3

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -8,7 +8,7 @@ transaction
        id: Int (id)
        email: String (email)
        role: Enum<Role> (role)
-       posts: {
+       posts (from @nested$posts): {
            id: Int (id)
            title: String (title)
            userId: Int (userId)
@@ -80,6 +80,6 @@ transaction
                                     "public"."Post" WHERE
                                     "public"."Post"."userId" = $1 OFFSET $2»
                              params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as posts
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
              in get 9
       in get 9

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_22971.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_22971.rs
@@ -8,15 +8,15 @@ mod prisma_22971 {
             r#"model User {
               #id(id, Int, @id, @map("hello"))
               updatedAt String @default("now") @map("updated_at")
-            
+
               postId Int?  @map("post")
               post   Post? @relation("User_post", fields: [postId], references: [id])
             }
-            
+
             model Post {
               #id(id, Int, @id, @map("world"))
               updatedAt String @default("now") @map("up_at")
-            
+
               from_User_post User[] @relation("User_post")
             }"#
         };
@@ -26,7 +26,7 @@ mod prisma_22971 {
 
     // Ensures that mapped fields are correctly resolved, even when there's a conflict between a scalar field name and a relation field name.
     #[connector_test]
-    async fn test_22971(runner: Runner) -> TestResult<()> {
+    async fn top_level(runner: Runner) -> TestResult<()> {
         run_query!(&runner, r#"mutation { createOnePost(data: { id: 1 }) { id } }"#);
         run_query!(
             &runner,
@@ -38,13 +38,76 @@ mod prisma_22971 {
             findManyUser {
               id
               updatedAt
+              postId
               post {
                 id
                 updatedAt
               }
             }
           }"#),
-          @r###"{"data":{"findManyUser":[{"id":1,"updatedAt":"now","post":{"id":1,"updatedAt":"now"}}]}}"###
+          @r###"{"data":{"findManyUser":[{"id":1,"updatedAt":"now","postId":1,"post":{"id":1,"updatedAt":"now"}}]}}"###
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn nested(runner: Runner) -> TestResult<()> {
+        run_query!(&runner, r#"mutation { createOnePost(data: { id: 1 }) { id } }"#);
+        run_query!(
+            &runner,
+            r#"mutation { createOneUser(data: { id: 2, postId: 1 }) { id } }"#
+        );
+
+        insta::assert_snapshot!(
+          run_query_pretty!(&runner, r#"{
+              findManyUser {
+                id
+                updatedAt
+                postId
+                post {
+                  id
+                  updatedAt
+                  from_User_post {
+                    id
+                    updatedAt
+                    postId
+                    post {
+                      id
+                      updatedAt
+                    }
+                  }
+                }
+              }
+          }"#),
+          @r#"
+        {
+          "data": {
+            "findManyUser": [
+              {
+                "id": 2,
+                "updatedAt": "now",
+                "postId": 1,
+                "post": {
+                  "id": 1,
+                  "updatedAt": "now",
+                  "from_User_post": [
+                    {
+                      "id": 2,
+                      "updatedAt": "now",
+                      "postId": 1,
+                      "post": {
+                        "id": 1,
+                        "updatedAt": "now"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+        "#
         );
 
         Ok(())


### PR DESCRIPTION
Ref: https://github.com/prisma/prisma/pull/27502
Fixes: https://linear.app/prisma-company/issue/ORM-966/mapped-db-level-field-name-conflicts-with-relation-field

/prisma-branch push-ovorzkonxwrl