### PR TITLE
fix: fixing missing read parent

### DIFF
--- a/query-engine/core/src/interpreter/expression.rs
+++ b/query-engine/core/src/interpreter/expression.rs
@@ -38,6 +38,12 @@ pub(crate) enum Expression {
     },
 }
 
+impl Expression {
+    pub fn is_empty_seq(&self) -> bool {
+        matches!(self, Expression::Sequence { seq } if seq.is_empty())
+    }
+}
+
 pub(crate) struct Binding {
     pub name: String,
     pub expr: Expression,

--- a/query-engine/core/src/interpreter/expressionista.rs
+++ b/query-engine/core/src/interpreter/expressionista.rs
@@ -26,7 +26,10 @@ impl Expressionista {
             .into_iter()
             .map(|root_node| Self::build_expression(&mut graph, &root_node, vec![]))
             .collect::<InterpretationResult<Vec<Expression>>>()
-            .map(|res| Expression::Sequence { seq: res })
+            .map(|mut res| {
+                res.retain(|expr| !expr.is_empty_seq());
+                Expression::Sequence { seq: res }
+            })
     }
 
     fn build_expression(

--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -330,13 +330,6 @@ impl UpdateRecord {
             UpdateRecord::WithoutSelection(_) => None,
         }
     }
-
-    pub(crate) fn set_record_filter(&mut self, record_filter: RecordFilter) {
-        match self {
-            UpdateRecord::WithSelection(u) => u.record_filter = record_filter,
-            UpdateRecord::WithoutSelection(u) => u.record_filter = record_filter,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This fixes a problem with MySQL flavour when the foreign key relation mode is used with the query compiler. In this scenario our update node in the query graph ends up having no prior read node. The read node is necessary for databases that don't support `RETURNING`. The query engine has a workaround for it which involves issuing queries dynamically at runtime whenever selectors for an update are missing but we can't do that in the query compiler workflow. I've modified how the graph is constructed to always add a read node prior to the update. I've also included a minor optimization for the case when relation mode is set to prisma (to avoid introducing a performance regression) - we avoid issuing a read query when `insert_emulated_on_update` connects no edges to it.