### PR TITLE
fix: include read parent for non-UpdateReturning dbs

### DIFF
--- a/query-engine/core/src/query_ast/write.rs
+++ b/query-engine/core/src/query_ast/write.rs
@@ -330,13 +330,6 @@ impl UpdateRecord {
             UpdateRecord::WithoutSelection(_) => None,
         }
     }
-
-    pub(crate) fn set_record_filter(&mut self, record_filter: RecordFilter) {
-        match self {
-            UpdateRecord::WithSelection(u) => u.record_filter = record_filter,
-            UpdateRecord::WithoutSelection(u) => u.record_filter = record_filter,
-        }
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/query-engine/core/src/query_graph_builder/write/update.rs
+++ b/query-engine/core/src/query_graph_builder/write/update.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::inputs::RecordQueryFilterInput;
+use crate::inputs::{RecordQueryFilterInput, UpdateRecordSelectorsInput};
 use crate::query_graph_builder::write::limit::validate_limit;
 use crate::query_graph_builder::write::write_args_parser::*;
 use crate::{
@@ -39,27 +39,23 @@ pub(crate) fn update_record(
         Some(&field),
     )?;
 
-    if query_schema.relation_mode().is_prisma() {
+    if !query_schema.has_capability(ConnectorCapability::UpdateReturning) || query_schema.relation_mode().is_prisma() {
         let read_parent_node = graph.create_node(utils::read_id_infallible(
             model.clone(),
             model.shard_aware_primary_identifier(),
-            filter,
+            filter.clone(),
         ));
 
-        utils::insert_emulated_on_update(graph, query_schema, &model, &read_parent_node, &update_node)?;
+        if query_schema.relation_mode().is_prisma() {
+            utils::insert_emulated_on_update(graph, query_schema, &model, &read_parent_node, &update_node)?;
+        }
 
         graph.create_edge(
             &read_parent_node,
             &update_node,
-            QueryGraphDependency::ProjectedDataDependency(
+            QueryGraphDependency::ProjectedDataSinkDependency(
                 model.shard_aware_primary_identifier(),
-                Box::new(move |mut update_node, parent_ids| {
-                    if let Node::Query(Query::Write(WriteQuery::UpdateRecord(ref mut ur))) = update_node {
-                        ur.set_record_filter(parent_ids.into());
-                    }
-
-                    Ok(update_node)
-                }),
+                RowSink::All(&UpdateRecordSelectorsInput),
                 Some(DataExpectation::non_empty_rows(
                     MissingRecord::builder().operation(DataOperation::Update).build(),
                 )),


### PR DESCRIPTION
Makes https://github.com/prisma/prisma/pull/27489 tests pass.

This change fixes updates in MySQL with the query compiler. Before this change, the graphs did not have a read node connected to the update node, which is incorrect for databases with no support for `RETURNING`. It worked fine with Planetscale because the read node was being inserted due to the relation mode being set to Prisma. It also worked fine in the query engine, because the query engine dynamically dispatches queries at runtime whenever an update in the graph is missing selectors - we can't do that at runtime in the query interpreter though, so the graph creation needs to be adjusted.