### PR TITLE
chore: update rust to 1.88.0

### DIFF
--- a/libs/driver-adapters/src/conversion/js_arg_type.rs
+++ b/libs/driver-adapters/src/conversion/js_arg_type.rs
@@ -65,7 +65,7 @@ impl core::fmt::Display for JSArgType {
             JSArgType::Time => "Time",
         };
 
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/libs/driver-adapters/src/queryable.rs
+++ b/libs/driver-adapters/src/queryable.rs
@@ -149,7 +149,7 @@ impl QuaintQueryable for JsBaseQueryable {
             AdapterProvider::SqlServer => visitor::Mssql::version_expr(),
         };
 
-        let query = format!(r#"SELECT {} AS version"#, version_expr);
+        let query = format!(r#"SELECT {version_expr} AS version"#);
         let rows = self.query_raw(query.as_str(), &[]).await?;
 
         let version_string = rows
@@ -187,7 +187,7 @@ impl QuaintQueryable for JsBaseQueryable {
 
 impl JsBaseQueryable {
     pub fn phantom_query_message(stmt: &str) -> String {
-        format!(r#"-- Implicit "{}" query via underlying driver"#, stmt)
+        format!(r#"-- Implicit "{stmt}" query via underlying driver"#)
     }
 
     async fn do_query_raw_inner(&self, sql: &str, params: &[quaint::Value<'_>]) -> quaint::Result<ResultSet> {

--- a/libs/telemetry/src/id.rs
+++ b/libs/telemetry/src/id.rs
@@ -8,7 +8,7 @@ use derive_more::Display;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Display, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[display(fmt = "{}", _0)]
+#[display(fmt = "{_0}")]
 #[repr(transparent)]
 struct SerializableNonZeroU64(NonZeroU64);
 

--- a/libs/telemetry/src/layer.rs
+++ b/libs/telemetry/src/layer.rs
@@ -228,7 +228,7 @@ impl<Filter: AllowAttribute> field::Visit for SpanAttributeVisitor<'_, Filter> {
 
     fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
         if Filter::allow_on_span(field.name()) {
-            self.record_str(field, &format!("{:?}", value))
+            self.record_str(field, &format!("{value:?}"))
         }
     }
 }
@@ -285,7 +285,7 @@ impl<Filter: AllowAttribute> field::Visit for EventAttributeVisitor<'_, Filter> 
 
     fn record_debug(&mut self, field: &field::Field, value: &dyn std::fmt::Debug) {
         if Filter::allow_on_event(field.name()) {
-            self.record_str(field, &format!("{:?}", value))
+            self.record_str(field, &format!("{value:?}"))
         }
     }
 }

--- a/prisma-fmt/src/code_actions/field.rs
+++ b/prisma-fmt/src/code_actions/field.rs
@@ -56,7 +56,7 @@ pub(super) fn add_missing_opposite_relation(
         .find(|attr| attr.name() == "relation")
         .and_then(|attr| attr.arguments.arguments.iter().find(|arg| arg.value.is_string()));
 
-    let relation = name_arg.map_or(Default::default(), |arg| format!(" @relation({})", arg));
+    let relation = name_arg.map_or(Default::default(), |arg| format!(" @relation({arg})"));
 
     let formatted_content = format!("{separator}{indentation}{name} {name}[]{relation}{newline}");
 
@@ -71,7 +71,7 @@ pub(super) fn add_missing_opposite_relation(
     };
 
     let action = CodeAction {
-        title: format!("Add missing relation field to model {}", target_name),
+        title: format!("Add missing relation field to model {target_name}"),
         kind: Some(CodeActionKind::QUICKFIX),
         edit: Some(edit),
         diagnostics: Some(diagnostics),

--- a/prisma-fmt/src/code_actions/relations.rs
+++ b/prisma-fmt/src/code_actions/relations.rs
@@ -304,7 +304,7 @@ pub(super) fn add_referencing_side_relation(
                 .find(|arg| arg.value.is_string())
                 .map_or(Default::default(), |arg| format!("{arg}, "));
 
-            let new_text = format!("@relation({}{}, {})", name, fields_arg, references);
+            let new_text = format!("@relation({name}{fields_arg}, {references})");
             let range = super::span_to_range(attr.span(), ctx.initiating_file_source());
 
             (range, new_text)

--- a/prisma-fmt/src/references.rs
+++ b/prisma-fmt/src/references.rs
@@ -135,7 +135,7 @@ fn reference_locations_for_target(ctx: ReferencesContext<'_>, target: SchemaPosi
                 let referenced_model = field.field_type.name();
 
                 let Some(ref_model_id) = ctx.db.find_model(referenced_model) else {
-                    warn!("Could not find model with name: {}", referenced_model);
+                    warn!("Could not find model with name: {referenced_model}");
                     return empty_references();
                 };
 

--- a/psl/parser-database/src/attributes/default.rs
+++ b/psl/parser-database/src/attributes/default.rs
@@ -398,7 +398,7 @@ fn format_valid_values<const N: usize>(valid_values: &[u8; N]) -> String {
 
             let (last, rest) = valid_values.split_last().unwrap();
             let rest_str = rest.iter().map(|v| v.to_string()).join(", ");
-            format!("{}, or {}", rest_str, last)
+            format!("{rest_str}, or {last}")
         }
     }
 }

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -355,7 +355,7 @@ impl ScalarFieldAssert for walkers::ScalarFieldWalker<'_> {
 
         let nt = match connector.parse_native_type(r#type, params, span, &mut diagnostics) {
             Some(nt) => nt,
-            None => panic!("Invalid native type {}", r#type),
+            None => panic!("Invalid native type {type}"),
         };
 
         diagnostics.to_result().unwrap();

--- a/quaint/quaint-test-macros/src/test_each_connector.rs
+++ b/quaint/quaint-test-macros/src/test_each_connector.rs
@@ -120,7 +120,7 @@ fn test_each_connector_async_wrapper_functions(
     for connector in args.connectors_to_test() {
         let connector_name = connector.name();
         let feature_name = connector.feature_name();
-        let connector_test_fn_name = Ident::new(&format!("{}_on_{}", test_fn_name, connector_name), Span::call_site());
+        let connector_test_fn_name = Ident::new(&format!("{test_fn_name}_on_{connector_name}"), Span::call_site());
 
         let conn_api_factory = Ident::new(connector.test_api(), Span::call_site());
 

--- a/quaint/quaint-test-setup/src/lib.rs
+++ b/quaint/quaint-test-setup/src/lib.rs
@@ -29,7 +29,7 @@ pub static CONNECTORS: LazyLock<Connectors> = LazyLock::new(|| {
         .map(|(name, feature_name, tags)| ConnectorDefinition {
             name: (*name).to_owned(),
             feature_name: (*feature_name).to_owned(),
-            test_api_factory_name: format!("{}_test_api", name),
+            test_api_factory_name: format!("{name}_test_api"),
             tags: *tags,
         })
         .collect();

--- a/quaint/src/connector/connection_info.rs
+++ b/quaint/src/connector/connection_info.rs
@@ -186,7 +186,7 @@ impl ConnectionInfo {
     }
 
     /// The provided database user name. This will be `None` on SQLite.
-    pub fn username(&self) -> Option<Cow<str>> {
+    pub fn username(&self) -> Option<Cow<'_, str>> {
         // TODO: why do some of the native `.username()` methods return an `Option<&str>` and others a `Cow<str>`?
         match self {
             #[cfg(any(

--- a/quaint/src/connector/external.rs
+++ b/quaint/src/connector/external.rs
@@ -90,7 +90,7 @@ impl FromStr for AdapterProvider {
             "sqlite" => Ok(Self::Sqlite),
             #[cfg(feature = "mssql")]
             "sqlserver" => Ok(Self::SqlServer),
-            _ => Err(format!("Unsupported adapter flavour: {:?}", s)),
+            _ => Err(format!("Unsupported adapter flavour: {s:?}")),
         }
     }
 }

--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -40,7 +40,7 @@ impl MysqlUrl {
     }
 
     /// The percent-decoded database username.
-    pub fn username(&self) -> Cow<str> {
+    pub fn username(&self) -> Cow<'_, str> {
         match percent_decode(self.url.username().as_bytes()).decode_utf8() {
             Ok(username) => username,
             Err(_) => {
@@ -52,7 +52,7 @@ impl MysqlUrl {
     }
 
     /// The percent-decoded database password.
-    pub fn password(&self) -> Option<Cow<str>> {
+    pub fn password(&self) -> Option<Cow<'_, str>> {
         match self
             .url
             .password()

--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -408,7 +408,7 @@ mod tests {
                 assert_eq!(Some("Unknown database \'this_does_not_exist\'"), err.original_message());
                 assert_eq!(&Name::available("this_does_not_exist"), db_name)
             }
-            e => panic!("Expected `DatabaseDoesNotExist`, got {:?}", e),
+            e => panic!("Expected `DatabaseDoesNotExist`, got {e:?}"),
         }
     }
 

--- a/quaint/src/connector/postgres/error.rs
+++ b/quaint/src/connector/postgres/error.rs
@@ -21,10 +21,10 @@ impl Display for PostgresError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
         write!(fmt, "{}: {}", self.severity, self.message)?;
         if let Some(detail) = &self.detail {
-            write!(fmt, "\nDETAIL: {}", detail)?;
+            write!(fmt, "\nDETAIL: {detail}")?;
         }
         if let Some(hint) = &self.hint {
-            write!(fmt, "\nHINT: {}", hint)?;
+            write!(fmt, "\nHINT: {hint}")?;
         }
         Ok(())
     }

--- a/quaint/src/connector/postgres/url.rs
+++ b/quaint/src/connector/postgres/url.rs
@@ -156,7 +156,7 @@ impl PostgresNativeUrl {
     }
 
     /// The percent-decoded database username.
-    pub fn username(&self) -> Cow<str> {
+    pub fn username(&self) -> Cow<'_, str> {
         match percent_decode(self.url.username().as_bytes()).decode_utf8() {
             Ok(username) => username,
             Err(_) => {
@@ -202,7 +202,7 @@ impl PostgresNativeUrl {
     }
 
     /// The percent-decoded database password.
-    pub fn password(&self) -> Cow<str> {
+    pub fn password(&self) -> Cow<'_, str> {
         match self
             .url
             .password()

--- a/quaint/src/connector/postgres/url.rs
+++ b/quaint/src/connector/postgres/url.rs
@@ -701,7 +701,7 @@ mod tests {
                     );
                     assert_eq!(&Name::available("this_does_not_exist"), db_name)
                 }
-                kind => panic!("Expected `DatabaseDoesNotExist`, got {:?}", kind),
+                kind => panic!("Expected `DatabaseDoesNotExist`, got {kind:?}"),
             },
         }
     }
@@ -731,7 +731,7 @@ mod tests {
             Ok(_) => unreachable!(),
             Err(e) => match e.kind() {
                 ErrorKind::Native(NativeErrorKind::TlsError { .. }) => (),
-                other => panic!("{:#?}", other),
+                other => panic!("{other:#?}"),
             },
         }
     }
@@ -752,7 +752,7 @@ mod tests {
                     assert_eq!(1, *expected);
                     assert_eq!(2, *actual);
                 }
-                other => panic!("{:#?}", other),
+                other => panic!("{other:#?}"),
             },
         }
     }

--- a/quaint/src/connector/result_set.rs
+++ b/quaint/src/connector/result_set.rs
@@ -56,12 +56,12 @@ impl ResultSet {
     }
 
     /// Returns the first row of the `ResultSet`, or None if the set is empty.
-    pub fn first(&self) -> Option<ResultRowRef> {
+    pub fn first(&self) -> Option<ResultRowRef<'_>> {
         self.get(0)
     }
 
     /// Returns a reference to a row in a given position.
-    pub fn get(&self, index: usize) -> Option<ResultRowRef> {
+    pub fn get(&self, index: usize) -> Option<ResultRowRef<'_>> {
         self.rows.get(index).map(|row| ResultRowRef {
             columns: Arc::clone(&self.columns),
             values: row,

--- a/quaint/src/connector/result_set/result_row.rs
+++ b/quaint/src/connector/result_set/result_row.rs
@@ -79,7 +79,7 @@ impl ResultRow {
     }
 
     /// Make a referring [ResultRowRef](struct.ResultRowRef.html).
-    pub fn as_ref(&self) -> ResultRowRef {
+    pub fn as_ref(&self) -> ResultRowRef<'_> {
         ResultRowRef {
             columns: Arc::clone(&self.columns),
             values: &self.values,

--- a/quaint/src/connector/sqlite/native/mod.rs
+++ b/quaint/src/connector/sqlite/native/mod.rs
@@ -212,7 +212,7 @@ mod tests {
             ErrorKind::TableDoesNotExist { table } => {
                 assert_eq!(&Name::available("not_there"), table);
             }
-            e => panic!("Expected error TableDoesNotExist, got {:?}", e),
+            e => panic!("Expected error TableDoesNotExist, got {e:?}"),
         }
     }
 

--- a/quaint/src/tests/query.rs
+++ b/quaint/src/tests/query.rs
@@ -2110,8 +2110,8 @@ fn value_into_json(value: &Value) -> Option<serde_json::Value> {
     match value.typed.clone() {
         // MariaDB returns JSON as text
         ValueType::Text(Some(text)) => {
-            let json: serde_json::Value = serde_json::from_str(&text)
-                .unwrap_or_else(|_| panic!("expected parsable text to json, found {}", text));
+            let json: serde_json::Value =
+                serde_json::from_str(&text).unwrap_or_else(|_| panic!("expected parsable text to json, found {text}"));
 
             Some(json)
         }

--- a/quaint/src/tests/query/error.rs
+++ b/quaint/src/tests/query/error.rs
@@ -15,7 +15,7 @@ async fn table_does_not_exist(api: &mut dyn TestApi) -> crate::Result<()> {
         ErrorKind::TableDoesNotExist { table } => {
             assert_eq!(&Name::available("not_there"), table);
         }
-        e => panic!("Expected error TableDoesNotExist, got {:?}", e),
+        e => panic!("Expected error TableDoesNotExist, got {e:?}"),
     }
 
     Ok(())
@@ -31,7 +31,7 @@ async fn database_already_exists(api: &mut dyn TestApi) -> crate::Result<()> {
         ErrorKind::DatabaseAlreadyExists { db_name } => {
             assert_eq!(&Name::available("master"), db_name);
         }
-        e => panic!("Expected error DatabaseAlreadyExists, got {:?}", e),
+        e => panic!("Expected error DatabaseAlreadyExists, got {e:?}"),
     }
 
     Ok(())
@@ -52,7 +52,7 @@ async fn column_does_not_exist_on_write(api: &mut dyn TestApi) -> crate::Result<
         ErrorKind::ColumnNotFound { column } => {
             assert_eq!(&Name::available("does_not_exist"), column);
         }
-        e => panic!("Expected error ColumnNotFound, got {:?}", e),
+        e => panic!("Expected error ColumnNotFound, got {e:?}"),
     }
 
     Ok(())
@@ -76,7 +76,7 @@ async fn column_does_not_exist_on_read(api: &mut dyn TestApi) -> crate::Result<(
         ErrorKind::ColumnNotFound { column } => {
             assert_eq!(&Name::available("does_not_exist"), column);
         }
-        e => panic!("Expected error ColumnNotFound, got {:?}", e),
+        e => panic!("Expected error ColumnNotFound, got {e:?}"),
     }
 
     Ok(())
@@ -283,7 +283,7 @@ async fn garbage_datetime_values(api: &mut dyn TestApi) -> crate::Result<()> {
 
             assert_eq!(&expected_message, message);
         }
-        e => panic!("Expected error ColumnNotFound, got {:?}", e),
+        e => panic!("Expected error ColumnNotFound, got {e:?}"),
     }
 
     Ok(())

--- a/query-compiler/query-compiler/src/binding.rs
+++ b/query-compiler/query-compiler/src/binding.rs
@@ -44,5 +44,5 @@ pub fn nested_relation_field(field: &RelationField) -> Cow<'static, str> {
 }
 
 pub fn nested_relation_field_by_name(field_name: &str) -> Cow<'static, str> {
-    format!("{NESTED}{FIELD_SEPARATOR}{}", field_name).into()
+    format!("{NESTED}{FIELD_SEPARATOR}{field_name}").into()
 }

--- a/query-engine/black-box-tests/tests/helpers/mod.rs
+++ b/query-engine/black-box-tests/tests/helpers/mod.rs
@@ -54,13 +54,13 @@ pub(crate) fn query_engine_cmd(dml: &str) -> (process::Command, String) {
     let port = generate_free_port();
     cmd.env("PRISMA_DML", dml).arg("--port").arg(port.to_string()).arg("-g");
 
-    (cmd, format!("http://0.0.0.0:{}", port))
+    (cmd, format!("http://0.0.0.0:{port}"))
 }
 
 /// Returns the path of the query-engine binary
 pub(crate) fn query_engine_bin_path() -> path::PathBuf {
     let name = "query-engine";
-    let env_var = format!("CARGO_BIN_EXE_{}", name);
+    let env_var = format!("CARGO_BIN_EXE_{name}");
     std::env::var_os(env_var)
         .map(|p| p.into())
         .unwrap_or_else(|| target_dir().join(format!("{}{}", name, env::consts::EXE_SUFFIX)))

--- a/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
+++ b/query-engine/black-box-tests/tests/metrics/smoke_tests.rs
@@ -22,14 +22,10 @@ mod smoke_tests {
                 let value = capture.get(1).unwrap().as_str().parse::<f64>().unwrap();
                 assert!(
                     value >= low && value <= high,
-                    "expected {} value of {} to be between {} and {}",
-                    metric,
-                    value,
-                    low,
-                    high
+                    "expected {metric} value of {value} to be between {low} and {high}"
                 );
             }
-            None => panic!("Metric {} not found in metrics text", metric),
+            None => panic!("Metric {metric} not found in metrics text"),
         }
     }
 

--- a/query-engine/connector-test-kit-rs/qe-setup/src/driver_adapters.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/driver_adapters.rs
@@ -47,6 +47,6 @@ impl From<DriverAdapter> for String {
 impl Display for DriverAdapter {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s: String = (*self).into();
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
@@ -87,16 +87,17 @@ pub async fn setup_external<'a>(
             initializer
                 .init_with_migration(migration_script)
                 .await
-                .map_err(|err| ConnectorError::from_msg(format!("Error migrating with D1 adapter: {}", err)))
+                .map_err(|err| ConnectorError::from_msg(format!("Error migrating with D1 adapter: {err}")))
         }
         _ => {
             setup(prisma_schema, db_schemas).await?;
 
             // 3. Tell JavaScript to initialize the external test session.
             //    The schema migration is taken care of by the Schema Engine.
-            initializer.init().await.map_err(|err| {
-                ConnectorError::from_msg(format!("Error initializing {} adapter: {}", driver_adapter, err))
-            })
+            initializer
+                .init()
+                .await
+                .map_err(|err| ConnectorError::from_msg(format!("Error initializing {driver_adapter} adapter: {err}")))
         }
     }?;
 

--- a/query-engine/connector-test-kit-rs/qe-setup/src/providers.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/providers.rs
@@ -41,7 +41,7 @@ impl TryFrom<&str> for Provider {
         } else if COCKROACH.is_provider(provider) {
             Ok(Provider::Cockroach)
         } else {
-            Err(format!("Connector {} is not supported yet", provider))
+            Err(format!("Connector {provider} is not supported yet"))
         }
     }
 }
@@ -55,6 +55,6 @@ impl From<Provider> for String {
 impl Display for Provider {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let s: String = (*self).into();
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/logs.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/logs.rs
@@ -185,7 +185,7 @@ mod logs {
             .collect::<Vec<_>>();
         assert!(!query_logs.is_empty(), "expected db.query.text logs in {logs:?}");
 
-        let expected_traceparent = format!("/* traceparent='{}' */", traceparent);
+        let expected_traceparent = format!("/* traceparent='{traceparent}' */");
         let matching = query_logs
             .iter()
             .filter(|log| log.contains(&expected_traceparent))

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_11789.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/regressions/prisma_11789.rs
@@ -28,7 +28,7 @@ mod prisma_concurrent_write {
     // Runs 100 `run_create_user` queries in parallel, followed by 100 `run_create_profile` queries in parallel.
     async fn concurrent_creates_should_succeed(runner: Runner) -> TestResult<()> {
         let n = 100;
-        let ids: Vec<String> = (1..=n).map(|i| format!("{:05}", i)).collect();
+        let ids: Vec<String> = (1..=n).map(|i| format!("{i:05}")).collect();
 
         let runner_arc = Arc::new(runner);
 
@@ -73,7 +73,7 @@ mod prisma_concurrent_write {
     // Runs 2 `run_create_user` queries in parallel, followed by 2 `run_upsert_profile` queries in parallel.
     async fn concurrent_upserts_should_succeed(runner: Runner) -> TestResult<()> {
         let n = 2;
-        let ids: Vec<String> = (1..=n).map(|i| format!("{:05}", i)).collect();
+        let ids: Vec<String> = (1..=n).map(|i| format!("{i:05}")).collect();
 
         let runner_arc = Arc::new(runner);
 

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/chunking.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/chunking.rs
@@ -46,9 +46,8 @@ mod chunking {
                     runner,
                     &format!(
                         r#"
-                        {{ id: {}, posts: {{ create: [{{ id: {} }}, {{ id: {} }}] }} }}
-                        "#,
-                        i, post_a_id, post_b_id
+                        {{ id: {i}, posts: {{ create: [{{ id: {post_a_id} }}, {{ id: {post_b_id} }}] }} }}
+                        "#
                     ),
                 )
                 .await?;
@@ -110,7 +109,7 @@ mod chunking {
                 .map(|x| x["id"].as_i64().unwrap())
                 .collect::<Vec<i64>>();
 
-            let posts_as_graphql: Vec<String> = ids_vec.into_iter().map(|id| format!("{{ id: {} }}", id)).collect();
+            let posts_as_graphql: Vec<String> = ids_vec.into_iter().map(|id| format!("{{ id: {id} }}")).collect();
             assert_eq!(posts_as_graphql.len(), 400);
 
             let query = format!("{{ id: 201, posts: {{ connect: [{}] }} }}", posts_as_graphql.join(", "));

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bigint.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bigint.rs
@@ -93,7 +93,7 @@ mod bigint {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bool.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bool.rs
@@ -93,7 +93,7 @@ mod bool {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bytes.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/bytes.rs
@@ -70,7 +70,7 @@ mod bytes {
 
         async fn create_child(runner: &Runner, data: &str) -> TestResult<()> {
             runner
-                .query(format!("mutation {{ createOneChild(data: {}) {{ childId }} }}", data))
+                .query(format!("mutation {{ createOneChild(data: {data}) {{ childId }} }}"))
                 .await?
                 .assert_success();
             Ok(())
@@ -78,7 +78,7 @@ mod bytes {
 
         async fn create_parent(runner: &Runner, data: &str) -> TestResult<()> {
             runner
-                .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+                .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
                 .await?
                 .assert_success();
             Ok(())
@@ -174,7 +174,7 @@ mod bytes {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/datetime.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/datetime.rs
@@ -93,7 +93,7 @@ mod datetime {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/decimal.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/decimal.rs
@@ -104,7 +104,7 @@ mod decimal {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/enum_type.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/enum_type.rs
@@ -189,7 +189,7 @@ mod enum_type {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/float.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/float.rs
@@ -93,7 +93,7 @@ mod float {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/int.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/int.rs
@@ -93,7 +93,7 @@ mod int {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/json.rs
@@ -400,7 +400,7 @@ mod json {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mssql.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mssql.rs
@@ -106,7 +106,7 @@ mod mssql_string {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mysql.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/mysql.rs
@@ -63,7 +63,7 @@ mod datetime {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -123,7 +123,7 @@ mod mysql_decimal {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -198,7 +198,7 @@ mod mysql_string {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -276,7 +276,7 @@ mod mysql_bytes {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
@@ -65,7 +65,7 @@ mod postgres_datetime {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -127,7 +127,7 @@ mod postgres_decimal {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -205,7 +205,7 @@ mod postgres_string {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -316,7 +316,7 @@ mod postgres_others {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/string.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/string.rs
@@ -93,7 +93,7 @@ mod string {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneTestModel(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneTestModel(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/through_relation.rs
@@ -362,7 +362,7 @@ mod scalar_relations {
 
     async fn create_child(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneChild(data: {}) {{ childId }} }}", data))
+            .query(format!("mutation {{ createOneChild(data: {data}) {{ childId }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -370,7 +370,7 @@ mod scalar_relations {
 
     async fn create_parent(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/one2m.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/one2m.rs
@@ -49,7 +49,7 @@ mod simple {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ id }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ id }} }}"))
             .await?
             .assert_success();
         Ok(())
@@ -118,7 +118,7 @@ mod nested {
 
     async fn create_row(runner: &Runner, data: &str) -> TestResult<()> {
         runner
-            .query(format!("mutation {{ createOneParent(data: {}) {{ parentId }} }}", data))
+            .query(format!("mutation {{ createOneParent(data: {data}) {{ parentId }} }}"))
             .await?
             .assert_success();
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/top_level_mutations/delete_many.rs
@@ -283,7 +283,7 @@ mod delete_many {
                 assert_eq!(count, array_res.len());
             }
             _ => {
-                panic!("Unexpected result when counting todos: {}", res);
+                panic!("Unexpected result when counting todos: {res}");
             }
         }
 

--- a/query-engine/connector-test-kit-rs/query-test-macros/src/ensure_db_names.rs
+++ b/query-engine/connector-test-kit-rs/query-test-macros/src/ensure_db_names.rs
@@ -22,10 +22,9 @@ impl UniqueTestDatabaseNames {
                         "Test database (or schema) names must be unique.\n\
                          It is concatenation of the test suite and the test case names.\n\
                          To resolve this error rename them until they are unique.\n\
-                         - Test suite: `{}`\n\
-                         - Test case: `{}`\n\
-                         - Database (or schema): `{}`\n",
-                        suite_name, test_name, test_database_name
+                         - Test suite: `{suite_name}`\n\
+                         - Test case: `{test_name}`\n\
+                         - Database (or schema): `{test_database_name}`\n"
                     );
                 }
                 names.insert(test_database_name.to_string());
@@ -42,10 +41,9 @@ impl UniqueTestDatabaseNames {
                 "Test database (or schema) names must be at most 64 characters \
                  for PostgreSQL compatibility.\n\
                  To resolve this error shorten the name of the test suite and/or test case.\n\
-                 - Test suite: `{}`\n\
-                 - Test case: `{}`\n\
-                 - Database (or schema): `{}`\n",
-                suite_name, test_name, test_database_name
+                 - Test suite: `{suite_name}`\n\
+                 - Test case: `{test_name}`\n\
+                 - Database (or schema): `{test_database_name}`\n"
             );
         }
     }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/config.rs
@@ -415,7 +415,7 @@ impl TestConfig {
             let path = PathBuf::from(file);
             let md = path.metadata();
             if !path.exists() || md.is_err() || !md.unwrap().is_file() {
-                exit_with_message(&format!("The external test executor path `{}` must be a file", file));
+                exit_with_message(&format!("The external test executor path `{file}` must be a file"));
             }
             #[cfg(unix)]
             {
@@ -426,8 +426,7 @@ impl TestConfig {
                 };
                 if !is_executable {
                     exit_with_message(&format!(
-                        "The external test executor file `{}` must be have permissions to execute",
-                        file
+                        "The external test executor file `{file}` must be have permissions to execute"
                     ));
                 }
             }

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/datasource.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/datamodel_rendering/datasource.rs
@@ -66,7 +66,7 @@ impl<'a> DatasourceBuilder<'a> {
     }
 
     fn add_debug(&mut self, key: &'static str, value: impl std::fmt::Debug) {
-        self.properties.insert(key, format!("{:?}", value));
+        self.properties.insert(key, format!("{value:?}"));
     }
 }
 

--- a/query-engine/connectors/query-connector/src/error.rs
+++ b/query-engine/connectors/query-connector/src/error.rs
@@ -115,7 +115,7 @@ impl ConnectorError {
 
             ErrorKind::TooManyConnections(e) => Some(user_facing_errors::KnownError::new(
                 user_facing_errors::query_engine::TooManyConnections {
-                    message: format!("{}", e),
+                    message: format!("{e}"),
                 },
             )),
             _ => None,

--- a/query-engine/connectors/sql-query-connector/examples/tokio_pg.rs
+++ b/query-engine/connectors/sql-query-connector/examples/tokio_pg.rs
@@ -13,7 +13,7 @@ async fn main() {
     tokio::spawn(async move {
         let now = Instant::now();
         if let Err(e) = connection.await {
-            eprintln!("connection error: {}", e);
+            eprintln!("connection error: {e}");
         }
         eprintln!("connection time: {:?}", now.elapsed());
     });

--- a/query-engine/core/src/interactive_transactions/mod.rs
+++ b/query-engine/core/src/interactive_transactions/mod.rs
@@ -11,7 +11,7 @@ pub(crate) use manager::*;
 pub(crate) use transaction::*;
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize, Display)]
-#[display(fmt = "{}", _0)]
+#[display(fmt = "{_0}")]
 pub struct TxId(String);
 
 impl Default for TxId {

--- a/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-engine/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -443,8 +443,7 @@ impl<'a> ScalarFilterParser<'a> {
                         .find(|container| container.name() == container_ref_name)
                         .ok_or_else(|| {
                             QueryGraphBuilderError::InputError(format!(
-                                "Model or composite type {} used for field ref {} does not exist.",
-                                container_ref_name, field_ref_name
+                                "Model or composite type {container_ref_name} used for field ref {field_ref_name} does not exist."
                             ))
                         })?;
 

--- a/query-engine/core/src/query_graph_builder/write/limit.rs
+++ b/query-engine/core/src/query_graph_builder/write/limit.rs
@@ -12,8 +12,7 @@ pub(crate) fn validate_limit(limit_arg: Option<ParsedArgument<'_>>) -> QueryGrap
         Some(i) => {
             if i < 0 {
                 return Err(QueryGraphBuilderError::InputError(format!(
-                    "Provided limit ({}) must be a positive integer.",
-                    i
+                    "Provided limit ({i}) must be a positive integer."
                 )));
             }
 

--- a/query-engine/dmmf/src/tests/tests.rs
+++ b/query-engine/dmmf/src/tests/tests.rs
@@ -21,7 +21,7 @@ fn views_ignore() {
 fn assert_comment(actual: Option<&String>, expected: &str) {
     match actual {
         Some(actual) => assert_eq!(actual.as_str(), expected),
-        None => panic!("Expected comment: {}", expected),
+        None => panic!("Expected comment: {expected}"),
     }
 }
 

--- a/query-engine/query-builders/query-builder/src/lib.rs
+++ b/query-engine/query-builders/query-builder/src/lib.rs
@@ -241,7 +241,7 @@ impl fmt::Display for DbQuery {
     fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
         match self {
             DbQuery::RawSql { sql, .. } => {
-                write!(formatter, "{}", sql)?;
+                write!(formatter, "{sql}")?;
             }
             DbQuery::TemplateSql { fragments, .. } => {
                 let placeholder_format = PlaceholderFormat {

--- a/query-engine/query-builders/sql-query-builder/src/filter/alias.rs
+++ b/query-engine/query-builders/sql-query-builder/src/filter/alias.rs
@@ -31,8 +31,8 @@ impl Alias {
 impl fmt::Display for Alias {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Table(index) => write!(f, "t{}", index),
-            Self::Join(index) => write!(f, "j{}", index),
+            Self::Table(index) => write!(f, "t{index}"),
+            Self::Join(index) => write!(f, "j{index}"),
         }
     }
 }

--- a/query-engine/query-builders/sql-query-builder/src/value.rs
+++ b/query-engine/query-builders/sql-query-builder/src/value.rs
@@ -51,7 +51,7 @@ impl fmt::Display for GeneratorCall {
             if i > 0 {
                 write!(f, ", ")?;
             }
-            write!(f, "{}", arg)?;
+            write!(f, "{arg}")?;
         }
         write!(f, ")")
     }

--- a/query-engine/query-engine-node-api/src/logger.rs
+++ b/query-engine/query-engine-node-api/src/logger.rs
@@ -158,7 +158,7 @@ impl StringCallback for CallbackLayer {
         let status = self.callback.call(message, ThreadsafeFunctionCallMode::Blocking);
 
         if status != napi::Status::Ok {
-            Err(format!("Could not call JS callback: {}", status))
+            Err(format!("Could not call JS callback: {status}"))
         } else {
             Ok(())
         }

--- a/query-engine/query-engine-wasm/rust-toolchain.toml
+++ b/query-engine/query-engine-wasm/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2025-02-14"
+channel = "nightly-2025-06-27"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = ["wasm32-unknown-unknown"]

--- a/query-engine/query-structure/src/default_value.rs
+++ b/query-engine/query-structure/src/default_value.rs
@@ -324,7 +324,7 @@ impl ValueGeneratorFn {
         PrismaValue::String(match version {
             1 => cuid::cuid1(),
             2 => cuid::cuid2(),
-            _ => panic!("Unknown `cuid` version: {}", version),
+            _ => panic!("Unknown `cuid` version: {version}"),
         })
     }
 
@@ -333,7 +333,7 @@ impl ValueGeneratorFn {
         PrismaValue::Uuid(match version {
             4 => uuid::Uuid::new_v4(),
             7 => uuid::Uuid::now_v7(),
-            _ => panic!("Unknown UUID version: {}", version),
+            _ => panic!("Unknown UUID version: {version}"),
         })
     }
 

--- a/query-engine/query-structure/src/internal_data_model.rs
+++ b/query-engine/query-structure/src/internal_data_model.rs
@@ -69,7 +69,7 @@ impl InternalDataModel {
             .map(move |rf| self.clone().zip(rf.id))
     }
 
-    pub fn walk<I>(&self, id: I) -> psl::parser_database::walkers::Walker<I> {
+    pub fn walk<I>(&self, id: I) -> psl::parser_database::walkers::Walker<'_, I> {
         self.schema.db.walk(id)
     }
 

--- a/query-engine/query-structure/src/write_args.rs
+++ b/query-engine/query-structure/src/write_args.rs
@@ -385,7 +385,7 @@ impl WriteArgs {
         self.args.swap_remove(field)
     }
 
-    pub fn keys(&self) -> Keys<DatasourceFieldName, WriteOperation> {
+    pub fn keys(&self) -> Keys<'_, DatasourceFieldName, WriteOperation> {
         self.args.keys()
     }
 

--- a/query-engine/schema/examples/schema_builder_build_odoo.rs
+++ b/query-engine/schema/examples/schema_builder_build_odoo.rs
@@ -7,5 +7,5 @@ fn main() {
     let _ = schema::build(validated_schema, true);
     let elapsed = now.elapsed();
 
-    println!("Elapsed: {:.2?}", elapsed);
+    println!("Elapsed: {elapsed:.2?}");
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # WASM target for serverless and edge environments.

--- a/schema-engine/cli/src/main.rs
+++ b/schema-engine/cli/src/main.rs
@@ -114,7 +114,7 @@ async fn async_main() {
         match tokio::time::timeout(*GRACEFUL_SHUTDOWN_TIMEOUT, work).await {
             Ok(Ok(())) => (),
             Ok(Err(err)) => {
-                panic!("main task panicked: {}", err);
+                panic!("main task panicked: {err}");
             }
             Err(_) => {
                 tracing::error!("Graceful shutdown timed out");

--- a/schema-engine/commands/src/commands/create_migration.rs
+++ b/schema-engine/commands/src/commands/create_migration.rs
@@ -6,7 +6,7 @@ use user_facing_errors::schema_engine::MigrationNameTooLong;
 /// Create a directory name for a new migration.
 pub fn generate_migration_directory_name(migration_name: &str) -> String {
     let timestamp = format_utc_now("%Y%m%d%H%M%S");
-    let directory_name = format!("{}_{}", timestamp, migration_name);
+    let directory_name = format!("{timestamp}_{migration_name}");
     directory_name
 }
 

--- a/schema-engine/connectors/mongodb-schema-connector/tests/introspection/test_api/utils.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/introspection/test_api/utils.rs
@@ -56,10 +56,9 @@ pub(crate) fn generator_block_string(features: BitFlags<PreviewFeature>) -> Stri
         r#"
           generator js {{
             provider        = "prisma-client-js"
-            previewFeatures = [{}]
+            previewFeatures = [{features}]
           }}
       "#,
-        features,
     )
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -119,8 +119,7 @@ impl<'a> PpgParams<'a> {
 
     fn required_param_error(param_name: &str) -> ConnectorError {
         ConnectorError::url_parse_error(format!(
-            "Required `{}` query string parameter was not provided in a connection URL",
-            param_name
+            "Required `{param_name}` query string parameter was not provided in a connection URL"
         ))
     }
 }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connector/wasm/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connector/wasm/mod.rs
@@ -105,7 +105,7 @@ impl Connection {
 
         let truncate_sql = table_ids
             .iter()
-            .map(|(table_name, _)| format!("DELETE FROM {}", table_name))
+            .map(|(table_name, _)| format!("DELETE FROM {table_name}"))
             .collect::<Vec<_>>()
             .join("; ");
 

--- a/schema-engine/datamodel-renderer/src/value/documentation.rs
+++ b/schema-engine/datamodel-renderer/src/value/documentation.rs
@@ -12,7 +12,7 @@ impl<'a> Documentation<'a> {
                 d.push_str(docs.as_ref());
             }
             Cow::Borrowed(existing) => {
-                self.0 = Cow::Owned(format!("{existing}\n{}", docs));
+                self.0 = Cow::Owned(format!("{existing}\n{docs}"));
             }
         }
     }

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -195,9 +195,9 @@ impl TestApi {
 
                 while let Some(idx) = line.find('?') {
                     let replacer = if self.is_postgres() || self.is_cockroach() {
-                        format!("${}", counter)
+                        format!("${counter}")
                     } else if self.is_mssql() {
-                        format!("@P{}", counter)
+                        format!("@P{counter}")
                     } else {
                         unimplemented!()
                     };

--- a/schema-engine/sql-migration-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -451,7 +451,7 @@ fn with_a_failed_migration(api: TestApi) {
     assert!(action
         .as_reset()
         .unwrap()
-        .contains(&format!("The migration `{}` failed.", generated_migration_name)));
+        .contains(&format!("The migration `{generated_migration_name}` failed.")));
 }
 
 #[test_connector]
@@ -500,10 +500,8 @@ fn with_an_invalid_unapplied_migration_should_report_it(api: TestApi) {
         .to_user_facing()
         .unwrap_known();
 
-    let expected_msg = format!(
-        "Migration `{}` failed to apply cleanly to the shadow database. \nError",
-        generated_migration_name
-    );
+    let expected_msg =
+        format!("Migration `{generated_migration_name}` failed to apply cleanly to the shadow database. \nError");
 
     assert_eq!(err.error_code, MigrationDoesNotApplyCleanly::ERROR_CODE);
     assert!(err.message.starts_with(&expected_msg));

--- a/schema-engine/sql-migration-tests/tests/migrations/postgres/introspection.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/postgres/introspection.rs
@@ -68,7 +68,7 @@ ALTER TABLE blocks
     let expected = format!(
         r#"datasource db {{
   provider = "postgres"
-  url      = "{}"
+  url      = "{url_str}"
 }}
 
 /// This table is a partition table and requires additional setup for migrations. Visit https://pris.ly/d/partition-tables for more info.
@@ -81,8 +81,7 @@ model blocks {{
 
   @@id([account, id])
 }}
-"#,
-        url_str
+"#
     );
     pretty_assertions::assert_eq!(expected, result.schema.files.first().unwrap().content.as_str());
 }
@@ -144,7 +143,7 @@ CREATE TABLE capitals (
     let expected = format!(
         r#"datasource db {{
   provider = "postgres"
-  url      = "{}"
+  url      = "{url_str}"
 }}
 
 model capitals {{
@@ -160,8 +159,7 @@ model cities {{
   population Float? @db.Real
   elevation  Int?
 }}
-"#,
-        url_str
+"#
     );
     pretty_assertions::assert_eq!(expected, result.schema.files.first().unwrap().content.as_str());
 }
@@ -221,7 +219,7 @@ CREATE TABLE capitals (
     let expected = format!(
         r#"datasource db {{
   provider = "postgres"
-  url      = "{}"
+  url      = "{url_str}"
 }}
 
 /// The underlying table does not contain a valid unique identifier and can therefore currently not be handled by Prisma Client.
@@ -240,8 +238,7 @@ model cities {{
   population Float? @db.Real
   elevation  Int?
 }}
-"#,
-        url_str
+"#
     );
     pretty_assertions::assert_eq!(expected, result.schema.files.first().unwrap().content.as_str());
 }


### PR DESCRIPTION
1. Update stable Rust to 1.88.0 and fix a new clippy lint enforcing variables to be written inline in format strings.
2. Update nightly Rust for query-engine-wasm to latest and fix a new stylistic compiler warning suggesting for elided lifetimes in paths to be written explicitly when the lifetime flows from the function argument to its return type.