### PR TITLE
test(psl): add missing test cases for multiple generators with the same provider name

### DIFF
--- a/psl/psl/tests/validation/generator/multiple_prisma_clients.prisma
+++ b/psl/psl/tests/validation/generator/multiple_prisma_clients.prisma
@@ -1,0 +1,18 @@
+generator client {
+  provider = "prisma-client"
+  output = "../lib/.generated/prisma"
+  previewFeatures = ["driverAdapters", "queryCompiler"]
+}
+
+generator edge {
+  provider = "prisma-client"
+  output = "../lib/.generated/prisma-edge"
+  runtime = "edge-light"
+  previewFeatures = ["driverAdapters", "queryCompiler"]
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}

--- a/psl/psl/tests/validation/generator/multiple_prisma_clients_same_name.prisma
+++ b/psl/psl/tests/validation/generator/multiple_prisma_clients_same_name.prisma
@@ -1,0 +1,23 @@
+generator client {
+  provider = "prisma-client"
+  output = "../lib/.generated/prisma"
+  previewFeatures = ["driverAdapters", "queryCompiler"]
+}
+
+generator client {
+  provider = "prisma-client"
+  output = "../lib/.generated/prisma-edge"
+  runtime = "edge-light"
+}
+
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
+}
+// [1;91merror[0m: [1mThe generator "client" cannot be defined because a generator with that name already exists.[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
+// [1;94m   | [0m
+// [1;94m 6 | [0m
+// [1;94m 7 | [0mgenerator [1;91mclient[0m {
+// [1;94m   | [0m


### PR DESCRIPTION
This PR adds missing test cases for multiple generators with the same provider name