### PR TITLE
chore(driver-adapters): add two more packages to workspace

### DIFF
--- a/libs/driver-adapters/pnpm-workspace.yaml
+++ b/libs/driver-adapters/pnpm-workspace.yaml
@@ -11,4 +11,6 @@ packages:
   - '../../../prisma/packages/client-engine-runtime'
   - '../../../prisma/packages/debug'
   - '../../../prisma/packages/driver-adapter-utils'
+  - '../../../prisma/packages/dmmf'
+  - '../../../prisma/packages/generator'
   - './executor'


### PR DESCRIPTION
Add `@prisma/generator` and `@prisma/dmmf` to the pnpm workspace because
of the changes in <prisma/prisma#27566>.