### PR TITLE
fix: preserve arity of aggregation fields

### DIFF
--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -8,7 +8,7 @@ use query_core::{
     CreateManyRecordsFields, DeleteRecordFields, Node, Query, QueryGraph, ReadQuery, UpdateManyRecordsFields,
     UpdateRecord, WriteQuery, schema::constants::aggregations,
 };
-use query_structure::{AggregationSelection, FieldSelection, SelectedField};
+use query_structure::{AggregationSelection, FieldSelection, FieldTypeInformation, SelectedField};
 use std::{borrow::Cow, collections::HashMap};
 
 pub fn map_result_structure(graph: &QueryGraph, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
@@ -227,12 +227,13 @@ fn get_result_node_for_aggregation(
                     } else {
                         (ident.name, ident.db_name)
                     };
-                (aggregate_underscore_name(sel), name, db_name, ident.typ)
+                let type_info = FieldTypeInformation::new(ident.typ, ident.arity, None);
+                (aggregate_underscore_name(sel), name, db_name, type_info)
             })
         })
         .sorted_by_key(|(underscore_name, name, _, _)| ordered_set.get_index_of(&(*underscore_name, *name)))
     {
-        let value = builder.new_value(db_name.to_owned(), typ.into());
+        let value = builder.new_value(db_name.to_owned(), typ);
         if let Some(undescore_name) = underscore_name {
             node.entry_or_insert_nested(undescore_name)
                 .add_field(name.to_owned(), value);

--- a/query-compiler/query-engine-tests-todo/neon/fail/join
+++ b/query-compiler/query-engine-tests-todo/neon/fail/join
@@ -1,5 +1,3 @@
-new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
-new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/neon/fail/query
+++ b/query-compiler/query-engine-tests-todo/neon/fail/query
@@ -1,5 +1,3 @@
-new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
-new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/join
@@ -1,5 +1,3 @@
-new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
-new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_7434::not_in_chunking_cockroachdb::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::aggregation::many_count_relation::many_count_rel::count_with_distinct

--- a/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/query
@@ -1,5 +1,3 @@
-new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
-new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_7434::not_in_chunking_cockroachdb::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -1,5 +1,3 @@
-new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
-new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-compiler/query-engine-tests-todo/pg/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg/fail/query
@@ -1,5 +1,3 @@
-new::regressions::prisma_13097::prisma_13097::group_by_boolean_array
-new::regressions::prisma_13097::prisma_13097::group_by_enum_array
 new::regressions::prisma_7434::not_in_chunking::not_in_batch_filter
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
 queries::chunking::chunking::order_by_aggregation_should_fail

--- a/query-engine/query-structure/src/field/mod.rs
+++ b/query-engine/query-structure/src/field/mod.rs
@@ -297,6 +297,14 @@ pub struct FieldTypeInformation {
 }
 
 impl FieldTypeInformation {
+    pub fn new(typ: Type, arity: FieldArity, native_type: Option<NativeTypeInstance>) -> Self {
+        FieldTypeInformation {
+            typ,
+            arity,
+            native_type,
+        }
+    }
+
     pub fn to_prisma_type(&self) -> PrismaValueType {
         let type_ = match (self.typ.id, self.native_type.as_ref()) {
             (TypeIdentifier::DateTime, Some(native_type))


### PR DESCRIPTION
[ORM-965](https://linear.app/prisma-company/issue/ORM-965/grouping-by-array-returns-weird-result)