### PR TITLE
chore(driver-adapters): remove unused pnpm workspace deps

### DIFF
--- a/libs/driver-adapters/pnpm-workspace.yaml
+++ b/libs/driver-adapters/pnpm-workspace.yaml
@@ -11,6 +11,4 @@ packages:
   - '../../../prisma/packages/client-engine-runtime'
   - '../../../prisma/packages/debug'
   - '../../../prisma/packages/driver-adapter-utils'
-  - '../../../prisma/packages/dmmf'
-  - '../../../prisma/packages/generator'
   - './executor'


### PR DESCRIPTION
Remove the dependencies which are not necessary anymore after https://github.com/prisma/prisma/pull/27575 from the pnpm workspace.

/prisma-branch push-wlmvrwqwxwwk