### PR TITLE
fix: fix prisma#24068

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/destructive_change_checker.rs
@@ -76,7 +76,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: None,
+                        namespace: columns.previous.table().namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -88,7 +88,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: None,
+                        namespace: columns.previous.table().namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type: format!("{:?}", columns.previous.column_type_family()),
                         next_type: format!("{:?}", columns.next.column_type_family()),
@@ -134,7 +134,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
-                    namespace: None,
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/destructive_change_checker.rs
@@ -74,7 +74,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: None,
+                        namespace: columns.previous.table().namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -86,7 +86,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: None,
+                        namespace: columns.previous.table().namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -133,7 +133,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
-                    namespace: None,
+                    namespace: columns.previous.table().namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/destructive_change_checker.rs
@@ -61,7 +61,7 @@ impl DestructiveChangeCheckerFlavour for SqliteDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: None,
+                        namespace: columns.previous.table().namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type: format!("{:?}", columns.previous.column_type_family()),
                         next_type: format!("{:?}", columns.next.column_type_family()),


### PR DESCRIPTION
[ORM-1099](https://linear.app/prisma-company/issue/ORM-1099/24068-sqlserver-migrate-issues)

We've been discarding the namespace in a few places. I kept the namespace wherever it's available even if it's currently not used (mysql and sqlite).

Fixes https://github.com/prisma/prisma/issues/24068