### PR TITLE
chore: ORM-1115 multi schema todos

### DIFF
--- a/schema-engine/commands/src/commands/diagnose_migration_history.rs
+++ b/schema-engine/commands/src/commands/diagnose_migration_history.rs
@@ -137,8 +137,6 @@ pub async fn diagnose_migration_history(
         if input.opt_in_to_shadow_database {
             let mut dialect = connector.schema_dialect();
             let target = ExternalShadowDatabase::DriverAdapter(adapter_factory);
-            // TODO(MultiSchema): this should probably fill the following namespaces from the CLI since there is
-            // no schema to grab the namespaces off, in the case of MultiSchema.
             let from = migration_schema_cache
                 .get_or_insert(&applied_migrations, || async {
                     connector
@@ -164,8 +162,6 @@ pub async fn diagnose_migration_history(
 
             let error_in_unapplied_migration = if !matches!(drift, Some(DriftDiagnostic::MigrationFailedToApply { .. }))
             {
-                // TODO(MultiSchema): Not entirely sure passing no namespaces here is correct. Probably should
-                // also grab this as a CLI argument.
                 dialect
                     .validate_migrations_with_target(&migrations_from_filesystem, namespaces, target)
                     .await

--- a/schema-engine/commands/src/commands/diff.rs
+++ b/schema-engine/commands/src/commands/diff.rs
@@ -22,8 +22,6 @@ pub async fn diff(
     // In order to properly handle MultiSchema, we need to make sure the preview feature is
     // correctly set, and we need to grab the namespaces from the Schema, if any.
     // Note that currently, we union all namespaces and preview features. This may not be correct.
-    // TODO: This effectively reads and parses (parts of) the schema twice: once here, and once
-    // below, when defining 'from'/'to'. We should revisit this.
     let (namespaces, preview_features) =
         namespaces_and_preview_features_from_diff_targets(&[&params.from, &params.to])?;
 

--- a/schema-engine/commands/src/commands/evaluate_data_loss.rs
+++ b/schema-engine/commands/src/commands/evaluate_data_loss.rs
@@ -22,11 +22,9 @@ pub async fn evaluate_data_loss(
 
     let from = migration_schema_cache
         .get_or_insert(&input.migrations_list.migration_directories, || async {
+            // We only consider the namespaces present in the "to" schema aka the PSL file for the introspection of the "from" schema.
+            // So when the user removes a previously existing namespace from their PSL file we will not introspect that namespace in the database.
             let namespaces = dialect.extract_namespaces(&to);
-
-            // TODO(MultiSchema): we may need to do something similar to
-            // namespaces_and_preview_features_from_diff_targets here as well,
-            // particularly if it's not correctly setting the preview features flags.
             connector
                 .schema_from_migrations(&migrations_from_directory, namespaces)
                 .await

--- a/schema-engine/commands/src/commands/schema_push.rs
+++ b/schema-engine/commands/src/commands/schema_push.rs
@@ -24,11 +24,9 @@ pub async fn schema_push(input: SchemaPushInput, connector: &mut dyn SchemaConne
     let dialect = connector.schema_dialect();
 
     let to = dialect.schema_from_datamodel(sources)?;
+    // We only consider the namespaces present in the "to" schema aka the PSL file for the introspection of the "from" schema.
+    // So when the user removes a previously existing namespace from their PSL file we will not modify that namespace in the database.
     let namespaces = dialect.extract_namespaces(&to);
-
-    // TODO(MultiSchema): we may need to do something similar to
-    // namespaces_and_preview_features_from_diff_targets here as well,
-    // particulalry if it's not correctly setting the preview features flags.
     let from = connector
         .schema_from_database(namespaces)
         .instrument(tracing::info_span!("Calculate from database"))

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
@@ -50,7 +50,7 @@ impl PostgresRenderer {
 }
 
 impl SqlRenderer for PostgresRenderer {
-    // TODO(MultiSchema): We only do alter_sequence on CockroachDB.
+    // TODO: We only do alter_sequence on CockroachDB.
     fn render_alter_sequence(
         &self,
         sequence_idx: MigrationPair<u32>,

--- a/schema-engine/core/src/commands/diagnose_migration_history_cli.rs
+++ b/schema-engine/core/src/commands/diagnose_migration_history_cli.rs
@@ -76,8 +76,6 @@ pub async fn diagnose_migration_history_cli(
     let (drift, error_in_unapplied_migration) = {
         if input.opt_in_to_shadow_database {
             let dialect = connector.schema_dialect();
-            // TODO(MultiSchema): this should probably fill the following namespaces from the CLI since there is
-            // no schema to grab the namespaces off, in the case of MultiSchema.
             let from = migration_schema_cache
                 .get_or_insert(&applied_migrations, || async {
                     connector
@@ -103,8 +101,6 @@ pub async fn diagnose_migration_history_cli(
 
             let error_in_unapplied_migration = if !matches!(drift, Some(DriftDiagnostic::MigrationFailedToApply { .. }))
             {
-                // TODO(MultiSchema): Not entirely sure passing no namespaces here is correct. Probably should
-                // also grab this as a CLI argument.
                 connector
                     .validate_migrations(&migrations_from_filesystem, namespaces)
                     .await

--- a/schema-engine/core/src/rpc.rs
+++ b/schema-engine/core/src/rpc.rs
@@ -78,7 +78,6 @@ async fn run_command(
         INTROSPECT_SQL => render(executor.introspect_sql(params.parse()?).await),
         MARK_MIGRATION_APPLIED => render(executor.mark_migration_applied(params.parse()?).await),
         MARK_MIGRATION_ROLLED_BACK => render(executor.mark_migration_rolled_back(params.parse()?).await),
-        // TODO(MultiSchema): we probably need to grab the namespaces from the params
         RESET => render(executor.reset().await),
         SCHEMA_PUSH => render(executor.schema_push(params.parse()?).await),
         other => unreachable!("Unknown command {}", other),

--- a/schema-engine/sql-schema-describer/src/postgres.rs
+++ b/schema-engine/sql-schema-describer/src/postgres.rs
@@ -684,7 +684,7 @@ impl<'a> SqlSchemaDescriber<'a> {
     }
 
     async fn get_namespaces(&self, sql_schema: &mut SqlSchema, namespaces: &[&str]) -> DescriberResult<()> {
-        // TODO: this query isn't really useful. We already have namespaces.
+        // Although we have a list of namespaces we should introspect, we still need to check whether they actually already exist in the database.
         let sql = include_str!("postgres/namespaces_query.sql");
 
         let rows = self.conn.query_raw(sql, &[Value::array(namespaces)]).await?;


### PR DESCRIPTION
This PR removes various left over ToDo comments related to the multi schema feature. They all seem irrelevant or even incorrect by now.

Some explainers:
- Some ToDos mention to consider also a list of schemas given through CLI args. The only command where we accept a list of schemas (via `--schemas`) on the CLI is `db pull` and for it is implemented.
- We have a potential issue when a user removes a schema from their PSL file. We then won't consider this schema anymore for diffing in the `migrate dev` call. Hence dropping the schema (and its models) will NOT create a migration that drops that schema and related tables on the database. Which in my opinion is a fine limitation. ([see slack](https://prisma-company.slack.com/archives/C0350LQSUF2/p1752062839564359))
- One ToDo was related to CockroachDB but not MultiSchema at all.
- One ToDo was incorrectly doubting a query => replaced it with an explainer