### PR TITLE
feat: ORM-1100 fix config validations

### DIFF
--- a/psl/psl/tests/config/datasources.rs
+++ b/psl/psl/tests/config/datasources.rs
@@ -302,3 +302,30 @@ fn parse_direct_url_should_work() {
 
     assert_eq!("DIRECT_DATABASE_URL", result);
 }
+
+#[test]
+fn parse_multi_schema_for_unsupported_connector_should_error() {
+    let schema = indoc! {r#"
+        generator js {
+          provider        = "prisma-client-js"
+        }
+
+        datasource ds {
+          provider   = "mysql"
+          url        = env("DATABASE_URL")
+          schemas = ["test"]
+        }
+    "#};
+
+    let actual = parse_config(schema).unwrap_err();
+    let expect = expect![[r#"
+        [1;91merror[0m: [1mThe `schemas` property is not supported on the current connector.[0m
+          [1;94m-->[0m  [4mschema.prisma:8[0m
+        [1;94m   | [0m
+        [1;94m 7 | [0m  url        = env("DATABASE_URL")
+        [1;94m 8 | [0m  schemas = [1;91m["test"][0m
+        [1;94m   | [0m
+    "#]];
+
+    expect.assert_eq(&actual);
+}

--- a/psl/psl/tests/validation/attributes/schema/on_mysql.prisma
+++ b/psl/psl/tests/validation/attributes/schema/on_mysql.prisma
@@ -22,9 +22,3 @@ model Test {
 // [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
 // [1;94m 4 | [0m    schemas = [1;91m["public", "sphere"][0m
 // [1;94m   | [0m
-// [1;91merror[0m: [1m@@schema is not supported on the current datasource provider[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
-// [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  @@schema([1;91m"public"[0m)
-// [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/on_sqlite.prisma
+++ b/psl/psl/tests/validation/attributes/schema/on_sqlite.prisma
@@ -22,9 +22,3 @@ model Test {
 // [1;94m 3 | [0m    url = env("TEST_DATABASE_URL")
 // [1;94m 4 | [0m    schemas = [1;91m["public", "sphere"][0m
 // [1;94m   | [0m
-// [1;91merror[0m: [1m@@schema is not supported on the current datasource provider[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
-// [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  @@schema([1;91m"public"[0m)
-// [1;94m   | [0m

--- a/schema-engine/connectors/schema-connector/src/filter.rs
+++ b/schema-engine/connectors/schema-connector/src/filter.rs
@@ -1,0 +1,14 @@
+/// Configuration of entities in the schema/database to be included or excluded from an operation.
+#[derive(Debug, Default)]
+pub struct SchemaFilter {
+    /// Tables that shall be considered 'externally" managed. As per prisma.config.ts > tables.external.
+    pub external_tables: Vec<String>,
+}
+
+impl From<json_rpc::types::SchemaFilter> for SchemaFilter {
+    fn from(filter: json_rpc::types::SchemaFilter) -> Self {
+        Self {
+            external_tables: filter.external_tables,
+        }
+    }
+}

--- a/schema-engine/connectors/schema-connector/src/introspection_context.rs
+++ b/schema-engine/connectors/schema-connector/src/introspection_context.rs
@@ -43,7 +43,7 @@ impl IntrospectionContext {
         composite_type_depth: CompositeTypeDepth,
         namespaces: Option<Vec<String>>,
         base_directory_path: PathBuf,
-    ) -> Self {
+    ) -> Result<Self, String> {
         let mut config_blocks = String::new();
 
         for source in previous_schema.db.datasources() {
@@ -60,15 +60,14 @@ impl IntrospectionContext {
         let previous_schema_config_only = psl::parse_schema_multi(&[(
             Self::introspection_file_path_impl(&previous_schema, &base_directory_path).to_string(),
             config_blocks.into(),
-        )])
-        .unwrap();
+        )])?;
 
-        Self::new(
+        Ok(Self::new(
             previous_schema_config_only,
             composite_type_depth,
             namespaces,
             base_directory_path,
-        )
+        ))
     }
 
     /// The PSL file with the previous schema definition.

--- a/schema-engine/core/src/state.rs
+++ b/schema-engine/core/src/state.rs
@@ -378,16 +378,16 @@ impl GenericApi for EngineState {
                 PathBuf::new().join(&params.base_directory_path),
             )
         } else {
-            let previous_schema =
-                psl::parse_schema_multi(&source_files).map_err(ConnectorError::new_schema_parser_error)?;
-
-            schema_connector::IntrospectionContext::new(
-                previous_schema,
-                composite_type_depth,
-                params.namespaces,
-                PathBuf::new().join(&params.base_directory_path),
-            )
-        };
+            psl::parse_schema_multi(&source_files).map(|previous_schema| {
+                schema_connector::IntrospectionContext::new(
+                    previous_schema,
+                    composite_type_depth,
+                    params.namespaces,
+                    PathBuf::new().join(&params.base_directory_path),
+                )
+            })
+        }
+        .map_err(ConnectorError::new_schema_parser_error)?;
 
         if !ctx
             .configuration()

--- a/schema-engine/schema-engine-wasm/src/wasm/engine.rs
+++ b/schema-engine/schema-engine-wasm/src/wasm/engine.rs
@@ -312,16 +312,16 @@ impl SchemaEngine {
                     PathBuf::new().join(&params.base_directory_path),
                 )
             } else {
-                let previous_schema = psl::parse_schema_multi(&source_files)
-                    .map_err(|e| ConnectorError::new_schema_parser_error(e).into_js_error())?;
-
-                schema_connector::IntrospectionContext::new(
-                    previous_schema,
-                    composite_type_depth,
-                    params.namespaces,
-                    PathBuf::new().join(&params.base_directory_path),
-                )
-            };
+                psl::parse_schema_multi(&source_files).map(|previous_schema| {
+                    schema_connector::IntrospectionContext::new(
+                        previous_schema,
+                        composite_type_depth,
+                        params.namespaces,
+                        PathBuf::new().join(&params.base_directory_path),
+                    )
+                })
+            }
+            .map_err(|e| ConnectorError::new_schema_parser_error(e).into_js_error())?;
 
             if !ctx
                 .configuration()

--- a/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/cockroachdb/mod.rs
@@ -31,7 +31,8 @@ async fn introspecting_cockroach_db_with_postgres_provider_fails(api: TestApi) {
     api.raw_cmd(setup).await;
 
     let schema = psl::parse_schema(schema).unwrap();
-    let ctx = IntrospectionContext::new_config_only(schema, CompositeTypeDepth::Infinite, None, PathBuf::new());
+    let ctx =
+        IntrospectionContext::new_config_only(schema, CompositeTypeDepth::Infinite, None, PathBuf::new()).unwrap();
 
     // Instantiate the schema connector manually for this test because `TestApi`
     // chooses the provider type based on the current database under test and

--- a/schema-engine/sql-introspection-tests/tests/re_introspection/multi_file.rs
+++ b/schema-engine/sql-introspection-tests/tests/re_introspection/multi_file.rs
@@ -310,7 +310,7 @@ async fn reintrospect_force_invalid_config(api: &mut TestApi) -> TestResult {
     let invalid_config_dm = indoc! {r#"
       datasource db {
         provider = "mysql"
-        url = "env(TEST_DATABASE_URL)"
+        url = env("TEST_DATABASE_URL")
         schemas  = ["foo"]
       }
 
@@ -326,7 +326,7 @@ async fn reintrospect_force_invalid_config(api: &mut TestApi) -> TestResult {
         [1;91merror[0m: [1mThe `schemas` property is not supported on the current connector.[0m
           [1;94m-->[0m  [4mfoo.prisma:4[0m
         [1;94m   | [0m
-        [1;94m 3 | [0m  url = "env(TEST_DATABASE_URL)"
+        [1;94m 3 | [0m  url = env("TEST_DATABASE_URL")
         [1;94m 4 | [0m  schemas  = [1;91m["foo"][0m
         [1;94m   | [0m
 


### PR DESCRIPTION
This PR primarily fixes a panic during `prisma db pull` (see https://github.com/prisma/prisma/issues/21386). This panic however was a symptom of missing validation and missing failed validation handling.

Closes https://github.com/prisma/prisma/issues/21386
