### PR TITLE
feat(multi-schema): ORM-1113 external tables push and diff

### DIFF
--- a/schema-engine/commands/src/commands/dev_diagnostic.rs
+++ b/schema-engine/commands/src/commands/dev_diagnostic.rs
@@ -24,7 +24,7 @@ pub async fn dev_diagnostic(
     let diagnose_input = DiagnoseMigrationHistoryInput {
         migrations_list: input.migrations_list,
         opt_in_to_shadow_database: true,
-        schema_filter: input.schema_filter,
+        filters: input.filters,
     };
 
     let diagnose_migration_history_output = diagnose_migration_history(

--- a/schema-engine/commands/src/commands/diagnose_migration_history.rs
+++ b/schema-engine/commands/src/commands/diagnose_migration_history.rs
@@ -147,7 +147,7 @@ pub async fn diagnose_migration_history(
                 .await;
             let to = connector.schema_from_database(namespaces.clone()).await;
             let drift = match from
-                .and_then(|from| to.map(|to| dialect.diff(from, to, &input.schema_filter.into())))
+                .and_then(|from| to.map(|to| dialect.diff(from, to, &input.filters.into())))
                 .map(|mig| {
                     if dialect.migration_is_empty(&mig) {
                         None

--- a/schema-engine/commands/src/commands/diff.rs
+++ b/schema-engine/commands/src/commands/diff.rs
@@ -11,7 +11,7 @@ use json_rpc::types::MigrationList;
 use psl::SourceFile;
 use quaint::connector::ExternalConnectorFactory;
 use schema_connector::{
-    ConnectorError, DatabaseSchema, ExternalShadowDatabase, Namespaces, SchemaConnector, SchemaDialect, SchemaFilter,
+    ConnectorError, DatabaseSchema, ExternalShadowDatabase, Namespaces, SchemaConnector, SchemaDialect,
 };
 
 pub async fn diff(
@@ -49,8 +49,7 @@ pub async fn diff(
     let from = schema_from.unwrap_or_else(|| dialect.empty_database_schema());
     let to = schema_to.unwrap_or_else(|| dialect.empty_database_schema());
 
-    // TODO:(schema-filter) get filter from params and prisma config
-    let migration = dialect.diff(from, to, &SchemaFilter::default());
+    let migration = dialect.diff(from, to, &params.filters.into());
 
     let mut stdout = if params.script {
         dialect.render_script(&migration, &Default::default())?

--- a/schema-engine/commands/src/commands/schema_push.rs
+++ b/schema-engine/commands/src/commands/schema_push.rs
@@ -1,5 +1,5 @@
 use crate::{CoreResult, SchemaContainerExt, json_rpc::types::*, parse_schema_multi};
-use schema_connector::{ConnectorError, SchemaConnector, SchemaFilter};
+use schema_connector::{ConnectorError, SchemaConnector};
 use tracing_futures::Instrument;
 
 /// Command to bring the local database in sync with the prisma schema, without
@@ -31,8 +31,7 @@ pub async fn schema_push(input: SchemaPushInput, connector: &mut dyn SchemaConne
         .schema_from_database(namespaces)
         .instrument(tracing::info_span!("Calculate from database"))
         .await?;
-    // TODO:(schema-filter) get filter from prisma config
-    let database_migration = dialect.diff(from, to, &SchemaFilter::default());
+    let database_migration = dialect.diff(from, to, &input.filters.into());
 
     tracing::debug!(migration = dialect.migration_summary(&database_migration).as_str());
 

--- a/schema-engine/core/src/commands/dev_diagnostic_cli.rs
+++ b/schema-engine/core/src/commands/dev_diagnostic_cli.rs
@@ -20,7 +20,7 @@ pub async fn dev_diagnostic_cli(
     let diagnose_input = DiagnoseMigrationHistoryInput {
         migrations_list: input.migrations_list,
         opt_in_to_shadow_database: true,
-        schema_filter: input.schema_filter,
+        filters: input.filters,
     };
 
     let diagnose_migration_history_output =

--- a/schema-engine/core/src/commands/diagnose_migration_history_cli.rs
+++ b/schema-engine/core/src/commands/diagnose_migration_history_cli.rs
@@ -86,7 +86,7 @@ pub async fn diagnose_migration_history_cli(
 
             let to = connector.schema_from_database(namespaces.clone()).await;
             let drift = match from
-                .and_then(|from| to.map(|to| dialect.diff(from, to, &input.schema_filter.into())))
+                .and_then(|from| to.map(|to| dialect.diff(from, to, &input.filters.into())))
                 .map(|mig| {
                     if dialect.migration_is_empty(&mig) {
                         None

--- a/schema-engine/core/src/commands/diff_cli.rs
+++ b/schema-engine/core/src/commands/diff_cli.rs
@@ -9,7 +9,6 @@ use enumflags2::BitFlags;
 use json_rpc::types::MigrationList;
 use schema_connector::{
     ConnectorError, ConnectorHost, DatabaseSchema, ExternalShadowDatabase, Namespaces, SchemaConnector, SchemaDialect,
-    SchemaFilter,
 };
 use sql_schema_connector::SqlSchemaConnector;
 
@@ -59,8 +58,7 @@ pub async fn diff_cli(params: DiffParams, host: Arc<dyn ConnectorHost>) -> CoreR
         }
     };
 
-    // TODO:(schema-filter) get filter from params and prisma config
-    let migration = dialect.diff(from, to, &SchemaFilter::default());
+    let migration = dialect.diff(from, to, &params.filters.into());
 
     let mut stdout = if params.script {
         dialect.render_script(&migration, &Default::default())?

--- a/schema-engine/json-rpc-api/src/types.rs
+++ b/schema-engine/json-rpc-api/src/types.rs
@@ -355,7 +355,7 @@ pub struct DevDiagnosticInput {
     pub migrations_list: MigrationList,
 
     /// The schema filter to use during checks on the database.
-    pub schema_filter: Option<SchemaFilter>,
+    pub filters: Option<SchemaFilter>,
 }
 
 /// The response type for `devDiagnostic`.
@@ -383,7 +383,7 @@ pub struct DiagnoseMigrationHistoryInput {
 
     /// The schema filter to use during checks on the database.
     /// Note: Only used if opt_in_to_shadow_database is true.
-    pub schema_filter: Option<SchemaFilter>,
+    pub filters: Option<SchemaFilter>,
 }
 
 /// The result type for `diagnoseMigrationHistory` responses.

--- a/schema-engine/json-rpc-api/src/types.rs
+++ b/schema-engine/json-rpc-api/src/types.rs
@@ -441,6 +441,9 @@ pub struct DiffParams {
     /// If this is set, the engine will return exitCode = 2 in the diffResult in case the diff is
     /// non-empty. Other than this, it does not change the behaviour of the command.
     pub exit_code: Option<bool>,
+
+    /// The schema filter to use during the diff.
+    pub filters: Option<SchemaFilter>,
 }
 
 /// The result type for the `diff` method.
@@ -743,6 +746,9 @@ pub struct SchemaPushInput {
 
     /// The Prisma schema files.
     pub schema: SchemasContainer,
+
+    /// The schema filter to use during the push.
+    pub filters: Option<SchemaFilter>,
 }
 
 /// Response result for the `schemaPush` method.

--- a/schema-engine/sql-migration-tests/src/commands/dev_diagnostic.rs
+++ b/schema-engine/sql-migration-tests/src/commands/dev_diagnostic.rs
@@ -31,7 +31,7 @@ impl<'a> DevDiagnostic<'a> {
         let fut = dev_diagnostic_cli(
             DevDiagnosticInput {
                 migrations_list,
-                schema_filter: Some(self.filter),
+                filters: Some(self.filter),
             },
             None,
             self.api,

--- a/schema-engine/sql-migration-tests/src/commands/diagnose_migration_history.rs
+++ b/schema-engine/sql-migration-tests/src/commands/diagnose_migration_history.rs
@@ -37,7 +37,7 @@ impl<'a> DiagnoseMigrationHistory<'a> {
             DiagnoseMigrationHistoryInput {
                 migrations_list,
                 opt_in_to_shadow_database: self.opt_in_to_shadow_database,
-                schema_filter: None,
+                filters: None,
             },
             None,
             self.api,

--- a/schema-engine/sql-migration-tests/src/commands/schema_push.rs
+++ b/schema-engine/sql-migration-tests/src/commands/schema_push.rs
@@ -14,10 +14,16 @@ pub struct SchemaPush<'a> {
     migration_id: Option<&'a str>,
     // In eventually-consistent systems, we might need to wait for a while before the system refreshes
     max_ddl_refresh_delay: Option<Duration>,
+    schema_filter: Option<SchemaFilter>,
 }
 
 impl<'a> SchemaPush<'a> {
-    pub fn new(api: &'a mut dyn SchemaConnector, files: &[(&str, &str)], max_refresh_delay: Option<Duration>) -> Self {
+    pub fn new(
+        api: &'a mut dyn SchemaConnector,
+        files: &[(&str, &str)],
+        max_refresh_delay: Option<Duration>,
+        schema_filter: Option<SchemaFilter>,
+    ) -> Self {
         SchemaPush {
             api,
             files: files
@@ -30,6 +36,7 @@ impl<'a> SchemaPush<'a> {
             force: false,
             migration_id: None,
             max_ddl_refresh_delay: max_refresh_delay,
+            schema_filter,
         }
     }
 
@@ -47,7 +54,7 @@ impl<'a> SchemaPush<'a> {
         let input = SchemaPushInput {
             schema: SchemasContainer { files: self.files },
             force: self.force,
-            filters: None,
+            filters: self.schema_filter,
         };
 
         let fut = schema_push(input, self.api)

--- a/schema-engine/sql-migration-tests/src/commands/schema_push.rs
+++ b/schema-engine/sql-migration-tests/src/commands/schema_push.rs
@@ -47,6 +47,7 @@ impl<'a> SchemaPush<'a> {
         let input = SchemaPushInput {
             schema: SchemasContainer { files: self.files },
             force: self.force,
+            filters: None,
         };
 
         let fut = schema_push(input, self.api)

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -359,6 +359,7 @@ impl EngineTestApi {
             &mut self.connector,
             &[("schema.prisma", &dm)],
             self.max_ddl_refresh_delay,
+            None,
         )
     }
 

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -475,15 +475,24 @@ impl TestApi {
 
     /// Plan a `schemaPush` command
     pub fn schema_push(&mut self, dm: impl Into<String>) -> SchemaPush<'_> {
-        let max_ddl_refresh_delay = self.max_ddl_refresh_delay();
-        let dm: String = dm.into();
-
-        SchemaPush::new(&mut self.connector, &[("schema.prisma", &dm)], max_ddl_refresh_delay)
+        self.schema_push_with_filter(dm, None)
     }
 
     pub fn schema_push_multi_file(&mut self, files: &[(&str, &str)]) -> SchemaPush<'_> {
         let max_ddl_refresh_delay = self.max_ddl_refresh_delay();
-        SchemaPush::new(&mut self.connector, files, max_ddl_refresh_delay)
+        SchemaPush::new(&mut self.connector, files, max_ddl_refresh_delay, None)
+    }
+
+    pub fn schema_push_with_filter(&mut self, dm: impl Into<String>, filter: Option<SchemaFilter>) -> SchemaPush<'_> {
+        let max_ddl_refresh_delay = self.max_ddl_refresh_delay();
+        let dm: String = dm.into();
+
+        SchemaPush::new(
+            &mut self.connector,
+            &[("schema.prisma", &dm)],
+            max_ddl_refresh_delay,
+            filter,
+        )
     }
 
     pub fn tags(&self) -> BitFlags<Tags> {

--- a/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
@@ -36,6 +36,7 @@ fn db_push_on_cockroach_db_with_postgres_provider_fails(api: TestApi) {
                 content: schema,
             }],
         },
+        filters: None,
     }))
     .unwrap_err()
     .message()

--- a/schema-engine/sql-migration-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -619,7 +619,7 @@ fn dev_diagnostic_shadow_database_creation_error_is_special_cased_mysql(api: Tes
         migration_api
             .dev_diagnostic(DevDiagnosticInput {
                 migrations_list,
-                schema_filter: None,
+                filters: None,
             })
             .await
     })
@@ -670,7 +670,7 @@ fn dev_diagnostic_shadow_database_creation_error_is_special_cased_postgres(api: 
         migration_api
             .dev_diagnostic(DevDiagnosticInput {
                 migrations_list,
-                schema_filter: None,
+                filters: None,
             })
             .await
     })
@@ -832,7 +832,7 @@ ALTER TABLE "prisma-tests".profiles ADD CONSTRAINT profiles_id_fkey FOREIGN KEY 
 
     tok(api.dev_diagnostic(DevDiagnosticInput {
         migrations_list,
-        schema_filter: None,
+        filters: None,
     }))
     .unwrap();
 }

--- a/schema-engine/sql-migration-tests/tests/migrations/diagnose_migration_history_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diagnose_migration_history_tests.rs
@@ -817,7 +817,7 @@ fn shadow_database_creation_error_is_special_cased_mysql(api: TestApi) {
     let output = tok(migration_api.diagnose_migration_history(DiagnoseMigrationHistoryInput {
         migrations_list,
         opt_in_to_shadow_database: true,
-        schema_filter: None,
+        filters: None,
     }))
     .unwrap();
 
@@ -867,7 +867,7 @@ fn shadow_database_creation_error_is_special_cased_postgres(api: TestApi) {
             .diagnose_migration_history(DiagnoseMigrationHistoryInput {
                 migrations_list,
                 opt_in_to_shadow_database: true,
-                schema_filter: None,
+                filters: None,
             })
             .await
     })
@@ -938,7 +938,7 @@ fn shadow_database_creation_error_is_special_cased_mssql(api: TestApi) {
     let output = tok(migration_api.diagnose_migration_history(DiagnoseMigrationHistoryInput {
         migrations_list,
         opt_in_to_shadow_database: true,
-        schema_filter: None,
+        filters: None,
     }))
     .unwrap();
 

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -71,6 +71,7 @@ fn from_unique_index_to_without(mut api: TestApi) {
             }],
         }),
         script: true,
+        filters: None,
     })
     .unwrap();
 
@@ -175,6 +176,7 @@ fn from_unique_index_to_pk(mut api: TestApi) {
             }],
         }),
         script: true,
+        filters: None,
     })
     .unwrap();
 
@@ -390,6 +392,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
             }],
         }),
         script: true,
+        filters: None,
     })
     .unwrap();
 
@@ -409,6 +412,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
             }],
         }),
         script: false,
+        filters: None,
     })
     .unwrap();
 
@@ -448,6 +452,7 @@ fn from_empty_to_migrations_directory(mut api: TestApi) {
         to: DiffTarget::Migrations(migrations_list),
         script: true,
         shadow_database_url: Some(api.connection_string().to_owned()),
+        filters: None,
     };
 
     let host = Arc::new(TestConnectorHost::default());
@@ -489,6 +494,7 @@ fn from_empty_to_migrations_folder_without_shadow_db_url_must_error(mut api: Tes
         to: DiffTarget::Migrations(migrations_list),
         script: true,
         shadow_database_url: None, // TODO: ?
+        filters: None,
     };
 
     let err = api.diff(params).unwrap_err();
@@ -539,6 +545,7 @@ fn from_schema_datamodel_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
+        filters: None,
     };
 
     api.diff(input).unwrap();
@@ -591,6 +598,7 @@ fn from_schema_datasource_relative(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Empty,
+        filters: None,
     };
 
     api.diff(params).unwrap();
@@ -651,6 +659,7 @@ fn from_schema_datasource_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
+        filters: None,
     };
 
     api.diff(input).unwrap();
@@ -693,6 +702,7 @@ fn from_url_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
+        filters: None,
     };
 
     api.diff(input).unwrap();
@@ -759,6 +769,7 @@ fn diffing_mongo_schemas_to_script_returns_a_nice_error() {
             }],
         }),
         script: true,
+        filters: None,
     };
 
     let expected = expect![[r#"
@@ -786,6 +797,7 @@ fn diff_sqlite_migration_directories() {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Migrations(migrations_list_2),
+        filters: None,
     };
 
     tok(schema_core::schema_api(None, None).unwrap().diff(params)).unwrap();
@@ -846,6 +858,7 @@ fn diffing_mongo_schemas_works() {
             }],
         }),
         script: false,
+        filters: None,
     };
 
     let expected_printed_messages = expect![[r#"
@@ -906,6 +919,7 @@ fn diffing_two_schema_datamodels_with_missing_datasource_env_vars() {
                     content: schema_b.to_string(),
                 }],
             }),
+            filters: None,
         }))
     }
 }
@@ -943,6 +957,7 @@ fn diff_with_exit_code_and_empty_diff_returns_zero() {
         }),
         script: false,
         shadow_database_url: None,
+        filters: None,
     });
 
     assert_eq!(result.exit_code, 0);
@@ -980,6 +995,7 @@ fn diff_with_exit_code_and_non_empty_diff_returns_two() {
         }),
         script: false,
         shadow_database_url: None,
+        filters: None,
     });
 
     assert_eq!(result.exit_code, 2);
@@ -1006,6 +1022,7 @@ fn diff_with_non_existing_sqlite_database_from_url() {
         to: DiffTarget::Url(UrlContainer {
             url: format!("file:{}", tmpdir.path().join("db.sqlite").to_string_lossy()),
         }),
+        filters: None,
     });
 
     let error = error
@@ -1043,6 +1060,7 @@ fn diff_with_non_existing_sqlite_database_from_datasource() {
             }],
             config_dir: schema_path.parent().unwrap().to_string_lossy().into_owned(),
         }),
+        filters: None,
     });
 
     if cfg!(target_os = "windows") {
@@ -1109,6 +1127,7 @@ fn from_multi_file_schema_datasource_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
+        filters: None,
     };
 
     api.diff(input).unwrap();
@@ -1175,6 +1194,7 @@ fn from_multi_file_schema_datamodel_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
+        filters: None,
     };
 
     api.diff(input).unwrap();

--- a/schema-engine/sql-migration-tests/tests/migrations/drift_summary.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/drift_summary.rs
@@ -24,6 +24,7 @@ fn check(from: &str, to: &str, expectation: Expect) {
                 content: to.to_string(),
             }],
         }),
+        filters: None,
     };
 
     let host = Arc::new(TestConnectorHost::default());

--- a/schema-engine/sql-migration-tests/tests/migrations/mysql.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/mysql.rs
@@ -484,6 +484,7 @@ fn dropping_m2m_relation_from_datamodel_works() {
         }),
         script: true,
         shadow_database_url: None,
+        filters: None,
     });
 
     let expected = expect![[r#"

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
@@ -112,6 +112,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
                 content: text.to_string(),
             }],
         }),
+        filters: None,
     }))
     .unwrap();
 
@@ -140,6 +141,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
                 content: text.to_string(),
             }],
         }),
+        filters: None,
     }))
     .unwrap();
 


### PR DESCRIPTION
This PR adds support for external tables during `prisma migrate dev` and `prisma db push`. For external tables no SQL DDL statements will be issued during those commands.

Also see https://github.com/prisma/prisma-engines/pull/5529 & https://github.com/prisma/prisma/pull/27652.