### PR TITLE
feat(multi schema): ORM-1108 respect external tables during migration persistence init

### DIFF
--- a/schema-engine/commands/src/commands/apply_migrations.rs
+++ b/schema-engine/commands/src/commands/apply_migrations.rs
@@ -18,7 +18,10 @@ pub async fn apply_migrations(
     let migrations_from_filesystem = list_migrations(input.migrations_list.migration_directories);
 
     connector.acquire_lock().await?;
-    connector.migration_persistence().initialize(namespaces).await?;
+    connector
+        .migration_persistence()
+        .initialize(namespaces, input.filters.into())
+        .await?;
 
     let migrations_from_database = connector
         .migration_persistence()

--- a/schema-engine/connectors/mongodb-schema-connector/src/migration_persistence.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/src/migration_persistence.rs
@@ -1,12 +1,16 @@
 use crate::MongoDbSchemaConnector;
-use schema_connector::{BoxFuture, ConnectorResult, MigrationPersistence, Namespaces};
+use schema_connector::{BoxFuture, ConnectorResult, MigrationPersistence, Namespaces, SchemaFilter};
 
 impl MigrationPersistence for MongoDbSchemaConnector {
     fn baseline_initialize(&mut self) -> schema_connector::BoxFuture<'_, ConnectorResult<()>> {
         unsupported_command_error()
     }
 
-    fn initialize(&mut self, _namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<()>> {
+    fn initialize(
+        &mut self,
+        _namespaces: Option<Namespaces>,
+        _filters: SchemaFilter,
+    ) -> BoxFuture<'_, ConnectorResult<()>> {
         unsupported_command_error()
     }
 

--- a/schema-engine/connectors/schema-connector/src/migration_persistence.rs
+++ b/schema-engine/connectors/schema-connector/src/migration_persistence.rs
@@ -1,4 +1,4 @@
-use crate::{checksum, BoxFuture, ConnectorError, ConnectorResult, Namespaces};
+use crate::{checksum, BoxFuture, ConnectorError, ConnectorResult, Namespaces, SchemaFilter};
 
 /// A timestamp.
 pub type Timestamp = chrono::DateTime<chrono::Utc>;
@@ -14,7 +14,11 @@ pub trait MigrationPersistence: Send + Sync {
     /// If the migration persistence is not present in the target database,
     /// check whether the database schema is empty. If it is, initialize the
     /// migration persistence. If not, return a DatabaseSchemaNotEmpty error.
-    fn initialize(&mut self, namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<()>>;
+    fn initialize(
+        &mut self,
+        namespaces: Option<Namespaces>,
+        filters: SchemaFilter,
+    ) -> BoxFuture<'_, ConnectorResult<()>>;
 
     /// Implementation in the connector for the core's MarkMigrationApplied
     /// command. See the docs there. Note that the started_at and finished_at

--- a/schema-engine/connectors/sql-schema-connector/src/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour.rs
@@ -35,7 +35,7 @@ use psl::{PreviewFeature, PreviewFeatures, ValidatedSchema};
 use quaint::prelude::{NativeConnectionInfo, Table};
 use schema_connector::{
     migrations_directory::MigrationDirectory, BoxFuture, ConnectorError, ConnectorResult, IntrospectionContext,
-    MigrationRecord, Namespaces, PersistenceNotInitializedError,
+    MigrationRecord, Namespaces, PersistenceNotInitializedError, SchemaFilter,
 };
 use sql_schema_describer::SqlSchema;
 use std::fmt::Debug;
@@ -195,7 +195,11 @@ pub(crate) trait SqlConnector: Send + Sync + Debug {
 
     /// List all visible tables in the given namespaces,
     /// including the search path.
-    fn table_names(&mut self, namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<Vec<String>>>;
+    fn table_names(
+        &mut self,
+        namespaces: Option<Namespaces>,
+        filters: SchemaFilter,
+    ) -> BoxFuture<'_, ConnectorResult<Vec<String>>>;
 
     /// Check a connection to make sure it is usable by the schema engine.
     /// This can include some set up on the database, like ensuring that the

--- a/schema-engine/connectors/sql-schema-connector/src/sql_migration_persistence.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_migration_persistence.rs
@@ -2,7 +2,7 @@ use crate::SqlSchemaConnector;
 use quaint::ast::*;
 use schema_connector::{
     BoxFuture, ConnectorError, ConnectorResult, MigrationPersistence, MigrationRecord, Namespaces,
-    PersistenceNotInitializedError,
+    PersistenceNotInitializedError, SchemaFilter,
 };
 use uuid::Uuid;
 
@@ -15,9 +15,13 @@ impl MigrationPersistence for SqlSchemaConnector {
     }
 
     #[tracing::instrument(skip(self))]
-    fn initialize(&mut self, namespaces: Option<Namespaces>) -> BoxFuture<'_, ConnectorResult<()>> {
+    fn initialize(
+        &mut self,
+        namespaces: Option<Namespaces>,
+        filters: SchemaFilter,
+    ) -> BoxFuture<'_, ConnectorResult<()>> {
         Box::pin(async move {
-            let table_names = self.inner.table_names(namespaces).await?;
+            let table_names = self.inner.table_names(namespaces, filters).await?;
 
             if table_names.iter().any(|name| name == crate::MIGRATIONS_TABLE_NAME) {
                 return Ok(());

--- a/schema-engine/json-rpc-api/src/types.rs
+++ b/schema-engine/json-rpc-api/src/types.rs
@@ -227,6 +227,9 @@ pub struct DevActionReset {
 pub struct ApplyMigrationsInput {
     /// The list of migrations, already loaded from disk.
     pub migrations_list: MigrationList,
+
+    /// The schema filter to use during the apply migrations.
+    pub filters: Option<SchemaFilter>,
 }
 
 /// The output of the `applyMigrations` command.

--- a/schema-engine/sql-migration-tests/src/commands/apply_migrations.rs
+++ b/schema-engine/sql-migration-tests/src/commands/apply_migrations.rs
@@ -31,7 +31,15 @@ impl<'a> ApplyMigrations<'a> {
 
     pub async fn send(self) -> CoreResult<ApplyMigrationsAssertion<'a>> {
         let migrations_list = utils::list_migrations(self.migrations_directory.path()).unwrap();
-        let output = apply_migrations(ApplyMigrationsInput { migrations_list }, self.api, self.namespaces).await?;
+        let output = apply_migrations(
+            ApplyMigrationsInput {
+                migrations_list,
+                filters: None,
+            },
+            self.api,
+            self.namespaces,
+        )
+        .await?;
 
         Ok(ApplyMigrationsAssertion {
             output,

--- a/schema-engine/sql-migration-tests/tests/migrations/mark_migration_rolled_back_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/mark_migration_rolled_back_tests.rs
@@ -1,4 +1,5 @@
 use pretty_assertions::assert_eq;
+use schema_core::schema_connector::SchemaFilter;
 use sql_migration_tests::test_api::*;
 use user_facing_errors::UserFacingError;
 
@@ -13,7 +14,7 @@ fn mark_migration_rolled_back_on_an_empty_database_errors(api: TestApi) {
 
 #[test_connector]
 fn mark_migration_rolled_back_on_a_database_with_migrations_table_errors(api: TestApi) {
-    tok(api.migration_persistence().initialize(None)).unwrap();
+    tok(api.migration_persistence().initialize(None, SchemaFilter::default())).unwrap();
 
     let err = api
         .mark_migration_rolled_back("anything")


### PR DESCRIPTION
During migration application we check that the database is either empty or already has a migrations table. This empty check needs to now consider externally managed tables, too, and not fail if such exist.