### PR TITLE
feat(multi schema): ORM-1226 do not reset external tables during a soft/best-effort reset

### DIFF
--- a/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
@@ -1,6 +1,9 @@
 use connection_string::JdbcString;
 use quaint::{prelude::*, single::Quaint};
-use schema_core::schema_connector::{ConnectorError, ConnectorParams, ConnectorResult};
+use schema_core::{
+    json_rpc::types::ResetInput,
+    schema_connector::{ConnectorError, ConnectorParams, ConnectorResult},
+};
 use std::str::FromStr;
 
 pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResult<()> {
@@ -21,7 +24,7 @@ pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[
         conn.raw_cmd(&sql).await.unwrap();
     } else {
         let mut api = schema_core::schema_api(Some(prisma_schema.to_owned()), None)?;
-        api.reset().await.ok();
+        api.reset(ResetInput { filter: None }).await.ok();
         api.dispose().await.ok();
         // Without these, our poor connection gets deadlocks if other schemas
         // are modified while we introspect.

--- a/schema-engine/commands/src/api.rs
+++ b/schema-engine/commands/src/api.rs
@@ -66,7 +66,7 @@ pub trait GenericApi: Send + Sync + 'static {
     ) -> CoreResult<MarkMigrationRolledBackOutput>;
 
     /// Reset a database to an empty state (no data, no schema).
-    async fn reset(&self) -> CoreResult<()>;
+    async fn reset(&self, input: ResetInput) -> CoreResult<()>;
 
     /// The command behind `prisma db push`.
     async fn schema_push(&self, input: SchemaPushInput) -> CoreResult<SchemaPushOutput>;

--- a/schema-engine/connectors/mongodb-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/src/lib.rs
@@ -99,6 +99,7 @@ impl SchemaDialect for MongoDbSchemaDialect {
         &'a mut self,
         _migrations: &'a [MigrationDirectory],
         _namespaces: Option<Namespaces>,
+        _filter: &SchemaFilter,
         _target: ExternalShadowDatabase,
     ) -> BoxFuture<'a, ConnectorResult<()>> {
         Box::pin(future::ready(Ok(())))
@@ -108,6 +109,7 @@ impl SchemaDialect for MongoDbSchemaDialect {
         &'a self,
         _migrations: &'a [MigrationDirectory],
         _namespaces: Option<Namespaces>,
+        _filter: &SchemaFilter,
         _target: ExternalShadowDatabase,
     ) -> BoxFuture<'a, ConnectorResult<DatabaseSchema>> {
         Box::pin(async { Err(unsupported_command_error()) })
@@ -161,11 +163,12 @@ impl SchemaConnector for MongoDbSchemaConnector {
         Box::pin(async { self.client().await?.drop_database().await })
     }
 
-    fn reset(
-        &mut self,
+    fn reset<'a>(
+        &'a mut self,
         _soft: bool,
         _namespaces: Option<Namespaces>,
-    ) -> BoxFuture<'_, schema_connector::ConnectorResult<()>> {
+        _filter: &'a SchemaFilter,
+    ) -> BoxFuture<'a, schema_connector::ConnectorResult<()>> {
         Box::pin(async { self.client().await?.drop_database().await })
     }
 
@@ -207,6 +210,7 @@ impl SchemaConnector for MongoDbSchemaConnector {
         &'a mut self,
         _migrations: &'a [MigrationDirectory],
         _namespaces: Option<Namespaces>,
+        _filter: &SchemaFilter,
     ) -> BoxFuture<'a, ConnectorResult<()>> {
         Box::pin(future::ready(Ok(())))
     }
@@ -229,6 +233,7 @@ impl SchemaConnector for MongoDbSchemaConnector {
         &'a mut self,
         _migrations: &'a [MigrationDirectory],
         _namespaces: Option<Namespaces>,
+        _filter: &SchemaFilter,
     ) -> BoxFuture<'a, ConnectorResult<DatabaseSchema>> {
         Box::pin(async { Err(unsupported_command_error()) })
     }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour.rs
@@ -322,6 +322,7 @@ pub(crate) trait SqlConnector: Send + Sync + Debug {
         &'a mut self,
         migrations: &'a [MigrationDirectory],
         namespaces: Option<Namespaces>,
+        filter: &'a SchemaFilter,
         external_shadow_db: UsingExternalShadowDb,
     ) -> BoxFuture<'a, ConnectorResult<SqlSchema>>;
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -494,6 +494,7 @@ impl SqlConnector for MssqlConnector {
         &'a mut self,
         migrations: &'a [MigrationDirectory],
         namespaces: Option<Namespaces>,
+        filter: &'a SchemaFilter,
         external_shadow_db: UsingExternalShadowDb,
     ) -> BoxFuture<'a, ConnectorResult<SqlSchema>> {
         match external_shadow_db {
@@ -502,7 +503,7 @@ impl SqlConnector for MssqlConnector {
                 tracing::info!("Connected to an external shadow database.");
 
                 if self.reset(namespaces.clone()).await.is_err() {
-                    crate::best_effort_reset(self, namespaces.clone()).await?;
+                    crate::best_effort_reset(self, namespaces.clone(), filter).await?;
                 }
 
                 shadow_db::sql_schema_from_migrations_history(migrations, self, namespaces).await

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -374,6 +374,7 @@ impl SqlConnector for MysqlConnector {
         &'a mut self,
         migrations: &'a [MigrationDirectory],
         namespaces: Option<Namespaces>,
+        filter: &'a SchemaFilter,
         external_shadow_db: UsingExternalShadowDb,
     ) -> BoxFuture<'a, ConnectorResult<SqlSchema>> {
         match external_shadow_db {
@@ -382,7 +383,7 @@ impl SqlConnector for MysqlConnector {
                 tracing::info!("Connected to an external shadow database.");
 
                 if self.reset(None).await.is_err() {
-                    crate::best_effort_reset(self, namespaces).await?;
+                    crate::best_effort_reset(self, namespaces, filter).await?;
                 }
 
                 shadow_db::sql_schema_from_migrations_history(migrations, self).await

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -582,6 +582,7 @@ impl SqlConnector for PostgresConnector {
         &'a mut self,
         migrations: &'a [MigrationDirectory],
         namespaces: Option<Namespaces>,
+        filter: &'a SchemaFilter,
         external_shadow_db: UsingExternalShadowDb,
     ) -> BoxFuture<'a, ConnectorResult<SqlSchema>> {
         Box::pin(imp::shadow_db::sql_schema_from_migration_history(
@@ -589,6 +590,7 @@ impl SqlConnector for PostgresConnector {
             self.provider,
             migrations,
             namespaces,
+            filter,
             external_shadow_db,
         ))
     }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/wasm/shadow_db.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/wasm/shadow_db.rs
@@ -1,7 +1,7 @@
 use crate::flavour::postgres::{
     sql_schema_from_migrations_and_db, PostgresConnector, PostgresProvider, UsingExternalShadowDb,
 };
-use schema_connector::{migrations_directory::MigrationDirectory, ConnectorResult};
+use schema_connector::{migrations_directory::MigrationDirectory, ConnectorResult, SchemaFilter};
 use schema_connector::{ConnectorError, Namespaces};
 use sql_schema_describer::SqlSchema;
 
@@ -10,6 +10,7 @@ pub async fn sql_schema_from_migration_history(
     _provider: PostgresProvider,
     migrations: &[MigrationDirectory],
     namespaces: Option<Namespaces>,
+    _filter: &SchemaFilter,
     external_shadow_db: UsingExternalShadowDb,
 ) -> ConnectorResult<SqlSchema> {
     let schema = connector.schema_name().to_owned();
@@ -21,6 +22,8 @@ pub async fn sql_schema_from_migration_history(
             "PostgreSQL shadow DB must be provided through an external factory".to_owned(),
         ));
     }
+
+    // TODO: should we do a best effort reset here similar to in sql_schema_from_migration_history_for_external_db?
 
     connector
         .with_connection(|conn, params| {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
@@ -357,6 +357,7 @@ impl SqlConnector for SqliteConnector {
         &'a mut self,
         migrations: &'a [MigrationDirectory],
         _namespaces: Option<Namespaces>,
+        _filter: &'a SchemaFilter,
         external_shadow_db: UsingExternalShadowDb,
     ) -> BoxFuture<'a, ConnectorResult<SqlSchema>> {
         async fn apply_migrations_and_describe(

--- a/schema-engine/core/src/rpc.rs
+++ b/schema-engine/core/src/rpc.rs
@@ -78,7 +78,7 @@ async fn run_command(
         INTROSPECT_SQL => render(executor.introspect_sql(params.parse()?).await),
         MARK_MIGRATION_APPLIED => render(executor.mark_migration_applied(params.parse()?).await),
         MARK_MIGRATION_ROLLED_BACK => render(executor.mark_migration_rolled_back(params.parse()?).await),
-        RESET => render(executor.reset().await),
+        RESET => render(executor.reset(params.parse()?).await),
         SCHEMA_PUSH => render(executor.schema_push(params.parse()?).await),
         other => unreachable!("Unknown command {}", other),
     }

--- a/schema-engine/json-rpc-api/src/types.rs
+++ b/schema-engine/json-rpc-api/src/types.rs
@@ -729,7 +729,10 @@ pub struct MarkMigrationRolledBackOutput {}
 #[derive(Debug, Deserialize)]
 #[cfg_attr(target_arch = "wasm32", derive(Tsify))]
 #[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
-pub struct ResetInput {}
+pub struct ResetInput {
+    /// The schema filter to use during the reset. Only relevant during "soft" resets though - usually we try to drop the whole database.
+    pub filter: Option<SchemaFilter>,
+}
 
 /// The output of the `reset` command.
 #[derive(Debug, Serialize)]

--- a/schema-engine/schema-engine-wasm/src/wasm/engine.rs
+++ b/schema-engine/schema-engine-wasm/src/wasm/engine.rs
@@ -454,13 +454,13 @@ impl SchemaEngine {
 
     /// Reset a database to an empty state (no data, no schema).
     #[wasm_bindgen]
-    pub async fn reset(&mut self) -> Result<(), JsValue> {
+    pub async fn reset(&mut self, input: ResetInput) -> Result<(), JsValue> {
         let dispatch = self.dispatch.clone();
         async move {
             tracing::info!("Resetting the database.");
             let namespaces = self.namespaces();
 
-            SchemaConnector::reset(&mut self.connector, false, namespaces)
+            SchemaConnector::reset(&mut self.connector, false, namespaces, &input.filter.into())
                 .instrument(tracing::info_span!("Reset"))
                 .await?;
             Ok(())

--- a/schema-engine/sql-introspection-tests/src/test_api.rs
+++ b/schema-engine/sql-introspection-tests/src/test_api.rs
@@ -8,6 +8,7 @@ use schema_connector::ConnectorError;
 use schema_connector::ConnectorResult;
 use schema_connector::IntrospectionContext;
 use schema_connector::IntrospectionResult;
+use schema_connector::SchemaFilter;
 use schema_connector::ViewDefinition;
 pub use test_macros::test_connector;
 pub use test_setup::{BitFlags, Capabilities, Tags};
@@ -53,9 +54,13 @@ impl TestApi {
             };
             let mut me = SqlSchemaConnector::new_mysql(params).unwrap();
 
-            me.reset(true, schema_connector::Namespaces::from_vec(&mut namespaces.clone()))
-                .await
-                .unwrap();
+            me.reset(
+                true,
+                schema_connector::Namespaces::from_vec(&mut namespaces.clone()),
+                &SchemaFilter::default(),
+            )
+            .await
+            .unwrap();
 
             (
                 Quaint::new(connection_string).await.unwrap(),

--- a/schema-engine/sql-migration-tests/src/commands/reset.rs
+++ b/schema-engine/sql-migration-tests/src/commands/reset.rs
@@ -1,5 +1,5 @@
 use schema_core::{
-    schema_connector::{Namespaces, SchemaConnector},
+    schema_connector::{Namespaces, SchemaConnector, SchemaFilter},
     CoreResult,
 };
 
@@ -7,11 +7,16 @@ use schema_core::{
 pub struct Reset<'a> {
     api: &'a mut dyn SchemaConnector,
     soft: bool,
+    filter: SchemaFilter,
 }
 
 impl<'a> Reset<'a> {
     pub fn new(api: &'a mut dyn SchemaConnector) -> Self {
-        Reset { api, soft: false }
+        Reset {
+            api,
+            soft: false,
+            filter: SchemaFilter::default(),
+        }
     }
 
     pub fn soft(mut self, value: bool) -> Self {
@@ -19,8 +24,13 @@ impl<'a> Reset<'a> {
         self
     }
 
+    pub fn filter(mut self, filter: SchemaFilter) -> Self {
+        self.filter = filter;
+        self
+    }
+
     pub async fn send(self, namespaces: Option<Namespaces>) -> CoreResult<ResetAssertion> {
-        self.api.reset(self.soft, namespaces).await?;
+        self.api.reset(self.soft, namespaces, &self.filter).await?;
 
         Ok(ResetAssertion {})
     }

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -18,7 +18,7 @@ use quaint::{
     prelude::{ConnectionInfo, NativeConnectionInfo, Queryable, ResultSet},
     single::Quaint,
 };
-use schema_core::schema_connector::{ConnectorParams, ConnectorResult, SchemaConnector};
+use schema_core::schema_connector::{self, ConnectorParams, ConnectorResult, SchemaConnector};
 use sql_schema_connector::SqlSchemaConnector;
 use tempfile::TempDir;
 use test_setup::{DatasourceBlock, TestApiArgs};
@@ -52,7 +52,7 @@ impl TestApi {
                 shadow_database_connection_string: args.shadow_database_url().map(String::from),
             };
             let mut conn = SqlSchemaConnector::new_mysql(params).unwrap();
-            tok(conn.reset(false, None)).unwrap();
+            tok(conn.reset(false, None, &schema_connector::SchemaFilter::default())).unwrap();
 
             (
                 tok(Quaint::new(args.database_url())).unwrap(),

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -399,8 +399,15 @@ impl TestApi {
         to: DiffTarget<'_>,
         namespaces: Option<Namespaces>,
     ) -> String {
-        let from = tok(self.connector.schema_from_diff_target(from, namespaces.clone())).unwrap();
-        let to = tok(self.connector.schema_from_diff_target(to, namespaces)).unwrap();
+        let from =
+            tok(self
+                .connector
+                .schema_from_diff_target(from, namespaces.clone(), &SchemaFilter::default().into()))
+            .unwrap();
+        let to = tok(self
+            .connector
+            .schema_from_diff_target(to, namespaces, &SchemaFilter::default().into()))
+        .unwrap();
         let dialect = self.connector.schema_dialect();
         let migration = dialect.diff(from, to, &SchemaFilter::default().into());
         dialect.render_script(&migration, &Default::default()).unwrap()

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
@@ -1,6 +1,6 @@
 use schema_core::{
     json_rpc::types::SchemasContainer,
-    schema_connector::{ConnectorParams, SchemaConnector},
+    schema_connector::{ConnectorParams, SchemaConnector, SchemaFilter},
 };
 use sql_migration_tests::test_api::*;
 use sql_schema_connector::SqlSchemaConnector;
@@ -84,7 +84,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
             shadow_database_connection_string: None,
         };
         let mut conn = SqlSchemaConnector::new_mysql(params).unwrap();
-        tok(conn.reset(false, None)).unwrap();
+        tok(conn.reset(false, None, &SchemaFilter::default())).unwrap();
         test_api_args.database_url().to_owned()
     } else if tags.contains(Tags::Mysql) {
         let (_, connection_string) = tok(test_api_args.create_mysql_database());


### PR DESCRIPTION
This PR ensures that during soft resets (aka "best effort resets"), where Prisma cannot drop the whole database but drop individual tables, Prisma does not try to drop any externally managed tables.

Getting the filters down to the reset call is a bit messy as it often has to go through many layers. :/ In follow up work I might consider merging the `namespaces` config into the `schema_connector::SchemaFilter` object. For that I first want to have a fully working implementation of the overall feature to better see the overall consequences of such refactoring.