### PR TITLE
feat: disallow mutations on views

### DIFF
--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -481,6 +481,8 @@ impl ValidationError {
     }
 }
 
+impl std::error::Error for ValidationError {}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct OutputTypeDescription {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/views.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/views.rs
@@ -73,6 +73,85 @@ mod views {
         Ok(())
     }
 
+    #[connector_test]
+    async fn no_create_one_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_create_one_mutation",
+            r#"mutation { createOneTestView(data: { firstName: "Test", lastName: "User", fullName: "Test User" }) { id } }"#
+        ).await
+    }
+
+    #[connector_test]
+    async fn no_update_one_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_update_one_mutation",
+            r#"mutation { updateOneTestView(where: { id: 1 }, data: { firstName: "Updated" }) { id } }"#,
+        )
+        .await
+    }
+
+    #[connector_test]
+    async fn no_delete_one_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_delete_one_mutation",
+            r#"mutation { deleteOneTestView(where: { id: 1 }) { id } }"#,
+        )
+        .await
+    }
+
+    #[connector_test]
+    async fn no_upsert_one_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_upsert_one_mutation",
+            r#"mutation { upsertOneTestView(where: { id: 1 }, create: { firstName: "New", lastName: "User", fullName: "New User" }, update: { firstName: "Updated" }) { id } }"#
+        ).await
+    }
+
+    #[connector_test]
+    async fn no_create_many_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_create_many_mutation",
+            r#"mutation { createManyTestView(data: [{ firstName: "Test", lastName: "User", fullName: "Test User" }]) { count } }"#
+        ).await
+    }
+
+    #[connector_test]
+    async fn no_update_many_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_update_many_mutation",
+            r#"mutation { updateManyTestView(where: { id: 1 }, data: { firstName: "Updated" }) { count } }"#,
+        )
+        .await
+    }
+
+    #[connector_test]
+    async fn no_delete_many_mutation(runner: Runner) -> TestResult<()> {
+        test_no_toplevel_mutation(
+            runner,
+            "no_delete_many_mutation",
+            r#"mutation { deleteManyTestView(where: { id: { gt: 0 } }) { count } }"#,
+        )
+        .await
+    }
+
+    async fn test_no_toplevel_mutation(runner: Runner, schema_name: &str, query: &str) -> TestResult<()> {
+        create_test_data(&runner, schema_name).await?;
+
+        match runner.query(query).await {
+            Ok(res) => res.assert_failure(2009, None),
+            Err(TestError::QueryConversionError(err)) if err.kind().code() == "P2009" => (),
+            Err(err) => return Err(err),
+        }
+
+        Ok(())
+    }
+
     async fn create_test_data(runner: &Runner, schema_name: &str) -> TestResult<()> {
         migrate_view(runner, schema_name).await?;
 

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/error.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/error.rs
@@ -2,6 +2,7 @@ use crate::TemplatingError;
 use quaint::error::Error as QuaintError;
 use std::env::VarError;
 use thiserror::Error;
+use user_facing_errors::query_engine::validation::ValidationError;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Error)]
@@ -32,6 +33,9 @@ pub enum TestError {
 
     #[error("External process error: {0}")]
     External(#[from] Box<dyn std::error::Error + Send + Sync>),
+
+    #[error("Error converting GraphQL query to JSON: {0}")]
+    QueryConversionError(#[from] ValidationError),
 }
 
 impl TestError {

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/runner/mod.rs
@@ -364,7 +364,7 @@ impl Runner {
         let request_body = match self.protocol {
             EngineProtocol::Json => {
                 // Translate the GraphQL query to JSON
-                let json_query = JsonRequest::from_graphql(&query, self.query_schema()).unwrap();
+                let json_query = JsonRequest::from_graphql(&query, self.query_schema())?;
                 println!("{}", serde_json::to_string_pretty(&json_query).unwrap().green());
 
                 RequestBody::Json(JsonBody::Single(json_query))

--- a/query-engine/query-structure/src/model.rs
+++ b/query-engine/query-structure/src/model.rs
@@ -67,7 +67,7 @@ impl Model {
             .scalar_fields()
             .any(|sf| sf.ast_field().arity.is_required() && sf.is_unsupported() && sf.default_value().is_none());
 
-        !has_unsupported_field
+        !has_unsupported_field && !self.is_view()
     }
 
     /// The name of the model in the database
@@ -85,6 +85,10 @@ impl Model {
             .indexes()
             .filter(|idx| idx.is_unique())
             .filter(|index| !index.fields().any(|f| f.is_unsupported()))
+    }
+
+    pub fn is_view(&self) -> bool {
+        self.walker().ast_model().is_view()
     }
 }
 

--- a/query-engine/schema/src/build/output_types/mutation_type.rs
+++ b/query-engine/schema/src/build/output_types/mutation_type.rs
@@ -16,6 +16,10 @@ pub(crate) fn mutation_fields(ctx: &QuerySchema) -> Vec<FieldFn> {
     }
 
     for model in ctx.internal_data_model.models() {
+        if model.is_view() {
+            continue;
+        }
+
         if model.supports_create_operation() {
             field!(create_one, model);
 


### PR DESCRIPTION
Disallow mutations on views.

The query schema changes propagate automagically all the way to the client types generation so there's no need for any additional changes on TS side:

<img width="1188" height="308" alt="image" src="https://github.com/user-attachments/assets/eb6e7d69-cd57-4f1c-a04e-4658b8d1c4ea" />

Closes: https://linear.app/prisma-company/issue/ORM-1227/disallow-writes-to-views