### PR TITLE
fix(external tables): ensure mysql settings for table name case sensitivity are respected during external table filtering

### DIFF
--- a/schema-engine/connectors/schema-connector/src/filter.rs
+++ b/schema-engine/connectors/schema-connector/src/filter.rs
@@ -7,20 +7,6 @@ pub struct SchemaFilter {
     pub external_tables: Vec<String>,
 }
 
-impl SchemaFilter {
-    /// Check if the given table name is in the list of external tables.
-    /// `external_tables` can contain fully qualified table names with namespace
-    /// (e.g. "auth.user") or just the table name.
-    pub fn is_table_external(&self, namespace: Option<&str>, table_name: &str) -> bool {
-        if let Some(namespace) = namespace {
-            self.external_tables.contains(&format!("{namespace}.{table_name}"))
-                || self.external_tables.contains(&table_name.to_string())
-        } else {
-            self.external_tables.contains(&table_name.to_string())
-        }
-    }
-}
-
 impl From<json_rpc::types::SchemaFilter> for SchemaFilter {
     fn from(filter: json_rpc::types::SchemaFilter) -> Self {
         Self {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -310,7 +310,14 @@ impl SqlConnector for MssqlConnector {
 
                     ns.and_then(|ns| table_name.map(|table_name| (ns, table_name)))
                 })
-                .filter(|(ns, table_name)| namespaces.contains(ns) && !filters.is_table_external(Some(ns), table_name))
+                .filter(|(ns, table_name)| {
+                    namespaces.contains(ns)
+                        && !self.dialect().schema_differ().contains_table(
+                            &filters.external_tables,
+                            Some(ns),
+                            table_name,
+                        )
+                })
                 .map(|(_, table_name)| table_name)
                 .collect();
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -216,7 +216,12 @@ impl SqlConnector for MysqlConnector {
             let table_names: Vec<String> = rows
                 .into_iter()
                 .flat_map(|row| row.get("table_name").and_then(|s| s.to_string()))
-                .filter(|table_name| !filters.is_table_external(None, table_name))
+                .filter(|table_name| {
+                    !self
+                        .dialect()
+                        .schema_differ()
+                        .contains_table(&filters.external_tables, None, table_name)
+                })
                 .collect();
 
             Ok(table_names)

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/schema_differ.rs
@@ -118,15 +118,15 @@ impl SqlSchemaDifferFlavour for MysqlSchemaDifferFlavour {
     /// The table names  can contain fully qualified table names with namespace
     /// (e.g. "auth.user") or just the table name.
     fn contains_table(&self, tables: &[String], namespace: Option<&str>, table_name: &str) -> bool {
-        let cmp = if self.lower_cases_table_names() {
+        let str_eq = if self.lower_cases_table_names() {
             str::eq_ignore_ascii_case
         } else {
             str::eq
         };
-        let namespaced_table_name = namespace.map(|ns| format!("{namespace}.{table_name}"));
+        let namespaced_table_name = namespace.map(|ns| format!("{ns}.{table_name}"));
         tables
             .iter()
-            .any(|t| cmp(t, table_name) || namespaced_table_name.is_none_or(|n| cmp(n, table_name)))
+            .any(|t| str_eq(t, table_name) || namespaced_table_name.as_deref().is_some_and(|n| str_eq(t, n)))
     }
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/schema_differ.rs
@@ -113,6 +113,26 @@ impl SqlSchemaDifferFlavour for MysqlSchemaDifferFlavour {
             names.previous == names.next
         }
     }
+
+    fn contains_table(&self, tables: &[String], namespace: Option<&str>, table_name: &str) -> bool {
+        let table_name = if self.lower_cases_table_names() {
+            table_name.to_ascii_lowercase()
+        } else {
+            table_name.to_string()
+        };
+
+        let namespace = if self.lower_cases_table_names() {
+            namespace.map(|ns| ns.to_ascii_lowercase())
+        } else {
+            namespace.map(|ns| ns.to_string())
+        };
+
+        if let Some(namespace) = namespace {
+            tables.contains(&format!("{namespace}.{table_name}")) || tables.contains(&table_name)
+        } else {
+            tables.contains(&table_name)
+        }
+    }
 }
 
 fn risky() -> ColumnTypeChange {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -422,7 +422,12 @@ impl SqlConnector for PostgresConnector {
 
                     ns.and_then(|ns| table_name.map(|table_name| (ns, table_name)))
                 })
-                .filter(|(ns, table_name)| !filters.is_table_external(Some(ns), table_name))
+                .filter(|(ns, table_name)| {
+                    !self
+                        .dialect()
+                        .schema_differ()
+                        .contains_table(&filters.external_tables, Some(ns), table_name)
+                })
                 .map(|(_, table_name)| table_name)
                 .collect();
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite.rs
@@ -167,7 +167,12 @@ impl SqlConnector for SqliteConnector {
             let table_names: Vec<String> = rows
                 .into_iter()
                 .flat_map(|row| row.get("table_name").and_then(|s| s.to_string()))
-                .filter(|table_name| !filters.is_table_external(None, table_name))
+                .filter(|table_name| {
+                    !self
+                        .dialect()
+                        .schema_differ()
+                        .contains_table(&filters.external_tables, None, table_name)
+                })
                 .collect();
 
             Ok(table_names)

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/differ_database.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/differ_database.rs
@@ -327,7 +327,8 @@ impl<'a> DifferDatabase<'a> {
 
     fn is_table_external(&self, table: &TableWalker<'_>) -> bool {
         // TODO:(schema-filter) optimize for speed to avoid recomputing the underlying contains?
-        self.filter.is_table_external(table.namespace(), table.name())
+        self.flavour
+            .contains_table(&self.filter.external_tables, table.namespace(), table.name())
     }
 
     fn is_table_pair_external(&self, tables: MigrationPair<TableWalker<'_>>) -> bool {
@@ -344,7 +345,10 @@ impl<'a> DifferDatabase<'a> {
             .tables
             .iter()
             .filter(|(k, _)| k.0.as_deref() == Some(namespace.name()))
-            .all(|(k, _)| self.filter.is_table_external(k.0.as_deref(), k.1.as_ref()));
+            .all(|(k, _)| {
+                self.flavour
+                    .contains_table(&self.filter.external_tables, k.0.as_deref(), k.1.as_ref())
+            });
         let has_enums = self.created_enums().any(|e| e.namespace() == Some(namespace.name()));
         all_tables_are_external && !has_enums
     }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -142,11 +142,8 @@ pub(crate) trait SqlSchemaDifferFlavour {
     /// The table names  can contain fully qualified table names with namespace
     /// (e.g. "auth.user") or just the table name.
     fn contains_table(&self, tables: &[String], namespace: Option<&str>, table_name: &str) -> bool {
-        if let Some(namespace) = namespace {
-            tables.contains(&format!("{namespace}.{table_name}")) || tables.contains(&table_name.to_string())
-        } else {
-            tables.contains(&table_name.to_string())
-        }
+        tables.iter().any(|t| t == table_name)
+            || namespace.is_some_and(|ns| tables.contains(&format!("{ns}.{table_name}")))
     }
 
     /// Return the tables that cannot be migrated without being redefined. This

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -138,6 +138,14 @@ pub(crate) trait SqlSchemaDifferFlavour {
         names.previous == names.next
     }
 
+    fn contains_table(&self, tables: &[String], namespace: Option<&str>, table_name: &str) -> bool {
+        if let Some(namespace) = namespace {
+            tables.contains(&format!("{namespace}.{table_name}")) || tables.contains(&table_name.to_string())
+        } else {
+            tables.contains(&table_name.to_string())
+        }
+    }
+
     /// Return the tables that cannot be migrated without being redefined. This
     /// is currently useful only on SQLite.
     fn set_tables_to_redefine(&self, _db: &mut DifferDatabase<'_>) {}

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/sql_schema_differ_flavour.rs
@@ -138,6 +138,9 @@ pub(crate) trait SqlSchemaDifferFlavour {
         names.previous == names.next
     }
 
+    /// Check if the given table name is in the given list of tables names.
+    /// The table names  can contain fully qualified table names with namespace
+    /// (e.g. "auth.user") or just the table name.
     fn contains_table(&self, tables: &[String], namespace: Option<&str>, table_name: &str) -> bool {
         if let Some(namespace) = namespace {
             tables.contains(&format!("{namespace}.{table_name}")) || tables.contains(&table_name.to_string())

--- a/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
@@ -233,7 +233,7 @@ fn schema_filter_migration_adding_external_tables_incl_relations(api: TestApi) {
         });
 }
 
-#[test_connector(exclude(CockroachDb))]
+#[test_connector(exclude(CockroachDb, Vitess))]
 fn schema_filter_migration_removing_external_tables_incl_relations(mut api: TestApi) {
     let schema_1 = api.datamodel_with_provider(
         r#"


### PR DESCRIPTION
For mysql we need to consider the database specific settings for how table names shall be compared case sensitive wise during the filtering for external tables.

This should fix the currently failing windows+mysql tests on the main branch.