### PR TITLE
refactor: don't collect results in `Vec` in `parse_arguments`

### DIFF
--- a/query-engine/core/src/query_document/parser.rs
+++ b/query-engine/core/src/query_document/parser.rs
@@ -226,8 +226,6 @@ impl QueryDocumentParser {
                     ))),
                 }
             })
-            .collect::<Vec<QueryParserResult<ParsedArgument<'_>>>>()
-            .into_iter()
             .collect()
     }
 


### PR DESCRIPTION
Don't collect results into an intermediate `Vec` in `QueryDocumentParser::parse_arguments`, collect them into a `Result<Vec<_>, _>` directly. This shouldn't have difference in behaviour since parsing each argument doesn't (hopefully) have any side effects.