### PR TITLE
feat(schema): disable `cursor` for views

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/views.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/views.rs
@@ -73,6 +73,20 @@ mod views {
         Ok(())
     }
 
+    #[connector_test]
+    async fn no_cursor(runner: Runner) -> TestResult<()> {
+        create_test_data(&runner, "no_cursor").await?;
+
+        assert_error!(
+            runner,
+            r#"{ findManyTestView(cursor: { id: 1 }) { fullName } }"#,
+            2009,
+            "Argument does not exist in enclosing type"
+        );
+
+        Ok(())
+    }
+
     async fn create_test_data(runner: &Runner, schema_name: &str) -> TestResult<()> {
         migrate_view(runner, schema_name).await?;
 


### PR DESCRIPTION
`cursor` can only use `@unique` or `@id` fields, which will not be available in views anymore, so it doesn't make sense to have `cursor` either. I realized this while working on https://linear.app/prisma-company/issue/ORM-1228/disallow-implicit-ordering-for-views.

I also changed `ManyRecordsSelectionArgumentsBuilder::build` to use chained iterators instead of pushing items to a vector, so that `collect` can make use of the iterator's `size_hint` to allocate a vector with the correct capacity from the very beginning without having to re-allocate and grow it.

Closes: https://linear.app/prisma-company/issue/ORM-1240/possibly-disable-or-limit-cursor-for-views