### PR TITLE
docs: update documentation about running tests

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -5,8 +5,6 @@ export RUST_LOG=info
 
 ### Various query engine local dev env vars ###
 export PRISMA_DML_PATH=$(pwd)/dev_datamodel.prisma
-export PRISMA2_BINARY_PATH="/usr/local/lib/node_modules/prisma2/"
-export PRISMA_BINARY_PATH=$(pwd)/target/release/query-engine
 
 ### QE config vars, set to testing values ###
 export SQLITE_MAX_VARIABLE_NUMBER=250000 # This must be in sync with the setting in the engineer build CLI

--- a/Makefile
+++ b/Makefile
@@ -555,15 +555,6 @@ qe-dmmf:
 qe-dev-mongo_4_4: start-mongodb_4_4
 	cp $(SCHEMA_EXAMPLES_PATH)/generic_mongo4.prisma $(DEV_SCHEMA_FILE)
 
-use-local-schema-engine:
-	cargo build --release
-	cp target/release/schema-engine $(PRISMA2_BINARY_PATH)/
-
-use-local-query-engine:
-	cargo build --release
-	cp target/release/query-engine $(PRISMA2_BINARY_PATH)/runtime/
-	cp target/release/query-engine $(PRISMA2_BINARY_PATH)/query-engine-darwin
-
 show-metrics:
 	docker compose -f docker-compose.yml up --wait -d --remove-orphans grafana prometheus
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,35 @@ integration tests.
 
   You can find them at `./query-engine/connector-test-kit-rs`.
 
-### Set up & run tests:
+> [!NOTE]
+> Help needed: document how to run
+> - `quaint` tests
+> - schema engine tests
+>
+> This can be a good first contribution.
+
+### Run unit tests
+
+To run unit tests for the whole workspace (except `quaint`, which requires
+additional steps), skipping the packages with heavy integration tests (you
+probably want to run them separately) as well as the `query-engine-node-api`
+package, use this command:
+
+```bash
+make test-unit
+```
+
+> [!WARNING]
+> Running just `cargo test` for the whole workspace will not work because the
+> `query-engine-node-api` package can only be compiled as a library crate and
+> can't be linked into a test binary due to the dependency on external Node.js
+> symbols. Additionally, some crates require passing explicit cargo features to
+> enable database connectors.
+>
+> If you really want to run *all* tests for the whole workspace, use
+> `cargo test --workspace --exclude=query-engine-node-api --all-features`.
+
+### Set up & run query engine integration tests:
 
 **Prerequisites:**
 
@@ -234,16 +262,12 @@ To actually get the tests working, read the contents of `.envrc`. Then `Edit env
 the correct values for the following variables:
 
 - `WORKSPACE_ROOT` should point to the root directory of `prisma-engines` project.
-- `PRISMA_BINARY_PATH` is usually
-  `%WORKSPACE_ROOT%\target\release\query-engine.exe`.
-- `SCHEMA_ENGINE_BINARY_PATH` should be
-  `%WORKSPACE_ROOT%\target\release\schema-engine.exe`.
 
 Other variables may or may not be useful.
 
 **Run:**
 
-Run `cargo test` in the repository root.
+Run `cargo test -p query-engine-tests` in the repository root.
 
 ### Testing driver adapters
 


### PR DESCRIPTION
- Document new `make test-unit` command added in #5552.
- Delete outdated information and unused env vars.
- Add more details about unit tests and QE tests.
- Add a note about missing docs and a call to action for contributors.