### PR TITLE
fix(user-facing-errors): make `element_type` serialized in camelCase

### DIFF
--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -514,7 +514,7 @@ impl OutputTypeDescriptionField {
     }
 }
 #[derive(Debug, Serialize, Clone)]
-#[serde(tag = "kind", rename_all = "camelCase")]
+#[serde(tag = "kind", rename_all = "camelCase", rename_all_fields = "camelCase")]
 pub enum InputTypeDescription {
     Object {
         name: String,


### PR DESCRIPTION
We didn't have tests that would trigger a validation error where a required argument was a list, so we weren't aware of the bug which makes Prisma Client crash in this case.

The client expects the `element_type` field to be serialized in camelCase, as `elementType`, but we serialized it in snake_case.

`rename_all` attribute in serde applies to enum variants and not fields when specified on enums (it only applies to fields when specified on structs). To rename fields in enums, `rename_all_fields` attribute must be used.

I ran into this when adding the client tests for https://linear.app/prisma-company/issue/ORM-1228/disallow-implicit-ordering-for-views so it will be covered by them.