### PR TITLE
feat(dmmf): expose `requires_other_fields` in DMMF

### DIFF
--- a/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
+++ b/query-engine/dmmf/src/ast_builders/schema_ast_builder/field_renderer.rs
@@ -16,6 +16,11 @@ pub(super) fn render_input_field<'a>(input_field: &InputField<'a>, ctx: &mut Ren
         input_types: type_references,
         is_required: input_field.is_required(),
         is_nullable: nullable,
+        requires_other_fields: input_field
+            .requires_other_fields()
+            .iter()
+            .map(|f| f.to_string())
+            .collect(),
         deprecation: None,
     }
 }

--- a/query-engine/dmmf/src/serialization_ast/schema_ast.rs
+++ b/query-engine/dmmf/src/serialization_ast/schema_ast.rs
@@ -75,6 +75,9 @@ pub struct DmmfInputField {
     pub is_nullable: bool,
     pub input_types: Vec<DmmfTypeReference>,
 
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub requires_other_fields: Vec<String>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deprecation: Option<DmmfDeprecation>,
 }


### PR DESCRIPTION
Ref: https://linear.app/prisma-company/issue/ORM-1256/adapt-ts-types-for-orderby-with-pagination-in-views