### PR TITLE
refactor: make schema-filter non optional

### DIFF
--- a/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/mssql.rs
@@ -1,7 +1,7 @@
 use connection_string::JdbcString;
 use quaint::{prelude::*, single::Quaint};
 use schema_core::{
-    json_rpc::types::ResetInput,
+    json_rpc::types::{ResetInput, SchemaFilter},
     schema_connector::{ConnectorError, ConnectorParams, ConnectorResult},
 };
 use std::str::FromStr;
@@ -24,7 +24,11 @@ pub(crate) async fn mssql_setup(url: String, prisma_schema: &str, db_schemas: &[
         conn.raw_cmd(&sql).await.unwrap();
     } else {
         let mut api = schema_core::schema_api(Some(prisma_schema.to_owned()), None)?;
-        api.reset(ResetInput { filter: None }).await.ok();
+        api.reset(ResetInput {
+            filter: SchemaFilter::default(),
+        })
+        .await
+        .ok();
         api.dispose().await.ok();
         // Without these, our poor connection gets deadlocks if other schemas
         // are modified while we introspect.

--- a/schema-engine/connectors/schema-connector/src/filter.rs
+++ b/schema-engine/connectors/schema-connector/src/filter.rs
@@ -35,11 +35,3 @@ impl From<json_rpc::types::SchemaFilter> for SchemaFilter {
         }
     }
 }
-
-impl From<Option<json_rpc::types::SchemaFilter>> for SchemaFilter {
-    fn from(filter: Option<json_rpc::types::SchemaFilter>) -> Self {
-        Self {
-            external_tables: filter.map(|f| f.external_tables).unwrap_or_default(),
-        }
-    }
-}

--- a/schema-engine/json-rpc-api/src/types.rs
+++ b/schema-engine/json-rpc-api/src/types.rs
@@ -232,7 +232,7 @@ pub struct ApplyMigrationsInput {
     pub migrations_list: MigrationList,
 
     /// The schema filter to use during the apply migrations.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// The output of the `applyMigrations` command.
@@ -287,7 +287,7 @@ pub struct CreateMigrationInput {
     pub schema: SchemasContainer,
 
     /// Entities to be included or excluded from the migration.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// The output of the `createMigration` command.
@@ -361,7 +361,7 @@ pub struct DevDiagnosticInput {
     pub migrations_list: MigrationList,
 
     /// The schema filter to use during checks on the database.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// The response type for `devDiagnostic`.
@@ -389,7 +389,7 @@ pub struct DiagnoseMigrationHistoryInput {
 
     /// The schema filter to use during checks on the database.
     /// Note: Only used if opt_in_to_shadow_database is true.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// The result type for `diagnoseMigrationHistory` responses.
@@ -449,7 +449,7 @@ pub struct DiffParams {
     pub exit_code: Option<bool>,
 
     /// The schema filter to use during the diff.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// The result type for the `diff` method.
@@ -627,7 +627,7 @@ pub struct EvaluateDataLossInput {
     /// The prisma schema files to migrate to.
     pub schema: SchemasContainer,
     /// Entities to be included or excluded during the data loss evaluation.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// The output of the `evaluateDataLoss` command.
@@ -734,7 +734,7 @@ pub struct MarkMigrationRolledBackOutput {}
 #[cfg_attr(target_arch = "wasm32", tsify(missing_as_null, from_wasm_abi))]
 pub struct ResetInput {
     /// The schema filter to use during the reset. Only relevant during "soft" resets though - usually we try to drop the whole database.
-    pub filter: Option<SchemaFilter>,
+    pub filter: SchemaFilter,
 }
 
 /// The output of the `reset` command.
@@ -757,7 +757,7 @@ pub struct SchemaPushInput {
     pub schema: SchemasContainer,
 
     /// The schema filter to use during the push.
-    pub filters: Option<SchemaFilter>,
+    pub filters: SchemaFilter,
 }
 
 /// Response result for the `schemaPush` method.

--- a/schema-engine/sql-migration-tests/src/commands/apply_migrations.rs
+++ b/schema-engine/sql-migration-tests/src/commands/apply_migrations.rs
@@ -34,7 +34,7 @@ impl<'a> ApplyMigrations<'a> {
         let output = apply_migrations(
             ApplyMigrationsInput {
                 migrations_list,
-                filters: None,
+                filters: SchemaFilter::default(),
             },
             self.api,
             self.namespaces,

--- a/schema-engine/sql-migration-tests/src/commands/create_migration.rs
+++ b/schema-engine/sql-migration-tests/src/commands/create_migration.rs
@@ -133,7 +133,7 @@ impl<'a> CreateMigration<'a> {
                 schema: SchemasContainer { files: self.files },
                 draft: self.draft,
                 migration_name: migration_name.clone(),
-                filters: Some(self.filter),
+                filters: self.filter,
             },
             self.api,
             &mut migration_schema_cache,

--- a/schema-engine/sql-migration-tests/src/commands/dev_diagnostic.rs
+++ b/schema-engine/sql-migration-tests/src/commands/dev_diagnostic.rs
@@ -31,7 +31,7 @@ impl<'a> DevDiagnostic<'a> {
         let fut = dev_diagnostic_cli(
             DevDiagnosticInput {
                 migrations_list,
-                filters: Some(self.filter),
+                filters: self.filter,
             },
             None,
             self.api,

--- a/schema-engine/sql-migration-tests/src/commands/diagnose_migration_history.rs
+++ b/schema-engine/sql-migration-tests/src/commands/diagnose_migration_history.rs
@@ -1,7 +1,7 @@
 use schema_core::{
     CoreError, CoreResult,
-    commands::DiagnoseMigrationHistoryOutput,
-    commands::{DiagnoseMigrationHistoryInput, diagnose_migration_history_cli},
+    commands::{DiagnoseMigrationHistoryInput, DiagnoseMigrationHistoryOutput, diagnose_migration_history_cli},
+    json_rpc::types::SchemaFilter,
     schema_connector::SchemaConnector,
 };
 use tempfile::TempDir;
@@ -37,7 +37,7 @@ impl<'a> DiagnoseMigrationHistory<'a> {
             DiagnoseMigrationHistoryInput {
                 migrations_list,
                 opt_in_to_shadow_database: self.opt_in_to_shadow_database,
-                filters: None,
+                filters: SchemaFilter::default(),
             },
             None,
             self.api,

--- a/schema-engine/sql-migration-tests/src/commands/evaluate_data_loss.rs
+++ b/schema-engine/sql-migration-tests/src/commands/evaluate_data_loss.rs
@@ -40,7 +40,7 @@ impl<'a> EvaluateDataLoss<'a> {
             EvaluateDataLossInput {
                 migrations_list,
                 schema: SchemasContainer { files: self.files },
-                filters: Some(self.filter),
+                filters: self.filter,
             },
             self.api,
             &mut migration_schema_cache,

--- a/schema-engine/sql-migration-tests/src/commands/schema_push.rs
+++ b/schema-engine/sql-migration-tests/src/commands/schema_push.rs
@@ -14,7 +14,7 @@ pub struct SchemaPush<'a> {
     migration_id: Option<&'a str>,
     // In eventually-consistent systems, we might need to wait for a while before the system refreshes
     max_ddl_refresh_delay: Option<Duration>,
-    schema_filter: Option<SchemaFilter>,
+    schema_filter: SchemaFilter,
 }
 
 impl<'a> SchemaPush<'a> {
@@ -22,7 +22,7 @@ impl<'a> SchemaPush<'a> {
         api: &'a mut dyn SchemaConnector,
         files: &[(&str, &str)],
         max_refresh_delay: Option<Duration>,
-        schema_filter: Option<SchemaFilter>,
+        schema_filter: SchemaFilter,
     ) -> Self {
         SchemaPush {
             api,

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -360,7 +360,7 @@ impl EngineTestApi {
             &mut self.connector,
             &[("schema.prisma", &dm)],
             self.max_ddl_refresh_delay,
-            None,
+            SchemaFilter::default(),
         )
     }
 

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -486,15 +486,20 @@ impl TestApi {
 
     /// Plan a `schemaPush` command
     pub fn schema_push(&mut self, dm: impl Into<String>) -> SchemaPush<'_> {
-        self.schema_push_with_filter(dm, None)
+        self.schema_push_with_filter(dm, SchemaFilter::default())
     }
 
     pub fn schema_push_multi_file(&mut self, files: &[(&str, &str)]) -> SchemaPush<'_> {
         let max_ddl_refresh_delay = self.max_ddl_refresh_delay();
-        SchemaPush::new(&mut self.connector, files, max_ddl_refresh_delay, None)
+        SchemaPush::new(
+            &mut self.connector,
+            files,
+            max_ddl_refresh_delay,
+            SchemaFilter::default(),
+        )
     }
 
-    pub fn schema_push_with_filter(&mut self, dm: impl Into<String>, filter: Option<SchemaFilter>) -> SchemaPush<'_> {
+    pub fn schema_push_with_filter(&mut self, dm: impl Into<String>, filter: SchemaFilter) -> SchemaPush<'_> {
         let max_ddl_refresh_delay = self.max_ddl_refresh_delay();
         let dm: String = dm.into();
 

--- a/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/cockroachdb.rs
@@ -4,7 +4,10 @@ mod failure_modes;
 use prisma_value::PrismaValue;
 use psl::parser_database::*;
 use quaint::prelude::Insert;
-use schema_core::{json_rpc::types::SchemasContainer, schema_connector::DiffTarget};
+use schema_core::{
+    json_rpc::types::{SchemaFilter, SchemasContainer},
+    schema_connector::DiffTarget,
+};
 use serde_json::json;
 use sql_migration_tests::test_api::*;
 use sql_schema_describer::{ColumnTypeFamily, ForeignKeyAction};
@@ -36,7 +39,7 @@ fn db_push_on_cockroach_db_with_postgres_provider_fails(api: TestApi) {
                 content: schema,
             }],
         },
-        filters: None,
+        filters: SchemaFilter::default(),
     }))
     .unwrap_err()
     .message()

--- a/schema-engine/sql-migration-tests/tests/migrations/dev_diagnostic_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/dev_diagnostic_tests.rs
@@ -621,7 +621,7 @@ fn dev_diagnostic_shadow_database_creation_error_is_special_cased_mysql(api: Tes
         migration_api
             .dev_diagnostic(DevDiagnosticInput {
                 migrations_list,
-                filters: None,
+                filters: SchemaFilter::default(),
             })
             .await
     })
@@ -672,7 +672,7 @@ fn dev_diagnostic_shadow_database_creation_error_is_special_cased_postgres(api: 
         migration_api
             .dev_diagnostic(DevDiagnosticInput {
                 migrations_list,
-                filters: None,
+                filters: SchemaFilter::default(),
             })
             .await
     })
@@ -834,7 +834,7 @@ ALTER TABLE "prisma-tests".profiles ADD CONSTRAINT profiles_id_fkey FOREIGN KEY 
 
     tok(api.dev_diagnostic(DevDiagnosticInput {
         migrations_list,
-        filters: None,
+        filters: SchemaFilter::default(),
     }))
     .unwrap();
 }

--- a/schema-engine/sql-migration-tests/tests/migrations/diagnose_migration_history_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diagnose_migration_history_tests.rs
@@ -1,7 +1,7 @@
 use pretty_assertions::assert_eq;
 use schema_core::{
     commands::{DiagnoseMigrationHistoryInput, DiagnoseMigrationHistoryOutput, DriftDiagnostic, HistoryDiagnostic},
-    json_rpc::types::CreateMigrationOutput,
+    json_rpc::types::{CreateMigrationOutput, SchemaFilter},
     schema_api,
 };
 use sql_migration_tests::{test_api::*, utils::list_migrations};
@@ -817,7 +817,7 @@ fn shadow_database_creation_error_is_special_cased_mysql(api: TestApi) {
     let output = tok(migration_api.diagnose_migration_history(DiagnoseMigrationHistoryInput {
         migrations_list,
         opt_in_to_shadow_database: true,
-        filters: None,
+        filters: SchemaFilter::default(),
     }))
     .unwrap();
 
@@ -867,7 +867,7 @@ fn shadow_database_creation_error_is_special_cased_postgres(api: TestApi) {
             .diagnose_migration_history(DiagnoseMigrationHistoryInput {
                 migrations_list,
                 opt_in_to_shadow_database: true,
-                filters: None,
+                filters: SchemaFilter::default(),
             })
             .await
     })
@@ -938,7 +938,7 @@ fn shadow_database_creation_error_is_special_cased_mssql(api: TestApi) {
     let output = tok(migration_api.diagnose_migration_history(DiagnoseMigrationHistoryInput {
         migrations_list,
         opt_in_to_shadow_database: true,
-        filters: None,
+        filters: SchemaFilter::default(),
     }))
     .unwrap();
 

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -71,7 +71,7 @@ fn from_unique_index_to_without(mut api: TestApi) {
             }],
         }),
         script: true,
-        filters: None,
+        filters: SchemaFilter::default(),
     })
     .unwrap();
 
@@ -176,7 +176,7 @@ fn from_unique_index_to_pk(mut api: TestApi) {
             }],
         }),
         script: true,
-        filters: None,
+        filters: SchemaFilter::default(),
     })
     .unwrap();
 
@@ -392,7 +392,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
             }],
         }),
         script: true,
-        filters: None,
+        filters: SchemaFilter::default(),
     })
     .unwrap();
 
@@ -412,7 +412,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
             }],
         }),
         script: false,
-        filters: None,
+        filters: SchemaFilter::default(),
     })
     .unwrap();
 
@@ -452,7 +452,7 @@ fn from_empty_to_migrations_directory(mut api: TestApi) {
         to: DiffTarget::Migrations(migrations_list),
         script: true,
         shadow_database_url: Some(api.connection_string().to_owned()),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     let host = Arc::new(TestConnectorHost::default());
@@ -494,7 +494,7 @@ fn from_empty_to_migrations_folder_without_shadow_db_url_must_error(mut api: Tes
         to: DiffTarget::Migrations(migrations_list),
         script: true,
         shadow_database_url: None, // TODO: ?
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     let err = api.diff(params).unwrap_err();
@@ -545,7 +545,7 @@ fn from_schema_datamodel_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     api.diff(input).unwrap();
@@ -598,7 +598,7 @@ fn from_schema_datasource_relative(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Empty,
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     api.diff(params).unwrap();
@@ -659,7 +659,7 @@ fn from_schema_datasource_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     api.diff(input).unwrap();
@@ -718,9 +718,9 @@ fn with_schema_filters(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: Some(SchemaFilter {
+        filters: SchemaFilter {
             external_tables: vec!["external_table".to_string()],
-        }),
+        },
     };
 
     api.diff(input).unwrap();
@@ -767,9 +767,9 @@ fn with_invalid_schema_filters(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: Some(SchemaFilter {
+        filters: SchemaFilter {
             external_tables: vec!["public.external_table".to_string()],
-        }),
+        },
     };
 
     let err = api.diff(input).unwrap_err();
@@ -807,7 +807,7 @@ fn from_url_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     api.diff(input).unwrap();
@@ -874,7 +874,7 @@ fn diffing_mongo_schemas_to_script_returns_a_nice_error() {
             }],
         }),
         script: true,
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     let expected = expect![[r#"
@@ -902,7 +902,7 @@ fn diff_sqlite_migration_directories() {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Migrations(migrations_list_2),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     tok(schema_core::schema_api(None, None).unwrap().diff(params)).unwrap();
@@ -963,7 +963,7 @@ fn diffing_mongo_schemas_works() {
             }],
         }),
         script: false,
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     let expected_printed_messages = expect![[r#"
@@ -1024,7 +1024,7 @@ fn diffing_two_schema_datamodels_with_missing_datasource_env_vars() {
                     content: schema_b.to_string(),
                 }],
             }),
-            filters: None,
+            filters: SchemaFilter::default(),
         }))
     }
 }
@@ -1062,7 +1062,7 @@ fn diff_with_exit_code_and_empty_diff_returns_zero() {
         }),
         script: false,
         shadow_database_url: None,
-        filters: None,
+        filters: SchemaFilter::default(),
     });
 
     assert_eq!(result.exit_code, 0);
@@ -1100,7 +1100,7 @@ fn diff_with_exit_code_and_non_empty_diff_returns_two() {
         }),
         script: false,
         shadow_database_url: None,
-        filters: None,
+        filters: SchemaFilter::default(),
     });
 
     assert_eq!(result.exit_code, 2);
@@ -1127,7 +1127,7 @@ fn diff_with_non_existing_sqlite_database_from_url() {
         to: DiffTarget::Url(UrlContainer {
             url: format!("file:{}", tmpdir.path().join("db.sqlite").to_string_lossy()),
         }),
-        filters: None,
+        filters: SchemaFilter::default(),
     });
 
     let error = error
@@ -1165,7 +1165,7 @@ fn diff_with_non_existing_sqlite_database_from_datasource() {
             }],
             config_dir: schema_path.parent().unwrap().to_string_lossy().into_owned(),
         }),
-        filters: None,
+        filters: SchemaFilter::default(),
     });
 
     if cfg!(target_os = "windows") {
@@ -1232,7 +1232,7 @@ fn from_multi_file_schema_datasource_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     api.diff(input).unwrap();
@@ -1299,7 +1299,7 @@ fn from_multi_file_schema_datamodel_to_url(mut api: TestApi) {
         script: true,
         shadow_database_url: None,
         to: DiffTarget::Url(UrlContainer { url: second_url }),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     api.diff(input).unwrap();

--- a/schema-engine/sql-migration-tests/tests/migrations/drift_summary.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/drift_summary.rs
@@ -1,5 +1,5 @@
 use expect_test::{Expect, expect};
-use schema_core::json_rpc::types::SchemasContainer;
+use schema_core::json_rpc::types::{SchemaFilter, SchemasContainer};
 use sql_migration_tests::test_api::*;
 use std::sync::Arc;
 
@@ -24,7 +24,7 @@ fn check(from: &str, to: &str, expectation: Expect) {
                 content: to.to_string(),
             }],
         }),
-        filters: None,
+        filters: SchemaFilter::default(),
     };
 
     let host = Arc::new(TestConnectorHost::default());

--- a/schema-engine/sql-migration-tests/tests/migrations/mysql.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/mysql.rs
@@ -484,7 +484,7 @@ fn dropping_m2m_relation_from_datamodel_works() {
         }),
         script: true,
         shadow_database_url: None,
-        filters: None,
+        filters: SchemaFilter::default(),
     });
 
     let expected = expect![[r#"

--- a/schema-engine/sql-migration-tests/tests/schema_push/mod.rs
+++ b/schema-engine/sql-migration-tests/tests/schema_push/mod.rs
@@ -471,9 +471,9 @@ fn schema_push_with_schema_filters(api: TestApi) {
 
     api.schema_push_with_filter(
         dm,
-        Some(SchemaFilter {
+        SchemaFilter {
             external_tables: vec!["ExternalTable".to_string()],
-        }),
+        },
     )
     .send()
     .assert_green()
@@ -499,9 +499,9 @@ fn schema_push_with_invalid_schema_filters(api: TestApi) {
     let err = api
         .schema_push_with_filter(
             dm,
-            Some(SchemaFilter {
+            SchemaFilter {
                 external_tables: vec!["public.ExternalTable".to_string()],
-            }),
+            },
         )
         .send_unwrap_err();
 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests.rs
@@ -1,6 +1,6 @@
 use schema_core::{
-    json_rpc::types::SchemasContainer,
-    schema_connector::{ConnectorParams, SchemaConnector, SchemaFilter},
+    json_rpc::types::{SchemaFilter, SchemasContainer},
+    schema_connector::{ConnectorParams, SchemaConnector},
 };
 use sql_migration_tests::test_api::*;
 use sql_schema_connector::SqlSchemaConnector;
@@ -80,7 +80,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
             shadow_database_connection_string: None,
         };
         let mut conn = SqlSchemaConnector::new_mysql(params).unwrap();
-        tok(conn.reset(false, None, &SchemaFilter::default())).unwrap();
+        tok(conn.reset(false, None, &SchemaFilter::default().into())).unwrap();
         test_api_args.database_url().to_owned()
     } else if tags.contains(Tags::Mysql) {
         let (_, connection_string) = tok(test_api_args.create_mysql_database());
@@ -108,7 +108,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
                 content: text.to_string(),
             }],
         }),
-        filters: None,
+        filters: SchemaFilter::default(),
     }))
     .unwrap();
 
@@ -137,7 +137,7 @@ fn run_single_migration_test(test_file_path: &str, test_function_name: &'static 
                 content: text.to_string(),
             }],
         }),
-        filters: None,
+        filters: SchemaFilter::default(),
     }))
     .unwrap();
 


### PR DESCRIPTION
Small refactoring PR to make schema-filter non optional but work with a default filter instead. Removes some annoying optional handling. Will require minor update on the types on the TS side.