### PR TITLE
fix: ORM-1269 fix table recreation through default schema

### DIFF
--- a/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/lib.rs
@@ -78,7 +78,8 @@ pub async fn setup_external<'a>(
             // 1. Compute the diff migration script.
             std::fs::remove_file(source.url.as_literal().unwrap().trim_start_matches("file:")).ok();
             let dialect = sql_schema_connector::SqlSchemaDialect::sqlite();
-            let migration_script = crate::diff(prisma_schema, &dialect).await?;
+            let d1_default_namespace = "main"; // as for any SQLite DB
+            let migration_script = crate::diff(prisma_schema, &dialect, Some(d1_default_namespace)).await?;
 
             // 2. Tell JavaScript to take care of the schema migration.
             //    This results in a JSON-RPC call to the JS runtime.
@@ -148,15 +149,21 @@ pub async fn teardown(prisma_schema: &str, db_schemas: &[&str]) -> ConnectorResu
 
 /// Compute an initialisation migration script via
 /// `prisma migrate diff --from-empty --to-schema-datamodel $SCHEMA_PATH --script`.
-pub(crate) async fn diff(schema: &str, dialect: &dyn SchemaDialect) -> ConnectorResult<String> {
+pub(crate) async fn diff(
+    schema: &str,
+    dialect: &dyn SchemaDialect,
+    default_namespace: Option<&str>,
+) -> ConnectorResult<String> {
     let from = dialect.empty_database_schema();
-    let to = dialect.schema_from_datamodel(vec![("schema.prisma".to_string(), schema.into())])?;
+    let to = dialect.schema_from_datamodel(vec![("schema.prisma".to_string(), schema.into())], default_namespace)?;
     let migration = dialect.diff(from, to, &SchemaFilter::default());
     dialect.render_script(&migration, &Default::default())
 }
 
 /// Apply the script returned by [`diff`] against the database.
 pub(crate) async fn diff_and_apply(schema: &str, connector: &mut dyn SchemaConnector) -> ConnectorResult<()> {
-    let script = diff(schema, &*connector.schema_dialect()).await.unwrap();
+    let script = diff(schema, &*connector.schema_dialect(), connector.default_namespace())
+        .await
+        .unwrap();
     connector.db_execute(script).await
 }

--- a/schema-engine/commands/src/commands/create_migration.rs
+++ b/schema-engine/commands/src/commands/create_migration.rs
@@ -32,9 +32,10 @@ pub async fn create_migration(
     let sources: Vec<_> = input.schema.to_psl_input();
     let dialect = connector.schema_dialect();
     let filter: schema_connector::SchemaFilter = input.filters.into();
+    let default_namespace = connector.default_namespace();
     // We need to start with the 'to', which is the Schema, in order to grab the
     // namespaces, in case we've got MultiSchema enabled.
-    let to = dialect.schema_from_datamodel(sources)?;
+    let to = dialect.schema_from_datamodel(sources, default_namespace)?;
     let namespaces = dialect.extract_namespaces(&to);
     filter.validate(namespaces.as_ref())?;
 

--- a/schema-engine/commands/src/commands/diff.rs
+++ b/schema-engine/commands/src/commands/diff.rs
@@ -138,7 +138,7 @@ async fn diff_target_to_dialect(
         DiffTarget::SchemaDatamodel(schemas) => {
             let sources = schemas.to_psl_input();
             let dialect = schema_to_dialect(&sources)?;
-            let schema = dialect.schema_from_datamodel(sources)?;
+            let schema = dialect.schema_from_datamodel(sources, connector.default_namespace())?;
             Ok(Some((dialect, schema)))
         }
         DiffTarget::Url(UrlContainer { .. }) => Err(ConnectorError::from_msg(

--- a/schema-engine/commands/src/commands/evaluate_data_loss.rs
+++ b/schema-engine/commands/src/commands/evaluate_data_loss.rs
@@ -18,7 +18,7 @@ pub async fn evaluate_data_loss(
     let dialect = connector.schema_dialect();
     let filter: schema_connector::SchemaFilter = input.filters.into();
 
-    let to = dialect.schema_from_datamodel(sources)?;
+    let to = dialect.schema_from_datamodel(sources, connector.default_namespace())?;
 
     let from = migration_schema_cache
         .get_or_insert(&input.migrations_list.migration_directories, || async {

--- a/schema-engine/commands/src/commands/schema_push.rs
+++ b/schema-engine/commands/src/commands/schema_push.rs
@@ -24,7 +24,7 @@ pub async fn schema_push(input: SchemaPushInput, connector: &mut dyn SchemaConne
     let dialect = connector.schema_dialect();
     let filter: schema_connector::SchemaFilter = input.filters.into();
 
-    let to = dialect.schema_from_datamodel(sources)?;
+    let to = dialect.schema_from_datamodel(sources, connector.default_namespace())?;
     // We only consider the namespaces present in the "to" schema aka the PSL file for the introspection of the "from" schema.
     // So when the user removes a previously existing namespace from their PSL file we will not modify that namespace in the database.
     let namespaces = dialect.extract_namespaces(&to);

--- a/schema-engine/connectors/mongodb-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/src/lib.rs
@@ -90,7 +90,11 @@ impl SchemaDialect for MongoDbSchemaDialect {
         DatabaseSchema::new(MongoSchema::default())
     }
 
-    fn schema_from_datamodel(&self, sources: Vec<(String, psl::SourceFile)>) -> ConnectorResult<DatabaseSchema> {
+    fn schema_from_datamodel(
+        &self,
+        sources: Vec<(String, psl::SourceFile)>,
+        _default_namespace: Option<&str>,
+    ) -> ConnectorResult<DatabaseSchema> {
         let validated_schema = psl::parse_schema_multi(&sources).map_err(ConnectorError::new_schema_parser_error)?;
         Ok(DatabaseSchema::new(schema_calculator::calculate(&validated_schema)))
     }
@@ -119,6 +123,10 @@ impl SchemaDialect for MongoDbSchemaDialect {
 impl SchemaConnector for MongoDbSchemaConnector {
     fn schema_dialect(&self) -> Box<dyn SchemaDialect> {
         Box::new(MongoDbSchemaDialect)
+    }
+
+    fn default_namespace(&self) -> Option<&str> {
+        None
     }
 
     fn host(&self) -> &Arc<dyn ConnectorHost> {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/test_api.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/test_api.rs
@@ -182,7 +182,7 @@ pub(crate) fn test_scenario(scenario_name: &str) {
         let dialect = connector.schema_dialect();
         let from = connector.schema_from_database(None).await.unwrap();
         let to = dialect
-            .schema_from_datamodel(vec![("schema.prisma".to_string(), schema.clone())])
+            .schema_from_datamodel(vec![("schema.prisma".to_string(), schema.clone())], None)
             .unwrap();
         let migration = dialect.diff(from, to, &SchemaFilter::default());
 
@@ -220,7 +220,7 @@ Snapshot comparison failed. Run the test again with UPDATE_EXPECT=1 in the envir
         // Check that the migration is idempotent.
         let from = connector.schema_from_database(None).await.unwrap();
         let to = dialect
-            .schema_from_datamodel(vec![("schema.prisma".to_string(), schema.clone())])
+            .schema_from_datamodel(vec![("schema.prisma".to_string(), schema.clone())], None)
             .unwrap();
         let migration = dialect.diff(from, to, &SchemaFilter::default());
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 
 pub(crate) fn calculate_sql_schema(
     datamodel: &ValidatedSchema,
+    default_namespace: &str,
     flavour: &dyn SqlSchemaCalculatorFlavour,
 ) -> SqlDatabaseSchema {
     let mut schema = SqlDatabaseSchema::default();
@@ -38,6 +39,8 @@ pub(crate) fn calculate_sql_schema(
         }
     }
 
+    push_namespaces(&mut context, default_namespace);
+
     flavour.calculate_enums(&mut context);
 
     // Two types of tables: model tables and implicit M2M relation tables (a.k.a. join tables.).
@@ -51,6 +54,28 @@ pub(crate) fn calculate_sql_schema(
     flavour.push_connector_data(&mut context);
 
     schema
+}
+
+fn push_namespaces<'a>(ctx: &mut Context<'a>, default_namespace: &'a str) {
+    ctx.schemas.insert(
+        default_namespace,
+        ctx.schema
+            .describer_schema
+            .push_namespace(default_namespace.to_string()),
+    );
+
+    let namespaces = ctx
+        .datamodel
+        .configuration
+        .first_datasource()
+        .namespaces
+        .iter()
+        .filter(|(n, _)| n != default_namespace);
+
+    for (schema, _) in namespaces {
+        ctx.schemas
+            .insert(schema, ctx.schema.describer_schema.push_namespace(schema.clone()));
+    }
 }
 
 fn push_model_tables(ctx: &mut Context<'_>) {

--- a/schema-engine/core/src/commands/diff_cli.rs
+++ b/schema-engine/core/src/commands/diff_cli.rs
@@ -143,7 +143,9 @@ async fn json_rpc_diff_target_to_dialect(
         DiffTarget::SchemaDatamodel(schemas) => {
             let sources = schemas.to_psl_input();
             let dialect = crate::schema_to_dialect(&sources)?;
-            let schema = dialect.schema_from_datamodel(sources)?;
+            // Connector only needed to infer the default namespace.
+            let connector = crate::schema_to_connector(&sources, None)?;
+            let schema = dialect.schema_from_datamodel(sources, connector.default_namespace())?;
             Ok(Some((dialect, schema)))
         }
         DiffTarget::Url(UrlContainer { url }) => {

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -403,14 +403,21 @@ impl TestApi {
         to: DiffTarget<'_>,
         namespaces: Option<Namespaces>,
     ) -> String {
-        let from =
-            tok(self
-                .connector
-                .schema_from_diff_target(from, namespaces.clone(), &SchemaFilter::default().into()))
-            .unwrap();
-        let to = tok(self
-            .connector
-            .schema_from_diff_target(to, namespaces, &SchemaFilter::default().into()))
+        let default_namespace = self.connector.default_namespace().map(|s| s.to_string());
+
+        let from = tok(self.connector.schema_from_diff_target(
+            from,
+            namespaces.clone(),
+            default_namespace.as_deref(),
+            &SchemaFilter::default().into(),
+        ))
+        .unwrap();
+        let to = tok(self.connector.schema_from_diff_target(
+            to,
+            namespaces,
+            default_namespace.as_deref(),
+            &SchemaFilter::default().into(),
+        ))
         .unwrap();
         let dialect = self.connector.schema_dialect();
         let migration = dialect.diff(from, to, &SchemaFilter::default().into());


### PR DESCRIPTION
This PR fixes an issue when enabling the multi schema preview feature but not using explicit schema names and relying on the default schema instead.

During diffing the existing tables in the database/applied migrations were introspected with a namespace (the db default one from the connection string). But the tables from the schema file (the target state) didn't have a namespace. 
=> actually identical tables were treated as different => tables got dropped and created

This PR fixes this by making the schema generated from the schema file aware of the default schema name. Tables in both schemas now have the same schema name and diffing works as intended.