### PR TITLE
fix: ORM-1269 fix found issues

### DIFF
--- a/schema-engine/commands/src/commands/create_migration.rs
+++ b/schema-engine/commands/src/commands/create_migration.rs
@@ -37,7 +37,7 @@ pub async fn create_migration(
     // namespaces, in case we've got MultiSchema enabled.
     let to = dialect.schema_from_datamodel(sources, default_namespace)?;
     let namespaces = dialect.extract_namespaces(&to);
-    filter.validate(namespaces.as_ref())?;
+    filter.validate(&*dialect)?;
 
     let from = migration_schema_cache
         .get_or_insert(&input.migrations_list.migration_directories, || async {

--- a/schema-engine/commands/src/commands/diff.rs
+++ b/schema-engine/commands/src/commands/diff.rs
@@ -26,7 +26,7 @@ pub async fn diff(
         namespaces_and_preview_features_from_diff_targets(&[&params.from, &params.to])?;
 
     let filter: SchemaFilter = params.filters.into();
-    filter.validate(namespaces.as_ref())?;
+    filter.validate(&*connector.schema_dialect())?;
 
     let (conn_from, schema_from) = diff_target_to_dialect(
         &params.from,

--- a/schema-engine/commands/src/commands/schema_push.rs
+++ b/schema-engine/commands/src/commands/schema_push.rs
@@ -28,7 +28,7 @@ pub async fn schema_push(input: SchemaPushInput, connector: &mut dyn SchemaConne
     // We only consider the namespaces present in the "to" schema aka the PSL file for the introspection of the "from" schema.
     // So when the user removes a previously existing namespace from their PSL file we will not modify that namespace in the database.
     let namespaces = dialect.extract_namespaces(&to);
-    filter.validate(namespaces.as_ref())?;
+    filter.validate(&*dialect)?;
 
     let from = connector
         .schema_from_database(namespaces)

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -31,14 +31,6 @@ pub(crate) fn calculate_sql_schema(
         schemas: Default::default(),
     };
 
-    if let Some(ds) = context.datamodel.configuration.datasources.first() {
-        for (schema, _) in &ds.namespaces {
-            context
-                .schemas
-                .insert(schema, context.schema.describer_schema.push_namespace(schema.clone()));
-        }
-    }
-
     push_namespaces(&mut context, default_namespace);
 
     flavour.calculate_enums(&mut context);
@@ -57,20 +49,24 @@ pub(crate) fn calculate_sql_schema(
 }
 
 fn push_namespaces<'a>(ctx: &mut Context<'a>, default_namespace: Option<&'a str>) {
-    if let Some(default_namespace) = default_namespace {
+    // We either use the explicit namespaces from the datamodel
+    if let Some(ds) = ctx.datamodel.configuration.datasources.first() {
+        for (schema, _) in ds.namespaces.iter() {
+            ctx.schemas
+                .insert(schema, ctx.schema.describer_schema.push_namespace(schema.clone()));
+        }
+    }
+
+    // or the default namespace from the connector. But not mix both!
+    if ctx.schemas.is_empty()
+        && let Some(default_namespace) = default_namespace
+    {
         ctx.schemas.insert(
             default_namespace,
             ctx.schema
                 .describer_schema
                 .push_namespace(default_namespace.to_string()),
         );
-
-        if let Some(ds) = ctx.datamodel.configuration.datasources.first() {
-            for (schema, _) in ds.namespaces.iter().filter(|(n, _)| n != default_namespace) {
-                ctx.schemas
-                    .insert(schema, ctx.schema.describer_schema.push_namespace(schema.clone()));
-            }
-        }
     }
 }
 


### PR DESCRIPTION
The integration with prisma/prisma uncovered two bugs in the current implementation of the default schema paths.

a) A migrate test was failing due to incorrect schema filter validations. The logic for this had to be updated to better follow the updated semantic.
b) Tests related to db push commands and multi schema uncovered that we were doing e.g. data loss checks on the default schema even if the default schema is not in the list of explicitly set schemas in the datasource block.