### PR TITLE
fix: fix enum introspection for SQLite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5452,6 +5452,7 @@ dependencies = [
  "expect-test",
  "indexmap 2.2.2",
  "indoc",
+ "itertools 0.13.0",
  "prisma-value",
  "psl",
  "quaint",

--- a/schema-engine/connectors/sql-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/sql-schema-connector/Cargo.toml
@@ -36,6 +36,7 @@ serde.workspace = true
 indoc.workspace = true
 uuid.workspace = true
 indexmap.workspace = true
+itertools.workspace = true
 
 prisma-value.workspace = true
 schema-connector.workspace = true

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/enumerator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/enumerator.rs
@@ -1,130 +1,213 @@
-use super::IntrospectionPair;
-use crate::introspection::sanitize_datamodel_names::{EnumVariantName, ModelName};
+use crate::introspection::{
+    datamodel_calculator::DatamodelCalculatorContext,
+    sanitize_datamodel_names::{EnumVariantName, ModelName},
+};
+use indexmap::IndexMap;
+use itertools::EitherOrBoth;
 use psl::{
     parser_database::{self as db, walkers},
-    schema_ast::ast::WithDocumentation,
+    schema_ast::ast::{WithDocumentation, WithName},
 };
 use sql_schema_describer as sql;
 use std::borrow::Cow;
 
-/// Pairing the PSL enums (previous) to database enums (next).
-pub(crate) type EnumPair<'a> = IntrospectionPair<'a, Option<walkers::EnumWalker<'a>>, sql::EnumWalker<'a>>;
-
-/// Pairing the PSL enum values (previous) to database enums (next).
-pub(crate) type EnumVariantPair<'a> =
-    IntrospectionPair<'a, Option<walkers::EnumValueWalker<'a>>, sql::EnumVariantWalker<'a>>;
+/// Pairing of a PSL enum to a database enum.
+pub(crate) struct EnumPair<'a> {
+    previous_and_next: EitherOrBoth<walkers::EnumWalker<'a>, sql::EnumWalker<'a>>,
+    ctx: &'a DatamodelCalculatorContext<'a>,
+}
 
 impl<'a> EnumPair<'a> {
+    pub fn from_model(previous: walkers::EnumWalker<'a>, ctx: &'a DatamodelCalculatorContext<'a>) -> Self {
+        Self {
+            previous_and_next: EitherOrBoth::Left(previous),
+            ctx,
+        }
+    }
+
+    pub fn from_db(db: sql::EnumWalker<'a>, ctx: &'a DatamodelCalculatorContext<'a>) -> Self {
+        Self {
+            previous_and_next: EitherOrBoth::Right(db),
+            ctx,
+        }
+    }
+
+    pub fn insert_model(&mut self, model: walkers::EnumWalker<'a>) {
+        self.previous_and_next.insert_left(model);
+    }
+
     /// The documentation on top of the enum.
-    pub(crate) fn documentation(self) -> Option<&'a str> {
-        self.previous.and_then(|enm| enm.ast_enum().documentation())
+    pub fn documentation(&self) -> Option<&'a str> {
+        self.as_pair_ref().left().and_then(|enm| enm.ast_enum().documentation())
     }
 
     /// The mapped name, if defined, is the actual name of the enum in
     /// the database.
-    pub(crate) fn mapped_name(self) -> Option<&'a str> {
-        self.context.enum_prisma_name(self.next.id).mapped_name()
+    pub fn mapped_name(&self) -> Option<&'a str> {
+        self.ctx.enum_prisma_name(self.as_pair_ref().right()?.id).mapped_name()
     }
 
     /// Name of the enum in the PSL. The value can be sanitized if it
     /// contains characters that are not allowed in the PSL
     /// definition.
-    pub(crate) fn name(self) -> Cow<'a, str> {
-        self.context.enum_prisma_name(self.next.id).prisma_name()
+    pub fn name(&self) -> Cow<'a, str> {
+        self.as_pair_ref()
+            .map_any(
+                |model_enum| model_enum.ast_enum().name().into(),
+                |sql_enum| self.ctx.enum_prisma_name(sql_enum.id).prisma_name(),
+            )
+            .reduce(|_from_model, from_sql| from_sql)
     }
 
     /// The name of the variant is taken from the PSL.
-    pub(crate) fn name_from_psl(self) -> bool {
+    pub fn name_from_psl(&self) -> bool {
         matches!(
-            self.context.enum_prisma_name(self.next.id),
-            ModelName::FromPsl {
+            self.as_pair_ref().right().map(|e| self.ctx.enum_prisma_name(e.id)),
+            Some(ModelName::FromPsl {
                 mapped_name: Some(_),
                 ..
-            }
+            })
         )
     }
 
     /// The namespace of the enumerator, if using the multi-schema feature.
-    pub(crate) fn namespace(self) -> Option<&'a str> {
-        self.context.uses_namespaces().then(|| self.next.namespace()).flatten()
+    pub fn namespace(&self) -> Option<&'a str> {
+        self.ctx
+            .uses_namespaces()
+            .then(|| self.as_pair_ref().right()?.namespace())
+            .flatten()
     }
 
     /// The position of the enum from the PSL, if existing. Used for
     /// sorting the enums in the final introspected data model.
-    pub(crate) fn previous_position(self) -> Option<db::EnumId> {
-        self.previous.map(|e| e.id)
+    pub fn previous_position(&self) -> Option<db::EnumId> {
+        self.as_pair_ref().left().map(|e| e.id)
     }
 
     /// True, if enum uses the same name as another top-level item from
     /// a different namespace.
-    pub(crate) fn uses_duplicate_name(self) -> bool {
-        self.previous.is_none() && !self.context.name_is_unique(self.next.name())
+    pub fn uses_duplicate_name(&self) -> bool {
+        self.as_pair_ref().left().is_none()
+            && !self
+                .as_pair_ref()
+                .right()
+                .is_some_and(|e| self.ctx.name_is_unique(e.name()))
     }
 
     /// The COMMENT of the enum.
-    pub(crate) fn description(self) -> Option<&'a str> {
-        self.next.description()
+    pub fn description(&self) -> Option<&'a str> {
+        self.as_pair_ref().right()?.description()
     }
 
     /// True if we have a new enum and it has a comment.
-    pub(crate) fn adds_a_description(self) -> bool {
-        self.previous.is_none() && self.description().is_some()
+    pub fn adds_a_description(&self) -> bool {
+        self.as_pair_ref().left().is_none() && self.description().is_some()
     }
 
     /// Iterates all of the variants that are part of the enum.
-    pub(crate) fn variants(self) -> impl ExactSizeIterator<Item = EnumVariantPair<'a>> + 'a {
-        self.next.variants().map(move |next| {
-            let variant_name = self.context.enum_variant_name(next.id);
-            let prisma_name = variant_name.prisma_name();
+    pub fn variants(&self) -> impl Iterator<Item = EnumVariantPair<'a>> + use<'a> {
+        let mut variants = IndexMap::<Cow<'_, str>, EnumVariantPair<'a>>::new();
 
-            let previous = self.previous.and_then(|prev| {
-                prev.values()
-                    .find(|val| val.database_name() == variant_name.mapped_name().unwrap_or(&prisma_name))
+        // Start with the variants we found in the database.
+        for variant in self.as_pair_ref().right().into_iter().flat_map(|enm| enm.variants()) {
+            let name = self.ctx.enum_variant_name(variant.id);
+            variants
+                .entry(name.mapped_name().map(Cow::Borrowed).unwrap_or(name.prisma_name()))
+                .or_insert(EnumVariantPair::from_db(variant, self.ctx));
+        }
+
+        let has_next = self.as_pair_ref().right().is_some();
+        // Next, add the variants that we have in the model.
+        for value in self.as_pair_ref().left().into_iter().flat_map(|enm| enm.values()) {
+            let entry = variants.entry(value.database_name().into()).and_modify(|pair| {
+                // If the variant has been found in the database, we insert its pair from the model.
+                pair.previous_and_next.insert_left(value);
             });
+            // If the variant was not found in the database, we insert it as a new pair, but only
+            // if the introspection produced no enum at all (needed for databases where enums are
+            // not natively supported).
+            if !has_next {
+                entry.or_insert(EnumVariantPair::from_model(value, self.ctx));
+            }
+        }
 
-            IntrospectionPair::new(self.context, previous, next)
-        })
+        variants.into_values()
+    }
+
+    fn as_pair_ref(&self) -> EitherOrBoth<&walkers::EnumWalker<'a>, &sql::EnumWalker<'a>> {
+        self.previous_and_next.as_ref()
     }
 }
 
+/// Pairing of a PSL enum value a to database enum value.
+pub struct EnumVariantPair<'a> {
+    previous_and_next: EitherOrBoth<walkers::EnumValueWalker<'a>, sql::EnumVariantWalker<'a>>,
+    ctx: &'a DatamodelCalculatorContext<'a>,
+}
+
 impl<'a> EnumVariantPair<'a> {
+    fn from_model(previous: walkers::EnumValueWalker<'a>, ctx: &'a DatamodelCalculatorContext<'a>) -> Self {
+        Self {
+            previous_and_next: EitherOrBoth::Left(previous),
+            ctx,
+        }
+    }
+
+    fn from_db(db: sql::EnumVariantWalker<'a>, ctx: &'a DatamodelCalculatorContext<'a>) -> Self {
+        Self {
+            previous_and_next: EitherOrBoth::Right(db),
+            ctx,
+        }
+    }
+
     /// The documentation on top of the enum.
-    pub(crate) fn documentation(self) -> Option<&'a str> {
-        self.previous.and_then(|variant| variant.documentation())
+    pub fn documentation(&self) -> Option<&'a str> {
+        self.as_pair_ref().left().and_then(|variant| variant.documentation())
     }
 
     /// The mapped name, if defined, is the actual name of the variant in
     /// the database.
-    pub(crate) fn mapped_name(self) -> Option<&'a str> {
-        self.context.enum_variant_name(self.next.id).mapped_name()
+    pub fn mapped_name(&self) -> Option<&'a str> {
+        self.ctx.enum_variant_name(self.as_pair_ref().right()?.id).mapped_name()
     }
 
     /// The name of the variant is taken from the PSL.
-    pub(crate) fn name_from_psl(self) -> bool {
+    pub fn name_from_psl(&self) -> bool {
         matches!(
-            self.context.enum_variant_name(self.next.id),
-            EnumVariantName::FromPsl {
+            self.as_pair_ref().right().map(|e| self.ctx.enum_variant_name(e.id)),
+            Some(EnumVariantName::FromPsl {
                 mapped_name: Some(_),
                 ..
-            }
+            })
         )
     }
 
     /// Name of the variant in the PSL. The value can be sanitized if
     /// it contains characters that are not allowed in the PSL
     /// definition.
-    pub(crate) fn name(self) -> Cow<'a, str> {
-        let name = self.context.enum_variant_name(self.next.id).prisma_name();
+    pub fn name(&self) -> Cow<'a, str> {
+        self.as_pair_ref()
+            .map_any(
+                |model_value| model_value.ast_value().name().into(),
+                |sql_value| {
+                    let n = self.ctx.enum_variant_name(sql_value.id).prisma_name();
 
-        // If the variant is sanitized as an empty string, we will
-        // comment the variant out and add a warning.
-        //
-        // The commented out variant cannot have an empty name, so we
-        // just print the non-sanitized one.
-        if name.is_empty() {
-            Cow::Borrowed(self.next.name())
-        } else {
-            name
-        }
+                    // If the variant is sanitized as an empty string, we will
+                    // comment the variant out and add a warning.
+                    //
+                    // The commented out variant cannot have an empty name, so we
+                    // just print the non-sanitized one.
+                    if n.is_empty() {
+                        Cow::Borrowed(sql_value.name())
+                    } else {
+                        n
+                    }
+                },
+            )
+            .reduce(|_from_model, from_sql| from_sql)
+    }
+
+    fn as_pair_ref(&self) -> EitherOrBoth<&walkers::EnumValueWalker<'a>, &sql::EnumVariantWalker<'a>> {
+        self.previous_and_next.as_ref()
     }
 }

--- a/schema-engine/sql-introspection-tests/tests/enums/mod.rs
+++ b/schema-engine/sql-introspection-tests/tests/enums/mod.rs
@@ -1,6 +1,7 @@
 mod cockroachdb;
 mod mysql;
 mod postgres;
+mod sqlite;
 
 use barrel::types;
 use quaint::prelude::Queryable;

--- a/schema-engine/sql-introspection-tests/tests/enums/sqlite.rs
+++ b/schema-engine/sql-introspection-tests/tests/enums/sqlite.rs
@@ -1,0 +1,84 @@
+use sql_introspection_tests::test_api::*;
+
+#[test_connector(tags(Sqlite))]
+async fn an_enum_in_the_model_is_preserved_when_introspected(api: &mut TestApi) -> TestResult {
+    let original = indoc! { r#"
+        /// User model.
+        model User {
+          id   String @id @default(uuid())
+          role Role
+        }
+
+        /// Role enum.
+        enum Role {
+          USER
+          ADMIN
+        }
+    "#
+    };
+
+    api.raw_cmd(
+        r#"
+        CREATE TABLE "User" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "role" TEXT NOT NULL
+        );
+        "#,
+    )
+    .await;
+
+    let result = api.re_introspect(original).await?;
+    api.assert_eq_datamodels(original, &result);
+    Ok(())
+}
+
+#[test_connector(tags(Sqlite))]
+async fn an_enum_in_the_model_is_preserved_without_redundant_attributes_when_introspected(
+    api: &mut TestApi,
+) -> TestResult {
+    let original = indoc! { r#"
+        /// User model.
+        model User {
+          id   String @id @default(uuid())
+          role Role
+        }
+
+        /// Role enum.
+        enum Role {
+          USER
+          ADMIN
+          // the @map has no effect because the enum does exist in the database
+          @@map("r0le")
+        }
+    "#
+    };
+
+    let expected = indoc! { r#"
+        /// User model.
+        model User {
+          id   String @id @default(uuid())
+          role Role
+        }
+
+        /// Role enum.
+        enum Role {
+          USER
+          ADMIN
+        }
+    "#
+    };
+
+    api.raw_cmd(
+        r#"
+        CREATE TABLE "User" (
+            "id" TEXT NOT NULL PRIMARY KEY,
+            "role" TEXT NOT NULL
+        );
+        "#,
+    )
+    .await;
+
+    let result = api.re_introspect(original).await?;
+    api.assert_eq_datamodels(expected, &result);
+    Ok(())
+}


### PR DESCRIPTION
[ORM-1283](https://linear.app/prisma-company/issue/ORM-1283/fix-sqlite-enum-introspection)

I've made changes to ensure that we preserve enums in the prisma schema when doing introspection in SQLite. It required some refactoring to make the `EnumPair` work without an actual sql enum. I've used `EitherOrBoth` to represent the idea that enums must be present either in the schema, in the database or in both.