### PR TITLE
fix: ORM-1315 fix external tables empty db check

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -295,8 +295,6 @@ impl SqlConnector for MssqlConnector {
         Box::pin(async move {
             let search_path = self.schema_name().to_string();
 
-            let uses_explicit_namespaces = namespaces.is_some();
-
             let mut namespaces: Vec<_> = namespaces.map(|ns| ns.into_iter().collect()).unwrap_or_default();
             namespaces.push(search_path);
 
@@ -323,7 +321,7 @@ impl SqlConnector for MssqlConnector {
                     namespaces.contains(ns)
                         && !self.dialect().schema_differ().contains_table(
                             &filters.external_tables,
-                            uses_explicit_namespaces.then_some(ns),
+                            Some(ns),
                             table_name,
                         )
                 })

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -403,8 +403,6 @@ impl SqlConnector for PostgresConnector {
         Box::pin(async move {
             let search_path = self.schema_name().to_string();
 
-            let uses_explicit_namespaces = namespaces.is_some();
-
             let mut namespaces: Vec<_> = namespaces
                 .map(|ns| ns.into_iter().map(Value::text).collect())
                 .unwrap_or_default();
@@ -429,11 +427,10 @@ impl SqlConnector for PostgresConnector {
                     ns.and_then(|ns| table_name.map(|table_name| (ns, table_name)))
                 })
                 .filter(|(ns, table_name)| {
-                    !self.dialect().schema_differ().contains_table(
-                        &filters.external_tables,
-                        uses_explicit_namespaces.then_some(ns),
-                        table_name,
-                    )
+                    !self
+                        .dialect()
+                        .schema_differ()
+                        .contains_table(&filters.external_tables, Some(ns), table_name)
                 })
                 .map(|(_, table_name)| table_name)
                 .collect();

--- a/schema-engine/sql-migration-tests/tests/migrations/migration_persistence_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/migration_persistence_tests.rs
@@ -198,15 +198,10 @@ fn starting_a_migration_on_a_non_empty_database_errors(api: TestApi) {
 fn starting_a_migration_on_db_with_existing_external_table_does_not_errors(api: TestApi) {
     api.raw_cmd("CREATE TABLE cats (id INT)");
 
+    let filter = api.namespaced_schema_filter(&["cats"]).into();
     let persistence = api.migration_persistence();
 
-    let result = tok(persistence.initialize(
-        None,
-        SchemaFilter {
-            external_tables: vec!["cats".to_string()],
-            external_enums: vec![],
-        },
-    ));
+    let result = tok(persistence.initialize(None, filter));
 
     assert!(result.is_ok());
 }


### PR DESCRIPTION
When not using multi schema the "is the database empty" check during migration creation was failing on postgres and sql server because the check does not correctly treat namespaced table names. 
This was missed due to an incorrect test case that did not account for the namespacing behavior.