### PR TITLE
fix(qc): fix nested aggregations

### DIFF
--- a/query-compiler/query-compiler/tests/data/aggregate-nested-m2m.json
+++ b/query-compiler/query-compiler/tests/data/aggregate-nested-m2m.json
@@ -1,0 +1,40 @@
+{
+  "modelName": "User",
+  "action": "findFirst",
+  "query": {
+    "arguments": {
+      "where": {
+        "email": {
+          "contains": "prisma.io"
+        }
+      },
+      "relationLoadStrategy": "query"
+    },
+    "selection": {
+      "posts": {
+        "arguments": {
+          "orderBy": {
+            "id": "asc"
+          }
+        },
+        "selection": {
+          "_count": {
+            "arguments": {},
+            "selection": {
+              "categories": {
+                "arguments": {
+                  "where": {
+                    "name": {
+                      "contains": "tech"
+                    }
+                  }
+                },
+                "selection": {}
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-nested-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-nested-m2m.json.snap
@@ -1,0 +1,35 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/aggregate-nested-m2m.json
+---
+dataMap {
+    posts (from @nested$posts): {
+        _count (inlined): {
+            categories: Int (_aggr_count_categories)
+        }
+    }
+}
+unique (let @parent = query «SELECT "public"."User"."id" FROM "public"."User"
+                             WHERE "public"."User"."email"::text LIKE $1 LIMIT
+                             $2 OFFSET $3»
+                      params [const(String("%prisma.io%")), const(BigInt(1)),
+                              const(BigInt(0))]
+in let @parent$id = mapField id (get @parent)
+   in join (get @parent)
+      with (query «SELECT "public"."Post"."id", "public"."Post"."userId",
+                   COALESCE("aggr_selection_0_Category"."_aggr_count_categories",
+                   0) AS "_aggr_count_categories" FROM "public"."Post" LEFT JOIN
+                   (SELECT "public"."_CategoryToPost"."B",
+                   COUNT("public"."_CategoryToPost"."B") AS
+                   "_aggr_count_categories" FROM "public"."Category" LEFT JOIN
+                   "public"."_CategoryToPost" ON ("public"."Category"."id" =
+                   "public"."_CategoryToPost"."A") WHERE
+                   "public"."Category"."name"::text LIKE $1 GROUP BY
+                   "public"."_CategoryToPost"."B") AS
+                   "aggr_selection_0_Category" ON ("public"."Post"."id" =
+                   "aggr_selection_0_Category"."B") WHERE
+                   "public"."Post"."userId" IN [$2] ORDER BY
+                   "public"."Post"."id" ASC OFFSET $3»
+            params [const(String("%tech%")), var(@parent$id as Int),
+                    const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -113,15 +113,20 @@ transaction
                                                      OFFSET $2»
                                               params [var(@parent$userId as Int),
                                                       const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user,
-                                             (query «SELECT "t1"."id",
-                                                     "t1"."name", "t0"."B" AS
+                                             (query «SELECT
+                                                     "public"."Category"."id",
+                                                     "public"."Category"."name",
+                                                     "t0"."B" AS
                                                      "CategoryToPost@Post" FROM
+                                                     "public"."Category" INNER
+                                                     JOIN
                                                      "public"."_CategoryToPost"
-                                                     AS "t0" INNER JOIN
-                                                     "public"."Category" AS "t1"
-                                                     ON "t0"."A" = "t1"."id"
-                                                     WHERE "t0"."B" = $1»
-                                              params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+                                                     AS "t0" ON "t0"."A" =
+                                                     "public"."Category"."id"
+                                                     WHERE (1=1 AND "t0"."B" =
+                                                     $1) OFFSET $2»
+                                              params [var(@parent$id as Int),
+                                                      const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
                               in get 11
                        in get 11
              in get 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -98,14 +98,16 @@ transaction
                                               $2»
                                        params [var(@parent$userId as Int),
                                                const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user,
-                                      (query «SELECT "t1"."id", "t1"."name",
+                                      (query «SELECT "public"."Category"."id",
+                                              "public"."Category"."name",
                                               "t0"."B" AS "CategoryToPost@Post"
-                                              FROM "public"."_CategoryToPost" AS
-                                              "t0" INNER JOIN
-                                              "public"."Category" AS "t1" ON
-                                              "t0"."A" = "t1"."id" WHERE
-                                              "t0"."B" = $1»
-                                       params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+                                              FROM "public"."Category" INNER
+                                              JOIN "public"."_CategoryToPost" AS
+                                              "t0" ON "t0"."A" =
+                                              "public"."Category"."id" WHERE
+                                              (1=1 AND "t0"."B" = $1) OFFSET $2»
+                                       params [var(@parent$id as Int),
+                                               const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
                        in get 7
                 in get 7
       in get 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
@@ -20,8 +20,10 @@ let @parent = unique (query «SELECT "public"."Post"."id",
                               const(BigInt(0))])
 in let @parent$id = mapField id (get @parent)
    in join (get @parent)
-      with (query «SELECT "t1"."id", "t1"."name", "t0"."B" AS
-                   "CategoryToPost@Post" FROM "public"."_CategoryToPost" AS "t0"
-                   INNER JOIN "public"."Category" AS "t1" ON "t0"."A" =
-                   "t1"."id" WHERE "t0"."B" = $1»
-            params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+      with (query «SELECT "public"."Category"."id", "public"."Category"."name",
+                   "t0"."B" AS "CategoryToPost@Post" FROM "public"."Category"
+                   INNER JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
+                   "public"."Category"."id" WHERE (1=1 AND "t0"."B" = $1) OFFSET
+                   $2»
+            params [var(@parent$id as Int),
+                    const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-m2m.json.snap
@@ -18,8 +18,10 @@ let @parent = query «SELECT "public"."Post"."id", "public"."Post"."title",
               params [const(BigInt(0))]
 in let @parent$id = mapField id (get @parent)
    in join (get @parent)
-      with (query «SELECT "t1"."id", "t1"."name", "t0"."B" AS
-                   "CategoryToPost@Post" FROM "public"."_CategoryToPost" AS "t0"
-                   INNER JOIN "public"."Category" AS "t1" ON "t0"."A" =
-                   "t1"."id" WHERE "t0"."B" IN [$1]»
-            params [var(@parent$id as Int)]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+      with (query «SELECT "public"."Category"."id", "public"."Category"."name",
+                   "t0"."B" AS "CategoryToPost@Post" FROM "public"."Category"
+                   INNER JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
+                   "public"."Category"."id" WHERE (1=1 AND "t0"."B" IN [$1])
+                   OFFSET $2»
+            params [var(@parent$id as Int),
+                    const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m-pagination.json.snap
@@ -22,8 +22,12 @@ in let @parent$id = mapField id (get @parent)
            skip 1
            take 1
            distinct by (id, CategoryToPost@Post)
-           (query «SELECT "t1"."id", "t1"."name", "t0"."B" AS
-                   "CategoryToPost@Post" FROM "public"."_CategoryToPost" AS "t0"
-                   INNER JOIN "public"."Category" AS "t1" ON "t0"."A" =
-                   "t1"."id" WHERE "t0"."B" IN [$1] ORDER BY "t1"."id" ASC»
-            params [var(@parent$id as Int)])) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+           (query «SELECT "public"."Category"."id", "public"."Category"."name",
+                   "t0"."B" AS "CategoryToPost@Post" FROM "public"."Category"
+                   INNER JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
+                   "public"."Category"."id" WHERE ("public"."Category"."id" >=
+                   (SELECT "public"."Category"."id" FROM "public"."Category"
+                   WHERE ("public"."Category"."id") = ($1)) AND "t0"."B" IN
+                   [$2]) ORDER BY "public"."Category"."id" ASC OFFSET $3»
+            params [const(BigInt(1)), var(@parent$id as Int),
+                    const(BigInt(0))])) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@test.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@test.json.snap
@@ -1,0 +1,29 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/test.json
+---
+dataMap {
+    posts (from posts): {
+        _count (from _count): {
+            categories: Int (categories)
+        }
+    }
+}
+unique (query «SELECT "t0"."id", "User_posts"."__prisma_data__" AS "posts" FROM
+               "public"."User" AS "t0" LEFT JOIN LATERAL (SELECT
+               COALESCE(JSONB_AGG("__prisma_data__"), '[]') AS "__prisma_data__"
+               FROM (SELECT "t3"."__prisma_data__" FROM (SELECT
+               JSONB_BUILD_OBJECT('_count', JSONB_BUILD_OBJECT('categories',
+               COALESCE("t5"."_aggr_count_categories", 0))) AS
+               "__prisma_data__", "t2"."id" FROM (SELECT "t1".* FROM
+               "public"."Post" AS "t1" WHERE "t0"."id" = "t1"."userId" /* root
+               select */) AS "t2" LEFT JOIN LATERAL (SELECT COUNT(*) AS
+               "_aggr_count_categories" FROM "public"."Category" AS "t6" LEFT
+               JOIN "public"."_CategoryToPost" AS "t7" ON "t7"."A" = "t6"."id"
+               WHERE ("t7"."B" = "t2"."id" AND "t6"."name"::text LIKE $1)) AS
+               "t5" ON true /* inner select */) AS "t3" ORDER BY "t3"."id" ASC
+               /* middle select */) AS "t4" /* outer select */) AS "User_posts"
+               ON true WHERE "t0"."email" = $2 LIMIT $3»
+        params [const(String("%tech%")), const(String("john@doe.com")),
+                const(BigInt(1))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -16,11 +16,12 @@ transaction
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0$id = mapField id (get 0)
-      in let 1 = query «SELECT "t1"."id", "t0"."B" AS "CategoryToPost@Post" FROM
-                        "public"."_CategoryToPost" AS "t0" INNER JOIN
-                        "public"."Category" AS "t1" ON "t0"."A" = "t1"."id"
-                        WHERE ("t1"."id" = $1 AND 1=1 AND "t0"."B" IN [$2])»
-                 params [const(BigInt(1)), var(0$id as Int)]
+      in let 1 = query «SELECT "public"."Category"."id", "t0"."B" AS
+                        "CategoryToPost@Post" FROM "public"."Category" INNER
+                        JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
+                        "public"."Category"."id" WHERE ("public"."Category"."id"
+                        = $1 AND 1=1 AND "t0"."B" IN [$2]) OFFSET $3»
+                 params [const(BigInt(1)), var(0$id as Int), const(BigInt(0))]
          in let 0 = validate (get 0)
                 [ rowCountNeq 0
                 ] orRaise "MISSING_RELATED_RECORD";

--- a/query-engine/query-builders/sql-query-builder/src/lib.rs
+++ b/query-engine/query-builders/sql-query-builder/src/lib.rs
@@ -115,22 +115,17 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
     ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>> {
         use std::slice;
 
+        use crate::read::SelectDefinition;
         use filter::default_scalar_filter;
         use itertools::Itertools;
-        use quaint::ast::{Aliasable, Joinable, Select};
-        use select::{JoinConditionExt, SelectBuilderExt};
+        use quaint::ast::{Aliasable, Joinable};
+        use select::JoinConditionExt;
 
         let link_alias = linkage.to_string();
         let (rf, conditions_per_field) = linkage.into_parent_field_and_conditions();
 
         let m2m_alias = self.context.next_table_alias();
         let m2m_table = rf.as_table(&self.context).alias(m2m_alias.to_string());
-
-        let related_alias = self.context.next_table_alias();
-        let related_table = rf
-            .related_model()
-            .as_table(&self.context)
-            .alias(related_alias.to_string());
 
         let m2m_col = rf
             .related_field()
@@ -162,26 +157,24 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
 
         let columns = ModelProjection::from(selected_fields)
             .as_columns(&self.context)
-            .map(|col| col.table(related_alias.to_string()))
+            .map(|col| col.table(rf.related_model().as_table(&self.context)))
             // Add an m2m column with an alias to make it possible to join it outside of this
             // function.
             .chain([m2m_col.alias(link_alias)]);
 
-        let join_condition = rf.m2m_join_conditions(Some(m2m_alias), Some(related_alias), &self.context);
+        let join_condition = rf.m2m_join_conditions(Some(m2m_alias), None, &self.context);
 
-        let select = Select::from_table(m2m_table)
-            .columns(columns)
-            .inner_join(related_table.on(join_condition))
-            .with_distinct(&query_arguments, related_alias)
-            .with_ordering(&query_arguments, Some(related_alias.to_string()), &self.context)
-            .with_pagination(&query_arguments, None)
-            .with_filters(query_arguments.filter, Some(related_alias), &self.context);
-
+        let (select, additional_selection_set) =
+            query_arguments.into_select(&rf.related_model(), selected_fields.virtuals(), &self.context);
+        let select = select.columns(columns).inner_join(m2m_table.on(join_condition.clone()));
         let select = if let Some(filter) = filter {
             select.and_where(filter)
         } else {
             select
         };
+        let select = additional_selection_set
+            .into_iter()
+            .fold(select, |acc, val| acc.value(val));
 
         self.convert_query(select)
     }


### PR DESCRIPTION
[ORM-1170](https://linear.app/prisma-company/issue/ORM-1170/fix-failing-filter-count-relations-test)

Refactors the code to re-use `into_select` which automatically handles nested aggregations. It also adds cursor filters that we were previously missing and relied on finding the cursor in memory. It changed a lot of snapshots because I needed to swap the two sides of the `JOIN` in order to re-use existing code.

Also fixes a test on the client: https://github.com/prisma/prisma/pull/27792