### PR TITLE
fix(qc): fix missing nested take/limit 

### DIFF
--- a/query-compiler/query-compiler/tests/data/query-non-unique-one2m-pagination.json
+++ b/query-compiler/query-compiler/tests/data/query-non-unique-one2m-pagination.json
@@ -1,0 +1,22 @@
+{
+  "modelName": "User",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": {
+        "id": 1
+      }
+    },
+    "selection": {
+      "$scalars": true,
+      "posts": {
+        "arguments": {
+          "skip": 10,
+          "take": 10
+        },
+        "selection": { "id": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/query-unique-one2m-pagination.json
+++ b/query-compiler/query-compiler/tests/data/query-unique-one2m-pagination.json
@@ -1,0 +1,22 @@
+{
+  "modelName": "User",
+  "action": "findUnique",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": {
+        "id": 1
+      }
+    },
+    "selection": {
+      "$scalars": true,
+      "posts": {
+        "arguments": {
+          "skip": 10,
+          "take": 10
+        },
+        "selection": { "id": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-non-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-non-unique-one2m-pagination.json.snap
@@ -1,0 +1,32 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/query-non-unique-one2m-pagination.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+    posts (from @nested$posts): {
+        id: Int (id)
+    }
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+let @parent = query «SELECT "public"."User"."id", "public"."User"."email",
+                     "public"."User"."role"::text FROM "public"."User" WHERE
+                     "public"."User"."id" = $1 OFFSET $2»
+              params [const(BigInt(1)), const(BigInt(0))]
+in let @parent$id = mapField id (get @parent)
+   in join (get @parent)
+      with (skip 10
+           take 10
+           query «SELECT "public"."Post"."id", "public"."Post"."userId" FROM
+                  "public"."Post" WHERE "public"."Post"."userId" IN [$1] ORDER
+                  BY "public"."Post"."id" ASC OFFSET $2»
+           params [var(@parent$id as Int),
+                   const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
@@ -1,0 +1,33 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/query-unique-one2m-pagination.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+    posts (from @nested$posts): {
+        id: Int (id)
+    }
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+let @parent = unique (query «SELECT "public"."User"."id",
+                             "public"."User"."email",
+                             "public"."User"."role"::text FROM "public"."User"
+                             WHERE ("public"."User"."id" = $1 AND 1=1) LIMIT $2
+                             OFFSET $3»
+                      params [const(BigInt(1)), const(BigInt(1)),
+                              const(BigInt(0))])
+in let @parent$id = mapField id (get @parent)
+   in join (get @parent)
+      with (query «SELECT "public"."Post"."id", "public"."Post"."userId" FROM
+                   "public"."Post" WHERE "public"."Post"."userId" = $1 ORDER BY
+                   "public"."Post"."id" ASC LIMIT $2 OFFSET $3»
+            params [var(@parent$id as Int), const(BigInt(10)),
+                    const(BigInt(10))]) on left.(id) = right.(userId) as @nested$posts


### PR DESCRIPTION
[ORM-1096](https://linear.app/prisma-company/issue/ORM-1096/add-missing-limit-in-nested-pagination)

This is basically an optimization to do the pagination using the database when we can instead of doing it in-memory.