### PR TITLE
test(qc-test-runner): add env vars to enable debugging the test worker

### DIFF
--- a/libs/driver-adapters/executor/script/testd-qc.sh
+++ b/libs/driver-adapters/executor/script/testd-qc.sh
@@ -1,2 +1,12 @@
 #!/usr/bin/env bash
-node "$(dirname "${BASH_SOURCE[0]}")/../dist/qc-test-runner.js"
+
+DEBUG_FLAGS=""
+
+if [ -n "$QC_RUNNER_INSPECT_BRK" ]; then
+  DEBUG_FLAGS="--inspect-brk --experimental-worker-inspection"
+elif [ -n "$QC_RUNNER_INSPECT" ]; then
+  DEBUG_FLAGS="--inspect --experimental-worker-inspection"
+fi
+
+# shellcheck disable=SC2086
+node $DEBUG_FLAGS "$(dirname "${BASH_SOURCE[0]}")/../dist/qc-test-runner.js"


### PR DESCRIPTION
Add some env vars to make it easier to start the node inspector for the main thread and the test worker.