### PR TITLE
test(qc): forward data mapper errors for QE tests

### DIFF
--- a/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
+++ b/libs/driver-adapters/executor/src/qc-test-worker/worker-query.ts
@@ -1,6 +1,7 @@
 import * as util from 'node:util'
 
 import {
+  DataMapperError,
   noopTracingHelper,
   normalizeJsonProtocolValues,
   normalizeRawJsonProtocolResponse,
@@ -94,6 +95,18 @@ class QueryPipeline {
       if (error instanceof UserFacingError) {
         return safeJsonStringify({
           errors: [error.toQueryResponseErrorObject()],
+        })
+      } else if (error instanceof DataMapperError) {
+        return safeJsonStringify({
+          errors: [
+            {
+              error: error.message,
+              user_facing_error: {
+                is_panic: false,
+                message: error.message,
+              },
+            },
+          ],
         })
       }
       throw error

--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
@@ -1,6 +1,5 @@
 new::interactive_tx::interactive_tx::batch_queries_failure
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::data_types::enum_type::enum_type::read_one_invalid_sqlite
 queries::filters::self_relation_regression::sr_regression::all_categories
 raw::sql::typed_output::typed_output::all_scalars_sqlite
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent

--- a/query-compiler/query-engine-tests-todo/d1/fail/query
+++ b/query-compiler/query-engine-tests-todo/d1/fail/query
@@ -1,7 +1,6 @@
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_quaint
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_quaint
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::data_types::enum_type::enum_type::read_one_invalid_sqlite
 queries::filters::self_relation_regression::sr_regression::all_categories
 raw::sql::typed_output::typed_output::all_scalars_cfd1
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent

--- a/query-compiler/query-engine-tests-todo/libsql/fail/query
+++ b/query-compiler/query-engine-tests-todo/libsql/fail/query
@@ -2,7 +2,6 @@ new::interactive_tx::interactive_tx::batch_queries_failure
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_js
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_js
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::data_types::enum_type::enum_type::read_one_invalid_sqlite
 queries::filters::self_relation_regression::sr_regression::all_categories
 raw::sql::typed_output::typed_output::all_scalars_sqlite
 writes::nested_mutations::already_converted::nested_connect_inside_update::connect_inside_update::p1_c1req_rel_child_idempotent


### PR DESCRIPTION
[ORM-1231](https://linear.app/prisma-company/issue/ORM-1231/fix-failing-sqlite-data-type-tests)

We don't have a dedicated user facing error for invalid enum errors, so I think it's okay to just forward the `DataMapperError`.