### PR TITLE
feat(psl): enable `@unique` attributes on views

### DIFF
--- a/psl/psl-core/src/validate/validation_pipeline/validations.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations.rs
@@ -119,31 +119,35 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
         for index in model.indexes() {
             if model.ast_model().is_view() {
                 views::index(index, ctx);
-                continue;
+                indexes::unique_client_name_does_not_clash_with_field(index, ctx);
+            } else {
+                indexes::has_fields(index, ctx);
+                indexes::has_a_unique_constraint_name(index, &names, ctx);
+                indexes::unique_client_name_does_not_clash_with_field(index, ctx);
+                indexes::unique_index_has_a_unique_custom_name_per_model(index, &names, ctx);
+                indexes::field_length_prefix_supported(index, ctx);
+                indexes::index_algorithm_is_supported(index, ctx);
+                indexes::hash_index_must_not_use_sort_param(index, ctx);
+                indexes::fulltext_index_supported(index, ctx);
+                indexes::fulltext_columns_should_not_define_length(index, ctx);
+                indexes::fulltext_column_sort_is_supported(index, ctx);
+                indexes::fulltext_text_columns_should_be_bundled_together(index, ctx);
+                indexes::has_valid_mapped_name(index, ctx);
+                indexes::supports_clustering_setting(index, ctx);
+                indexes::clustering_can_be_defined_only_once(index, ctx);
+                indexes::opclasses_are_not_allowed_with_other_than_normal_indices(index, ctx);
+                indexes::composite_type_in_compound_unique_index(index, ctx);
             }
 
-            indexes::has_fields(index, ctx);
-            indexes::has_a_unique_constraint_name(index, &names, ctx);
-            indexes::unique_client_name_does_not_clash_with_field(index, ctx);
-            indexes::unique_index_has_a_unique_custom_name_per_model(index, &names, ctx);
-            indexes::field_length_prefix_supported(index, ctx);
-            indexes::index_algorithm_is_supported(index, ctx);
-            indexes::hash_index_must_not_use_sort_param(index, ctx);
-            indexes::fulltext_index_supported(index, ctx);
-            indexes::fulltext_columns_should_not_define_length(index, ctx);
-            indexes::fulltext_column_sort_is_supported(index, ctx);
-            indexes::fulltext_text_columns_should_be_bundled_together(index, ctx);
-            indexes::has_valid_mapped_name(index, ctx);
-            indexes::supports_clustering_setting(index, ctx);
-            indexes::clustering_can_be_defined_only_once(index, ctx);
-            indexes::opclasses_are_not_allowed_with_other_than_normal_indices(index, ctx);
-            indexes::composite_type_in_compound_unique_index(index, ctx);
-
             for field_attribute in index.scalar_field_attributes() {
-                let span = index.ast_attribute().span;
-                let attribute = (index.attribute_name(), span);
+                if model.ast_model().is_view() {
+                    views::index_field_attribute(index, field_attribute, ctx);
+                } else {
+                    let span = index.ast_attribute().span;
+                    let attribute = (index.attribute_name(), span);
 
-                fields::validate_length_used_with_correct_types(field_attribute, attribute, ctx);
+                    fields::validate_length_used_with_correct_types(field_attribute, attribute, ctx);
+                }
             }
         }
     }

--- a/psl/psl-core/src/validate/validation_pipeline/validations/views.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/views.rs
@@ -1,7 +1,7 @@
 use diagnostics::DatamodelError;
 use parser_database::{
     ast::WithSpan,
-    walkers::{IndexWalker, ModelWalker, PrimaryKeyWalker},
+    walkers::{IndexWalker, ModelWalker, PrimaryKeyWalker, ScalarFieldAttributeWalker},
 };
 
 use crate::validate::validation_pipeline::context::Context;
@@ -28,11 +28,41 @@ pub(super) fn primary_key(model: PrimaryKeyWalker<'_>, ctx: &mut Context<'_>) {
     ));
 }
 
-pub(super) fn index(model: IndexWalker<'_>, ctx: &mut Context<'_>) {
-    ctx.push_error(DatamodelError::new_validation_error(
-        "Views cannot have indexes.",
-        model.ast_attribute().span,
-    ));
+pub(super) fn index(index: IndexWalker<'_>, ctx: &mut Context<'_>) {
+    if !index.is_unique() {
+        ctx.push_error(DatamodelError::new_validation_error(
+            "Views cannot have indexes.",
+            index.ast_attribute().span,
+        ));
+    }
+
+    if index.mapped_name().is_some() {
+        ctx.push_error(DatamodelError::new_validation_error(
+            "@@unique annotations on views are not backed by unique indexes in the database and cannot specify a mapped database name.",
+            index.ast_attribute().span,
+        ));
+    }
+
+    if index.clustered().is_some() {
+        ctx.push_error(DatamodelError::new_validation_error(
+            "@@unique annotations on views are not backed by unique indexes in the database and cannot be clustered.",
+            index.ast_attribute().span,
+        ));
+    }
+}
+
+pub(super) fn index_field_attribute(
+    index: IndexWalker<'_>,
+    attr: ScalarFieldAttributeWalker<'_>,
+    ctx: &mut Context<'_>,
+) {
+    if attr.length().is_some() || attr.operator_class().is_some() || attr.sort_order().is_some() {
+        ctx.push_error(DatamodelError::new_attribute_validation_error(
+            "Scalar fields in @@unique attributes in views cannot have arguments.",
+            index.attribute_name(),
+            index.ast_attribute().span,
+        ));
+    }
 }
 
 pub(super) fn connector_specific(model: ModelWalker<'_>, ctx: &mut Context<'_>) {

--- a/psl/psl/tests/validation/attributes/index_clustering/clustered_unique_in_view.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/clustered_unique_in_view.prisma
@@ -1,0 +1,22 @@
+datasource test {
+  provider = "sqlserver"
+  url      = env("TEST_DATABASE_URL")
+}
+
+generator js {
+  provider        = "prisma-client-js"
+  previewFeatures = ["views"]
+}
+
+view A {
+  a Int
+  b Int
+
+  @@unique([a, b], clustered: true)
+}
+// [1;91merror[0m: [1mError validating: @@unique annotations on views are not backed by unique indexes in the database and cannot be clustered.[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m
+// [1;94m15 | [0m  [1;91m@@unique([a, b], clustered: true)[0m
+// [1;94m   | [0m

--- a/psl/psl/tests/validation/views/view_with_indexes.prisma
+++ b/psl/psl/tests/validation/views/view_with_indexes.prisma
@@ -4,25 +4,37 @@ datasource db {
 }
 
 generator js {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["views"]
 }
 
-view Mountain {
+view ValidUnique {
   name String @unique
+}
+
+view Mountain {
+  name   String @unique(map: "name_idx")
   region String
 
-  @@index([name, region])
+  @@unique([region(length: 10)])
+  @@index([name, region], type: Gin)
 }
+
+// [1;91merror[0m: [1mError validating: @@unique annotations on views are not backed by unique indexes in the database and cannot specify a mapped database name.[0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
+// [1;94m   | [0m
+// [1;94m15 | [0mview Mountain {
+// [1;94m16 | [0m  name   String [1;91m@unique(map: "name_idx")[0m
+// [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Views cannot have indexes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
 // [1;94m   | [0m
-// [1;94m11 | [0mview Mountain {
-// [1;94m12 | [0m  name String [1;91m@unique[0m
+// [1;94m19 | [0m  @@unique([region(length: 10)])
+// [1;94m20 | [0m  [1;91m@@index([name, region], type: Gin)[0m
 // [1;94m   | [0m
-// [1;91merror[0m: [1mError validating: Views cannot have indexes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;91merror[0m: [1mError parsing attribute "@@unique": Scalar fields in @@unique attributes in views cannot have arguments.[0m
+//   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  [1;91m@@index([name, region])[0m
+// [1;94m18 | [0m
+// [1;94m19 | [0m  [1;91m@@unique([region(length: 10)])[0m
 // [1;94m   | [0m

--- a/query-engine/query-structure/src/model.rs
+++ b/query-engine/query-structure/src/model.rs
@@ -21,21 +21,15 @@ impl Model {
     }
 
     fn primary_identifier_scalars(&self) -> impl Iterator<Item = psl::parser_database::ScalarFieldId> + use<'_> {
-        if self.walker().ast_model().is_view() {
-            return Either::Left(self.walker().scalar_fields().map(|sf| sf.id));
+        match self.walker().required_unique_criterias().next() {
+            Some(unique) => Either::Left(unique.fields().map(|f| {
+                f.as_scalar_field()
+                    .expect("primary identifier must consist of scalar fields")
+                    .id
+            })),
+            None if self.walker().ast_model().is_view() => Either::Right(self.walker().scalar_fields().map(|sf| sf.id)),
+            None => panic!("model must have at least one unique criterion"),
         }
-        Either::Right(
-            self.walker()
-                .required_unique_criterias()
-                .next()
-                .expect("model must have at least one unique criterion")
-                .fields()
-                .map(|f| {
-                    f.as_scalar_field()
-                        .expect("primary identifier must consist of scalar fields")
-                        .id
-                }),
-        )
     }
 
     pub fn shard_aware_primary_identifier(&self) -> FieldSelection {


### PR DESCRIPTION
Ref: https://linear.app/prisma-company/issue/ORM-1320/allow-unsafe-ids-on-views-and-relationship-api-again
Ref: https://github.com/prisma/prisma-engines/pull/5543