### PR TITLE
feat(da): preserve error codes and messages

### DIFF
--- a/libs/driver-adapters/src/error.rs
+++ b/libs/driver-adapters/src/error.rs
@@ -49,10 +49,19 @@ pub struct MssqlErrorDef {
     pub message: String,
 }
 
+/// Wrapper for JS-side errors
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DriverAdapterError {
+    pub original_message: Option<String>,
+    pub original_code: Option<String>,
+    #[serde(flatten)]
+    pub mapped: MappedDriverAdapterError,
+}
+
 #[derive(Deserialize)]
 #[serde(tag = "kind")]
-/// Wrapper for JS-side errors
-pub(crate) enum DriverAdapterError {
+pub(crate) enum MappedDriverAdapterError {
     /// Unexpected JS exception
     GenericJs {
         id: i32,

--- a/quaint/src/error/mod.rs
+++ b/quaint/src/error/mod.rs
@@ -89,12 +89,12 @@ pub struct ErrorBuilder {
 }
 
 impl ErrorBuilder {
-    pub(crate) fn set_original_code(&mut self, code: impl Into<String>) -> &mut Self {
+    pub fn set_original_code(&mut self, code: impl Into<String>) -> &mut Self {
         self.original_code = Some(code.into());
         self
     }
 
-    pub(crate) fn set_original_message(&mut self, message: impl Into<String>) -> &mut Self {
+    pub fn set_original_message(&mut self, message: impl Into<String>) -> &mut Self {
         self.original_message = Some(message.into());
         self
     }


### PR DESCRIPTION
Needed in order to have consistent messages between DA errors in QE and QC.

[ORM-1167](https://linear.app/prisma-company/issue/ORM-1167/align-transaction-manager-error-behavior-with-the-qe)