### PR TITLE
fix(qc): use prisma names for distinct with relationJoins

### DIFF
--- a/query-compiler/query-compiler/tests/data/in-mem-distinct-mapped-field-join.json
+++ b/query-compiler/query-compiler/tests/data/in-mem-distinct-mapped-field-join.json
@@ -1,0 +1,16 @@
+{
+  "modelName": "Item",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "join",
+      "distinct": ["float"],
+      "skip": 20,
+      "take": 10
+    },
+    "selection": {
+      "int": true,
+      "float": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/in-mem-distinct-mapped-field-query.json
+++ b/query-compiler/query-compiler/tests/data/in-mem-distinct-mapped-field-query.json
@@ -1,0 +1,16 @@
+{
+  "modelName": "Item",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "distinct": ["float"],
+      "skip": 20,
+      "take": 10
+    },
+    "selection": {
+      "int": true,
+      "float": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@in-mem-distinct-mapped-field-join.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@in-mem-distinct-mapped-field-join.json.snap
@@ -1,0 +1,20 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/in-mem-distinct-mapped-field-join.json
+---
+dataMap {
+    int: Int (int)
+    float: Float (float)
+}
+process {
+    .: {
+        distinct: (float)
+        pagination: {
+            skip: 20
+            take: 10
+        }
+    }
+} (query «SELECT "t0"."id", "t0"."db_int" AS "int", "t0"."db_float" AS "float"
+          FROM "public"."Item" AS "t0" ORDER BY "t0"."id" ASC»
+   params [])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@in-mem-distinct-mapped-field-query.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@in-mem-distinct-mapped-field-query.json.snap
@@ -1,0 +1,21 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/in-mem-distinct-mapped-field-query.json
+---
+dataMap {
+    int: Int (db_int)
+    float: Float (db_float)
+}
+process {
+    .: {
+        distinct: (db_float)
+        pagination: {
+            skip: 20
+            take: 10
+        }
+    }
+} (query «SELECT "public"."Item"."id", "public"."Item"."db_int",
+          "public"."Item"."db_float" FROM "public"."Item" WHERE 1=1 ORDER BY
+          "public"."Item"."id" ASC OFFSET $1»
+   params [const(BigInt(0))])


### PR DESCRIPTION
Closes: https://linear.app/prisma-company/issue/ORM-1330/fix-incorrect-field-names-in-process-expression-for-mapped-fields-with
Closes: https://github.com/prisma/prisma/issues/27796