### PR TITLE
fix(qc): add a workaround for prisma#16390

### DIFF
--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -23,6 +23,7 @@ pub enum ResultNode {
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
     fields: IndexMap<Cow<'static, str>, ResultNode>,
+    skip_nulls: bool,
 }
 
 impl Object {
@@ -30,7 +31,13 @@ impl Object {
         Self {
             serialized_name: serialized_name.map(Into::into),
             fields: IndexMap::new(),
+            skip_nulls: false,
         }
+    }
+
+    fn set_skip_nulls(&mut self, skip: bool) -> &mut Self {
+        self.skip_nulls = skip;
+        self
     }
 
     pub fn serialized_name(&self) -> Option<&str> {
@@ -85,6 +92,11 @@ impl ObjectBuilder {
         Self {
             object: Object::new(serialized_name),
         }
+    }
+
+    pub fn set_skip_nulls(&mut self, skip: bool) -> &mut Self {
+        self.object.set_skip_nulls(skip);
+        self
     }
 
     pub fn add_field(&mut self, key: impl Into<Cow<'static, str>>, node: ResultNode) {

--- a/query-compiler/query-engine-tests-todo/neon/fail/join
+++ b/query-compiler/query-engine-tests-todo/neon/fail/join
@@ -1,4 +1,3 @@
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_join_lateral
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_query_lateral
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::simple::m2m::m2m::repro_16390

--- a/query-compiler/query-engine-tests-todo/neon/fail/query
+++ b/query-compiler/query-engine-tests-todo/neon/fail/query
@@ -1,4 +1,3 @@
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_join_lateral
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_query_lateral
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::simple::m2m::m2m::repro_16390

--- a/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/query
@@ -1,4 +1,3 @@
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_join_lateral
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_query_lateral
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::simple::m2m::m2m::repro_16390

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -1,4 +1,3 @@
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_join_lateral
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_query_lateral
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::simple::m2m::m2m::repro_16390

--- a/query-compiler/query-engine-tests-todo/pg/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg/fail/query
@@ -1,4 +1,3 @@
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_join_lateral
 new::relation_load_strategy::batch::relation_load_strategy_batch::compacted_query_lateral
 queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation
-queries::simple::m2m::m2m::repro_16390


### PR DESCRIPTION
[ORM-1328](https://linear.app/prisma-company/issue/ORM-1328/fix-queriessimplem2mm2mrepro-16390)

Implements a workaround similar to what the QE does: https://github.com/prisma/prisma-engines/blob/fba13060ef3cfbe5e95af3aaba61eabf2b8a8a20/query-engine/connectors/sql-query-connector/src/database/operations/read/coerce.rs#L62

/prisma-branch fix/workaround-for-16390