### PR TITLE
chore: upgrade petgraph from 0.4 to 0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
  "bitvec",
  "chrono",
  "hex",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "js-sys",
  "once_cell",
  "rand 0.8.5",
@@ -528,7 +528,7 @@ checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
 dependencies = [
  "clap 4.5.41",
  "heck 0.5.0",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "log",
  "proc-macro2",
  "quote",
@@ -1186,7 +1186,7 @@ dependencies = [
  "colored 3.0.0",
  "expect-test",
  "flate2",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "indoc",
  "itertools 0.13.0",
  "pretty_assertions",
@@ -1396,9 +1396,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fixedbitset"
-version = "0.1.9"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1721,7 +1721,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.9",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2187,12 +2187,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -2590,7 +2590,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "metrics",
  "metrics-util",
  "quanta",
@@ -2607,7 +2607,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -2768,7 +2768,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "futures",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "mongodb",
  "mongodb-client",
@@ -3215,12 +3215,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3284,7 +3278,7 @@ dependencies = [
  "diagnostics",
  "either",
  "enumflags2",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "rustc-hash",
  "schema-ast",
@@ -3372,12 +3366,14 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.4.13"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
 dependencies = [
  "fixedbitset",
- "ordermap",
+ "hashbrown 0.15.2",
+ "indexmap 2.10.0",
+ "serde",
 ]
 
 [[package]]
@@ -3859,7 +3855,7 @@ name = "query-compiler"
 version = "0.1.0"
 dependencies = [
  "bon",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "insta",
  "itertools 0.13.0",
  "pretty",
@@ -3923,7 +3919,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "futures",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "prisma-value",
  "query-structure",
@@ -3950,7 +3946,7 @@ dependencies = [
  "derive_more",
  "enumflags2",
  "futures",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "lru 0.7.8",
  "petgraph",
@@ -3987,7 +3983,7 @@ dependencies = [
  "enumflags2",
  "graphql-parser",
  "hyper",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "indoc",
  "mongodb-query-connector",
  "panic-utils",
@@ -4178,7 +4174,7 @@ dependencies = [
  "chrono",
  "cuid",
  "getrandom 0.2.11",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itertools 0.13.0",
  "nanoid",
  "prisma-value",
@@ -4215,7 +4211,7 @@ dependencies = [
  "env_logger",
  "futures",
  "hyper",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "indoc",
  "insta",
  "itertools 0.13.0",
@@ -4544,7 +4540,7 @@ dependencies = [
  "dmmf",
  "futures",
  "graphql-parser",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "insta",
  "itertools 0.13.0",
  "mongodb-query-connector",
@@ -5073,7 +5069,7 @@ version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -5121,7 +5117,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5450,7 +5446,7 @@ dependencies = [
  "either",
  "enumflags2",
  "expect-test",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "indoc",
  "itertools 0.13.0",
  "prisma-value",
@@ -5484,7 +5480,7 @@ dependencies = [
  "either",
  "enumflags2",
  "expect-test",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "indoc",
  "itertools 0.13.0",
  "pretty_assertions",
@@ -5536,7 +5532,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.2",
  "hashlink 0.10.0",
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "log",
  "memchr",
  "once_cell",
@@ -6073,7 +6069,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.2",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,7 @@ paste = "1"
 percent-encoding = "2"
 pest = "2"
 pest_derive = "2"
-petgraph = "0.4"
+petgraph = "0.8"
 pin-project = "1"
 postgres-native-tls = { git = "https://github.com/prisma/rust-postgres", branch = "pgbouncer-mode" }
 postgres-types = { git = "https://github.com/prisma/rust-postgres", branch = "pgbouncer-mode" }

--- a/query-engine/core/src/query_graph/mod.rs
+++ b/query-engine/core/src/query_graph/mod.rs
@@ -415,7 +415,7 @@ impl QueryGraph {
 
     /// Checks if the given node is marked as one of the result nodes in the graph.
     pub fn is_result_node(&self, node: &NodeRef) -> bool {
-        self.result_nodes.iter().any(|rn| rn.index() == node.node_ix.index())
+        self.result_nodes.contains(&node.node_ix)
     }
 
     /// Checks if the subgraph starting at the given node contains the node designated as the overall result.


### PR DESCRIPTION
Update `petgraph` to the latest major version. This version adds `no_std` support which can help us move in that direction to reduce the WebAssembly binary size.