### PR TITLE
test: assert on f32 on the result of a numeric sum aggregation

### DIFF
--- a/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
+++ b/query-compiler/query-engine-tests-todo/better-sqlite3/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/d1/fail/query
+++ b/query-compiler/query-engine-tests-todo/d1/fail/query
@@ -1,3 +1,2 @@
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_quaint
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_quaint
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/libsql/fail/query
+++ b/query-compiler/query-engine-tests-todo/libsql/fail/query
@@ -1,3 +1,2 @@
 new::regressions::prisma_15204::conversion_error::convert_to_bigint_sqlite_js
 new::regressions::prisma_15204::conversion_error::convert_to_int_sqlite_js
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/mariadb/fail/join
+++ b/query-compiler/query-engine-tests-todo/mariadb/fail/join
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/mariadb/fail/query
+++ b/query-compiler/query-engine-tests-todo/mariadb/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/mssql/fail/query
+++ b/query-compiler/query-engine-tests-todo/mssql/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/neon/fail/join
+++ b/query-compiler/query-engine-tests-todo/neon/fail/join
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/neon/fail/query
+++ b/query-compiler/query-engine-tests-todo/neon/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/join
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg-cockroachdb/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/pg/fail/join
+++ b/query-compiler/query-engine-tests-todo/pg/fail/join
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/pg/fail/query
+++ b/query-compiler/query-engine-tests-todo/pg/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation

--- a/query-compiler/query-engine-tests-todo/planetscale/fail/query
+++ b/query-compiler/query-engine-tests-todo/planetscale/fail/query
@@ -1,1 +1,0 @@
-queries::aggregation::group_by::aggregation_group_by::group_by_ordering_sum_aggregation


### PR DESCRIPTION
The test was failing due to the numbers being expanded to 64 bits and the comparison no longer succeeding. I changed it to compare the numbers as f32.