### PR TITLE
feat: do not render default namespace not specified in schema

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/apply_migration.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/apply_migration.rs
@@ -149,7 +149,7 @@ fn render_raw_sql(
         SqlMigrationStep::DropTable { table_id } => {
             let table = schemas.previous.walk(*table_id);
 
-            renderer.render_drop_table(table.namespace(), table.name())
+            renderer.render_drop_table(table.explicit_namespace(), table.name())
         }
         SqlMigrationStep::RedefineIndex { index } => renderer.render_drop_and_recreate_index(schemas.walk(*index)),
         SqlMigrationStep::AddForeignKey { foreign_key_id } => {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/destructive_change_checker.rs
@@ -58,7 +58,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -76,7 +76,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -88,7 +88,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type: format!("{:?}", columns.previous.column_type_family()),
                         next_type: format!("{:?}", columns.next.column_type_family()),
@@ -115,7 +115,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -124,7 +124,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -134,7 +134,7 @@ impl DestructiveChangeCheckerFlavour for MssqlDestructiveChangeCheckerFlavour {
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer.rs
@@ -357,7 +357,11 @@ impl SqlRenderer for MssqlRenderer {
             result.extend(self.render_drop_table(tables.previous.explicit_namespace(), tables.previous.name()));
 
             // Rename the temporary table with the name defined in the migration.
-            result.push(self.render_rename_table(tables.next.explicit_namespace(), &temporary_table_name, tables.next.name()));
+            result.push(self.render_rename_table(
+                tables.next.explicit_namespace(),
+                &temporary_table_name,
+                tables.next.name(),
+            ));
 
             // Recreate the indexes.
             for index in tables.next.indexes().filter(|i| !i.is_unique() && !i.is_primary_key()) {
@@ -470,7 +474,11 @@ impl SqlRenderer for MssqlRenderer {
     fn render_rename_foreign_key(&self, fks: MigrationPair<sql::ForeignKeyWalker<'_>>) -> String {
         format!(
             r#"EXEC sp_rename '{schema}.{previous}', '{next}', 'OBJECT'"#,
-            schema = fks.previous.table().explicit_namespace().unwrap_or_else(|| self.schema_name()),
+            schema = fks
+                .previous
+                .table()
+                .explicit_namespace()
+                .unwrap_or_else(|| self.schema_name()),
             previous = fks.previous.constraint_name().unwrap(),
             next = fks.next.constraint_name().unwrap(),
         )

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer/alter_table.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer/alter_table.rs
@@ -98,7 +98,7 @@ impl AlterTableConstructor<'_> {
                 "{}.{}",
                 self.tables
                     .previous
-                    .namespace()
+                    .explicit_namespace()
                     .unwrap_or_else(|| self.renderer.schema_name()),
                 self.tables.previous.primary_key().unwrap().name()
             );

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/destructive_change_checker.rs
@@ -52,7 +52,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -74,7 +74,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -86,7 +86,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -113,7 +113,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -122,7 +122,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -133,7 +133,7 @@ impl DestructiveChangeCheckerFlavour for MysqlDestructiveChangeCheckerFlavour {
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                 },
                 step_index,
             )

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/destructive_change_checker.rs
@@ -55,7 +55,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -66,7 +66,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeScalarFieldIntoArrayField(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -82,7 +82,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(String::from),
+                        namespace: columns.previous.table().explicit_namespace().map(String::from),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -94,7 +94,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
                 plan.push_warning(
                     SqlMigrationWarningCheck::NotCastable {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(String::from),
+                        namespace: columns.previous.table().explicit_namespace().map(String::from),
                         column: columns.previous.name().to_owned(),
                         previous_type,
                         next_type,
@@ -121,7 +121,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
             plan.push_unexecutable(
                 UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -130,7 +130,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
             plan.push_unexecutable(
                 UnexecutableStepCheck::DropAndRecreateRequiredColumn(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -140,7 +140,7 @@ impl DestructiveChangeCheckerFlavour for PostgresDestructiveChangeCheckerFlavour
             plan.push_warning(
                 SqlMigrationWarningCheck::DropAndRecreateColumn {
                     column: columns.previous.name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(String::from),
+                    namespace: columns.previous.table().explicit_namespace().map(String::from),
                     table: columns.previous.table().name().to_owned(),
                 },
                 step_index,

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
@@ -228,7 +228,8 @@ impl SqlRenderer for PostgresRenderer {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
                 let previous_table = indexes.previous.table();
-                let index_previous_name = QuotedWithPrefix::pg_new(previous_table.namespace(), indexes.previous.name());
+                let index_previous_name =
+                    QuotedWithPrefix::pg_new(previous_table.explicit_namespace(), indexes.previous.name());
                 stmt.push_str("ALTER INDEX ");
                 stmt.push_str(&index_previous_name.to_string());
                 stmt.push_str(" RENAME TO ");
@@ -334,7 +335,7 @@ impl SqlRenderer for PostgresRenderer {
         } else {
             let alter_table = format!(
                 "ALTER TABLE {} {}",
-                QuotedWithPrefix::pg_new(tables.previous.namespace(), tables.previous.name()),
+                QuotedWithPrefix::pg_new(tables.previous.explicit_namespace(), tables.previous.name()),
                 lines.join(",\n")
             );
 
@@ -350,7 +351,7 @@ impl SqlRenderer for PostgresRenderer {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
                 stmt.push_str("CREATE TYPE ");
-                stmt.push_display(&QuotedWithPrefix::pg_new(enm.namespace(), enm.name()));
+                stmt.push_display(&QuotedWithPrefix::pg_new(enm.explicit_namespace(), enm.name()));
                 stmt.push_str(" AS ENUM (");
                 let mut values = enm.values().peekable();
                 while let Some(value) = values.next() {
@@ -429,7 +430,7 @@ impl SqlRenderer for PostgresRenderer {
         render_step(&mut |step| {
             step.render_statement(&mut |stmt| {
                 stmt.push_display(&ddl::DropType {
-                    type_name: PostgresIdentifier::new(dropped_enum.namespace(), dropped_enum.name()),
+                    type_name: PostgresIdentifier::new(dropped_enum.explicit_namespace(), dropped_enum.name()),
                 })
             })
         })
@@ -438,14 +439,14 @@ impl SqlRenderer for PostgresRenderer {
     fn render_drop_foreign_key(&self, foreign_key: ForeignKeyWalker<'_>) -> String {
         format!(
             "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
-            table = PostgresIdentifier::new(foreign_key.table().namespace(), foreign_key.table().name()),
+            table = PostgresIdentifier::new(foreign_key.table().explicit_namespace(), foreign_key.table().name()),
             constraint_name = Quoted::postgres_ident(foreign_key.constraint_name().unwrap()),
         )
     }
 
     fn render_drop_index(&self, index: IndexWalker<'_>) -> String {
         ddl::DropIndex {
-            index_name: PostgresIdentifier::new(index.table().namespace(), index.name()),
+            index_name: PostgresIdentifier::new(index.table().explicit_namespace(), index.name()),
         }
         .to_string()
     }
@@ -475,7 +476,7 @@ impl SqlRenderer for PostgresRenderer {
             let tables = schemas.walk(redefine_table.table_ids);
             let temporary_table_name = format!("_prisma_new_{}", &tables.next.name());
             let quoted_temporary_table = QuotedWithPrefix(
-                tables.next.namespace().map(Quoted::postgres_ident),
+                tables.next.explicit_namespace().map(Quoted::postgres_ident),
                 Quoted::postgres_ident(&temporary_table_name),
             );
             result.push(self.render_create_table_as(tables.next, quoted_temporary_table));
@@ -502,13 +503,17 @@ impl SqlRenderer for PostgresRenderer {
 
             result.push(
                 ddl::DropTable {
-                    table_name: PostgresIdentifier::new(tables.previous.namespace(), tables.previous.name()),
+                    table_name: PostgresIdentifier::new(tables.previous.explicit_namespace(), tables.previous.name()),
                     cascade: true,
                 }
                 .to_string(),
             );
 
-            result.push(self.render_rename_table(tables.next.namespace(), &temporary_table_name, tables.next.name()));
+            result.push(self.render_rename_table(
+                tables.next.explicit_namespace(),
+                &temporary_table_name,
+                tables.next.name(),
+            ));
 
             for index in tables.next.indexes().filter(|idx| !idx.is_primary_key()) {
                 result.push(self.render_create_index(index));
@@ -547,7 +552,7 @@ impl SqlRenderer for PostgresRenderer {
 fn render_column_type(col: TableColumnWalker<'_>, renderer: &PostgresRenderer) -> Cow<'static, str> {
     let t = col.column_type();
     if let Some(enm) = col.column_type_family_as_enum() {
-        let name = QuotedWithPrefix::pg_new(enm.namespace(), enm.name());
+        let name = QuotedWithPrefix::pg_new(enm.explicit_namespace(), enm.name());
         let arity = if t.arity.is_list() { "[]" } else { "" };
         return format!("{name}{arity}").into();
     }
@@ -739,7 +744,7 @@ fn render_alter_column(
                 // https://www.postgresql.org/docs/12/datatype-numeric.html#DATATYPE-SERIAL
                 let sequence_name = format!(
                     "{namespace}{table_name}_{column_name}_seq",
-                    namespace = match columns.next.table().namespace() {
+                    namespace = match columns.next.table().explicit_namespace() {
                         Some(namespace) => format!("{}.", Quoted::postgres_ident(namespace)),
                         None => String::from(""),
                     },
@@ -897,7 +902,7 @@ fn render_postgres_alter_enum(
                 format!(
                     "ALTER TYPE {enum_name} ADD VALUE {value}",
                     enum_name = QuotedWithPrefix::pg_new(
-                        schemas.walk(alter_enum.id).previous.namespace(),
+                        schemas.walk(alter_enum.id).previous.explicit_namespace(),
                         schemas.walk(alter_enum.id).previous.name()
                     ),
                     value = Quoted::postgres_string(created_value)
@@ -927,7 +932,7 @@ fn render_postgres_alter_enum(
     let mut stmts = Vec::with_capacity(10);
 
     let temporary_enum_name = format!("{}_new", &enums.next.name());
-    let tmp_name = QuotedWithPrefix::pg_new(enums.next.namespace(), temporary_enum_name.as_str());
+    let tmp_name = QuotedWithPrefix::pg_new(enums.next.explicit_namespace(), temporary_enum_name.as_str());
     let tmp_old_name = format!("{}_old", &enums.previous.name());
 
     stmts.push("BEGIN".to_string());
@@ -984,7 +989,7 @@ fn render_postgres_alter_enum(
     {
         let sql = format!(
             "ALTER TYPE {enum_name} RENAME TO {tmp_old_name}",
-            enum_name = QuotedWithPrefix::pg_new(enums.previous.namespace(), enums.previous.name()),
+            enum_name = QuotedWithPrefix::pg_new(enums.previous.explicit_namespace(), enums.previous.name()),
             tmp_old_name = Quoted::postgres_ident(&tmp_old_name)
         );
 
@@ -1004,7 +1009,7 @@ fn render_postgres_alter_enum(
     // Drop old enum
     {
         let sql = ddl::DropType {
-            type_name: PostgresIdentifier::new(enums.previous.namespace(), tmp_old_name.as_str()),
+            type_name: PostgresIdentifier::new(enums.previous.explicit_namespace(), tmp_old_name.as_str()),
         }
         .to_string();
 
@@ -1026,7 +1031,7 @@ fn render_postgres_alter_enum(
 
             let set_default = format!(
                 "ALTER TABLE {table_name} ALTER COLUMN {column_name} SET DEFAULT {default}",
-                table_name = QuotedWithPrefix::pg_new(columns.previous.table().namespace(), table_name),
+                table_name = QuotedWithPrefix::pg_new(columns.previous.table().explicit_namespace(), table_name),
                 column_name = Quoted::postgres_ident(&column_name),
                 default = default_str,
             );
@@ -1049,7 +1054,7 @@ fn render_cockroach_alter_enum(
     let mut prefix = String::new();
     prefix.push_str("ALTER TYPE ");
     prefix.push_str(
-        QuotedWithPrefix::pg_new(enums.previous.namespace(), enums.previous.name())
+        QuotedWithPrefix::pg_new(enums.previous.explicit_namespace(), enums.previous.name())
             .to_string()
             .as_str(),
     );

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/destructive_change_checker.rs
@@ -48,7 +48,7 @@ impl DestructiveChangeCheckerFlavour for SqliteDestructiveChangeCheckerFlavour {
             plan.push_unexecutable(
                 UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
                     table: columns.previous.table().name().to_owned(),
-                    namespace: columns.previous.table().namespace().map(str::to_owned),
+                    namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                     column: columns.previous.name().to_owned(),
                 }),
                 step_index,
@@ -61,7 +61,7 @@ impl DestructiveChangeCheckerFlavour for SqliteDestructiveChangeCheckerFlavour {
                 plan.push_warning(
                     SqlMigrationWarningCheck::RiskyCast {
                         table: columns.previous.table().name().to_owned(),
-                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                         column: columns.previous.name().to_owned(),
                         previous_type: format!("{:?}", columns.previous.column_type_family()),
                         next_type: format!("{:?}", columns.next.column_type_family()),

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/datamodel_calculator/context.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/datamodel_calculator/context.rs
@@ -190,7 +190,7 @@ impl<'a> DatamodelCalculatorContext<'a> {
         }
 
         let r#enum = self.sql_schema.walk(id);
-        ModelName::new_from_sql(r#enum.name(), r#enum.namespace(), self)
+        ModelName::new_from_sql(r#enum.name(), r#enum.explicit_namespace(), self)
     }
 
     /// Given a SQL enum variant from the database catalog, this method returns the name it will be
@@ -294,7 +294,7 @@ impl<'a> DatamodelCalculatorContext<'a> {
         }
 
         let table = self.sql_schema.walk(id);
-        ModelName::new_from_sql(table.name(), table.namespace(), self)
+        ModelName::new_from_sql(table.name(), table.explicit_namespace(), self)
     }
 
     // Use the existing view name when available.

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/enumerator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/enumerator.rs
@@ -74,7 +74,7 @@ impl<'a> EnumPair<'a> {
     pub fn namespace(&self) -> Option<&'a str> {
         self.ctx
             .uses_namespaces()
-            .then(|| self.as_pair_ref().right()?.namespace())
+            .then(|| self.as_pair_ref().right()?.explicit_namespace())
             .flatten()
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/model.rs
@@ -30,7 +30,10 @@ impl<'a> ModelPair<'a> {
 
     /// The namespace of the model, if using the multi-schema feature.
     pub(crate) fn namespace(self) -> Option<&'a str> {
-        self.context.uses_namespaces().then(|| self.next.explicit_namespace()).flatten()
+        self.context
+            .uses_namespaces()
+            .then(|| self.next.explicit_namespace())
+            .flatten()
     }
 
     /// Whether the model is a partition table or not.

--- a/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/model.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/introspection/introspection_pair/model.rs
@@ -30,7 +30,7 @@ impl<'a> ModelPair<'a> {
 
     /// The namespace of the model, if using the multi-schema feature.
     pub(crate) fn namespace(self) -> Option<&'a str> {
-        self.context.uses_namespaces().then(|| self.next.namespace()).flatten()
+        self.context.uses_namespaces().then(|| self.next.explicit_namespace()).flatten()
     }
 
     /// Whether the model is a partition table or not.

--- a/schema-engine/connectors/sql-schema-connector/src/sql_destructive_change_checker.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_destructive_change_checker.rs
@@ -57,7 +57,7 @@ impl SqlSchemaConnector {
         plan.push_warning(
             SqlMigrationWarningCheck::NonEmptyColumnDrop {
                 table: column.table().name().to_owned(),
-                namespace: column.table().namespace().map(str::to_owned),
+                namespace: column.table().explicit_namespace().map(str::to_owned),
                 column: column.name().to_owned(),
             },
             step_index,
@@ -86,13 +86,13 @@ impl SqlSchemaConnector {
         let typed_unexecutable = if has_virtual_default {
             UnexecutableStepCheck::AddedRequiredFieldToTableWithPrismaLevelDefault(Column {
                 table: column.table().name().to_owned(),
-                namespace: column.table().namespace().map(str::to_owned),
+                namespace: column.table().explicit_namespace().map(str::to_owned),
                 column: column.name().to_owned(),
             })
         } else {
             UnexecutableStepCheck::AddedRequiredFieldToTable(Column {
                 table: column.table().name().to_owned(),
-                namespace: column.table().namespace().map(str::to_owned),
+                namespace: column.table().explicit_namespace().map(str::to_owned),
                 column: column.name().to_owned(),
             })
         };
@@ -139,7 +139,7 @@ impl SqlSchemaConnector {
                             TableChange::DropPrimaryKey => plan.push_warning(
                                 SqlMigrationWarningCheck::PrimaryKeyChange {
                                     table: tables.previous.name().to_owned(),
-                                    namespace: tables.previous.namespace().map(str::to_owned),
+                                    namespace: tables.previous.explicit_namespace().map(str::to_owned),
                                 },
                                 step_index,
                             ),
@@ -161,7 +161,7 @@ impl SqlSchemaConnector {
                             plan.push_warning(
                                 SqlMigrationWarningCheck::PrimaryKeyChange {
                                     table: tables.previous.name().to_owned(),
-                                    namespace: tables.previous.namespace().map(str::to_owned),
+                                    namespace: tables.previous.explicit_namespace().map(str::to_owned),
                                 },
                                 step_index,
                             )
@@ -207,7 +207,7 @@ impl SqlSchemaConnector {
                                 plan.push_unexecutable(
                                     UnexecutableStepCheck::MadeOptionalFieldRequired(Column {
                                         table: columns.previous.table().name().to_owned(),
-                                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                                         column: columns.previous.name().to_owned(),
                                     }),
                                     step_index,
@@ -220,7 +220,7 @@ impl SqlSchemaConnector {
                                     plan.push_warning(
                                         SqlMigrationWarningCheck::RiskyCast {
                                             table: columns.previous.table().name().to_owned(),
-                                            namespace: columns.previous.table().namespace().map(str::to_owned),
+                                            namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                                             column: columns.previous.name().to_owned(),
                                             previous_type: format!("{:?}", columns.previous.column_type_family()),
                                             next_type: format!("{:?}", columns.next.column_type_family()),
@@ -231,7 +231,7 @@ impl SqlSchemaConnector {
                                 Some(ColumnTypeChange::NotCastable) => plan.push_warning(
                                     SqlMigrationWarningCheck::NotCastable {
                                         table: columns.previous.table().name().to_owned(),
-                                        namespace: columns.previous.table().namespace().map(str::to_owned),
+                                        namespace: columns.previous.table().explicit_namespace().map(str::to_owned),
                                         column: columns.previous.name().to_owned(),
                                         previous_type: format!("{:?}", columns.previous.column_type_family()),
                                         next_type: format!("{:?}", columns.next.column_type_family()),
@@ -244,7 +244,7 @@ impl SqlSchemaConnector {
                 }
                 SqlMigrationStep::DropTable { table_id } => {
                     let table = schemas.previous.walk(*table_id);
-                    self.check_table_drop(table.name(), table.namespace(), &mut plan, step_index);
+                    self.check_table_drop(table.name(), table.explicit_namespace(), &mut plan, step_index);
                 }
                 SqlMigrationStep::CreateIndex {
                     table_id: (Some(_), _),

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer/common.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer/common.rs
@@ -14,7 +14,7 @@ impl QuotedWithPrefix<&str> {
 
     pub(crate) fn pg_from_table_walker(table: TableWalker<'_>) -> QuotedWithPrefix<&str> {
         QuotedWithPrefix(
-            table.namespace().map(Quoted::postgres_ident),
+            table.explicit_namespace().map(Quoted::postgres_ident),
             Quoted::postgres_ident(table.name()),
         )
     }

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -57,16 +57,10 @@ fn push_namespaces<'a>(ctx: &mut Context<'a>, default_namespace: Option<&'a str>
         }
     }
 
-    // or the default namespace from the connector. But not mix both!
-    if ctx.schemas.is_empty()
-        && let Some(default_namespace) = default_namespace
-    {
-        ctx.schemas.insert(
-            default_namespace,
-            ctx.schema
-                .describer_schema
-                .push_namespace(default_namespace.to_string()),
-        );
+    if let Some(default_namespace) = default_namespace {
+        ctx.schema
+            .describer_schema
+            .set_default_namespace(default_namespace.to_owned());
     }
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_calculator.rs
@@ -49,7 +49,7 @@ pub(crate) fn calculate_sql_schema(
 }
 
 fn push_namespaces<'a>(ctx: &mut Context<'a>, default_namespace: Option<&'a str>) {
-    // We either use the explicit namespaces from the datamodel
+    // Define the explicit namespaces from the datamodel
     if let Some(ds) = ctx.datamodel.configuration.datasources.first() {
         for (schema, _) in ds.namespaces.iter() {
             ctx.schemas

--- a/schema-engine/sql-migration-tests/src/assertions.rs
+++ b/schema-engine/sql-migration-tests/src/assertions.rs
@@ -296,7 +296,7 @@ pub struct EnumAssertion<'a>(sql::EnumWalker<'a>);
 
 impl EnumAssertion<'_> {
     pub fn assert_namespace(self, namespace: &'static str) -> Self {
-        assert_eq!(self.0.namespace(), Some(namespace));
+        assert_eq!(self.0.explicit_namespace(), Some(namespace));
         self
     }
 
@@ -332,7 +332,7 @@ impl<'a> TableAssertion<'a> {
     }
 
     pub fn assert_namespace(self, namespace: &str) -> Self {
-        if self.table.namespace() != Some(namespace) {
+        if self.table.explicit_namespace() != Some(namespace) {
             self.print_context();
             println!(
                 "\n  {} has failed because table {}.{} {}",
@@ -1046,7 +1046,7 @@ fn print_tables(schema: &SqlSchema) {
     println!("\n  {}", "Tables in database:".italic());
     schema
         .table_walkers()
-        .map(|table| (table.name(), table.namespace()))
+        .map(|table| (table.name(), table.explicit_namespace()))
         .for_each(|(t, ns)| {
             println!(
                 "\t - {}",

--- a/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
@@ -39,7 +39,7 @@ fn basic_create_migration_works(mut api: TestApi) {
             } else if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."Cat" (
+                    CREATE TABLE "Cat" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
 
@@ -149,7 +149,7 @@ fn basic_create_migration_multi_file_works(api: TestApi) {
             } else if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."Cat" (
+                    CREATE TABLE "Cat" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
 
@@ -157,7 +157,7 @@ fn basic_create_migration_multi_file_works(api: TestApi) {
                     );
 
                     -- CreateTable
-                    CREATE TABLE "public"."Dog" (
+                    CREATE TABLE "Dog" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
 
@@ -290,7 +290,7 @@ fn creating_a_second_migration_should_have_the_previous_sql_schema_as_baseline(a
             } else if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."Dog" (
+                    CREATE TABLE "Dog" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
 
@@ -494,12 +494,12 @@ fn create_enum_step_only_rendered_when_needed(api: TestApi) {
                 indoc! {
                     r#"
                         -- CreateEnum
-                        CREATE TYPE "public"."Mood" AS ENUM ('HUNGRY', 'SLEEPY');
+                        CREATE TYPE "Mood" AS ENUM ('HUNGRY', 'SLEEPY');
 
                         -- CreateTable
-                        CREATE TABLE "public"."Cat" (
+                        CREATE TABLE "Cat" (
                             "id" INT4 NOT NULL,
-                            "mood" "public"."Mood" NOT NULL,
+                            "mood" "Mood" NOT NULL,
 
                             CONSTRAINT "Cat_pkey" PRIMARY KEY ("id")
                         );
@@ -509,12 +509,12 @@ fn create_enum_step_only_rendered_when_needed(api: TestApi) {
                 indoc! {
                     r#"
                         -- CreateEnum
-                        CREATE TYPE "public"."Mood" AS ENUM ('HUNGRY', 'SLEEPY');
+                        CREATE TYPE "Mood" AS ENUM ('HUNGRY', 'SLEEPY');
 
                         -- CreateTable
-                        CREATE TABLE "public"."Cat" (
+                        CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL,
-                            "mood" "public"."Mood" NOT NULL,
+                            "mood" "Mood" NOT NULL,
 
                             CONSTRAINT "Cat_pkey" PRIMARY KEY ("id")
                         );
@@ -568,12 +568,12 @@ fn create_enum_renders_correctly(api: TestApi) {
             let expected_script = indoc! {
                     r#"
                         -- CreateEnum
-                        CREATE TYPE "public"."Mood" AS ENUM ('HUNGRY', 'SLEEPY');
+                        CREATE TYPE "Mood" AS ENUM ('HUNGRY', 'SLEEPY');
 
                         -- CreateTable
-                        CREATE TABLE "public"."Cat" (
+                        CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL,
-                            "mood" "public"."Mood" NOT NULL,
+                            "mood" "Mood" NOT NULL,
 
                             CONSTRAINT "Cat_pkey" PRIMARY KEY ("id")
                         );
@@ -607,7 +607,7 @@ fn unsupported_type_renders_correctly(api: TestApi) {
             let expected_script = indoc! {
                 r#"
                         -- CreateTable
-                        CREATE TABLE "public"."Cat" (
+                        CREATE TABLE "Cat" (
                             "id" TEXT NOT NULL,
                             "home" point NOT NULL,
 
@@ -651,21 +651,21 @@ fn no_additional_unique_created(api: TestApi) {
                     indoc! {
                         r#"
                         -- CreateTable
-                        CREATE TABLE "public"."Cat" (
+                        CREATE TABLE "Cat" (
                             "id" INTEGER NOT NULL,
 
                             CONSTRAINT "Cat_pkey" PRIMARY KEY ("id")
                         );
 
                         -- CreateTable
-                        CREATE TABLE "public"."Collar" (
+                        CREATE TABLE "Collar" (
                             "id" INTEGER NOT NULL,
 
                             CONSTRAINT "Collar_pkey" PRIMARY KEY ("id")
                         );
 
                         -- AddForeignKey
-                        ALTER TABLE "public"."Collar" ADD CONSTRAINT "Collar_id_fkey" FOREIGN KEY ("id") REFERENCES "public"."Cat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+                        ALTER TABLE "Collar" ADD CONSTRAINT "Collar_id_fkey" FOREIGN KEY ("id") REFERENCES "Cat"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
                         "#
                     }
                 }
@@ -799,7 +799,7 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
             } else if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."A" (
+                    CREATE TABLE "A" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
                         "a" TEXT NOT NULL,
@@ -809,7 +809,7 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
                     );
 
                     -- CreateTable
-                    CREATE TABLE "public"."B" (
+                    CREATE TABLE "B" (
                         "a" TEXT NOT NULL,
                         "b" TEXT NOT NULL,
                         "aId" INTEGER NOT NULL,
@@ -818,19 +818,19 @@ fn create_constraint_name_tests_w_implicit_names(api: TestApi) {
                     );
 
                     -- CreateIndex
-                    CREATE UNIQUE INDEX "A_name_key" ON "public"."A"("name");
+                    CREATE UNIQUE INDEX "A_name_key" ON "A"("name");
 
                     -- CreateIndex
-                    CREATE INDEX "A_a_idx" ON "public"."A"("a");
+                    CREATE INDEX "A_a_idx" ON "A"("a");
 
                     -- CreateIndex
-                    CREATE UNIQUE INDEX "A_a_b_key" ON "public"."A"("a", "b");
+                    CREATE UNIQUE INDEX "A_a_b_key" ON "A"("a", "b");
 
                     -- CreateIndex
-                    CREATE INDEX "B_a_b_idx" ON "public"."B"("a", "b");
+                    CREATE INDEX "B_a_b_idx" ON "B"("a", "b");
 
                     -- AddForeignKey
-                    ALTER TABLE "public"."B" ADD CONSTRAINT "B_aId_fkey" FOREIGN KEY ("aId") REFERENCES "public"."A"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+                    ALTER TABLE "B" ADD CONSTRAINT "B_aId_fkey" FOREIGN KEY ("aId") REFERENCES "A"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
                 "#]]
             } else if is_mysql {
                 expect![[
@@ -1031,7 +1031,7 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
             }else if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."A" (
+                    CREATE TABLE "A" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
                         "a" TEXT NOT NULL,
@@ -1041,7 +1041,7 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
                     );
 
                     -- CreateTable
-                    CREATE TABLE "public"."B" (
+                    CREATE TABLE "B" (
                         "a" TEXT NOT NULL,
                         "b" TEXT NOT NULL,
                         "aId" INTEGER NOT NULL,
@@ -1050,22 +1050,22 @@ fn create_constraint_name_tests_w_explicit_names(api: TestApi) {
                     );
 
                     -- CreateIndex
-                    CREATE UNIQUE INDEX "SingleUnique" ON "public"."A"("name");
+                    CREATE UNIQUE INDEX "SingleUnique" ON "A"("name");
 
                     -- CreateIndex
-                    CREATE INDEX "SingleIndex" ON "public"."A"("a");
+                    CREATE INDEX "SingleIndex" ON "A"("a");
 
                     -- CreateIndex
-                    CREATE UNIQUE INDEX "NamedCompoundUnique" ON "public"."A"("a", "b");
+                    CREATE UNIQUE INDEX "NamedCompoundUnique" ON "A"("a", "b");
 
                     -- CreateIndex
-                    CREATE UNIQUE INDEX "UnNamedCompoundUnique" ON "public"."A"("a", "b");
+                    CREATE UNIQUE INDEX "UnNamedCompoundUnique" ON "A"("a", "b");
 
                     -- CreateIndex
-                    CREATE INDEX "CompoundIndex" ON "public"."B"("a", "b");
+                    CREATE INDEX "CompoundIndex" ON "B"("a", "b");
 
                     -- AddForeignKey
-                    ALTER TABLE "public"."B" ADD CONSTRAINT "ForeignKey" FOREIGN KEY ("aId") REFERENCES "public"."A"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+                    ALTER TABLE "B" ADD CONSTRAINT "ForeignKey" FOREIGN KEY ("aId") REFERENCES "A"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
                 "#]]
             } else if is_mysql {
                 expect![[
@@ -1262,26 +1262,26 @@ fn alter_constraint_name(mut api: TestApi) {
                 "#]]
             } else if is_postgres {
                 expect![[r#"
-                -- AlterTable
-                ALTER TABLE "A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
+                    -- AlterTable
+                    ALTER TABLE "public"."A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
 
-                -- AlterTable
-                ALTER TABLE "B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
+                    -- AlterTable
+                    ALTER TABLE "public"."B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
 
-                -- RenameForeignKey
-                ALTER TABLE "B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
+                    -- RenameForeignKey
+                    ALTER TABLE "public"."B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
 
-                -- RenameIndex
-                ALTER INDEX "A_a_b_key" RENAME TO "CustomCompoundUnique";
+                    -- RenameIndex
+                    ALTER INDEX "public"."A_a_b_key" RENAME TO "CustomCompoundUnique";
 
-                -- RenameIndex
-                ALTER INDEX "A_a_idx" RENAME TO "CustomIndex";
+                    -- RenameIndex
+                    ALTER INDEX "public"."A_a_idx" RENAME TO "CustomIndex";
 
-                -- RenameIndex
-                ALTER INDEX "A_name_key" RENAME TO "CustomUnique";
+                    -- RenameIndex
+                    ALTER INDEX "public"."A_name_key" RENAME TO "CustomUnique";
 
-                -- RenameIndex
-                ALTER INDEX "B_a_b_idx" RENAME TO "AnotherCustomIndex";
+                    -- RenameIndex
+                    ALTER INDEX "public"."B_a_b_idx" RENAME TO "AnotherCustomIndex";
                 "#]]
             } else if is_sqlite {
                 expect![[r#"

--- a/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
@@ -1263,25 +1263,25 @@ fn alter_constraint_name(mut api: TestApi) {
             } else if is_postgres {
                 expect![[r#"
                     -- AlterTable
-                    ALTER TABLE "public"."A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
+                    ALTER TABLE "A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
 
                     -- AlterTable
-                    ALTER TABLE "public"."B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
+                    ALTER TABLE "B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
 
                     -- RenameForeignKey
-                    ALTER TABLE "public"."B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
+                    ALTER TABLE "B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."A_a_b_key" RENAME TO "CustomCompoundUnique";
+                    ALTER INDEX "A_a_b_key" RENAME TO "CustomCompoundUnique";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."A_a_idx" RENAME TO "CustomIndex";
+                    ALTER INDEX "A_a_idx" RENAME TO "CustomIndex";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."A_name_key" RENAME TO "CustomUnique";
+                    ALTER INDEX "A_name_key" RENAME TO "CustomUnique";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."B_a_b_idx" RENAME TO "AnotherCustomIndex";
+                    ALTER INDEX "B_a_b_idx" RENAME TO "AnotherCustomIndex";
                 "#]]
             } else if is_sqlite {
                 expect![[r#"

--- a/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
@@ -1240,25 +1240,25 @@ fn alter_constraint_name(mut api: TestApi) {
             } else if is_postgres15 || is_postgres16 {
                 expect![[r#"
                     -- AlterTable
-                    ALTER TABLE "public"."A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
+                    ALTER TABLE "A" RENAME CONSTRAINT "A_pkey" TO "CustomId";
 
                     -- AlterTable
-                    ALTER TABLE "public"."B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
+                    ALTER TABLE "B" RENAME CONSTRAINT "B_pkey" TO "CustomCompoundId";
 
                     -- RenameForeignKey
-                    ALTER TABLE "public"."B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
+                    ALTER TABLE "B" RENAME CONSTRAINT "B_aId_fkey" TO "CustomFK";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."A_a_b_key" RENAME TO "CustomCompoundUnique";
+                    ALTER INDEX "A_a_b_key" RENAME TO "CustomCompoundUnique";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."A_a_idx" RENAME TO "CustomIndex";
+                    ALTER INDEX "A_a_idx" RENAME TO "CustomIndex";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."A_name_key" RENAME TO "CustomUnique";
+                    ALTER INDEX "A_name_key" RENAME TO "CustomUnique";
 
                     -- RenameIndex
-                    ALTER INDEX "public"."B_a_b_idx" RENAME TO "AnotherCustomIndex";
+                    ALTER INDEX "B_a_b_idx" RENAME TO "AnotherCustomIndex";
                 "#]]
             } else if is_postgres {
                 expect![[r#"

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -97,7 +97,7 @@ fn from_unique_index_to_without(mut api: TestApi) {
     } else if api.is_postgres() || api.is_cockroach() {
         expect![[r#"
             [
-                "-- DropIndex\nDROP INDEX \"public\".\"Post_authorId_key\";\n",
+                "-- DropIndex\nDROP INDEX \"Post_authorId_key\";\n",
             ]
         "#]]
     } else if api.is_mssql() {
@@ -214,20 +214,20 @@ fn from_unique_index_to_pk(mut api: TestApi) {
             [
                 [
                     "-- DropIndex",
-                    "DROP INDEX \"public\".\"C_secondary_key\";",
+                    "DROP INDEX \"C_secondary_key\";",
                     "",
                     "-- AlterTable",
-                    "ALTER TABLE \"public\".\"A\" DROP COLUMN \"name\",",
+                    "ALTER TABLE \"A\" DROP COLUMN \"name\",",
                     "ADD CONSTRAINT \"A_pkey\" PRIMARY KEY (\"id\");",
                     "",
                     "-- DropIndex",
-                    "DROP INDEX \"public\".\"A_id_key\";",
+                    "DROP INDEX \"A_id_key\";",
                     "",
                     "-- AlterTable",
-                    "ALTER TABLE \"public\".\"B\" ADD CONSTRAINT \"B_pkey\" PRIMARY KEY (\"x\", \"y\");",
+                    "ALTER TABLE \"B\" ADD CONSTRAINT \"B_pkey\" PRIMARY KEY (\"x\", \"y\");",
                     "",
                     "-- DropIndex",
-                    "DROP INDEX \"public\".\"B_x_y_key\";",
+                    "DROP INDEX \"B_x_y_key\";",
                     "",
                 ],
             ]

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -424,7 +424,7 @@ fn diffing_postgres_schemas_when_initialized_on_sqlite(mut api: TestApi) {
 
     let expected_printed_messages = expect![[r#"
         [
-            "-- AlterTable\nALTER TABLE \"public\".\"TestModel\" DROP COLUMN \"names\",\nADD COLUMN     \"names\" TEXT[];\n\n-- CreateTable\nCREATE TABLE \"public\".\"TestModel2\" (\n    \"id\" SERIAL NOT NULL,\n\n    CONSTRAINT \"TestModel2_pkey\" PRIMARY KEY (\"id\")\n);\n",
+            "-- AlterTable\nALTER TABLE \"TestModel\" DROP COLUMN \"names\",\nADD COLUMN     \"names\" TEXT[];\n\n-- CreateTable\nCREATE TABLE \"TestModel2\" (\n    \"id\" SERIAL NOT NULL,\n\n    CONSTRAINT \"TestModel2_pkey\" PRIMARY KEY (\"id\")\n);\n",
             "\n[+] Added tables\n  - TestModel2\n\n[*] Changed the `TestModel` table\n  [*] Column `names` would be dropped and recreated (changed from Required to List, type changed)\n",
         ]
     "#]];

--- a/schema-engine/sql-migration-tests/tests/migrations/enums.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/enums.rs
@@ -597,18 +597,15 @@ fn mapped_enum_defaults_must_work(api: TestApi) {
     "#;
 
     let expect = expect![[r#"
-        -- CreateSchema
-        CREATE SCHEMA IF NOT EXISTS "public";
-
         -- CreateEnum
-        CREATE TYPE "public"."Color" AS ENUM ('0', 'Grün', 'Blu', 'pfuh 🙄...');
+        CREATE TYPE "Color" AS ENUM ('0', 'Grün', 'Blu', 'pfuh 🙄...');
 
         -- CreateTable
-        CREATE TABLE "public"."Test" (
+        CREATE TABLE "Test" (
             "id" INTEGER NOT NULL,
-            "mainColor" "public"."Color" NOT NULL DEFAULT 'Grün',
-            "secondaryColor" "public"."Color" NOT NULL DEFAULT '0',
-            "colorOrdering" "public"."Color"[] DEFAULT ARRAY['Blu', '0', 'Grün', '0', 'Blu', '0']::"public"."Color"[],
+            "mainColor" "Color" NOT NULL DEFAULT 'Grün',
+            "secondaryColor" "Color" NOT NULL DEFAULT '0',
+            "colorOrdering" "Color"[] DEFAULT ARRAY['Blu', '0', 'Grün', '0', 'Blu', '0']::"Color"[],
 
             CONSTRAINT "Test_pkey" PRIMARY KEY ("id")
         );
@@ -685,17 +682,17 @@ fn alter_enum_and_change_default_must_work(api: TestApi) {
                 */
                 -- AlterEnum
                 BEGIN;
-                CREATE TYPE "public"."Mood_new" AS ENUM ('HUNGRY', 'SLEEPY');
+                CREATE TYPE "Mood_new" AS ENUM ('HUNGRY', 'SLEEPY');
                 ALTER TABLE "public"."Cat" ALTER COLUMN "moods" DROP DEFAULT;
-                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" TYPE "public"."Mood_new"[] USING ("moods"::text::"public"."Mood_new"[]);
+                ALTER TABLE "Cat" ALTER COLUMN "moods" TYPE "Mood_new"[] USING ("moods"::text::"Mood_new"[]);
                 ALTER TYPE "public"."Mood" RENAME TO "Mood_old";
-                ALTER TYPE "public"."Mood_new" RENAME TO "Mood";
+                ALTER TYPE "Mood_new" RENAME TO "Mood";
                 DROP TYPE "public"."Mood_old";
-                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"public"."Mood"[];
+                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"Mood"[];
                 COMMIT;
 
                 -- AlterTable
-                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"public"."Mood"[];
+                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"Mood"[];
             "#]];
             migration.expect_contents(expected_script)
         });

--- a/schema-engine/sql-migration-tests/tests/migrations/enums.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/enums.rs
@@ -685,14 +685,14 @@ fn alter_enum_and_change_default_must_work(api: TestApi) {
                 CREATE TYPE "Mood_new" AS ENUM ('HUNGRY', 'SLEEPY');
                 ALTER TABLE "public"."Cat" ALTER COLUMN "moods" DROP DEFAULT;
                 ALTER TABLE "Cat" ALTER COLUMN "moods" TYPE "Mood_new"[] USING ("moods"::text::"Mood_new"[]);
-                ALTER TYPE "public"."Mood" RENAME TO "Mood_old";
+                ALTER TYPE "Mood" RENAME TO "Mood_old";
                 ALTER TYPE "Mood_new" RENAME TO "Mood";
                 DROP TYPE "public"."Mood_old";
-                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"Mood"[];
+                ALTER TABLE "Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"Mood"[];
                 COMMIT;
 
                 -- AlterTable
-                ALTER TABLE "public"."Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"Mood"[];
+                ALTER TABLE "Cat" ALTER COLUMN "moods" SET DEFAULT ARRAY['SLEEPY']::"Mood"[];
             "#]];
             migration.expect_contents(expected_script)
         });

--- a/schema-engine/sql-migration-tests/tests/migrations/mssql.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/mssql.rs
@@ -313,9 +313,6 @@ fn bigint_defaults_work(api: TestApi) {
 
         BEGIN TRAN;
 
-        -- CreateSchema
-        IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'dbo') EXEC sp_executesql N'CREATE SCHEMA [dbo];';
-
         -- CreateTable
         CREATE TABLE [dbo].[foo] (
             [id] NVARCHAR(1000) NOT NULL,
@@ -361,9 +358,6 @@ fn float_columns(api: TestApi) {
         BEGIN TRY
 
         BEGIN TRAN;
-
-        -- CreateSchema
-        IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = N'dbo') EXEC sp_executesql N'CREATE SCHEMA [dbo];';
 
         -- CreateTable
         CREATE TABLE [dbo].[foo] (

--- a/schema-engine/sql-migration-tests/tests/migrations/postgres.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/postgres.rs
@@ -537,14 +537,11 @@ fn scalar_list_defaults_work(api: TestApi) {
     api.schema_push(schema).send().assert_green().assert_no_steps();
 
     let expected_sql = expect![[r#"
-        -- CreateSchema
-        CREATE SCHEMA IF NOT EXISTS "public";
-
         -- CreateEnum
-        CREATE TYPE "public"."Color" AS ENUM ('RED', 'GREEN', 'BLUE');
+        CREATE TYPE "Color" AS ENUM ('RED', 'GREEN', 'BLUE');
 
         -- CreateTable
-        CREATE TABLE "public"."Model" (
+        CREATE TABLE "Model" (
             "id" INTEGER NOT NULL,
             "int_empty" INTEGER[] DEFAULT ARRAY[]::INTEGER[],
             "int" INTEGER[] DEFAULT ARRAY[0, 1, 1, 2, 3, 5, 8, 13, 21]::INTEGER[],
@@ -552,8 +549,8 @@ fn scalar_list_defaults_work(api: TestApi) {
             "string" TEXT[] DEFAULT ARRAY['Arrabbiata', 'Carbonara', 'Al Ragù']::TEXT[],
             "boolean" BOOLEAN[] DEFAULT ARRAY[false, true, true, true]::BOOLEAN[],
             "dateTime" TIMESTAMP(3)[] DEFAULT ARRAY['2019-06-17 14:20:57 +00:00', '2020-09-21 20:00:00 +02:00']::TIMESTAMP(3)[],
-            "colors" "public"."Color"[] DEFAULT ARRAY['GREEN', 'BLUE']::"public"."Color"[],
-            "colors_empty" "public"."Color"[] DEFAULT ARRAY[]::"public"."Color"[],
+            "colors" "Color"[] DEFAULT ARRAY['GREEN', 'BLUE']::"Color"[],
+            "colors_empty" "Color"[] DEFAULT ARRAY[]::"Color"[],
             "bytes" BYTEA[] DEFAULT ARRAY['\x68656c6c6f20776f726c64']::BYTEA[],
             "json" JSONB[] DEFAULT ARRAY['{ "a": ["b"] }', '3']::JSONB[],
             "decimal" DECIMAL(65,30)[] DEFAULT ARRAY[121.10299000124800000001, 0.4, 1.1, -68.0]::DECIMAL(65,30)[],
@@ -631,11 +628,11 @@ fn scalar_list_default_diffing(api: TestApi) {
 
     let expected_migration = expect![[r#"
         -- AlterTable
-        ALTER TABLE "public"."Model" ALTER COLUMN "int" SET DEFAULT ARRAY[0, 1, 1, 2, 3, 5, 8, 13, 22]::INTEGER[],
+        ALTER TABLE "Model" ALTER COLUMN "int" SET DEFAULT ARRAY[0, 1, 1, 2, 3, 5, 8, 13, 22]::INTEGER[],
         ALTER COLUMN "float" SET DEFAULT ARRAY[3.20, 4.20, 9.9999999, 1000.7]::DOUBLE PRECISION[],
         ALTER COLUMN "string" SET DEFAULT ARRAY['Arrabbiata', 'Quattro Formaggi', 'Al Ragù']::TEXT[],
         ALTER COLUMN "boolean" SET DEFAULT ARRAY[true, true, true, true]::BOOLEAN[],
-        ALTER COLUMN "colors" SET DEFAULT ARRAY['BLUE', 'GREEN']::"public"."Color"[],
+        ALTER COLUMN "colors" SET DEFAULT ARRAY['BLUE', 'GREEN']::"Color"[],
         ALTER COLUMN "bytes" SET DEFAULT ARRAY['\x68656c6c6f20776f726c64', '\x68656c6c6f20777ef26c64']::BYTEA[],
         ALTER COLUMN "json" SET DEFAULT ARRAY['{ "a": ["b"] }', '4']::JSONB[],
         ALTER COLUMN "decimal" SET DEFAULT ARRAY[0.4, 1.1, -68.0]::DECIMAL(65,30)[];
@@ -674,11 +671,8 @@ fn json_defaults_with_escaped_quotes_work(api: TestApi) {
     api.schema_push(schema).send().assert_green().assert_no_steps();
 
     let sql = expect![[r#"
-        -- CreateSchema
-        CREATE SCHEMA IF NOT EXISTS "public";
-
         -- CreateTable
-        CREATE TABLE "public"."Foo" (
+        CREATE TABLE "Foo" (
             "id" INTEGER NOT NULL,
             "bar" JSONB DEFAULT '{"message": "This message includes a quote: Here''''s it!"}',
 
@@ -703,11 +697,8 @@ fn bigint_defaults_work(api: TestApi) {
         }
     "#;
     let sql = expect![[r#"
-        -- CreateSchema
-        CREATE SCHEMA IF NOT EXISTS "public";
-
         -- CreateTable
-        CREATE TABLE "public"."foo" (
+        CREATE TABLE "foo" (
             "id" TEXT NOT NULL,
             "bar" BIGINT NOT NULL DEFAULT 0,
 

--- a/schema-engine/sql-migration-tests/tests/migrations/postgres.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/postgres.rs
@@ -390,7 +390,7 @@ fn foreign_key_renaming_to_default_works(api: TestApi) {
     );
     let expected = expect![[r#"
         -- RenameForeignKey
-        ALTER TABLE "public"."Dog" RENAME CONSTRAINT "favouriteFood" TO "Dog_favourite_food_id_fkey";
+        ALTER TABLE "Dog" RENAME CONSTRAINT "favouriteFood" TO "Dog_favourite_food_id_fkey";
     "#]];
 
     expected.assert_eq(&migration);

--- a/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
@@ -343,7 +343,7 @@ fn schema_filter_migration_removing_external_tables_incl_relations(mut api: Test
                     ALTER TABLE "public"."cat" DROP CONSTRAINT "cat_externalTableId_fkey";
 
                     -- AlterTable
-                    ALTER TABLE "public"."cat" DROP COLUMN "externalTableId";
+                    ALTER TABLE "cat" DROP COLUMN "externalTableId";
                 "#]]
             } else if is_mysql {
                 expect![[r#"
@@ -485,7 +485,7 @@ fn schema_filter_migration_modifying_external_tables_incl_relations(mut api: Tes
             let expected_script = if is_postgres {
                 expect![[r#"
                     -- AlterTable
-                    ALTER TABLE "public"."cat" ADD COLUMN     "externalTableId" INTEGER;
+                    ALTER TABLE "cat" ADD COLUMN     "externalTableId" INTEGER;
 
                     -- AddForeignKey
                     ALTER TABLE "cat" ADD CONSTRAINT "cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "ExternalTableA"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
@@ -205,7 +205,7 @@ fn schema_filter_migration_adding_external_tables_incl_relations(api: TestApi) {
             let expected_script = if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."Cat" (
+                    CREATE TABLE "Cat" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
                         "externalTableId" INTEGER,
@@ -214,7 +214,7 @@ fn schema_filter_migration_adding_external_tables_incl_relations(api: TestApi) {
                     );
 
                     -- AddForeignKey
-                    ALTER TABLE "public"."Cat" ADD CONSTRAINT "Cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "public"."ExternalTableA"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+                    ALTER TABLE "Cat" ADD CONSTRAINT "Cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "ExternalTableA"("id") ON DELETE SET NULL ON UPDATE CASCADE;
                 "#]]
             } else if is_mysql {
                 expect![[r#"
@@ -488,7 +488,7 @@ fn schema_filter_migration_modifying_external_tables_incl_relations(mut api: Tes
                     ALTER TABLE "public"."cat" ADD COLUMN     "externalTableId" INTEGER;
 
                     -- AddForeignKey
-                    ALTER TABLE "public"."cat" ADD CONSTRAINT "cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "public"."ExternalTableA"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+                    ALTER TABLE "cat" ADD CONSTRAINT "cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "ExternalTableA"("id") ON DELETE SET NULL ON UPDATE CASCADE;
                 "#]]
             } else if is_mysql {
                 expect![[r#"
@@ -589,7 +589,7 @@ fn schema_filter_leveraging_init_script(api: TestApi) {
             let expected_script = if is_postgres {
                 expect![[r#"
                     -- CreateTable
-                    CREATE TABLE "public"."Cat" (
+                    CREATE TABLE "Cat" (
                         "id" INTEGER NOT NULL,
                         "name" TEXT NOT NULL,
                         "externalTableId" INTEGER,
@@ -598,7 +598,7 @@ fn schema_filter_leveraging_init_script(api: TestApi) {
                     );
 
                     -- AddForeignKey
-                    ALTER TABLE "public"."Cat" ADD CONSTRAINT "Cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "public"."external"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+                    ALTER TABLE "Cat" ADD CONSTRAINT "Cat_externalTableId_fkey" FOREIGN KEY ("externalTableId") REFERENCES "external"("id") ON DELETE SET NULL ON UPDATE CASCADE;
                 "#]]
             } else if is_mysql {
                 expect![[r#"

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_dbgenerated.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_dbgenerated.prisma
@@ -12,11 +12,8 @@ model table {
 }
 
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
-// 
 // -- CreateTable
-// CREATE TABLE "public"."table" (
+// CREATE TABLE "table" (
 //     "id" TEXT NOT NULL,
 //     "hereBeDragons" TEXT NOT NULL,
 // 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_directurl.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_directurl.prisma
@@ -12,13 +12,10 @@ model table {
     hereBeDragons String @default(dbgenerated())
 }
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
-// 
 // -- CreateTable
-// CREATE TABLE "public"."table" (
+// CREATE TABLE "table" (
 //     "id" TEXT NOT NULL,
 //     "hereBeDragons" TEXT NOT NULL,
-
+// 
 //     CONSTRAINT "table_pkey" PRIMARY KEY ("id")
 // );

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_unsupported_dbgenerated.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_unsupported_dbgenerated.prisma
@@ -12,11 +12,8 @@ model table {
 }
 
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
-// 
 // -- CreateTable
-// CREATE TABLE "public"."table" (
+// CREATE TABLE "table" (
 //     "id" TEXT NOT NULL,
 //     "hereBeDragons" tsvector,
 // 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_basic.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_basic.prisma
@@ -17,16 +17,13 @@ enum MyEnum {
 }
 
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
-// 
 // -- CreateEnum
-// CREATE TYPE "public"."MyEnum" AS ENUM ('A', 'B');
+// CREATE TYPE "MyEnum" AS ENUM ('A', 'B');
 // 
 // -- CreateTable
-// CREATE TABLE "public"."Test" (
+// CREATE TABLE "Test" (
 //     "id" TEXT NOT NULL,
-//     "enum" "public"."MyEnum" NOT NULL,
+//     "enum" "MyEnum" NOT NULL,
 // 
 //     CONSTRAINT "Test_pkey" PRIMARY KEY ("id")
 // );

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_fields.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_fields.prisma
@@ -31,24 +31,21 @@ enum Kind {
 }
 
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
+// -- CreateEnum
+// CREATE TYPE "Result" AS ENUM ('succeeded', 'failed');
 // 
 // -- CreateEnum
-// CREATE TYPE "public"."Result" AS ENUM ('succeeded', 'failed');
+// CREATE TYPE "Activity" AS ENUM ('DANCING', 'SLEEPING', 'READING');
 // 
 // -- CreateEnum
-// CREATE TYPE "public"."Activity" AS ENUM ('DANCING', 'SLEEPING', 'READING');
-// 
-// -- CreateEnum
-// CREATE TYPE "public"."Kind" AS ENUM ('info', 'warning', 'error');
+// CREATE TYPE "Kind" AS ENUM ('info', 'warning', 'error');
 // 
 // -- CreateTable
-// CREATE TABLE "public"."MyTable" (
+// CREATE TABLE "MyTable" (
 //     "id" INTEGER NOT NULL,
-//     "a" "public"."Activity" NOT NULL DEFAULT 'SLEEPING',
-//     "k" "public"."Kind" DEFAULT 'error',
-//     "r" "public"."Result" NOT NULL DEFAULT 'succeeded',
+//     "a" "Activity" NOT NULL DEFAULT 'SLEEPING',
+//     "k" "Kind" DEFAULT 'error',
+//     "r" "Result" NOT NULL DEFAULT 'succeeded',
 // 
 //     CONSTRAINT "MyTable_pkey" PRIMARY KEY ("id")
 // );

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/mapped_basic.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/mapped_basic.prisma
@@ -18,16 +18,13 @@ enum Ripeness {
     @@map("avocado_ripeness_status")
 }
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
-// 
 // -- CreateEnum
-// CREATE TYPE "public"."avocado_ripeness_status" AS ENUM ('NOT_RIPE_ENOUGH', 'TOO_RIPE');
+// CREATE TYPE "avocado_ripeness_status" AS ENUM ('NOT_RIPE_ENOUGH', 'TOO_RIPE');
 // 
 // -- CreateTable
-// CREATE TABLE "public"."Avocado" (
+// CREATE TABLE "Avocado" (
 //     "id" TEXT NOT NULL,
-//     "status" "public"."avocado_ripeness_status" NOT NULL,
+//     "status" "avocado_ripeness_status" NOT NULL,
 // 
 //     CONSTRAINT "Avocado_pkey" PRIMARY KEY ("id")
 // );

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/scalar_lists_with_enum_and_int_id.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/scalar_lists_with_enum_and_int_id.prisma
@@ -17,17 +17,14 @@ enum Status {
     ERROR
 }
 // Expected Migration:
-// -- CreateSchema
-// CREATE SCHEMA IF NOT EXISTS "public";
-// 
 // -- CreateEnum
-// CREATE TYPE "public"."Status" AS ENUM ('OK', 'ERROR');
+// CREATE TYPE "Status" AS ENUM ('OK', 'ERROR');
 // 
 // -- CreateTable
-// CREATE TABLE "public"."A" (
+// CREATE TABLE "A" (
 //     "id" INTEGER NOT NULL,
 //     "strings" TEXT[],
-//     "enums" "public"."Status"[],
+//     "enums" "Status"[],
 // 
 //     CONSTRAINT "A_pkey" PRIMARY KEY ("id")
 // );

--- a/schema-engine/sql-schema-describer/src/lib.rs
+++ b/schema-engine/sql-schema-describer/src/lib.rs
@@ -78,8 +78,8 @@ pub struct SqlSchema {
     user_defined_types: Vec<UserDefinedType>,
     /// Connector-specific data
     connector_data: connector_data::ConnectorData,
-    /// The default namespace, if any.
-    default_namespace: Option<String>,
+    /// The default runtime namespace, if one is set.
+    runtime_namespace: Option<String>,
 }
 
 impl SqlSchema {
@@ -462,12 +462,12 @@ impl SqlSchema {
 
     /// Get the default namespace, if any.
     pub fn default_namespace(&self) -> Option<&str> {
-        self.default_namespace.as_deref()
+        self.runtime_namespace.as_deref()
     }
 
     /// Set the default namespace.
     pub fn set_default_namespace(&mut self, namespace: String) {
-        self.default_namespace = Some(namespace);
+        self.runtime_namespace = Some(namespace);
     }
 }
 

--- a/schema-engine/sql-schema-describer/src/lib.rs
+++ b/schema-engine/sql-schema-describer/src/lib.rs
@@ -78,6 +78,8 @@ pub struct SqlSchema {
     user_defined_types: Vec<UserDefinedType>,
     /// Connector-specific data
     connector_data: connector_data::ConnectorData,
+    /// The default namespace, if any.
+    default_namespace: Option<String>,
 }
 
 impl SqlSchema {
@@ -456,6 +458,16 @@ impl SqlSchema {
     /// No tables or enums in the catalog.
     pub fn is_empty(&self) -> bool {
         self.tables.is_empty() && self.enums.is_empty()
+    }
+
+    /// Get the default namespace, if any.
+    pub fn default_namespace(&self) -> Option<&str> {
+        self.default_namespace.as_deref()
+    }
+
+    /// Set the default namespace.
+    pub fn set_default_namespace(&mut self, namespace: String) {
+        self.default_namespace = Some(namespace);
     }
 }
 

--- a/schema-engine/sql-schema-describer/src/walkers/enum.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/enum.rs
@@ -20,9 +20,9 @@ impl<'a> EnumWalker<'a> {
     }
 
     /// The namespace the enum belongs to, if defined.
-    /// If not, falls back to the schema's default namespace, if any.
+    /// If not, falls back to the default runtime namespace, if one is set.
     pub fn namespace(self) -> Option<&'a str> {
-        self.explicit_namespace().or(self.schema.default_namespace.as_deref())
+        self.explicit_namespace().or(self.schema.runtime_namespace.as_deref())
     }
 
     /// The name of the enum. This is a made up name on MySQL.

--- a/schema-engine/sql-schema-describer/src/walkers/enum.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/enum.rs
@@ -12,11 +12,17 @@ impl<'a> EnumWalker<'a> {
     }
 
     /// The namespace the enum belongs to, if defined.
-    pub fn namespace(self) -> Option<&'a str> {
+    pub fn explicit_namespace(self) -> Option<&'a str> {
         self.schema
             .namespaces
             .get_index(self.get().namespace_id.0 as usize)
             .map(|s| s.as_str())
+    }
+
+    /// The namespace the enum belongs to, if defined.
+    /// If not, falls back to the schema's default namespace, if any.
+    pub fn namespace(self) -> Option<&'a str> {
+        self.explicit_namespace().or(self.schema.default_namespace.as_deref())
     }
 
     /// The name of the enum. This is a made up name on MySQL.

--- a/schema-engine/sql-schema-describer/src/walkers/table.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/table.rs
@@ -68,11 +68,17 @@ impl<'a> TableWalker<'a> {
     }
 
     /// The namespace the table belongs to, if defined.
-    pub fn namespace(self) -> Option<&'a str> {
+    pub fn explicit_namespace(self) -> Option<&'a str> {
         self.schema
             .namespaces
             .get_index(self.table().namespace_id.0 as usize)
             .map(|s| s.as_str())
+    }
+
+    /// The namespace the table belongs to, if defined.
+    /// If not, falls back to the schema's default namespace, if any.
+    pub fn namespace(self) -> Option<&'a str> {
+        self.explicit_namespace().or(self.schema.default_namespace.as_deref())
     }
 
     /// The namespace the table belongs to.

--- a/schema-engine/sql-schema-describer/src/walkers/table.rs
+++ b/schema-engine/sql-schema-describer/src/walkers/table.rs
@@ -76,9 +76,9 @@ impl<'a> TableWalker<'a> {
     }
 
     /// The namespace the table belongs to, if defined.
-    /// If not, falls back to the schema's default namespace, if any.
+    /// If not, falls back to the default runtime namespace, if one is set.
     pub fn namespace(self) -> Option<&'a str> {
-        self.explicit_namespace().or(self.schema.default_namespace.as_deref())
+        self.explicit_namespace().or(self.schema.runtime_namespace.as_deref())
     }
 
     /// The namespace the table belongs to.

--- a/schema-engine/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -701,6 +701,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -993,6 +994,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
 
@@ -1415,6 +1417,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
 

--- a/schema-engine/sql-schema-describer/tests/describers/mssql_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/mssql_describer_tests.rs
@@ -701,7 +701,7 @@ fn all_mssql_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -994,7 +994,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
 
@@ -1417,7 +1417,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
 

--- a/schema-engine/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -2527,7 +2527,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -2826,7 +2826,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -2904,7 +2904,7 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -3014,7 +3014,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -3093,7 +3093,7 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -3535,7 +3535,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);

--- a/schema-engine/sql-schema-describer/tests/describers/mysql_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/mysql_describer_tests.rs
@@ -2527,6 +2527,7 @@ fn all_mysql_8_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -2825,6 +2826,7 @@ fn constraints_from_other_databases_should_not_be_introspected(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -2902,6 +2904,7 @@ fn introspected_default_strings_should_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -3011,6 +3014,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -3089,6 +3093,7 @@ fn escaped_backslashes_in_string_literals_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -3530,6 +3535,7 @@ fn function_expression_defaults_are_described_as_dbgenerated(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1001,7 +1001,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -1474,7 +1474,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -1555,7 +1555,7 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -2059,7 +2059,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
 
@@ -2549,7 +2549,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
 

--- a/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/postgres_describer_tests.rs
@@ -1001,6 +1001,7 @@ fn all_postgres_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -1473,6 +1474,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -1553,6 +1555,7 @@ fn seemingly_escaped_backslashes_in_string_literals_must_not_be_unescaped(api: T
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -2056,6 +2059,7 @@ fn multiple_schemas_with_same_table_names_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
 
@@ -2545,6 +2549,7 @@ fn multiple_schemas_with_same_foreign_key_are_described(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
 

--- a/schema-engine/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -206,7 +206,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -368,7 +368,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -445,7 +445,7 @@ fn backslashes_in_string_literals(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -654,7 +654,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
-            default_namespace: None,
+            runtime_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);

--- a/schema-engine/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
+++ b/schema-engine/sql-schema-describer/tests/describers/sqlite_describer_tests.rs
@@ -206,6 +206,7 @@ fn sqlite_column_types_must_work(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -367,6 +368,7 @@ fn escaped_quotes_in_string_defaults_must_be_unescaped(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -443,6 +445,7 @@ fn backslashes_in_string_literals(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);
@@ -651,6 +654,7 @@ fn broken_relations_are_filtered_out(api: TestApi) {
             procedures: [],
             user_defined_types: [],
             connector_data: <ConnectorData>,
+            default_namespace: None,
         }
     "#]];
     api.expect_schema(expectation);


### PR DESCRIPTION
[ORM-1381](https://linear.app/prisma-company/issue/ORM-1381/timeboxresearch-support-migrations-without-explicit-schema-again)
Fixes https://github.com/prisma/prisma/issues/27811

This PR creates a distinction between the default runtime namespace and the namespaces specified in the schema file. `explicit_namespace` refers to namespace that's been made explicit in the schema file and `namespace` refers to the namespace the table or enum will effectively belong to at runtime. The reason for this distinction is to enable us to correctly recognize that:
- the effective namespace of a table or an enum has not changed during diffing (it uses `namespace`)
- the namespace of a table or an enum should not be rendered (it uses `explicit_namespace`)