### PR TITLE
fix: allow negative-one take for find first

### DIFF
--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -78,7 +78,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
             }
 
             match take {
-                Take::One => Expression::Unique(Box::new(expr)),
+                Take::One | Take::NegativeOne => Expression::Unique(Box::new(expr)),
                 _ => expr,
             }
         }

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
@@ -48,6 +48,19 @@ mod find_first_query {
         Ok(())
     }
 
+    #[connector_test]
+    async fn find_first_with_take_negative_one(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: asc }, take: -1) { id }}",
+            r#"{"data":{"findFirstTestModel":{"id":5}}}"#
+        );
+
+        Ok(())
+    }
+
     async fn test_data(runner: &Runner) -> TestResult<()> {
         test_row(runner, r#"{ id: 1, field: "test1" }"#).await?;
         test_row(runner, r#"{ id: 2, field: "test2" }"#).await?;

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
@@ -49,13 +49,54 @@ mod find_first_query {
     }
 
     #[connector_test]
-    async fn find_first_with_take_negative_one(runner: Runner) -> TestResult<()> {
+    async fn find_first_with_take_negative_one_asc(runner: Runner) -> TestResult<()> {
         test_data(&runner).await?;
 
         assert_query!(
             runner,
             "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: asc }, take: -1) { id }}",
             r#"{"data":{"findFirstTestModel":{"id":5}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn find_first_with_take_negative_one_desc(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: desc }, take: -1) { id }}",
+            r#"{"data":{"findFirstTestModel":{"id":1}}}"#
+        );
+
+        Ok(())
+    }
+
+    #[connector_test]
+    async fn find_first_with_invalid_take_value(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
+
+        assert_error!(
+            runner,
+            r#"query { findFirstTestModel(orderBy: { id: asc }, take: 0) { id }}"#,
+            2019,
+            "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1"
+        );
+
+        assert_error!(
+            runner,
+            r#"query { findFirstTestModel(orderBy: { id: asc }, take: 2) { id }}"#,
+            2019,
+            "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1"
+        );
+
+        assert_error!(
+            runner,
+            r#"query { findFirstTestModel(orderBy: { id: asc }, take: -2) { id }}"#,
+            2019,
+            "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1"
         );
 
         Ok(())

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/simple/find_first.rs
@@ -32,6 +32,30 @@ mod find_first_query {
             r#"{"data":{"findFirstTestModel":{"id":2}}}"#
         );
 
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: asc }, take: -1) { id }}",
+            r#"{"data":{"findFirstTestModel":{"id":5}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { field: { not: null }}, cursor: { id: 2 }, orderBy: { id: asc }, take: -1, skip: 1) { id }}",
+            r#"{"data":{"findFirstTestModel":{"id":1}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: desc }, take: -1) { id }}",
+            r#"{"data":{"findFirstTestModel":{"id":1}}}"#
+        );
+
+        assert_query!(
+            runner,
+            "query { findFirstTestModel(where: { field: { not: null }}, cursor: { id: 2 }, orderBy: { id: desc }, take: -1, skip: 1) { id }}",
+            r#"{"data":{"findFirstTestModel":{"id":5}}}"#
+        );
+
         Ok(())
     }
 
@@ -43,32 +67,6 @@ mod find_first_query {
             runner,
             "query { findFirstTestModel(where: { id: 6 }) { id }}",
             r#"{"data":{"findFirstTestModel":null}}"#
-        );
-
-        Ok(())
-    }
-
-    #[connector_test]
-    async fn find_first_with_take_negative_one_asc(runner: Runner) -> TestResult<()> {
-        test_data(&runner).await?;
-
-        assert_query!(
-            runner,
-            "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: asc }, take: -1) { id }}",
-            r#"{"data":{"findFirstTestModel":{"id":5}}}"#
-        );
-
-        Ok(())
-    }
-
-    #[connector_test]
-    async fn find_first_with_take_negative_one_desc(runner: Runner) -> TestResult<()> {
-        test_data(&runner).await?;
-
-        assert_query!(
-            runner,
-            "query { findFirstTestModel(where: { field: { not: null }}, orderBy: { id: desc }, take: -1) { id }}",
-            r#"{"data":{"findFirstTestModel":{"id":1}}}"#
         );
 
         Ok(())

--- a/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/query_builder/read_query_builder.rs
@@ -463,7 +463,7 @@ fn take(take: Take, ignore: bool) -> Option<i64> {
     } else {
         match take {
             Take::All => None,
-            Take::One => Some(1),
+            Take::One | Take::NegativeOne => Some(1),
             Take::Some(n) => Some(n.abs()),
         }
     }

--- a/query-engine/core/src/query_ast/read.rs
+++ b/query-engine/core/src/query_ast/read.rs
@@ -19,8 +19,8 @@ impl ReadQuery {
     pub fn is_unique(&self) -> bool {
         match self {
             ReadQuery::RecordQuery(_) => true,
-            ReadQuery::ManyRecordsQuery(q) => q.args.take == Take::One,
-            ReadQuery::RelatedRecordsQuery(q) => q.args.take == Take::One,
+            ReadQuery::ManyRecordsQuery(q) => q.args.take == Take::One || q.args.take == Take::NegativeOne,
+            ReadQuery::RelatedRecordsQuery(q) => q.args.take == Take::One || q.args.take == Take::NegativeOne,
             ReadQuery::AggregateRecordsQuery(_) => false,
         }
     }

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -28,7 +28,7 @@ fn try_limit_to_one(mut query: ReadQuery) -> QueryGraphBuilderResult<ReadQuery> 
         ReadQuery::ManyRecordsQuery(ref mut m) => {
             m.args.take = match m.args.take {
                 Take::All | Take::Some(1) => Take::One,
-                Take::Some(-1) => Take::Some(-1),
+                Take::Some(-1) => Take::NegativeOne,
                 _ => {
                     return Err(QueryGraphBuilderError::InputError(
                         "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1".into(),

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -28,9 +28,11 @@ fn try_limit_to_one(mut query: ReadQuery) -> QueryGraphBuilderResult<ReadQuery> 
         ReadQuery::ManyRecordsQuery(ref mut m) => {
             if matches!(m.args.take, Take::All | Take::Some(1)) {
                 m.args.take = Take::One;
+            } else if let Take::Some(take) = m.args.take && take == -1 {
+                m.args.take = Take::Some(take);
             } else {
                 return Err(QueryGraphBuilderError::InputError(
-                    "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1".into(),
+                    "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1".into(),
                 ));
             }
             Ok(query)

--- a/query-engine/core/src/query_graph_builder/read/first.rs
+++ b/query-engine/core/src/query_graph_builder/read/first.rs
@@ -26,15 +26,15 @@ pub(crate) fn find_first_or_throw(
 fn try_limit_to_one(mut query: ReadQuery) -> QueryGraphBuilderResult<ReadQuery> {
     match query {
         ReadQuery::ManyRecordsQuery(ref mut m) => {
-            if matches!(m.args.take, Take::All | Take::Some(1)) {
-                m.args.take = Take::One;
-            } else if let Take::Some(take) = m.args.take && take == -1 {
-                m.args.take = Take::Some(take);
-            } else {
-                return Err(QueryGraphBuilderError::InputError(
-                    "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1".into(),
-                ));
-            }
+            m.args.take = match m.args.take {
+                Take::All | Take::Some(1) => Take::One,
+                Take::Some(-1) => Take::Some(-1),
+                _ => {
+                    return Err(QueryGraphBuilderError::InputError(
+                        "The 'findFirst' operation cannot be used with a 'take' argument that isn't 1 or -1".into(),
+                    ));
+                }
+            };
             Ok(query)
         }
         _ => Ok(query),

--- a/query-engine/query-structure/src/query_arguments.rs
+++ b/query-engine/query-structure/src/query_arguments.rs
@@ -32,6 +32,7 @@ pub struct QueryArguments {
 pub enum Take {
     All,
     One,
+    NegativeOne,
     Some(i64),
 }
 
@@ -47,15 +48,15 @@ impl Take {
     pub fn abs(self) -> Option<i64> {
         match self {
             Take::All => None,
-            Take::One => Some(1),
+            Take::One | Take::NegativeOne => Some(1),
             Take::Some(n) => Some(n.abs()),
         }
     }
 
     pub fn is_reversed(self) -> bool {
         match self {
-            Take::All => false,
-            Take::One => false,
+            Take::All | Take::One => false,
+            Take::NegativeOne => true,
             Take::Some(n) => n < 0,
         }
     }


### PR DESCRIPTION
Fixes [28107](https://github.com/prisma/prisma/issues/28107) and [5615](https://github.com/prisma/prisma-engines/issues/5615)