### PR TITLE
chore: use newer tiberius from git

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5835,8 +5835,7 @@ dependencies = [
 [[package]]
 name = "tiberius"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+source = "git+https://github.com/prisma/tiberius?branch=main#59db57960a14b422fb3a1309aa4aa47880896ff8"
 dependencies = [
  "async-native-tls",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ sqlparser = "0.32"
 sqlx-core = "0.8"
 sqlx-sqlite = "0.8"
 tempfile = "3"
-tiberius = { version = "0.12", default-features = false }
+tiberius = { git = "https://github.com/prisma/tiberius", branch = "main", default-features = false }
 tokio = { version = "1", features = ["sync"] }
 tokio-postgres = { git = "https://github.com/prisma/rust-postgres", branch = "pgbouncer-mode" }
 tokio-tungstenite = "0.26"


### PR DESCRIPTION
contains some fixes like https://github.com/prisma/tiberius/pull/372