### PR TITLE
fix: make sure columns are fully qualified in aggregates

### DIFF
--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -298,7 +298,7 @@ fn get_result_node_for_aggregation(
             sel.identifiers().map(move |ident| {
                 let db_alias = ident.db_alias();
                 let type_info = FieldTypeInformation::new(ident.typ, ident.arity, None);
-                (ident.name, sel.aggregation_name(), db_alias, type_info)
+                (ident.field.name(), sel.aggregation_name(), db_alias, type_info)
             })
         })
         .sorted_by_key(|(name, prefix, _, _)| ordered_set.get_index_of(&(*prefix, *name)))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@group-by.json.snap
@@ -11,8 +11,9 @@ dataMap {
         _all: Int (_count$_all)
     }
 }
-query «SELECT COUNT("id") AS "_count$id", COUNT("title") AS "_count$title",
-       COUNT("userId") AS "_count$userId", COUNT(*) AS "_count$_all" FROM
-       "public"."Post" WHERE "public"."Post"."title"::text LIKE $1 GROUP BY
-       "public"."Post"."title" OFFSET $2»
+query «SELECT COUNT("public"."Post"."id") AS "_count$id",
+       COUNT("public"."Post"."title") AS "_count$title",
+       COUNT("public"."Post"."userId") AS "_count$userId", COUNT(*) AS
+       "_count$_all" FROM "public"."Post" WHERE "public"."Post"."title"::text
+       LIKE $1 GROUP BY "public"."Post"."title" OFFSET $2»
 params [const(String("%something%")), const(BigInt(0))]

--- a/query-engine/connectors/mongodb-query-connector/src/output_meta.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/output_meta.rs
@@ -118,7 +118,7 @@ pub fn from_aggregation_selection(selection: &AggregationSelection) -> OutputMet
 
     for ident in selection.identifiers() {
         map.insert(
-            ident.field_db_name.into(),
+            ident.field.db_name().into(),
             OutputMeta::Scalar(ScalarOutputMeta {
                 ident: ident.typ.id,
                 default: None,


### PR DESCRIPTION
Restores the original behavior where group by aggregations would have column names with explicit table names. This behavior cannot be used with non-group-by aggregates, because they sometimes rely on referring to columns from a subquery.

[TML-1483](https://linear.app/prisma-company/issue/TML-1483/fix-groupby-regression)

Fixes https://github.com/prisma/prisma/issues/28084