### PR TITLE
 fix(schema-engine): fix trailing underscore in migration name

### DIFF
--- a/schema-engine/commands/src/commands/create_migration.rs
+++ b/schema-engine/commands/src/commands/create_migration.rs
@@ -7,10 +7,10 @@ use user_facing_errors::schema_engine::MigrationNameTooLong;
 /// Create a directory name for a new migration.
 pub fn generate_migration_directory_name(migration_name: &str) -> String {
     let timestamp = format_utc_now("%Y%m%d%H%M%S");
-    let directory_name = if migration_name.is_empty(){
-       timestamp
-    } else{
-      format!("{timestamp}_{migration_name}")
+    let directory_name = if migration_name.is_empty() {
+        timestamp
+    } else {
+        format!("{timestamp}_{migration_name}")
     };
     directory_name
 }

--- a/schema-engine/commands/src/commands/create_migration.rs
+++ b/schema-engine/commands/src/commands/create_migration.rs
@@ -7,7 +7,11 @@ use user_facing_errors::schema_engine::MigrationNameTooLong;
 /// Create a directory name for a new migration.
 pub fn generate_migration_directory_name(migration_name: &str) -> String {
     let timestamp = format_utc_now("%Y%m%d%H%M%S");
-    let directory_name = format!("{timestamp}_{migration_name}");
+    let directory_name = if migration_name.is_empty(){
+       timestamp
+    } else{
+      format!("{timestamp}_{migration_name}")
+    };
     directory_name
 }
 

--- a/schema-engine/commands/src/commands/create_migration.rs
+++ b/schema-engine/commands/src/commands/create_migration.rs
@@ -7,12 +7,11 @@ use user_facing_errors::schema_engine::MigrationNameTooLong;
 /// Create a directory name for a new migration.
 pub fn generate_migration_directory_name(migration_name: &str) -> String {
     let timestamp = format_utc_now("%Y%m%d%H%M%S");
-    let directory_name = if migration_name.is_empty() {
+    if migration_name.is_empty() {
         timestamp
     } else {
         format!("{timestamp}_{migration_name}")
-    };
-    directory_name
+    }
 }
 
 /// Create a new migration.

--- a/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
@@ -1320,11 +1320,10 @@ fn create_migration_with_empty_name_has_timestamp_directory(mut api: TestApi) {
     "#,
     );
     let dir = api.create_migrations_directory();
-    let  res = api.create_migration("", &dm, &dir).send_sync();
+    let res = api.create_migration("", &dm, &dir).send_sync();
     let created_dir_name = res.output.generated_migration_name.clone();
     res.assert_migration_directories_count(1);
     // Check it is exactly a 14-digit timestamp, no underscore.
     assert_eq!(created_dir_name.len(), 14);
     assert!(created_dir_name.chars().all(|c| c.is_ascii_digit()));
-
 }

--- a/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
@@ -1308,3 +1308,23 @@ fn alter_constraint_name(mut api: TestApi) {
             migration.expect_contents(expected_script)
         });
 }
+
+#[test_connector]
+fn create_migration_with_empty_name_has_timestamp_directory(mut api: TestApi) {
+    let dm = api.datamodel_with_provider(
+        r#"
+        model Cat {
+            id   Int @id
+            name String
+        }
+    "#,
+    );
+    let dir = api.create_migrations_directory();
+    let  res = api.create_migration("", &dm, &dir).send_sync();
+    let created_dir_name = res.output.generated_migration_name.clone();
+    res.assert_migration_directories_count(1);
+    // Check it is exactly a 14-digit timestamp, no underscore.
+    assert_eq!(created_dir_name.len(), 14);
+    assert!(created_dir_name.chars().all(|c| c.is_ascii_digit()));
+
+}


### PR DESCRIPTION
## Description
- Fixes railing underscore in migration name when migration name is omitted
- Add test to verify functionality

 Closes #[28018](https://github.com/prisma/prisma/issues/28018)