### PR TITLE
fix: fix unsupported type diff false positives

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/schema_differ.rs
@@ -382,10 +382,10 @@ fn postgres_column_type_change(columns: MigrationPair<TableColumnWalker<'_>>) ->
                 Some(RiskyCast)
             }
         }
-        // Unsupported types will have None as Native type
-        (None, Some(_)) => Some(RiskyCast),
-        (Some(_), None) => Some(RiskyCast),
-        (None, None)
+        // Unsupported types will have None as Native type when defined in the Prisma schema.
+        // When introspected, we get an Unknown type with name and args.
+        (None | Some(PostgresType::Unknown(_, _)), None | Some(PostgresType::Unknown(_, _)))
+        // TODO: this diffs columns.previous with columns.previous, which is incorrect
             if columns.previous.column_type().full_data_type == columns.previous.column_type().full_data_type =>
         {
             None


### PR DESCRIPTION
[TML-1493](https://linear.app/prisma-company/issue/TML-1493/fix-unsupported-data-type-issue)

The extension type changes accidentally caused unsupported types to produce diffs because they weren't considered equal to `PostgresType::Unknown`, which is what the introspection infers for unknown columns now.

`None` (no native type defined in schema) and `Some(PostgresType::Unknown(_))` (unknown type found in introspection) should be compared using the type name.

The existing type name check is broken though because it compares `columns.previous` to `columns.previous`. I left that behavior unchanged intentionally, because the diffs it produces are somewhat broken. They generate `ALTER TYPE` statements from `full_data_type`, which isn't always valid, for example when the column type is `vector(3)`, the `full_data_type` is `vector` so the statement ends up being invalid: `SET DATA TYPE vector`. This functionality works fine for types without modifiers though like plain `geometry`. As of this PR though, the diffs should never occur.

Fixes: https://github.com/prisma/prisma/issues/28237