### PR TITLE
ci: build integration releases from next branch

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - next
       - '*.*.x'
       - 'integration/*'
     paths-ignore:


### PR DESCRIPTION
[TML-1498](https://linear.app/prisma-company/issue/TML-1498/implement-automatic-integration-releases-for-prisma-enginesnext)

Adding a push for the branch event should be enough,
Publish runs for all `push` events:
https://github.com/prisma/prisma-engines/blob/0d2a61959034a140b7ee0d0c3fb6adad61ed17b1/.github/workflows/build-engines.yml#L119
And the wrapper repo then treats all non-patch and non-main branches as integration releases:
https://github.com/prisma/engines-wrapper/blob/329743f98d1929c7747488ba520eda862db23937/scripts/publish.ts#L14-L24