### PR TITLE
chore: fix broken lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.1.0",
+ "windows-link",
 ]
 
 [[package]]
@@ -6769,12 +6769,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
 name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6807,7 +6801,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]


### PR DESCRIPTION
Merging a bunch of dependabot PRs in succession without rebasing them in between caused some broken state in `Cargo.lock` (sometimes even if things can be automatically merged using git algorithms without merge conflicts, it doesn't mean that the result of the merge is going to be semantically correct — which is why merge queues exist and we should be using them).

This commit fixes the broken lockfile.