### PR TITLE
chore: standardize on `cruet` for case conversion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,15 +801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "convert_case"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,7 +2816,7 @@ name = "mongodb-schema-connector"
 version = "0.1.0"
 dependencies = [
  "bson",
- "convert_case 0.8.0",
+ "cruet",
  "datamodel-renderer",
  "dissimilar",
  "enumflags2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ chrono = "0.4"
 colored = "3"
 concat-idents = "1"
 connection-string = "0.2"
-convert_case = "0.8"
 crossbeam-channel = "0.5"
 cruet = "0.15"
 cuid = { git = "https://github.com/prisma/cuid-rust", branch = "v1.3.3-wasm32-unknown-unknown" }

--- a/schema-engine/connectors/mongodb-schema-connector/Cargo.toml
+++ b/schema-engine/connectors/mongodb-schema-connector/Cargo.toml
@@ -20,7 +20,7 @@ bson.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing.workspace = true
-convert_case.workspace = true
+cruet.workspace = true
 regex.workspace = true
 indoc.workspace = true
 

--- a/schema-engine/connectors/mongodb-schema-connector/src/sampler/statistics.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/src/sampler/statistics.rs
@@ -13,7 +13,7 @@ use schema_connector::{
 
 use super::field_type::FieldType;
 use bson::{Bson, Document};
-use convert_case::{Case, Casing};
+use cruet::Inflector;
 use datamodel_renderer as renderer;
 use mongodb_schema_describer::{CollectionWalker, IndexWalker};
 use psl::datamodel_connector::constraint_names::ConstraintNames;
@@ -63,7 +63,7 @@ impl<'a> Statistics<'a> {
     fn composite_type_name(&self, model: &str, field: &str) -> Name {
         let combined: String = format!("{model}_{field}").chars().filter(|c| c.is_ascii()).collect();
 
-        let name = Name::Model(combined.to_case(Case::Pascal));
+        let name = Name::Model(combined.to_pascal_case());
 
         let name = if self.models.contains_key(&name) {
             format!("{name}_")
@@ -521,7 +521,7 @@ impl<'a> Statistics<'a> {
                         (name, field.clone())
                     };
 
-                    let type_name = format!("{container_name}_{field}").to_case(Case::Pascal);
+                    let type_name = format!("{container_name}_{field}").to_pascal_case();
                     let type_name = sanitize_string(&type_name).unwrap_or(type_name);
                     container_name.clone_from(&type_name);
 


### PR DESCRIPTION
`cruet` supports both conversion to `camelCase`/`PascalCase`/etc and pluralization, while `convert_case` only supports case conversion.

48ac1378 introduced `cruet` in psl. This comit makes `mongodb-schema-connector` use `cruet` as well for consistency across the codebase.
