### PR TITLE
chore: update binaryen to v124

### DIFF
--- a/.github/workflows/build-engines.yml
+++ b/.github/workflows/build-engines.yml
@@ -10,8 +10,8 @@ on:
       - '*.*.x'
       - 'integration/*'
     paths-ignore:
-      - '!.github/workflows/build-engines*'
       - '.github/**'
+      - '!.github/workflows/build-engines*'
       - '*.md'
       - 'LICENSE'
       - 'CODEOWNERS'

--- a/.github/workflows/build-prisma-schema-wasm.yml
+++ b/.github/workflows/build-prisma-schema-wasm.yml
@@ -5,9 +5,9 @@ on:
       - main
   pull_request:
     paths-ignore:
+      - '.github/**'
       - '!.github/workflows/build-prisma-schema-wasm.yml'
       - '!.github/workflows/include/rust-wasm-setup/action.yml'
-      - '.github/**'
       - '*.md'
       - 'LICENSE'
       - 'CODEOWNERS'

--- a/.github/workflows/include/rust-wasm-setup/action.yml
+++ b/.github/workflows/include/rust-wasm-setup/action.yml
@@ -21,8 +21,8 @@ runs:
       uses: jaxxstorm/action-install-gh-release@v1.14.0
       with:
         repo: WebAssembly/binaryen
-        tag: version_122
-        binaries-location: binaryen-version_122/bin
+        tag: version_124
+        binaries-location: binaryen-version_124/bin
         cache: true
 
     - name: Install bc

--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -2,9 +2,9 @@ name: 'All crates'
 on:
   pull_request:
     paths-ignore:
+      - '.github/**'
       - '!.github/workflows/test-compilation.yml'
       - '!.github/workflows/test-compilation-template.yml'
-      - '.github/**'
       - '*.md'
       - 'LICENSE'
       - 'CODEOWNERS'

--- a/.github/workflows/test-quaint.yml
+++ b/.github/workflows/test-quaint.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     paths:
       - 'quaint/**'
-      - '!.github/workflows/test-quaint.yml'
+      - '.github/workflows/test-quaint.yml'
 
 jobs:
   tests:

--- a/.github/workflows/test-query-compiler.yml
+++ b/.github/workflows/test-query-compiler.yml
@@ -8,6 +8,7 @@ on:
       - '.github/**'
       - '!.github/workflows/test-query-compiler.yml'
       - '!.github/workflows/test-query-compiler-template.yml'
+      - '!.github/workflows/include/rust-wasm-setup/action.yml'
       - '*.md'
       - 'LICENSE'
       - 'CODEOWNERS'

--- a/.github/workflows/test-query-engine-black-box.yml
+++ b/.github/workflows/test-query-engine-black-box.yml
@@ -5,8 +5,8 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - '!.github/workflows/test-query-engine-black-box.yml'
       - '.github/**'
+      - '!.github/workflows/test-query-engine-black-box.yml'
       - '*.md'
       - 'LICENSE'
       - 'CODEOWNERS'


### PR DESCRIPTION
Update Binaryen (including wasm-bindgen) from v122 to v124.
