### PR TITLE
chore: fix building and testing with `next` branch of prisma

### DIFF
--- a/libs/driver-adapters/executor/src/driver-adapters-manager/better-sqlite3.ts
+++ b/libs/driver-adapters/executor/src/driver-adapters-manager/better-sqlite3.ts
@@ -1,4 +1,4 @@
-import { PrismaBetterSQLite3 } from '@prisma/adapter-better-sqlite3'
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3'
 import type {
   SqlDriverAdapter,
   SqlMigrationAwareDriverAdapterFactory,
@@ -20,7 +20,7 @@ export class BetterSQLite3Manager implements DriverAdaptersManager {
     private env: EnvForAdapter<TAG>,
     { url }: SetupDriverAdaptersInput,
   ) {
-    this.#factory = new PrismaBetterSQLite3({
+    this.#factory = new PrismaBetterSqlite3({
       url,
     })
   }

--- a/libs/driver-adapters/executor/src/driver-adapters-manager/libsql.ts
+++ b/libs/driver-adapters/executor/src/driver-adapters-manager/libsql.ts
@@ -1,4 +1,4 @@
-import { PrismaLibSQL } from '@prisma/adapter-libsql'
+import { PrismaLibSql } from '@prisma/adapter-libsql'
 import type {
   SqlDriverAdapter,
   SqlMigrationAwareDriverAdapterFactory,
@@ -20,7 +20,7 @@ export class LibSQLManager implements DriverAdaptersManager {
     private env: EnvForAdapter<TAG>,
     { url }: SetupDriverAdaptersInput,
   ) {
-    this.#factory = new PrismaLibSQL({
+    this.#factory = new PrismaLibSql({
       url,
       intMode: 'bigint',
     })

--- a/libs/driver-adapters/pnpm-workspace.yaml
+++ b/libs/driver-adapters/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ packages:
   - '../../../prisma/packages/adapter-mariadb'
   - '../../../prisma/packages/bundled-js-drivers'
   - '../../../prisma/packages/client-engine-runtime'
+  - '../../../prisma/packages/client-runtime-utils'
   - '../../../prisma/packages/debug'
   - '../../../prisma/packages/driver-adapter-utils'
   - './executor'


### PR DESCRIPTION
- Add missing `@prisma/client-runtime-utils` package added on the `next` branch in `prisma/prisma` to the pnpm workspace.

- Adapt to breaking changes in the exported driver adapter APIs.

/prisma-branch next
