### PR TITLE
fix: do not render default schema when dropping items in it

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer.rs
@@ -242,11 +242,11 @@ impl SqlRenderer for MssqlRenderer {
         )
     }
 
-    fn render_drop_enum(&self, _: sql::EnumWalker<'_>) -> Vec<String> {
+    fn render_drop_enum(&self, _namespace: Option<&str>, _: sql::EnumWalker<'_>) -> Vec<String> {
         unreachable!("render_drop_enum on MSSQL")
     }
 
-    fn render_drop_foreign_key(&self, foreign_key: sql::ForeignKeyWalker<'_>) -> String {
+    fn render_drop_foreign_key(&self, _namespace: Option<&str>, foreign_key: sql::ForeignKeyWalker<'_>) -> String {
         format!(
             "ALTER TABLE {table} DROP CONSTRAINT {constraint_name}",
             table = self.table_name(foreign_key.table()),
@@ -254,7 +254,7 @@ impl SqlRenderer for MssqlRenderer {
         )
     }
 
-    fn render_drop_index(&self, index: sql::IndexWalker<'_>) -> String {
+    fn render_drop_index(&self, _namespace: Option<&str>, index: sql::IndexWalker<'_>) -> String {
         let ext: &MssqlSchemaExt = index.schema.downcast_connector_data();
 
         if ext.index_is_a_constraint(index.id) {
@@ -297,7 +297,7 @@ impl SqlRenderer for MssqlRenderer {
 
             // Drop the indexes on the table.
             for index in tables.previous.indexes().filter(|idx| !idx.is_primary_key()) {
-                result.push(self.render_drop_index(index));
+                result.push(self.render_drop_index(None, index));
             }
 
             // Remove all constraints from our original table. This will allow
@@ -426,12 +426,12 @@ impl SqlRenderer for MssqlRenderer {
         vec![format!("DROP TABLE {}", self.quote_with_schema(namespace, table_name))]
     }
 
-    fn render_drop_view(&self, view: sql::ViewWalker<'_>) -> String {
-        format!("DROP VIEW {}", self.quote_with_schema(view.namespace(), view.name()))
+    fn render_drop_view(&self, namespace: Option<&str>, view: sql::ViewWalker<'_>) -> String {
+        format!("DROP VIEW {}", self.quote_with_schema(namespace, view.name()))
     }
 
-    fn render_drop_user_defined_type(&self, udt: &sql::UserDefinedTypeWalker<'_>) -> String {
-        format!("DROP TYPE {}", self.quote_with_schema(udt.namespace(), udt.name()))
+    fn render_drop_user_defined_type(&self, namespace: Option<&str>, udt: &sql::UserDefinedTypeWalker<'_>) -> String {
+        format!("DROP TYPE {}", self.quote_with_schema(namespace, udt.name()))
     }
 
     fn render_begin_transaction(&self) -> Option<&'static str> {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/renderer.rs
@@ -283,13 +283,13 @@ impl SqlRenderer for MysqlRenderer {
         ]
     }
 
-    fn render_drop_enum(&self, _: EnumWalker<'_>) -> Vec<String> {
+    fn render_drop_enum(&self, _namespace: Option<&str>, _: EnumWalker<'_>) -> Vec<String> {
         unreachable!(
             "Unreachable render_drop_enum() on MySQL. enums are defined on each column that uses them on MySQL"
         )
     }
 
-    fn render_drop_foreign_key(&self, foreign_key: ForeignKeyWalker<'_>) -> String {
+    fn render_drop_foreign_key(&self, _namespace: Option<&str>, foreign_key: ForeignKeyWalker<'_>) -> String {
         format!(
             "ALTER TABLE {table} DROP FOREIGN KEY {constraint_name}",
             table = self.quote(foreign_key.table().name()),
@@ -297,7 +297,7 @@ impl SqlRenderer for MysqlRenderer {
         )
     }
 
-    fn render_drop_index(&self, index: IndexWalker<'_>) -> String {
+    fn render_drop_index(&self, _namespace: Option<&str>, index: IndexWalker<'_>) -> String {
         sql_ddl::mysql::DropIndex {
             table_name: index.table().name().into(),
             index_name: index.name().into(),
@@ -333,7 +333,7 @@ impl SqlRenderer for MysqlRenderer {
         self.render_create_table_as(table, QuotedWithPrefix(None, Quoted::mysql_ident(table.name())))
     }
 
-    fn render_drop_view(&self, view: ViewWalker<'_>) -> String {
+    fn render_drop_view(&self, _namespace: Option<&str>, view: ViewWalker<'_>) -> String {
         format!("DROP VIEW {}", Quoted::mysql_ident(view.name()))
     }
 
@@ -344,7 +344,7 @@ impl SqlRenderer for MysqlRenderer {
         vec![]
     }
 
-    fn render_drop_user_defined_type(&self, _: &UserDefinedTypeWalker<'_>) -> String {
+    fn render_drop_user_defined_type(&self, _namespace: Option<&str>, _: &UserDefinedTypeWalker<'_>) -> String {
         unreachable!("render_drop_user_defined_type on MySQL")
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/renderer.rs
@@ -145,21 +145,21 @@ impl SqlRenderer for SqliteRenderer {
         create_table.to_string()
     }
 
-    fn render_drop_enum(&self, _: EnumWalker<'_>) -> Vec<String> {
+    fn render_drop_enum(&self, _namespace: Option<&str>, _: EnumWalker<'_>) -> Vec<String> {
         unreachable!("Unreachable render_drop_enum() on SQLite. SQLite does not have enums.")
     }
 
-    fn render_drop_foreign_key(&self, _foreign_key: ForeignKeyWalker<'_>) -> String {
+    fn render_drop_foreign_key(&self, _namespace: Option<&str>, _foreign_key: ForeignKeyWalker<'_>) -> String {
         unreachable!("render_drop_foreign_key on SQLite")
     }
 
-    fn render_drop_index(&self, index: IndexWalker<'_>) -> String {
+    fn render_drop_index(&self, _namespace: Option<&str>, index: IndexWalker<'_>) -> String {
         format!("DROP INDEX {}", self.quote(index.name()))
     }
 
     fn render_drop_and_recreate_index(&self, indexes: MigrationPair<IndexWalker<'_>>) -> Vec<String> {
         vec![
-            self.render_drop_index(indexes.previous),
+            self.render_drop_index(None, indexes.previous),
             self.render_create_index(indexes.next),
         ]
     }
@@ -241,11 +241,11 @@ impl SqlRenderer for SqliteRenderer {
         format!(r#"ALTER TABLE "{name}" RENAME TO "{new_name}""#)
     }
 
-    fn render_drop_view(&self, view: ViewWalker<'_>) -> String {
+    fn render_drop_view(&self, _namespace: Option<&str>, view: ViewWalker<'_>) -> String {
         format!(r#"DROP VIEW "{}""#, view.name())
     }
 
-    fn render_drop_user_defined_type(&self, _: &UserDefinedTypeWalker<'_>) -> String {
+    fn render_drop_user_defined_type(&self, _namespace: Option<&str>, _: &UserDefinedTypeWalker<'_>) -> String {
         unreachable!("render_drop_user_defined_type on SQLite")
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/sql_renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_renderer.rs
@@ -65,13 +65,13 @@ pub(crate) trait SqlRenderer: Send + Sync {
     }
 
     /// Render a `DropEnum` step.
-    fn render_drop_enum(&self, dropped_enum: EnumWalker<'_>) -> Vec<String>;
+    fn render_drop_enum(&self, namespace: Option<&str>, dropped_enum: EnumWalker<'_>) -> Vec<String>;
 
     /// Render a `DropForeignKey` step.
-    fn render_drop_foreign_key(&self, foreign_key: ForeignKeyWalker<'_>) -> String;
+    fn render_drop_foreign_key(&self, namespace: Option<&str>, foreign_key: ForeignKeyWalker<'_>) -> String;
 
     /// Render a `DropIndex` step.
-    fn render_drop_index(&self, index: IndexWalker<'_>) -> String;
+    fn render_drop_index(&self, namespace: Option<&str>, index: IndexWalker<'_>) -> String;
 
     /// Render a `DropTable` step.
     fn render_drop_table(&self, namespace: Option<&str>, table_name: &str) -> Vec<String> {
@@ -89,10 +89,10 @@ pub(crate) trait SqlRenderer: Send + Sync {
     fn render_rename_table(&self, namespace: Option<&str>, name: &str, new_name: &str) -> String;
 
     /// Render a drop view step.
-    fn render_drop_view(&self, view: ViewWalker<'_>) -> String;
+    fn render_drop_view(&self, namespace: Option<&str>, view: ViewWalker<'_>) -> String;
 
     /// Render a drop type step.
-    fn render_drop_user_defined_type(&self, udt: &UserDefinedTypeWalker<'_>) -> String;
+    fn render_drop_user_defined_type(&self, namespace: Option<&str>, udt: &UserDefinedTypeWalker<'_>) -> String;
 
     /// Render a transaction start.
     fn render_begin_transaction(&self) -> Option<&'static str> {

--- a/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/schema_filter.rs
@@ -340,7 +340,7 @@ fn schema_filter_migration_removing_external_tables_incl_relations(mut api: Test
 
                     */
                     -- DropForeignKey
-                    ALTER TABLE "public"."cat" DROP CONSTRAINT "cat_externalTableId_fkey";
+                    ALTER TABLE "cat" DROP CONSTRAINT "cat_externalTableId_fkey";
 
                     -- AlterTable
                     ALTER TABLE "cat" DROP COLUMN "externalTableId";


### PR DESCRIPTION
[TML-1527](https://linear.app/prisma-company/issue/TML-1527/regression-in-616-migrate-adds-explicit-schema-when-dropping-table)

We need some special handling when dropping items in the default schema. More explanation in comments.

Fixes https://github.com/prisma/prisma/issues/28312