### PR TITLE
chore: use the correct "Wasm" spelling

### DIFF
--- a/.github/workflows/build-prisma-schema-wasm.yml
+++ b/.github/workflows/build-prisma-schema-wasm.yml
@@ -1,4 +1,4 @@
-name: Prisma Schema (WASM)
+name: Prisma Schema (Wasm)
 on:
   push:
     branches:

--- a/.github/workflows/include/rust-wasm-setup/action.yml
+++ b/.github/workflows/include/rust-wasm-setup/action.yml
@@ -1,4 +1,4 @@
-name: Rust + WASM common deps
+name: Rust + Wasm common deps
 
 runs:
   using: 'composite'
@@ -7,7 +7,7 @@ runs:
       shell: bash
       run: rustup default stable
 
-    - name: Add WASM target
+    - name: Add Wasm target
       shell: bash
       run: rustup target add wasm32-unknown-unknown
 

--- a/.github/workflows/on-push-to-main.yml
+++ b/.github/workflows/on-push-to-main.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./.github/workflows/include/rust-wasm-setup
 
-      - name: Build WASM modules
+      - name: Build Wasm modules
         env:
           WASM_BUILD_PROFILE: release
           PKG_DIR: query-compiler/query-compiler-wasm/pkg

--- a/.github/workflows/wasm-size.yml
+++ b/.github/workflows/wasm-size.yml
@@ -129,7 +129,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             <!-- wasm-size -->
-            ### WASM Query Compiler File Size
+            ### Wasm Query Compiler File Size
 
             | Engine             | This PR                                             | Base branch                                         | Diff                                                |
             |--------------------|-----------------------------------------------------|-----------------------------------------------------|-----------------------------------------------------|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,7 @@
 ## 1. Big Picture
 - This repo hosts the **Prisma Engines**: PSL (schema parser/validator), schema-engine (migrate, introspect), query components (query compiler, driver adapters, compatibility harnesses), and utilities shared with Prisma Client.
 - Prisma 7 roadmap status:
-  - `directUrl` and `shadowDatabaseUrl` are **invalid** in PSL.
-  - `url` remains temporarily while downstream tooling finishes migrating to external datasource overrides; removal is tracked separately.
+  - `url`, `directUrl` and `shadowDatabaseUrl` are **invalid** in PSL.
   - CLI/tests override connection info via schema-engine CLI (`--datasource`) or shared `TestApi::new_engine_with_connection_strings`.
   - Reference commit: `34b5a692b7bd79939a9a2c3ef97d816e749cda2f` (driver adapter override plumbing).
 - Prisma has removed the **native Rust query engine** in favor of the **Query Compiler (QC)** architecture:
@@ -22,7 +21,7 @@ Key directories:
 - `prisma-fmt/` – Language server & formatter entry point (tests rely on `expect!` snapshots).
 - `schema-engine/sql-migration-tests` / `sql-introspection-tests` – Heavy integration suites (require DBs).
 - `query-engine/` – Unused MongoDB connector crate left for future reference and the connector test kit (integration tests exercise QC through the driver adapter executor here).
-- `query-compiler/` – Query planner + associated WASM, playground, and the new `core-tests` crate.
+- `query-compiler/` – Query planner + associated Wasm, playground, and the new `core-tests` crate.
 - `libs/` – Shared libraries (value types, driver adapters, test setup).
 - `driver-adapters/` – Rust-side adapter utilities for the new query interpreter.
 
@@ -101,7 +100,7 @@ Supporting infra:
 
 7. **Connector test kit (driver adapters + QC)**
    ```bash
-   make dev-pg-qc    # or another dev-*-qc helper; builds QC WASM + driver adapters and writes .test_config
+   make dev-pg-qc    # or another dev-*-qc helper; builds QC Wasm + driver adapters and writes .test_config
    cargo test -p query-engine-tests -- --nocapture
    ```
    Set `DRIVER_ADAPTER=<adapter>` (see Makefile) when you want to run against a specific adapter target. See `query-engine/connector-test-kit-rs/README.md` for env vars and adapter-specific notes.
@@ -144,7 +143,7 @@ Ensure diffs make sense and rerun without `UPDATE_EXPECT` to confirm.
   `rg "directUrl"`, `rg "shadowDatabaseUrl"`
 - Build schema-engine CLI:
   `cargo build -p schema-engine-cli`
-- Build query compiler WASM:
+- Build query compiler Wasm:
   `make build-qc-wasm`
 - Build driver adapters kit for QC:
   `make build-driver-adapters-kit-qc`
@@ -176,3 +175,4 @@ Prefer using Makefile targets that take care of setting up the environment corre
 ---
 
 **When modifying anything involving diagnostics or fixtures:** run relevant tests, refresh expectations, and ensure Git diffs are readable (no accidental CRLF/encoding swaps). Keep this file updated whenever we discover new traps.***
+s, and ensure Git diffs are readable (no accidental CRLF/encoding swaps). Keep this file updated whenever we discover new traps.***

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ the repository root in the `target/debug` (without `--release`) or `target/relea
 | Schema Engine    | `./target/[debug\|release]/schema-engine` |
 | Prisma Format    | `./target/[debug\|release]/prisma-fmt`    |
 
-The query compiler is a library crate. To produce the WASM bundles that power the JS runtime, use
+The query compiler is a library crate. To produce the Wasm bundles that power the JS runtime, use
 `make build-qc-wasm`. Driver adapters are compiled via `make build-driver-adapters-kit-qc`.
 
 ## Prisma Schema Language
@@ -128,7 +128,7 @@ The engine uses:
 
 ## Prisma format
 
-Prisma format can format prisma schema files. It also comes as a WASM module via
+Prisma format can format prisma schema files. It also comes as a Wasm module via
 a node package. You can read more [here](./prisma-schema-wasm/README.md).
 
 ## Debugging
@@ -188,7 +188,7 @@ exclusions used in the Makefile when invoking `cargo test --workspace --all-feat
 
 **Setup:**
 
-Use the `dev-*-qc` helpers to spin up a database (when needed), build the query-compiler WASM, build
+Use the `dev-*-qc` helpers to spin up a database (when needed), build the query-compiler Wasm, build
 the driver adapters, and write the `.test_config` consumed by the connector test kit:
 
 - `make dev-pg-qc`

--- a/libs/driver-adapters/executor/src/panic.ts
+++ b/libs/driver-adapters/executor/src/panic.ts
@@ -35,7 +35,7 @@ export function withLocalPanicHandler<T>(fn: () => T): T {
 
 export class PanicError extends Error {
   constructor(message: string) {
-    super('Panic in WASM module: ' + message)
+    super('Panic in Wasm module: ' + message)
     this.name = 'PanicError'
   }
 }

--- a/prisma-schema-wasm/README.md
+++ b/prisma-schema-wasm/README.md
@@ -5,7 +5,7 @@
 [![install size](https://packagephobia.com/badge?p=@prisma/prisma-schema-wasm)](https://packagephobia.com/result?p=@prisma/prisma-schema-wasm)
 
 This directory only contains build logic to package the `prisma-fmt` engine
-into a Node package as a WASM module. All the functionality is implemented in
+into a Node package as a Wasm module. All the functionality is implemented in
 other parts of prisma-engines.
 
 The published NPM package is internal to Prisma. Its API will break without prior warning.

--- a/prisma-schema-wasm/package.json
+++ b/prisma-schema-wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@prisma/prisma-schema-wasm",
   "version": null,
-  "description": "The WASM package for prisma-fmt",
+  "description": "The Wasm package for prisma-fmt",
   "main": "src/prisma_schema_build.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/query-compiler/core/src/request_context.rs
+++ b/query-compiler/core/src/request_context.rs
@@ -24,7 +24,7 @@ pub(crate) fn get_request_now() -> PrismaValue {
             // At the moment of writing, this happens only in query validation test suite.
             // In that case, we want to fall back to realtime value. On the other hand, if task local is
             // set, we want to use it, even if we are not running inside of tokio runtime (for example,
-            // in WASM case)
+            // in Wasm case)
             //
             // Eventually, this will go away when we have a plain query context reference we pass around.
             PrismaValue::DateTime(chrono::Utc::now().into()))

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/chunking.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/chunking.rs
@@ -4,11 +4,11 @@ use query_engine_tests::*;
 /// * It should be called QUERY_CHUNK_SIZE instead, because it's a knob to configure query chunking
 ///  which is splitting queries with more arguments than accepted by the database, in multiple
 ///  queries.
-/// * WASM versions of the engine don't allow for runtime configuration of this value so they default
+/// * Wasm versions of the engine don't allow for runtime configuration of this value so they default
 ///  the mininum supported by any database on a SQL family (eg. Postgres, MySQL, SQLite, SQL Server,
 ///  etc.) As such, in order to guarantee chunking happens, a large number of arguments --larger
 ///  than the default-- needs to be used, to have actual coverage of chunking code while exercising
-///  WASM query engines.
+///  Wasm query engines.
 #[test_suite(schema(schema))]
 mod chunking {
     use indoc::indoc;

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -232,9 +232,9 @@ impl ConnectorVersion {
 
     /// The maximum number of rows allowed in a single insert query.
     ///
-    /// max_bind_values is overriden by the QUERY_BATCH_SIZE env var in targets other than WASM.
+    /// max_bind_values is overriden by the QUERY_BATCH_SIZE env var in targets other than Wasm.
     ///
-    /// Connectors which underyling implementation is WASM don't have any max_bind_values override
+    /// Connectors which underyling implementation is Wasm don't have any max_bind_values override
     /// as there's no such thing as runtime environment.
     ///
     /// From the PoV of the test binary, the target architecture is that of where the test runs,
@@ -242,10 +242,10 @@ impl ConnectorVersion {
     ///
     /// As a consequence there is a mismatch between the max_bind_values as seen by the test
     /// binary (overriden by the QUERY_BATCH_SIZE env var) and the max_bind_values as seen by the
-    /// WASM engine being exercised in those tests, through the RunnerExecutor::External test runner.
+    /// Wasm engine being exercised in those tests, through the RunnerExecutor::External test runner.
     ///
     /// What we do in here, is returning the number of max_bind_values that the connector under test
-    /// will use. i.e. if it's a WASM connector, the default, not overridable one. Otherwise the one
+    /// will use. i.e. if it's a Wasm connector, the default, not overridable one. Otherwise the one
     /// as seen by the test binary (which will be the same as the engine exercised)
     pub fn max_bind_values(&self) -> Option<usize> {
         if matches!(self, Self::Sqlite(Some(SqliteVersion::CloudflareD1))) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,7 @@
 channel = "1.90.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
-    # WASM target for serverless and edge environments.
+    # Wasm target for serverless and edge environments.
     "wasm32-unknown-unknown",
 
     # React Native targets we support.

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -123,7 +123,7 @@ impl SqlDialect for MssqlDialect {
         &self,
         factory: Arc<dyn ExternalConnectorFactory>,
     ) -> BoxFuture<'_, ConnectorResult<Box<dyn SqlConnector>>> {
-        todo!("MSSQL WASM shadow database not supported yet")
+        todo!("MSSQL Wasm shadow database not supported yet")
     }
 }
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -103,7 +103,7 @@ impl SqlDialect for MysqlDialect {
         &self,
         _factory: std::sync::Arc<dyn quaint::connector::ExternalConnectorFactory>,
     ) -> BoxFuture<'_, ConnectorResult<Box<dyn SqlConnector>>> {
-        todo!("MySQL WASM shadow database not supported yet")
+        todo!("MySQL Wasm shadow database not supported yet")
     }
 }
 

--- a/schema-engine/schema-engine-wasm/build.sh
+++ b/schema-engine/schema-engine-wasm/build.sh
@@ -56,7 +56,7 @@ fi
 
 
 build() {
-    echo "ℹ️  Note that schema-engine compiled to WASM uses a different Rust toolchain"
+    echo "ℹ️  Note that schema-engine compiled to Wasm uses a different Rust toolchain"
     cargo --version
 
     local CARGO_TARGET_DIR


### PR DESCRIPTION
The official abbreviation of WebAssembly is Wasm, not WASM (which makes sense because it's an abbreviation, not an acronym).

See https://webassembly.org/

/prisma-branch next