### PR TITLE
chore: remove url attributes from all schema files

### DIFF
--- a/prisma-fmt/schema.prisma
+++ b/prisma-fmt/schema.prisma
@@ -1,4 +1,3 @@
 datasource db {
     provider = "postgresql"
-    url = env("MEOW")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model interm {

--- a/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_mongodb/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/add_missing_relation_attribute_mongodb/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model interm {

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }
 
 model Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 type Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_composite_type_crlf/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 type Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/create_missing_block_mongodb/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/create_missing_block_mongodb/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_multifile/config.prisma
@@ -4,5 +4,4 @@ generator client {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_with_validation_errors/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_at_map_with_validation_errors/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 model Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/mongodb_auto_native/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/mongodb_auto_native/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource RedPanda {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model Kattbjorn {

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider     = "postgresql"
-    url          = env("DATABASE_URL")
     schemas      = ["a", "b"]
     relationMode = "prisma"
 }

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_existing_schemas_multifile/datasource.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider     = "postgresql"
-    url          = env("DATABASE_URL")
     schemas      = ["a", "b"]
     relationMode = "prisma"
 }

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_nonexisting_schemas/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_add_to_nonexisting_schemas/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider     = "postgresql"
-    url          = env("DATABASE_URL")
     relationMode = "prisma"
 }
 

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["one", "two"]
 }
 

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_multifile/datasource.prisma
@@ -1,5 +1,4 @@
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["one", "two"]
 }

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["one", "two"]
 }
 

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_one_model_one_enum_multifile/config.prisma
@@ -5,6 +5,5 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["one", "two"]
 }

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_two_models/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_two_models/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["one", "two"]
 }
 

--- a/prisma-fmt/tests/code_actions/scenarios/multi_schema_two_models_relation_mode/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/multi_schema_two_models_relation_mode/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider     = "postgresql"
-    url          = "dummy-url"
     relationMode = "prisma"
     schemas      = ["one", "two"]
 }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_broken_relation/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_broken_relation/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_existing_arguments/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_existing_arguments/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_indentation_four_spaces/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_indentation_four_spaces/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_broken_relation/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_broken_relation/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_many_referenced_side_misses_unique_single_field_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model B {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_compound_field_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model B {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referenced_side_misses_unique_single_field_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model B {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_indentation_four_spaces/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model B {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_compound_field_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model B {

--- a/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/datasource.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/one_to_one_referencing_side_misses_unique_single_field_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider     = "mysql"
-    url          = env("DATABASE_URL")
     relationMode = "foreignKeys"
 }
 

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_mysql_foreign_keys_set_default_multifile/config.prisma
@@ -4,6 +4,5 @@ generator client {
 
 datasource db {
     provider     = "mysql"
-    url          = env("DATABASE_URL")
     relationMode = "foreignKeys"
 }

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/config.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_prisma_missing_index_multifile/config.prisma
@@ -4,6 +4,5 @@ generator client {
 
 datasource db {
     provider     = "mysql"
-    url          = "dummy-url"
     relationMode = "prisma"
 }

--- a/prisma-fmt/tests/code_actions/scenarios/relation_mode_referential_integrity/schema.prisma
+++ b/prisma-fmt/tests/code_actions/scenarios/relation_mode_referential_integrity/schema.prisma
@@ -1,5 +1,4 @@
 datasource db {
     provider             = "mongodb"
-    url                  = env("DATABASE_URL")
     referentialIntegrity = "prisma"
 }

--- a/prisma-fmt/tests/hover/scenarios/composite_from_block_name/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/composite_from_block_name/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model ModelNameA {

--- a/prisma-fmt/tests/hover/scenarios/composite_from_field_type/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/composite_from_field_type/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model User {

--- a/prisma-fmt/tests/hover/scenarios/embedded_m2n_mongodb/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/embedded_m2n_mongodb/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model Humans {

--- a/prisma-fmt/tests/hover/scenarios/enum_from_block_name/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/enum_from_block_name/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }
 
 model ModelNameA {

--- a/prisma-fmt/tests/hover/scenarios/enum_from_field_type/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/enum_from_field_type/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model User {

--- a/prisma-fmt/tests/hover/scenarios/field_from_composite_field_name/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/field_from_composite_field_name/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 type ModelNameA {

--- a/prisma-fmt/tests/hover/scenarios/field_from_model_field_name/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/field_from_model_field_name/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model ModelNameA {

--- a/prisma-fmt/tests/hover/scenarios/model_from_block_name/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/model_from_block_name/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }
 
 model ModelNameA {

--- a/prisma-fmt/tests/hover/scenarios/model_from_model_type_includes_broken_relations/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/model_from_model_type_includes_broken_relations/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model User {

--- a/prisma-fmt/tests/hover/scenarios/model_from_model_type_on_broken_relations/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/model_from_model_type_on_broken_relations/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model interm {

--- a/prisma-fmt/tests/hover/scenarios/model_from_view_type/config.prisma
+++ b/prisma-fmt/tests/hover/scenarios/model_from_view_type/config.prisma
@@ -5,5 +5,4 @@ generator js {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/hover/scenarios/value_from_enum_value_name/schema.prisma
+++ b/prisma-fmt/tests/hover/scenarios/value_from_enum_value_name/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 /// enum doc

--- a/prisma-fmt/tests/references/scenarios/composite_type_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/composite_type_as_type/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 type Address {

--- a/prisma-fmt/tests/references/scenarios/composite_type_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/composite_type_name/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 type Add<|>ress {

--- a/prisma-fmt/tests/references/scenarios/datasource_as_attribute/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/datasource_as_attribute/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 enum Pet {

--- a/prisma-fmt/tests/references/scenarios/datasource_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/datasource_name/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource d<|>b {
 provider = "mongodb"
-url      = env("DATABASE_URL")
 }
 
 enum Pet {

--- a/prisma-fmt/tests/references/scenarios/enum_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/enum_as_type/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 enum Pet {

--- a/prisma-fmt/tests/references/scenarios/enum_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/enum_name/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 enum P<|>et {

--- a/prisma-fmt/tests/references/scenarios/model_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_as_type/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 model UserTwo {

--- a/prisma-fmt/tests/references/scenarios/model_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_name/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 model User<|>Two {

--- a/prisma-fmt/tests/references/scenarios/model_relation_fields/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_fields/config.prisma
@@ -5,5 +5,4 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/references/scenarios/model_relation_references/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_relation_references/config.prisma
@@ -5,5 +5,4 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/references/scenarios/model_unique_fields/schema.prisma
+++ b/prisma-fmt/tests/references/scenarios/model_unique_fields/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }
 
 model Compound {

--- a/prisma-fmt/tests/references/scenarios/view_as_type/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_as_type/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 view UserTwo {

--- a/prisma-fmt/tests/references/scenarios/view_index_fields/schema.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_index_fields/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }
 
 model Compound {

--- a/prisma-fmt/tests/references/scenarios/view_name/a.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_name/a.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 view User<|>Two {

--- a/prisma-fmt/tests/references/scenarios/view_relation_fields/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_fields/config.prisma
@@ -5,5 +5,4 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/references/scenarios/view_relation_references/config.prisma
+++ b/prisma-fmt/tests/references/scenarios/view_relation_references/config.prisma
@@ -5,5 +5,4 @@ generator client {
 
 datasource db {
     provider = "postgres"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/argument_after_trailing_comma/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlserver"
-  url      = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_env_db_url/schema.prisma
@@ -1,9 +1,0 @@
-generator client {
-    provider        = "prisma-client"
-    previewFeatures = []
-}
-
-datasource db {
-    provider = "postgresql"
-    url      = env("<|>")
-}

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_multischema/schema.prisma
@@ -5,6 +5,5 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
     <|>
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/datasource_url_arguments/schema.prisma
@@ -1,9 +1,0 @@
-generator client {
-    provider        = "prisma-client"
-    previewFeatures = []
-}
-
-datasource db {
-    provider = "postgresql"
-    url      = <|>
-}

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_end_of_args_list/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_end_of_args_list/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlserver"
-  url      = env("DATABASE_URL")
 }
 
 model Test {

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "sqlserver"
-    url = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_in_arg_value/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_in_arg_value/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "sqlserver"
-    url      = env("DATABASE_URL")
 }
 
 model User {

--- a/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/config.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/default_map_mssql_multifile/config.prisma
@@ -1,4 +1,3 @@
 datasource db {
     provider = "sqlserver"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_basic/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_basic/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model Fulltext {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_cockroach_gin/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_cockroach_gin/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "cockroachdb"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_brin/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_brin/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_gin/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_gin/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_gist/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_gist/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_spgist/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_operators_postgres_spgist/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_cockroach/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_cockroach/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "cockroachdb"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_mongo/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_mongo/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_mysql/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_mysql/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/datasource.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_postgres_multifile/datasource.prisma
@@ -1,4 +1,3 @@
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_sqlite/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_sqlite/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_sqlserver/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/extended_indexes_types_sqlserver/schema.prisma
@@ -4,7 +4,6 @@ generator js {
 
 datasource db {
   provider = "sqlserver"
-  url      = env("DATABASE_URL")
 }
 
 model A {

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/config.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/no_default_map_on_postgres_multifile/config.prisma
@@ -1,4 +1,3 @@
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_end_of_args_list/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlserver"
-  url      = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "sqlserver"
-    url = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress_2/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_in_progress_2/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
 }
 
 model Test {

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_middle_of_args_list/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlserver"
-  url      = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_mssql/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_mssql/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "sqlserver"
-    url = env("DATABASE_URL")
 }
 
 model TestB {

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/config.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_multifile/config.prisma
@@ -1,5 +1,4 @@
 datasource db {
     provider     = "mysql"
-    url          = env("DATABASE_URL")
     relationMode = "prisma"
 }

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_relation_mode_fk_mysql/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_relation_mode_fk_mysql/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider     = "mysql"
-    url          = env("DATABASE_URL")
     relationMode = "foreignKeys"
 }
 

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_relation_mode_prisma_mongodb/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_relation_mode_prisma_mongodb/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "mongodb"
-    url      = env("DATABASE_URL")
 }
 
 model Post {

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_relation_mode_prisma_mysql/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_relation_mode_prisma_mysql/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider     = "mysql"
-    url          = env("DATABASE_URL")
     relationMode = "prisma"
 }
 

--- a/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/schema.prisma
+++ b/prisma-fmt/tests/text_document_completion/scenarios/referential_actions_with_trailing_comma/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlserver"
-  url      = env("DATABASE_URL")
 }
 
 model TestB {

--- a/psl/psl/tests/reformatter/regression_add_relation_attribute_on_field_with_multi_byte_trailing_comment.prisma
+++ b/psl/psl/tests/reformatter/regression_add_relation_attribute_on_field_with_multi_byte_trailing_comment.prisma
@@ -8,7 +8,6 @@ generator client {
 
 datasource db {
   provider = "sqlserver"
-  url = "***"
 }
 
 model somemodel {

--- a/psl/psl/tests/reformatter/regression_add_relation_attribute_on_field_with_multi_byte_trailing_comment.reformatted.prisma
+++ b/psl/psl/tests/reformatter/regression_add_relation_attribute_on_field_with_multi_byte_trailing_comment.reformatted.prisma
@@ -8,7 +8,6 @@ generator client {
 
 datasource db {
   provider = "sqlserver"
-  url      = "***"
 }
 
 model somemodel {

--- a/psl/psl/tests/reformatter/relations/native_types_in_missing_relation_fields.prisma
+++ b/psl/psl/tests/reformatter/relations/native_types_in_missing_relation_fields.prisma
@@ -1,6 +1,5 @@
 datasource pg {
   provider = "postgres"
-  url      = "postgres://meowmeowmeowmeowmeow"
 }
 
 model Blog {

--- a/psl/psl/tests/reformatter/relations/native_types_in_missing_relation_fields.reformatted.prisma
+++ b/psl/psl/tests/reformatter/relations/native_types_in_missing_relation_fields.reformatted.prisma
@@ -1,6 +1,5 @@
 datasource pg {
   provider = "postgres"
-  url      = "postgres://meowmeowmeowmeowmeow"
 }
 
 model Blog {

--- a/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.prisma
+++ b/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider     = "postgres" // "mysql" | "sqlite" ...
-    url          = env("TEST_POSTGRES_URI")
     relationMode = "prisma" /* = on or set to "foreignKeys" to turn off emulation */
 }
 

--- a/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.reformatted.prisma
+++ b/psl/psl/tests/reformatter/trailing_comments_allowed_in_configuration_blocks.reformatted.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider     = "postgres" // "mysql" | "sqlite" ...
-  url          = env("TEST_POSTGRES_URI")
   relationMode = "prisma" /* = on or set to "foreignKeys" to turn off emulation */
 }
 

--- a/psl/psl/tests/reformatter/type_aliases.prisma
+++ b/psl/psl/tests/reformatter/type_aliases.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url = env("TEST_DB_URL")
 }
 
 type MongoID = String @id @default(dbgenerated()) @map("_id") @db.ObjectId

--- a/psl/psl/tests/reformatter/type_aliases.reformatted.prisma
+++ b/psl/psl/tests/reformatter/type_aliases.reformatted.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("TEST_DB_URL")
 }
 
 type MongoID = String @id @default(dbgenerated()) @map("_id") @db.ObjectId

--- a/psl/psl/tests/reformatter_multi_file/align_blocks.reformatted/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/align_blocks.reformatted/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/align_blocks/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/align_blocks/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "sqlite"
-    url = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/relation_1_to_1.reformatted/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/relation_1_to_1.reformatted/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/relation_1_to_1/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/relation_1_to_1/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/relation_list.reformatted/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/relation_list.reformatted/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/relation_list/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/relation_list/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/relation_single.reformatted/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/relation_single.reformatted/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/reformatter_multi_file/relation_single/db.prisma
+++ b/psl/psl/tests/reformatter_multi_file/relation_single/db.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlite"
-  url      = env("DATABASE_URL")
 }
 
 generator client {

--- a/psl/psl/tests/validation/attributes/cuid/reject_random_int.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/reject_random_int.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(cuid(42))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `cuid()` takes either no argument, or a single integer argument which is either 1 or 2.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(cuid(42))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(cuid(42))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/cuid/reject_string_argument.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/reject_string_argument.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(cuid("asdf"))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `cuid()` takes a single Int argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(cuid("asdf"))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(cuid("asdf"))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/cuid/reject_string_column_with_int_256_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/reject_string_column_with_int_256_arg_valid.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(cuid(256))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `cuid()` takes either no argument, or a single integer argument which is either 1 or 2.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(cuid(256))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(cuid(256))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/cuid/require_string_column.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/require_string_column.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id Int @id @default(cuid())
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": The function `cuid()` cannot be used on fields of type `Int`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id Int @id [1;91m@default(cuid())[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id Int @id [1;91m@default(cuid())[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/cuid/string_column_with_int_1_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/string_column_with_int_1_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/cuid/string_column_with_int_2_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/string_column_with_int_2_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/cuid/string_column_with_no_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/cuid/string_column_with_no_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/mongodb.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/mongodb.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mongodb"
-    url = "dummy-url"
 }
 
 model SomeUser {

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_foreign_keys.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_foreign_keys.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
 }
 
 model SomeUser {

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_at_id.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_at_id.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider     = "mysql"
-    url          = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_at_unique.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_at_unique.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_id.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_id.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider     = "mysql"
-    url          = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_unique.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_at_unique.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_no_index.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/one_field_no_index.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 
@@ -17,8 +16,8 @@ model Post {
     user SomeUser @relation(fields: [userId], references: [id])
 }
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:17[0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
-// [1;94m16 | [0m    userId Int
-// [1;94m17 | [0m    user SomeUser [1;93m@relation(fields: [userId], references: [id])[0m
+// [1;94m15 | [0m    userId Int
+// [1;94m16 | [0m    user SomeUser [1;93m@relation(fields: [userId], references: [id])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_leftmost.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_leftmost.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 
@@ -25,8 +24,8 @@ model Post {
     @@index([userIdA, userIdB])
 }
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:23[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
-// [1;94m22 | [0m    userIdC Int
-// [1;94m23 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
+// [1;94m21 | [0m    userIdC Int
+// [1;94m22 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_rightmost.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_index_rightmost.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 
@@ -25,8 +24,8 @@ model Post {
     @@index([userIdB, userIdC])
 }
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:23[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
-// [1;94m22 | [0m    userIdC Int
-// [1;94m23 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
+// [1;94m21 | [0m    userIdC Int
+// [1;94m22 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_id.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_id.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider     = "mysql"
-    url          = "dummy-url"
     relationMode = "prisma"
 }
 
@@ -25,8 +24,8 @@ model Post {
 }
 
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:22[0m
+//   [1;94m-->[0m  [4mschema.prisma:21[0m
 // [1;94m   | [0m
-// [1;94m21 | [0m    userIdC Int      @unique
-// [1;94m22 | [0m    user    SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
+// [1;94m20 | [0m    userIdC Int      @unique
+// [1;94m21 | [0m    user    SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_unique.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_mixed_unique.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 
@@ -25,8 +24,8 @@ model Post {
     @@unique([userIdA, userIdB])
 }
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:23[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
-// [1;94m22 | [0m    userIdC Int @unique
-// [1;94m23 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
+// [1;94m21 | [0m    userIdC Int @unique
+// [1;94m22 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_no_index.prisma
+++ b/psl/psl/tests/validation/attributes/index/missing_index_warning/relation_mode_prisma/three_fields_no_index.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 
@@ -23,8 +22,8 @@ model Post {
     user SomeUser @relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])
 }
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:23[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
-// [1;94m22 | [0m    userIdC Int
-// [1;94m23 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
+// [1;94m21 | [0m    userIdC Int
+// [1;94m22 | [0m    user SomeUser [1;93m@relation(fields: [userIdA, userIdB, userIdC], references: [idA, idB, idC])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/mysql_missing_length.prisma
+++ b/psl/psl/tests/validation/attributes/index/mysql_missing_length.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "mysql"
-    url = "dummy-url"
 }
 
 model User {
@@ -11,14 +10,14 @@ model User {
 }
 
 // [1;91merror[0m: [1mNative type `Text` cannot be unique in MySQL. Please use the `length` argument to the field in the index definition to allow this.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m id         Int    @id
-// [1;94m 8 | [0m firstName  String [1;91m@unique [0m@test.Text
+// [1;94m 6 | [0m id         Int    @id
+// [1;94m 7 | [0m firstName  String [1;91m@unique [0m@test.Text
 // [1;94m   | [0m
 // [1;91merror[0m: [1mYou cannot define an index on fields with native type `Text` of MySQL. Please use the `length` argument to the field in the index definition to allow this.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m 
-// [1;94m10 | [0m [1;91m@@index([firstName])[0m
+// [1;94m 8 | [0m 
+// [1;94m 9 | [0m [1;91m@@index([firstName])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/sql_server_disallows_compound_unique_length_prefix.prisma
+++ b/psl/psl/tests/validation/attributes/index/sql_server_disallows_compound_unique_length_prefix.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlserver"
-    url = "dummy-url"
 }
 
 model A {
@@ -9,8 +8,8 @@ model A {
   @@unique([a(length: 10), b(length: 30)])
 }
 // [1;91merror[0m: [1mError parsing attribute "@@unique": The length argument is not supported in an index definition with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b String
-// [1;94m 9 | [0m  [1;91m@@unique([a(length: 10), b(length: 30)])[0m
+// [1;94m 7 | [0m  b String
+// [1;94m 8 | [0m  [1;91m@@unique([a(length: 10), b(length: 30)])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/sql_server_disallows_index_length_prefix.prisma
+++ b/psl/psl/tests/validation/attributes/index/sql_server_disallows_index_length_prefix.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlserver"
-    url = "dummy-url"
 }
 
 model A {
@@ -10,8 +9,8 @@ model A {
   @@index([a(length: 10)])
 }
 // [1;91merror[0m: [1mError parsing attribute "@@index": The length argument is not supported in an index definition with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(length: 10)])[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(length: 10)])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/sqlite_disallows_unique_length_prefix.prisma
+++ b/psl/psl/tests/validation/attributes/index/sqlite_disallows_unique_length_prefix.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlite"
-    url = "dummy-url"
 }
 
 model A {
@@ -8,8 +7,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel A {
-// [1;94m 7 | [0m  id String [1;91m@unique(length: 30)[0m
+// [1;94m 5 | [0mmodel A {
+// [1;94m 6 | [0m  id String [1;91m@unique(length: 30)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/sqlserver_disallows_unique_length_prefix.prisma
+++ b/psl/psl/tests/validation/attributes/index/sqlserver_disallows_unique_length_prefix.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlserver"
-    url = "dummy-url"
 }
 
 model A {
@@ -8,8 +7,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@unique": The length argument is not supported in an index definition with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel A {
-// [1;94m 7 | [0m  id String [1;91m@unique(length: 30)[0m @test.VarChar(255)
+// [1;94m 5 | [0mmodel A {
+// [1;94m 6 | [0m  id String [1;91m@unique(length: 30)[0m @test.VarChar(255)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index/unique_sort_order_as_string.prisma
+++ b/psl/psl/tests/validation/attributes/index/unique_sort_order_as_string.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model Post {
@@ -11,14 +10,14 @@ model Post {
 }
 
 // [1;91merror[0m: [1mExpected a constant value, but received string value `"Desc"`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  title      String   @db.VarChar(300)
-// [1;94m 8 | [0m  slug       String   @unique(sort: [1;91m"Desc"[0m, length: 42) @db.VarChar(3000)
+// [1;94m 6 | [0m  title      String   @db.VarChar(300)
+// [1;94m 7 | [0m  slug       String   @unique(sort: [1;91m"Desc"[0m, length: 42) @db.VarChar(3000)
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a constant value, but received string value `"Desc"`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  @@unique([title(length: 100, sort: [1;91m"Desc"[0m)])
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  @@unique([title(length: 100, sort: [1;91m"Desc"[0m)])
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/clustered_compound_unique_on_sqlite.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/clustered_compound_unique_on_sqlite.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlite"
-    url = "dummy-url"
 }
 
 model A {
@@ -13,8 +12,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@unique": Defining clustering is not supported in the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m
-// [1;94m11 | [0m  [1;91m@@unique([a, b], clustered: true)[0m
+// [1;94m 9 | [0m
+// [1;94m10 | [0m  [1;91m@@unique([a, b], clustered: true)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/clustered_unique_in_view.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/clustered_unique_in_view.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "sqlserver"
-  url      = "dummy-url"
 }
 
 generator js {
@@ -15,8 +14,8 @@ view A {
   @@unique([a, b], clustered: true)
 }
 // [1;91merror[0m: [1mError validating: @@unique annotations on views are not backed by unique indexes in the database and cannot be clustered.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  [1;91m@@unique([a, b], clustered: true)[0m
+// [1;94m13 | [0m
+// [1;94m14 | [0m  [1;91m@@unique([a, b], clustered: true)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/id_and_index_clustering_together_not_allowed.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/id_and_index_clustering_together_not_allowed.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlserver"
-    url = "dummy-url"
 }
 
 model A {
@@ -11,14 +10,14 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@id": A model can only hold one clustered index or id.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel A {
-// [1;94m 7 | [0m  id Int [1;91m@id[0m
+// [1;94m 5 | [0mmodel A {
+// [1;94m 6 | [0m  id Int [1;91m@id[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@@index": A model can only hold one clustered index or key.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a], clustered: true)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a], clustered: true)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/id_and_unique_clustering_together_not_allowed.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/id_and_unique_clustering_together_not_allowed.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlserver"
-    url = "dummy-url"
 }
 
 model A {
@@ -11,14 +10,14 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@id": A model can only hold one clustered index or id.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel A {
-// [1;94m 7 | [0m  id Int [1;91m@id[0m
+// [1;94m 5 | [0mmodel A {
+// [1;94m 6 | [0m  id Int [1;91m@id[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@@unique": A model can only hold one clustered index or key.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@unique([a], clustered: true)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@unique([a], clustered: true)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/non_boolean_index_clustering.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/non_boolean_index_clustering.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlserver"
-    url = "dummy-url"
 }
 
 model A {
@@ -9,8 +8,8 @@ model A {
 
 
 // [1;91merror[0m: [1mExpected a boolean value, but received literal value `meow`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel A {
-// [1;94m 7 | [0m  id Int @id(clustered: [1;91mmeow[0m)
+// [1;94m 5 | [0mmodel A {
+// [1;94m 6 | [0m  id Int @id(clustered: [1;91mmeow[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/non_clustered_compound_id_sqlite.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/non_clustered_compound_id_sqlite.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlite"
-    url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@id": Defining clustering is not supported in the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@id([left, right], clustered: false)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@id([left, right], clustered: false)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/non_clustered_id_sqlite.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/non_clustered_id_sqlite.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "sqlite"
-    url = "dummy-url"
 }
 
 model A {
@@ -8,8 +7,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@id": Defining clustering is not supported in the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel A {
-// [1;94m 7 | [0m  id Int [1;91m@id(clustered: false)[0m @map("_id")
+// [1;94m 5 | [0mmodel A {
+// [1;94m 6 | [0m  id Int [1;91m@id(clustered: false)[0m @map("_id")
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/on_mysql.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/on_mysql.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "mysql"
-    url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": Defining clustering is not supported in the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a], clustered: true)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a], clustered: true)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/index_clustering/on_postgres.prisma
+++ b/psl/psl/tests/validation/attributes/index_clustering/on_postgres.prisma
@@ -1,6 +1,5 @@
 datasource test {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": Defining clustering is not supported in the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a], clustered: true)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a], clustered: true)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/map/duplicate_models_with_map_on_both_sides.prisma
+++ b/psl/psl/tests/validation/attributes/map/duplicate_models_with_map_on_both_sides.prisma
@@ -1,6 +1,5 @@
 datasource mydb {
     provider = "sqlite"
-    url = env("TEST_DB_URL")
 }
 
 model Dog {
@@ -16,8 +15,8 @@ model Cat {
 }
 
 // [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model or view with this name exists: "Dog"[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  [1;91m@@map("pets")[0m
+// [1;94m13 | [0m
+// [1;94m14 | [0m  [1;91m@@map("pets")[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/map/mongodb_field_map_cannot_contain_periods.prisma
+++ b/psl/psl/tests/validation/attributes/map/mongodb_field_map_cannot_contain_periods.prisma
@@ -1,6 +1,5 @@
 datasource mydb {
     provider = "mongodb"
-    url = env("TEST_DB_URL")
 }
 
 model Foo {
@@ -9,8 +8,8 @@ model Foo {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@map": The field name cannot contain a `.` character[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id    Int    @id @map("_id")
-// [1;94m 8 | [0m  field String [1;91m@map("field.schwield")[0m
+// [1;94m 6 | [0m  id    Int    @id @map("_id")
+// [1;94m 7 | [0m  field String [1;91m@map("field.schwield")[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/map/mongodb_field_map_cannot_start_with_dollar_sign.prisma
+++ b/psl/psl/tests/validation/attributes/map/mongodb_field_map_cannot_start_with_dollar_sign.prisma
@@ -1,6 +1,5 @@
 datasource mydb {
     provider = "mongodb"
-    url = env("TEST_DB_URL")
 }
 
 model Foo {
@@ -9,8 +8,8 @@ model Foo {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@map": The field name cannot start with a `$` character[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id    Int    @id @map("_id")
-// [1;94m 8 | [0m  field String [1;91m@map("$field")[0m
+// [1;94m 6 | [0m  id    Int    @id @map("_id")
+// [1;94m 7 | [0m  field String [1;91m@map("$field")[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/nanoid/reject_string_column_with_int_256_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/nanoid/reject_string_column_with_int_256_arg_valid.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(nanoid(256))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `nanoid()` takes either no argument, or a single integer argument between 2 and 255.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(nanoid(256))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(nanoid(256))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/nanoid/require_int_argument.prisma
+++ b/psl/psl/tests/validation/attributes/nanoid/require_int_argument.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(nanoid("asdf"))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `nanoid()` takes a single Int argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(nanoid("asdf"))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(nanoid("asdf"))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/nanoid/require_minimum_value.prisma
+++ b/psl/psl/tests/validation/attributes/nanoid/require_minimum_value.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(nanoid(1))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `nanoid()` takes either no argument, or a single integer argument between 2 and 255.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(nanoid(1))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(nanoid(1))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/nanoid/require_string_column.prisma
+++ b/psl/psl/tests/validation/attributes/nanoid/require_string_column.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id Int @id @default(nanoid(1))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": The function `nanoid()` cannot be used on fields of type `Int`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id Int @id [1;91m@default(nanoid(1))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id Int @id [1;91m@default(nanoid(1))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/nanoid/string_column_with_length_valid.prisma
+++ b/psl/psl/tests/validation/attributes/nanoid/string_column_with_length_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/nanoid/string_column_with_no_argument_valid.prisma
+++ b/psl/psl/tests/validation/attributes/nanoid/string_column_with_no_argument_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/relation_mode/referential_integrity_attr_is_deprecated.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/referential_integrity_attr_is_deprecated.prisma
@@ -1,11 +1,10 @@
 datasource db {
   provider = "sqlite"
-  url = "sqlite"
   referentialIntegrity = "foreignKeys"
 }
 // [1;93mwarning[0m: [1mThe `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m  url = "sqlite"
-// [1;94m 4 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
+// [1;94m 2 | [0m  provider = "sqlite"
+// [1;94m 3 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
+++ b/psl/psl/tests/validation/attributes/relation_mode/relation_mode_and_referential_integrity_cannot_cooccur.prisma
@@ -1,18 +1,17 @@
 datasource db {
   provider = "sqlite"
-  url = "sqlite"
   relationMode = "prisma"
   referentialIntegrity = "foreignKeys"
 }
 // [1;93mwarning[0m: [1mThe `referentialIntegrity` attribute is deprecated. Please use `relationMode` instead. Learn more at https://pris.ly/d/relation-mode[0m
-//   [1;94m-->[0m  [4mschema.prisma:5[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
 // [1;94m   | [0m
-// [1;94m 4 | [0m  relationMode = "prisma"
-// [1;94m 5 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
+// [1;94m 3 | [0m  relationMode = "prisma"
+// [1;94m 4 | [0m  [1;93mreferentialIntegrity = "foreignKeys"[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mThe `referentialIntegrity` and `relationMode` attributes cannot be used together. Please use only `relationMode` instead.[0m
-//   [1;94m-->[0m  [4mschema.prisma:5[0m
+//   [1;94m-->[0m  [4mschema.prisma:4[0m
 // [1;94m   | [0m
-// [1;94m 4 | [0m  relationMode = "prisma"
-// [1;94m 5 | [0m  [1;91mreferentialIntegrity = "foreignKeys"[0m
+// [1;94m 3 | [0m  relationMode = "prisma"
+// [1;94m 4 | [0m  [1;91mreferentialIntegrity = "foreignKeys"[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/bad_schema_attribute.prisma
+++ b/psl/psl/tests/validation/attributes/schema/bad_schema_attribute.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public"]
 }
 
@@ -28,20 +27,20 @@ model Test2 {
 
 
 // [1;91merror[0m: [1mArgument "map" is missing.[0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m  id Int @id
-// [1;94m14 | [0m  [1;91m@@schema[0m
+// [1;94m12 | [0m  id Int @id
+// [1;94m13 | [0m  [1;91m@@schema[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mArgument "map" is missing.[0m
-//   [1;94m-->[0m  [4mschema.prisma:21[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
 // [1;94m   | [0m
-// [1;94m20 | [0m
-// [1;94m21 | [0m  [1;91m@@schema[0m
+// [1;94m19 | [0m
+// [1;94m20 | [0m  [1;91m@@schema[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a string value, but received numeric value `101`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:26[0m
+//   [1;94m-->[0m  [4mschema.prisma:25[0m
 // [1;94m   | [0m
-// [1;94m25 | [0m  id Int @id
-// [1;94m26 | [0m  @@schema([1;91m101[0m)
+// [1;94m24 | [0m  id Int @id
+// [1;94m25 | [0m  @@schema([1;91m101[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/enums_in_different_schemas_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/enums_in_different_schemas_with_same_mapped_name.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "dummy-url"
   schemas  = ["base", "transactional"]
 }
 

--- a/psl/psl/tests/validation/attributes/schema/enums_in_same_schema_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/enums_in_same_schema_with_same_mapped_name.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "dummy-url"
   schemas  = ["base", "transactional"]
 }
 
@@ -29,16 +28,16 @@ enum Size {
 }
 
 // [1;91merror[0m: [1mAn enum with the same database name is already defined.[0m
-//   [1;94m-->[0m  [4mschema.prisma:21[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
 // [1;94m   | [0m
-// [1;94m20 | [0m
-// [1;94m21 | [0m[1;91menum Size {[0m
-// [1;94m22 | [0m    SMALL
-// [1;94m23 | [0m    MEDIUM
-// [1;94m24 | [0m    LARGE
-// [1;94m25 | [0m    VENTI
-// [1;94m26 | [0m
-// [1;94m27 | [0m    @@map("attribute")
-// [1;94m28 | [0m    @@schema("transactional")
-// [1;94m29 | [0m}
+// [1;94m19 | [0m
+// [1;94m20 | [0m[1;91menum Size {[0m
+// [1;94m21 | [0m    SMALL
+// [1;94m22 | [0m    MEDIUM
+// [1;94m23 | [0m    LARGE
+// [1;94m24 | [0m    VENTI
+// [1;94m25 | [0m
+// [1;94m26 | [0m    @@map("attribute")
+// [1;94m27 | [0m    @@schema("transactional")
+// [1;94m28 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/missing_schema_annotations.prisma
+++ b/psl/psl/tests/validation/attributes/schema/missing_schema_annotations.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public", "security", "users"]
 }
 
@@ -28,20 +27,20 @@ enum UserType {
 }
 
 // [1;91merror[0m: [1mError validating model "Test": This model is missing an `@@schema` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m[1;91mmodel Test {[0m
-// [1;94m16 | [0m  id Int @id
-// [1;94m17 | [0m}
+// [1;94m13 | [0m
+// [1;94m14 | [0m[1;91mmodel Test {[0m
+// [1;94m15 | [0m  id Int @id
+// [1;94m16 | [0m}
 // [1;94m   | [0m
 // [1;91merror[0m: [1mThis enum is missing an `@@schema` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:24[0m
+//   [1;94m-->[0m  [4mschema.prisma:23[0m
 // [1;94m   | [0m
-// [1;94m23 | [0m
-// [1;94m24 | [0m[1;91menum UserType {[0m
-// [1;94m25 | [0m  Bacteria
-// [1;94m26 | [0m  Archea
-// [1;94m27 | [0m  Eukaryote
-// [1;94m28 | [0m}
+// [1;94m22 | [0m
+// [1;94m23 | [0m[1;91menum UserType {[0m
+// [1;94m24 | [0m  Bacteria
+// [1;94m25 | [0m  Archea
+// [1;94m26 | [0m  Eukaryote
+// [1;94m27 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/multiple_schemas_valid.prisma
+++ b/psl/psl/tests/validation/attributes/schema/multiple_schemas_valid.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public", "security", "users"]
 }
 

--- a/psl/psl/tests/validation/attributes/schema/no_schema_attributes.prisma
+++ b/psl/psl/tests/validation/attributes/schema/no_schema_attributes.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["public", "security", "users"]
 }
 
@@ -26,28 +25,28 @@ enum UserType {
     Eukaryote
 }
 // [1;91merror[0m: [1mError validating model "Test": This model is missing an `@@schema` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m[1;91mmodel Test {[0m
-// [1;94m16 | [0m    id Int @id
-// [1;94m17 | [0m}
+// [1;94m13 | [0m
+// [1;94m14 | [0m[1;91mmodel Test {[0m
+// [1;94m15 | [0m    id Int @id
+// [1;94m16 | [0m}
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating model "Test2": This model is missing an `@@schema` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:19[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
 // [1;94m   | [0m
-// [1;94m18 | [0m
-// [1;94m19 | [0m[1;91mmodel Test2 {[0m
-// [1;94m20 | [0m    id Int @id
-// [1;94m21 | [0m}
+// [1;94m17 | [0m
+// [1;94m18 | [0m[1;91mmodel Test2 {[0m
+// [1;94m19 | [0m    id Int @id
+// [1;94m20 | [0m}
 // [1;94m   | [0m
 // [1;91merror[0m: [1mThis enum is missing an `@@schema` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:23[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
-// [1;94m22 | [0m
-// [1;94m23 | [0m[1;91menum UserType {[0m
-// [1;94m24 | [0m    Bacteria
-// [1;94m25 | [0m    Archea
-// [1;94m26 | [0m    Eukaryote
-// [1;94m27 | [0m}
+// [1;94m21 | [0m
+// [1;94m22 | [0m[1;91menum UserType {[0m
+// [1;94m23 | [0m    Bacteria
+// [1;94m24 | [0m    Archea
+// [1;94m25 | [0m    Eukaryote
+// [1;94m26 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/non_existing_schema.prisma
+++ b/psl/psl/tests/validation/attributes/schema/non_existing_schema.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public"]
 }
 
@@ -25,14 +24,14 @@ enum Language {
 
 
 // [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  @@schema([1;91m"nonpublic"[0m)
+// [1;94m13 | [0m
+// [1;94m14 | [0m  @@schema([1;91m"nonpublic"[0m)
 // [1;94m   | [0m
 // [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema[0m
-//   [1;94m-->[0m  [4mschema.prisma:22[0m
+//   [1;94m-->[0m  [4mschema.prisma:21[0m
 // [1;94m   | [0m
-// [1;94m21 | [0m
-// [1;94m22 | [0m  @@schema([1;91m"nonpublic"[0m)
+// [1;94m20 | [0m
+// [1;94m21 | [0m  @@schema([1;91m"nonpublic"[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/on_mysql.prisma
+++ b/psl/psl/tests/validation/attributes/schema/on_mysql.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "mysql"
-    url = "dummy-url"
     schemas = ["public", "sphere"]
 }
 
@@ -17,8 +16,8 @@ model Test {
 
 
 // [1;91merror[0m: [1mThe `schemas` property is not supported on the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "dummy-url"
-// [1;94m 4 | [0m    schemas = [1;91m["public", "sphere"][0m
+// [1;94m 2 | [0m    provider = "mysql"
+// [1;94m 3 | [0m    schemas = [1;91m["public", "sphere"][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/on_sqlite.prisma
+++ b/psl/psl/tests/validation/attributes/schema/on_sqlite.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "sqlite"
-    url = "dummy-url"
     schemas = ["public", "sphere"]
 }
 
@@ -17,8 +16,8 @@ model Test {
 
 
 // [1;91merror[0m: [1mThe `schemas` property is not supported on the current connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "dummy-url"
-// [1;94m 4 | [0m    schemas = [1;91m["public", "sphere"][0m
+// [1;94m 2 | [0m    provider = "sqlite"
+// [1;94m 3 | [0m    schemas = [1;91m["public", "sphere"][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/repeated_schema_attribute.prisma
+++ b/psl/psl/tests/validation/attributes/schema/repeated_schema_attribute.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public", "private"]
 }
 
@@ -25,14 +24,14 @@ enum toggle {
 
 
 // [1;91merror[0m: [1mAttribute "@schema" can only be defined once.[0m
-//   [1;94m-->[0m  [4mschema.prisma:21[0m
+//   [1;94m-->[0m  [4mschema.prisma:20[0m
 // [1;94m   | [0m
-// [1;94m20 | [0m
-// [1;94m21 | [0m  [1;91m@@schema("public")[0m
+// [1;94m19 | [0m
+// [1;94m20 | [0m  [1;91m@@schema("public")[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mAttribute "@schema" can only be defined once.[0m
-//   [1;94m-->[0m  [4mschema.prisma:22[0m
+//   [1;94m-->[0m  [4mschema.prisma:21[0m
 // [1;94m   | [0m
-// [1;94m21 | [0m  @@schema("public")
-// [1;94m22 | [0m  [1;91m@@schema("private")[0m
+// [1;94m20 | [0m  @@schema("public")
+// [1;94m21 | [0m  [1;91m@@schema("private")[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/tables_in_different_schemas_with_same_constraint_names.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_different_schemas_with_same_constraint_names.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["base", "transactional"]
 }
 

--- a/psl/psl/tests/validation/attributes/schema/tables_in_different_schemas_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_different_schemas_with_same_mapped_name.prisma
@@ -7,7 +7,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "dummy-url"
   schemas  = ["base", "transactional"]
 }
 

--- a/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_constraint_names.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_constraint_names.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = "dummy-url"
     schemas  = ["base", "transactional"]
 }
 
@@ -29,20 +28,20 @@ model Post {
 }
 
 // [1;91merror[0m: [1mThe model with database name "some_table" could not be defined because another model or view with this name exists: "User"[0m
-//   [1;94m-->[0m  [4mschema.prisma:27[0m
+//   [1;94m-->[0m  [4mschema.prisma:26[0m
 // [1;94m   | [0m
-// [1;94m26 | [0m
-// [1;94m27 | [0m    [1;91m@@map("some_table")[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError parsing attribute "@id": The given constraint name `some_table_pkey` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
-// [1;94m   | [0m
-// [1;94m12 | [0mmodel User {
-// [1;94m13 | [0m    id    String [1;91m@id [0m@default(cuid())
+// [1;94m25 | [0m
+// [1;94m26 | [0m    [1;91m@@map("some_table")[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@id": The given constraint name `some_table_pkey` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:22[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m21 | [0mmodel Post {
-// [1;94m22 | [0m    id       String [1;91m@id [0m@default(cuid())
+// [1;94m11 | [0mmodel User {
+// [1;94m12 | [0m    id    String [1;91m@id [0m@default(cuid())
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError parsing attribute "@id": The given constraint name `some_table_pkey` has to be unique in the following namespace: global for primary key, indexes and unique constraints. Please provide a different name using the `map` argument.[0m
+//   [1;94m-->[0m  [4mschema.prisma:21[0m
+// [1;94m   | [0m
+// [1;94m20 | [0mmodel Post {
+// [1;94m21 | [0m    id       String [1;91m@id [0m@default(cuid())
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_mapped_name.prisma
+++ b/psl/psl/tests/validation/attributes/schema/tables_in_same_schema_with_same_mapped_name.prisma
@@ -1,6 +1,5 @@
 datasource mydb {
   provider = "sqlserver"
-  url = env("TEST_DB_URL")
   schemas  = ["base", "transactional"]
 }
 
@@ -25,8 +24,8 @@ model Cat {
 }
 
 // [1;91merror[0m: [1mThe model with database name "pets" could not be defined because another model or view with this name exists: "Dog"[0m
-//   [1;94m-->[0m  [4mschema.prisma:23[0m
+//   [1;94m-->[0m  [4mschema.prisma:22[0m
 // [1;94m   | [0m
-// [1;94m22 | [0m
-// [1;94m23 | [0m  [1;91m@@map("pets")[0m
+// [1;94m21 | [0m
+// [1;94m22 | [0m  [1;91m@@map("pets")[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/schema/with_single_schema.prisma
+++ b/psl/psl/tests/validation/attributes/schema/with_single_schema.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public"]
 }
 

--- a/psl/psl/tests/validation/attributes/schema/with_single_schema_sqlserver.prisma
+++ b/psl/psl/tests/validation/attributes/schema/with_single_schema_sqlserver.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "sqlserver"
-    url = "dummy-url"
     schemas = ["public"]
 }
 

--- a/psl/psl/tests/validation/attributes/schema/without_preview_feature.prisma
+++ b/psl/psl/tests/validation/attributes/schema/without_preview_feature.prisma
@@ -1,6 +1,5 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model Test {
@@ -10,8 +9,8 @@ model Test {
 }
 
 // [1;91merror[0m: [1mThis schema is not defined in the datasource. Read more on `@@schema` at https://pris.ly/d/multi-schema[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m
-// [1;94m 9 | [0m    @@schema([1;91m"public"[0m)
+// [1;94m 7 | [0m
+// [1;94m 8 | [0m    @@schema([1;91m"public"[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/args_are_not_allowed.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/args_are_not_allowed.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -16,14 +15,14 @@ model A {
 }
 
 // [1;91merror[0m: [1mExpected a constant value, but received functional value `a(length: 10)`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  @@shardKey([[1;91ma(length: 10)[0m, b(length: 30)])
+// [1;94m13 | [0m
+// [1;94m14 | [0m  @@shardKey([[1;91ma(length: 10)[0m, b(length: 30)])
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a constant value, but received functional value `b(length: 30)`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  @@shardKey([a(length: 10), [1;91mb(length: 30)[0m])
+// [1;94m13 | [0m
+// [1;94m14 | [0m  @@shardKey([a(length: 10), [1;91mb(length: 30)[0m])
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/args_are_not_allowed_on_field.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/args_are_not_allowed_on_field.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -14,8 +13,8 @@ model Post {
 }
 
 // [1;91merror[0m: [1mNo such argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  title  String @id
-// [1;94m13 | [0m  region String @shardKey([1;91mtype: "string"[0m)
+// [1;94m11 | [0m  title  String @id
+// [1;94m12 | [0m  region String @shardKey([1;91mtype: "string"[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/disabled_preview_feature.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/disabled_preview_feature.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 model User {
@@ -8,8 +7,8 @@ model User {
   region String @shardKey
 }
 // [1;91merror[0m: [1mError parsing attribute "@shardKey": Defining shard keys requires enabling the `shardKeys` preview feature[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id     String @id
-// [1;94m 8 | [0m  region String [1;91m@shardKey[0m
+// [1;94m 6 | [0m  id     String @id
+// [1;94m 7 | [0m  region String [1;91m@shardKey[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/duplicate.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/duplicate.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -24,25 +23,25 @@ model B {
 }
 
 // [1;91merror[0m: [1mError validating model "A": At most one field must be marked as the shard key with the `@shardKey` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m
-// [1;94m11 | [0m[1;91mmodel A {[0m
-// [1;94m12 | [0m  a String @id
-// [1;94m13 | [0m  b String @shardKey
-// [1;94m14 | [0m  c String @shardKey
-// [1;94m15 | [0m}
+// [1;94m 9 | [0m
+// [1;94m10 | [0m[1;91mmodel A {[0m
+// [1;94m11 | [0m  a String @id
+// [1;94m12 | [0m  b String @shardKey
+// [1;94m13 | [0m  c String @shardKey
+// [1;94m14 | [0m}
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating model "B": Each model must have at most one shard key. You can't have `@shardKey` and `@@shardKey` at the same time.[0m
-//   [1;94m-->[0m  [4mschema.prisma:17[0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
-// [1;94m16 | [0m
-// [1;94m17 | [0m[1;91mmodel B {[0m
-// [1;94m18 | [0m  a String @id
-// [1;94m19 | [0m  b String @shardKey
-// [1;94m20 | [0m  c String
-// [1;94m21 | [0m  d String
-// [1;94m22 | [0m
-// [1;94m23 | [0m  @@shardKey([b, c])
-// [1;94m24 | [0m}
+// [1;94m15 | [0m
+// [1;94m16 | [0m[1;91mmodel B {[0m
+// [1;94m17 | [0m  a String @id
+// [1;94m18 | [0m  b String @shardKey
+// [1;94m19 | [0m  c String
+// [1;94m20 | [0m  d String
+// [1;94m21 | [0m
+// [1;94m22 | [0m  @@shardKey([b, c])
+// [1;94m23 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/empty.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/empty.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -15,8 +14,8 @@ model User {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@shardKey": The list of fields in a `@@shardKey()` attribute cannot be empty. Please specify at least one field.[0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m
-// [1;94m14 | [0m  [1;91m@@shardKey([])[0m
+// [1;94m12 | [0m
+// [1;94m13 | [0m  [1;91m@@shardKey([])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/optional_multi_shard_key.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/optional_multi_shard_key.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -16,8 +15,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError validating model "A": The shard key definition refers to the optional field `b`. Shard key definitions must reference only required fields.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
 // [1;94m   | [0m
-// [1;94m14 | [0m
-// [1;94m15 | [0m  [1;91m@@shardKey([a, b])[0m
+// [1;94m13 | [0m
+// [1;94m14 | [0m  [1;91m@@shardKey([a, b])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/optional_multi_shard_key_ignored.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/optional_multi_shard_key_ignored.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {

--- a/psl/psl/tests/validation/attributes/shard_key/optional_shard_key.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/optional_shard_key.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -14,8 +13,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@shardKey": Fields that are marked as shard keys must be required.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  a String  @id
-// [1;94m13 | [0m  b String? [1;91m@shardKey[0m
+// [1;94m11 | [0m  a String  @id
+// [1;94m12 | [0m  b String? [1;91m@shardKey[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/optional_shard_key_ignored.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/optional_shard_key_ignored.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {

--- a/psl/psl/tests/validation/attributes/shard_key/relation_fields.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/relation_fields.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -22,8 +21,8 @@ model Identification {
 }
 
 // [1;91merror[0m: [1mError validating model "User": The shard key definition refers to the relation field `identification`. Shard key definitions must reference only scalar fields.[0m
-//   [1;94m-->[0m  [4mschema.prisma:17[0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
-// [1;94m16 | [0m
-// [1;94m17 | [0m  [1;91m@@shardKey([identification])[0m
+// [1;94m15 | [0m
+// [1;94m16 | [0m  [1;91m@@shardKey([identification])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/string_field_names.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/string_field_names.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -17,14 +16,14 @@ model User {
 }
 
 // [1;91merror[0m: [1mExpected a constant value, but received string value `"firstName"`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m
-// [1;94m16 | [0m  @@shardKey([[1;91m"firstName"[0m, "lastName"])
+// [1;94m14 | [0m
+// [1;94m15 | [0m  @@shardKey([[1;91m"firstName"[0m, "lastName"])
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a constant value, but received string value `"lastName"`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m
-// [1;94m16 | [0m  @@shardKey(["firstName", [1;91m"lastName"[0m])
+// [1;94m14 | [0m
+// [1;94m15 | [0m  @@shardKey(["firstName", [1;91m"lastName"[0m])
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/unknown_field.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/unknown_field.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("url")
 }
 
 generator client {
@@ -15,8 +14,8 @@ model User {
 }
 
 // [1;91merror[0m: [1mError validating model "User": The multi field shard key declaration refers to the unknown fields `foo`, `bar`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m
-// [1;94m14 | [0m  @@shardKey([1;91m[foo, bar][0m)
+// [1;94m12 | [0m
+// [1;94m13 | [0m  @@shardKey([1;91m[foo, bar][0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/shard_key/unsupported_provider.prisma
+++ b/psl/psl/tests/validation/attributes/shard_key/unsupported_provider.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = env("url")
 }
 
 generator client {
@@ -13,8 +12,8 @@ model User {
   region String @shardKey
 }
 // [1;91merror[0m: [1mError parsing attribute "@shardKey": Shard keys are not currently supported for provider mongodb[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  id     String @id @map("_id") @db.ObjectId
-// [1;94m13 | [0m  region String [1;91m@shardKey[0m
+// [1;94m11 | [0m  id     String @id @map("_id") @db.ObjectId
+// [1;94m12 | [0m  region String [1;91m@shardKey[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/ulid/require_string_column.prisma
+++ b/psl/psl/tests/validation/attributes/ulid/require_string_column.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = "does_not_matter"
 }
 
 model Category {
@@ -8,8 +7,8 @@ model Category {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@default": The function `ulid()` cannot be used on fields of type `Int`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id Int @id [1;91m@default(ulid())[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id Int @id [1;91m@default(ulid())[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/ulid/string_column_with_no_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/ulid/string_column_with_no_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/uuid/reject_random_int.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/reject_random_int.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(uuid(42))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `uuid()` takes either no argument, or a single integer argument which is either 4 or 7.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(uuid(42))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(uuid(42))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/uuid/reject_string_argument.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/reject_string_argument.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(uuid("asdf"))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `uuid()` takes a single Int argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(uuid("asdf"))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(uuid("asdf"))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/uuid/reject_string_column_with_int_256_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/reject_string_column_with_int_256_arg_valid.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id String @id @default(uuid(256))
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": `uuid()` takes either no argument, or a single integer argument which is either 4 or 7.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id String @id [1;91m@default(uuid(256))[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id String @id [1;91m@default(uuid(256))[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/uuid/require_string_column.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/require_string_column.prisma
@@ -1,14 +1,13 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {
   id Int @id @default(uuid())
 }
 // [1;91merror[0m: [1mError parsing attribute "@default": The function `uuid()` cannot be used on fields of type `Int`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel Category {
-// [1;94m 7 | [0m  id Int @id [1;91m@default(uuid())[0m
+// [1;94m 5 | [0mmodel Category {
+// [1;94m 6 | [0m  id Int @id [1;91m@default(uuid())[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/attributes/uuid/string_column_with_int_4_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/string_column_with_int_4_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/uuid/string_column_with_int_7_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/string_column_with_int_7_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/attributes/uuid/string_column_with_no_arg_valid.prisma
+++ b/psl/psl/tests/validation/attributes/uuid/string_column_with_no_arg_valid.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "does_not_matter"
 }
 
 model Category {

--- a/psl/psl/tests/validation/capabilities/mongodb_does_not_support_autoincrement.prisma
+++ b/psl/psl/tests/validation/capabilities/mongodb_does_not_support_autoincrement.prisma
@@ -1,6 +1,5 @@
 datasource mydb {
     provider = "mongodb"
-    url = env("TEST_DB_URL")
 }
 
 model User {
@@ -9,8 +8,8 @@ model User {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@default": The `autoincrement()` default value is used with a datasource that does not support it.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mmodel User {
-// [1;94m 7 | [0m  id Int @id [1;91m@default(autoincrement())[0m @map("_id")
+// [1;94m 5 | [0mmodel User {
+// [1;94m 6 | [0m  id Int @id [1;91m@default(autoincrement())[0m @map("_id")
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/capabilities/mongodb_supports_composite_types.prisma
+++ b/psl/psl/tests/validation/capabilities/mongodb_supports_composite_types.prisma
@@ -1,6 +1,5 @@
 datasource mydb {
     provider = "mongodb"
-    url = env("TEST_DB_URL")
 }
 
 

--- a/psl/psl/tests/validation/cockroachdb/negative_time_precision.prisma
+++ b/psl/psl/tests/validation/cockroachdb/negative_time_precision.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "cockroachdb"
-  url      = env("DATABASE_URL")
 }
 
 model User {
@@ -10,14 +9,14 @@ model User {
 }
 
 // [1;91merror[0m: [1mExpected a nonnegative integer, but found (-1).[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id   Int      @id
-// [1;94m 8 | [0m  val  DateTime [1;91m@db.Timestamp(-1)[0m
+// [1;94m 6 | [0m  id   Int      @id
+// [1;94m 7 | [0m  val  DateTime [1;91m@db.Timestamp(-1)[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a nonnegative integer, but found (-1).[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  val  DateTime @db.Timestamp(-1)
-// [1;94m 9 | [0m  val2 DateTime [1;91m@db.Time(-1)[0m
+// [1;94m 7 | [0m  val  DateTime @db.Timestamp(-1)
+// [1;94m 8 | [0m  val2 DateTime [1;91m@db.Time(-1)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/composite_types/ignore_field_attribute_is_not_allowed.prisma
+++ b/psl/psl/tests/validation/composite_types/ignore_field_attribute_is_not_allowed.prisma
@@ -1,6 +1,5 @@
 datasource mdb {
   provider = "mongodb"
-  url = env("TESTDBURL")
 }
 
 type A {
@@ -17,8 +16,8 @@ model B {
 
 
 // [1;91merror[0m: [1mAttribute not known: "@ignore".[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  name String
-// [1;94m 8 | [0m  c String [1;91m@ignore[0m
+// [1;94m 6 | [0m  name String
+// [1;94m 7 | [0m  c String [1;91m@ignore[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/composite_types/index_attributes_on_composite_types.prisma
+++ b/psl/psl/tests/validation/composite_types/index_attributes_on_composite_types.prisma
@@ -1,6 +1,5 @@
 datasource mdb {
   provider = "mongodb"
-  url = env("TESTDBURL")
 }
 
 type A {
@@ -23,52 +22,52 @@ model B {
 
 
 // [1;91merror[0m: [1mError validating: Defining `@id` attribute for a field in a composite type is not allowed.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype A {
-// [1;94m 7 | [0m    [1;91mpk String @id[0m
-// [1;94m 8 | [0m    field Int @unique
+// [1;94m 5 | [0mtype A {
+// [1;94m 6 | [0m    [1;91mpk String @id[0m
+// [1;94m 7 | [0m    field Int @unique
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Defining `@unique` attribute for a field in a composite type is not allowed.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
-// [1;94m   | [0m
-// [1;94m 7 | [0m    pk String @id
-// [1;94m 8 | [0m    [1;91mfield Int @unique[0m
-// [1;94m 9 | [0m    content String
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError validating: A composite type cannot define an id.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
-// [1;94m   | [0m
-// [1;94m12 | [0m
-// [1;94m13 | [0m    [1;91m@@id([pk])[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError validating: A fulltext index should be defined in the model containing the embed.[0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
-// [1;94m   | [0m
-// [1;94m13 | [0m    @@id([pk])
-// [1;94m14 | [0m    [1;91m@@fulltext([content])[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError validating: An index should be defined in the model containing the embed.[0m
-//   [1;94m-->[0m  [4mschema.prisma:15[0m
-// [1;94m   | [0m
-// [1;94m14 | [0m    @@fulltext([content])
-// [1;94m15 | [0m    [1;91m@@index([other, field])[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError validating: A unique constraint should be defined in the model containing the embed.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
-// [1;94m   | [0m
-// [1;94m15 | [0m    @@index([other, field])
-// [1;94m16 | [0m    [1;91m@@unique([content, rank])[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mAttribute not known: "@id".[0m
 //   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype A {
-// [1;94m 7 | [0m    pk String [1;91m@id[0m
+// [1;94m 6 | [0m    pk String @id
+// [1;94m 7 | [0m    [1;91mfield Int @unique[0m
+// [1;94m 8 | [0m    content String
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: A composite type cannot define an id.[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
+// [1;94m   | [0m
+// [1;94m11 | [0m
+// [1;94m12 | [0m    [1;91m@@id([pk])[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: A fulltext index should be defined in the model containing the embed.[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
+// [1;94m   | [0m
+// [1;94m12 | [0m    @@id([pk])
+// [1;94m13 | [0m    [1;91m@@fulltext([content])[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: An index should be defined in the model containing the embed.[0m
+//   [1;94m-->[0m  [4mschema.prisma:14[0m
+// [1;94m   | [0m
+// [1;94m13 | [0m    @@fulltext([content])
+// [1;94m14 | [0m    [1;91m@@index([other, field])[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: A unique constraint should be defined in the model containing the embed.[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
+// [1;94m   | [0m
+// [1;94m14 | [0m    @@index([other, field])
+// [1;94m15 | [0m    [1;91m@@unique([content, rank])[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mAttribute not known: "@id".[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
+// [1;94m   | [0m
+// [1;94m 5 | [0mtype A {
+// [1;94m 6 | [0m    pk String [1;91m@id[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mAttribute not known: "@unique".[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m    pk String @id
-// [1;94m 8 | [0m    field Int [1;91m@unique[0m
+// [1;94m 6 | [0m    pk String @id
+// [1;94m 7 | [0m    field Int [1;91m@unique[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/composite_types/map_field_attribute_is_allowed.prisma
+++ b/psl/psl/tests/validation/composite_types/map_field_attribute_is_allowed.prisma
@@ -1,6 +1,5 @@
 datasource mdb {
   provider = "mongodb"
-  url = env("TESTDBURL")
 }
 
 type A {

--- a/psl/psl/tests/validation/composite_types/relation_field_attribute_not_allowed.prisma
+++ b/psl/psl/tests/validation/composite_types/relation_field_attribute_not_allowed.prisma
@@ -1,6 +1,5 @@
 datasource mdb {
   provider = "mongodb"
-  url = env("TESTDBURL")
 }
 
 type C {
@@ -18,15 +17,15 @@ model B {
 
 
 // [1;91merror[0m: [1mError validating: Defining `@relation` attribute for a field in a composite type is not allowed.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0mtype A {
-// [1;94m11 | [0m  [1;91mc C[] @relation("foo")[0m
-// [1;94m12 | [0m}
+// [1;94m 9 | [0mtype A {
+// [1;94m10 | [0m  [1;91mc C[] @relation("foo")[0m
+// [1;94m11 | [0m}
 // [1;94m   | [0m
 // [1;91merror[0m: [1mAttribute not known: "@relation".[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0mtype A {
-// [1;94m11 | [0m  c C[] [1;91m@relation("foo")[0m
+// [1;94m 9 | [0mtype A {
+// [1;94m10 | [0m  c C[] [1;91m@relation("foo")[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/composite_types/unique_index_field_clash.prisma
+++ b/psl/psl/tests/validation/composite_types/unique_index_field_clash.prisma
@@ -1,6 +1,5 @@
 datasource mdb {
   provider = "mongodb"
-  url = env("TESTDBURL")
 }
 
 type Street {
@@ -29,8 +28,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError validating model "A": The field `name_my_location_address_street_description` clashes with the `@@unique` name. Please resolve the conflict by providing a custom id name: `@@unique([...], name: "custom_name")`[0m
-//   [1;94m-->[0m  [4mschema.prisma:25[0m
+//   [1;94m-->[0m  [4mschema.prisma:24[0m
 // [1;94m   | [0m
-// [1;94m24 | [0m
-// [1;94m25 | [0m  [1;91m@@unique([name, my_location.address.street.description])[0m
+// [1;94m23 | [0m
+// [1;94m24 | [0m  [1;91m@@unique([name, my_location.address.street.description])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/direct_url_same_as_shadow.prisma
+++ b/psl/psl/tests/validation/datasource/direct_url_same_as_shadow.prisma
@@ -1,19 +1,18 @@
 datasource testds {
     provider = "mysql"
-    url = "mysql://testurl"
     directUrl = "mysql://testurl"
     shadowDatabaseUrl = "mysql://testurl"
 }
 
 // [1;91merror[0m: [1mThe datasource property `shadowDatabaseUrl` is no longer supported in schema files. Move connection URLs to `prisma.config.ts`. See https://pris.ly/d/config-datasource[0m
-//   [1;94m-->[0m  [4mschema.prisma:5[0m
-// [1;94m   | [0m
-// [1;94m 4 | [0m    directUrl = "mysql://testurl"
-// [1;94m 5 | [0m    [1;91mshadowDatabaseUrl = "mysql://testurl"[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mThe datasource property `directUrl` is no longer supported in schema files. Move connection URLs to `prisma.config.ts`. See https://pris.ly/d/config-datasource[0m
 //   [1;94m-->[0m  [4mschema.prisma:4[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "mysql://testurl"
-// [1;94m 4 | [0m    [1;91mdirectUrl = "mysql://testurl"[0m
+// [1;94m 3 | [0m    directUrl = "mysql://testurl"
+// [1;94m 4 | [0m    [1;91mshadowDatabaseUrl = "mysql://testurl"[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mThe datasource property `directUrl` is no longer supported in schema files. Move connection URLs to `prisma.config.ts`. See https://pris.ly/d/config-datasource[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
+// [1;94m   | [0m
+// [1;94m 2 | [0m    provider = "mysql"
+// [1;94m 3 | [0m    [1;91mdirectUrl = "mysql://testurl"[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/duplicates_in_schemas.prisma
+++ b/psl/psl/tests/validation/datasource/duplicates_in_schemas.prisma
@@ -1,18 +1,17 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["one", "two", "two", "three", "three"]
 }
 
 // [1;91merror[0m: [1mDuplicated schema names are not allowed[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "dummy-url"
-// [1;94m 4 | [0m    schemas = ["one", "two", "two", [1;91m"three"[0m, "three"]
+// [1;94m 2 | [0m    provider = "postgresql"
+// [1;94m 3 | [0m    schemas = ["one", "two", "two", [1;91m"three"[0m, "three"]
 // [1;94m   | [0m
 // [1;91merror[0m: [1mDuplicated schema names are not allowed[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "dummy-url"
-// [1;94m 4 | [0m    schemas = ["one", [1;91m"two"[0m, "two", "three", "three"]
+// [1;94m 2 | [0m    provider = "postgresql"
+// [1;94m 3 | [0m    schemas = ["one", [1;91m"two"[0m, "two", "three", "three"]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/schemas_array_with_non_string_values.prisma
+++ b/psl/psl/tests/validation/datasource/schemas_array_with_non_string_values.prisma
@@ -1,19 +1,18 @@
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["one", 2, ["three"]]
 }
 
 
 // [1;91merror[0m: [1mExpected a string value, but received numeric value `2`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "dummy-url"
-// [1;94m 4 | [0m    schemas = ["one", [1;91m2[0m, ["three"]]
+// [1;94m 2 | [0m    provider = "postgresql"
+// [1;94m 3 | [0m    schemas = ["one", [1;91m2[0m, ["three"]]
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a string value, but received array value `["three"]`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "dummy-url"
-// [1;94m 4 | [0m    schemas = ["one", 2, [1;91m["three"][0m]
+// [1;94m 2 | [0m    provider = "postgresql"
+// [1;94m 3 | [0m    schemas = ["one", 2, [1;91m["three"][0m]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/url_empty_named_arg.prisma
+++ b/psl/psl/tests/validation/datasource/url_empty_named_arg.prisma
@@ -1,11 +1,4 @@
 datasource testds {
     provider = "mysql"
-    url      = env(named: )
 }
 
-// [1;91merror[0m: [1mThe env function expects a singular, unnamed, string argument.[0m
-//   [1;94m-->[0m  [4mschema.prisma:3[0m
-// [1;94m   | [0m
-// [1;94m 2 | [0m    provider = "mysql"
-// [1;94m 3 | [0m    url      = [1;91menv(named: )[0m
-// [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/url_named_arg.prisma
+++ b/psl/psl/tests/validation/datasource/url_named_arg.prisma
@@ -1,11 +1,4 @@
 datasource testds {
     provider = "mysql"
-    url      = env(named: "DATABASE_URL")
 }
 
-// [1;93mwarning[0m: [1mThe env function doesn't expect named arguments[0m
-//   [1;94m-->[0m  [4mschema.prisma:3[0m
-// [1;94m   | [0m
-// [1;94m 2 | [0m    provider = "mysql"
-// [1;94m 3 | [0m    url      = env([1;93mnamed: "DATABASE_URL"[0m)
-// [1;94m   | [0m

--- a/psl/psl/tests/validation/datasource/url_same_as_shadow.prisma
+++ b/psl/psl/tests/validation/datasource/url_same_as_shadow.prisma
@@ -1,12 +1,11 @@
 datasource testds {
     provider = "mysql"
-    url = "mysql://testurl"
     shadowDatabaseUrl = "mysql://testurl"
 }
 
 // [1;91merror[0m: [1mThe datasource property `shadowDatabaseUrl` is no longer supported in schema files. Move connection URLs to `prisma.config.ts`. See https://pris.ly/d/config-datasource[0m
-//   [1;94m-->[0m  [4mschema.prisma:4[0m
+//   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
-// [1;94m 3 | [0m    url = "mysql://testurl"
-// [1;94m 4 | [0m    [1;91mshadowDatabaseUrl = "mysql://testurl"[0m
+// [1;94m 2 | [0m    provider = "mysql"
+// [1;94m 3 | [0m    [1;91mshadowDatabaseUrl = "mysql://testurl"[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/enums/value_with_non_ascii_ident_should_not_error.prisma
+++ b/psl/psl/tests/validation/enums/value_with_non_ascii_ident_should_not_error.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 enum CatVariant {

--- a/psl/psl/tests/validation/generator/multiple_prisma_clients.prisma
+++ b/psl/psl/tests/validation/generator/multiple_prisma_clients.prisma
@@ -11,5 +11,4 @@ generator edge {
 
 datasource db {
   provider  = "postgresql"
-  url       = env("DATABASE_URL")
 }

--- a/psl/psl/tests/validation/generator/multiple_prisma_clients_same_name.prisma
+++ b/psl/psl/tests/validation/generator/multiple_prisma_clients_same_name.prisma
@@ -11,7 +11,6 @@ generator client {
 
 datasource db {
   provider  = "postgresql"
-  url       = env("DATABASE_URL")
 }
 // [1;91merror[0m: [1mThe generator "client" cannot be defined because a generator with that name already exists.[0m
 //   [1;94m-->[0m  [4mschema.prisma:6[0m

--- a/psl/psl/tests/validation/models/field_with_non_ascii_ident_should_not_error.prisma
+++ b/psl/psl/tests/validation/models/field_with_non_ascii_ident_should_not_error.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model A {

--- a/psl/psl/tests/validation/models/field_with_same_map_should_not_error.prisma
+++ b/psl/psl/tests/validation/models/field_with_same_map_should_not_error.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model User {

--- a/psl/psl/tests/validation/models/model_with_non_ascii_ident_should_not_error.prisma
+++ b/psl/psl/tests/validation/models/model_with_non_ascii_ident_should_not_error.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
 }
 
 model Lööp {

--- a/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_no_warning_when_relation_mode_prisma.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "mysql"
-    url = "mysql://"
     relationMode = "prisma"
 }
 
@@ -19,20 +18,20 @@ model B {
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
 // [1;93mwarning[0m: [1mWith `relationMode = "prisma"`, no foreign keys are used, so relation fields will not benefit from the index usually created by the relational database under the hood. This can lead to poor performance when querying these fields. We recommend adding an index manually. Learn more at https://pris.ly/d/relation-mode-prisma-indexes" [0m
-//   [1;94m-->[0m  [4mschema.prisma:19[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
 // [1;94m   | [0m
-// [1;94m18 | [0m    aId Int? @default(3)
-// [1;94m19 | [0m    a   A?   [1;93m@relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
-//   [1;94m-->[0m  [4mschema.prisma:19[0m
-// [1;94m   | [0m
-// [1;94m18 | [0m    aId Int? @default(3)
-// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
+// [1;94m17 | [0m    aId Int? @default(3)
+// [1;94m18 | [0m    a   A?   [1;93m@relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
-//   [1;94m-->[0m  [4mschema.prisma:19[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
 // [1;94m   | [0m
-// [1;94m18 | [0m    aId Int? @default(3)
-// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m17 | [0m    aId Int? @default(3)
+// [1;94m18 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;91monDelete: SetDefault[0m)
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError validating: Invalid referential action: `SetDefault`. Allowed values: (`Cascade`, `Restrict`, `NoAction`, `SetNull`)[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
+// [1;94m   | [0m
+// [1;94m17 | [0m    aId Int? @default(3)
+// [1;94m18 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;91monUpdate: SetDefault[0m, onDelete: SetDefault)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_warning.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning.prisma
@@ -1,6 +1,5 @@
 datasource db {
     provider = "mysql"
-    url = "mysql://"
 }
 
 model A {
@@ -14,14 +13,14 @@ model B {
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
 // [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m    aId Int? @default(3)
-// [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
+// [1;94m12 | [0m    aId Int? @default(3)
+// [1;94m13 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m    aId Int? @default(3)
-// [1;94m14 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m12 | [0m    aId Int? @default(3)
+// [1;94m13 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
+++ b/psl/psl/tests/validation/mysql/set_default_warning_when_relation_mode_foreignkeys.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
     provider = "mysql"
-    url = "mysql://"
     relationMode = "foreignKeys"
 }
 
@@ -19,14 +18,14 @@ model B {
     a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, onDelete: SetDefault)
 }
 // [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
-//   [1;94m-->[0m  [4mschema.prisma:19[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
 // [1;94m   | [0m
-// [1;94m18 | [0m    aId Int? @default(3)
-// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
+// [1;94m17 | [0m    aId Int? @default(3)
+// [1;94m18 | [0m    a   A?   @relation(fields: [aId], references: [id], onUpdate: SetDefault, [1;93monDelete: SetDefault[0m)
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mMySQL does not actually support the `SetDefault` referential action, so using it may result in unexpected errors. Read more at https://pris.ly/d/mysql-set-default [0m
-//   [1;94m-->[0m  [4mschema.prisma:19[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
 // [1;94m   | [0m
-// [1;94m18 | [0m    aId Int? @default(3)
-// [1;94m19 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
+// [1;94m17 | [0m    aId Int? @default(3)
+// [1;94m18 | [0m    a   A?   @relation(fields: [aId], references: [id], [1;93monUpdate: SetDefault[0m, onDelete: SetDefault)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres/negative_time_precision.prisma
+++ b/psl/psl/tests/validation/postgres/negative_time_precision.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model User {
@@ -10,14 +9,14 @@ model User {
 }
 
 // [1;91merror[0m: [1mExpected a nonnegative integer, but found (-1).[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id   Int      @id
-// [1;94m 8 | [0m  val  DateTime [1;91m@db.Timestamp(-1)[0m
+// [1;94m 6 | [0m  id   Int      @id
+// [1;94m 7 | [0m  val  DateTime [1;91m@db.Timestamp(-1)[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mExpected a nonnegative integer, but found (-1).[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  val  DateTime @db.Timestamp(-1)
-// [1;94m 9 | [0m  val2 DateTime [1;91m@db.Time(-1)[0m
+// [1;94m 7 | [0m  val  DateTime @db.Timestamp(-1)
+// [1;94m 8 | [0m  val2 DateTime [1;91m@db.Time(-1)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_are_not_numbers.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_are_not_numbers.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [ 1 ]
 }
 // [1;91merror[0m: [1mExpected a constant or function value, but received numeric value `1`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [ [1;91m1[0m ]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [ [1;91m1[0m ]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_are_not_strings.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_are_not_strings.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [ "postgis" ]
 }
 // [1;91merror[0m: [1mExpected a constant or function value, but received string value `"postgis"`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [ [1;91m"postgis"[0m ]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [ [1;91m"postgis"[0m ]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mongodb.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mongodb.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "mongodb"
-  url        = "dummy-url"
   extensions = [postgis]
 }
 // [1;91merror[0m: [1mProperty not known: "extensions".[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m 7 | [0m  provider   = "mongodb"
+// [1;94m 8 | [0m  [1;91mextensions = [postgis][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mysql.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_mysql.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource db {
   provider   = "mysql"
-  url        = "dummy-url"
   extensions = [postgis]
 }
 // [1;91merror[0m: [1mProperty not known: "extensions".[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m 7 | [0m  provider   = "mysql"
+// [1;94m 8 | [0m  [1;91mextensions = [postgis][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlite.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlite.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource db {
   provider   = "sqlite"
-  url        = "dummy-url"
   extensions = [postgis]
 }
 // [1;91merror[0m: [1mProperty not known: "extensions".[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m 7 | [0m  provider   = "sqlite"
+// [1;94m 8 | [0m  [1;91mextensions = [postgis][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlserver.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_do_not_work_on_sqlserver.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource db {
   provider   = "sqlserver"
-  url        = "dummy-url"
   extensions = [postgis]
 }
 // [1;91merror[0m: [1mProperty not known: "extensions".[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  [1;91mextensions = [postgis][0m
+// [1;94m 7 | [0m  provider   = "sqlserver"
+// [1;94m 8 | [0m  [1;91mextensions = [postgis][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_require_feature_flag.prisma
@@ -4,12 +4,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [ postgis ]
 }
 // [1;91merror[0m: [1mThe `extensions` property is only available with the `postgresqlExtensions` preview feature.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  url        = "dummy-url"
-// [1;94m 8 | [0m  [1;91mextensions = [ postgis ][0m
+// [1;94m 6 | [0m  provider   = "postgresql"
+// [1;94m 7 | [0m  [1;91mextensions = [ postgis ][0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_arguments.prisma
@@ -5,6 +5,5 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [uuid_ossp(map: "uuid-ossp", schema: "meow", version: "2.1")]
 }

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_duplicate_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_duplicate_arguments.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [postgis(version: "2.1", version: "1.0")]
 }
 // [1;91merror[0m: [1mError validating: The argument `version` can only be defined once[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [postgis(version: "2.1", [1;91mversion: "1.0"[0m)]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [postgis(version: "2.1", [1;91mversion: "1.0"[0m)]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_float_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_float_arguments.prisma
@@ -5,18 +5,17 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [postgis(version: 2.1)]
 }
 // [1;91merror[0m: [1mExpected a string value, but received numeric value `2.1`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [postgis(version: [1;91m2.1[0m)]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [postgis(version: [1;91m2.1[0m)]
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: The `version` argument must be a string literal[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [postgis([1;91mversion: 2.1[0m)]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [postgis([1;91mversion: 2.1[0m)]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_garbage_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_garbage_arguments.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [postgis(version: "2.1", foobar: "1.0")]
 }
 // [1;91merror[0m: [1mArgument not known: "foobar".[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [postgis(version: "2.1", [1;91mfoobar: "1.0"[0m)]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [postgis(version: "2.1", [1;91mfoobar: "1.0"[0m)]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/extensions_with_unnamed_arguments.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/extensions_with_unnamed_arguments.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [postgis("2.1")]
 }
 // [1;91merror[0m: [1mError validating: The argument must have a name[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [postgis([1;91m"2.1"[0m)]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [postgis([1;91m"2.1"[0m)]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/feature_flag.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/feature_flag.prisma
@@ -5,5 +5,4 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
 }

--- a/psl/psl/tests/validation/postgres_extensions/invalid_characters_in_name.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/invalid_characters_in_name.prisma
@@ -5,12 +5,11 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [uuid-ossp]
 }
 // [1;91merror[0m: [1mError validating: The character `-` is not allowed in extension names.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  url        = "dummy-url"
-// [1;94m 9 | [0m  extensions = [[1;91muuid-ossp[0m]
+// [1;94m 7 | [0m  provider   = "postgresql"
+// [1;94m 8 | [0m  extensions = [[1;91muuid-ossp[0m]
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_extensions/simple_single_extension.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/simple_single_extension.prisma
@@ -5,6 +5,5 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = [ postgis ]
 }

--- a/psl/psl/tests/validation/postgres_extensions/single_extension_does_not_need_an_array.prisma
+++ b/psl/psl/tests/validation/postgres_extensions/single_extension_does_not_need_an_array.prisma
@@ -5,6 +5,5 @@ generator js {
 
 datasource mypg {
   provider   = "postgresql"
-  url        = "dummy-url"
   extensions = postgis
 }

--- a/psl/psl/tests/validation/postgres_indexes/brin/bit_minmax_no_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/bit_minmax_no_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `BitMinMaxOps` expects the field `a` to define a valid native type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: BitMinMaxOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: BitMinMaxOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/bit_minmax_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/bit_minmax_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -10,8 +9,8 @@ model A {
   @@index([a(ops: BitMinMaxOps)], type: Brin)
 }
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `BitMinMaxOps` does not support native type `VarBit` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: BitMinMaxOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: BitMinMaxOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/date_bloom_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/date_bloom_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -10,8 +9,8 @@ model A {
   @@index([a(ops: DateBloomOps)], type: Brin)
 }
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `DateBloomOps` does not support native type `Time` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: DateBloomOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: DateBloomOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/date_minmax_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/date_minmax_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -10,8 +9,8 @@ model A {
   @@index([a(ops: DateMinMaxOps)], type: Brin)
 }
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `DateMinMaxOps` does not support native type `Time` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: DateMinMaxOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: DateMinMaxOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/date_minmaxmulti_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/date_minmaxmulti_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `DateMinMaxMultiOps` does not support native type `Time` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: DateMinMaxMultiOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: DateMinMaxMultiOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/on_mysql.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/on_mysql.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given index type is not supported with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  @@index([a(ops: raw("whatever_ops"))], [1;91mtype: Brin[0m)
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  @@index([a(ops: raw("whatever_ops"))], [1;91mtype: Brin[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/uuid_bloom_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/uuid_bloom_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `UuidBloomOps` does not support native type `Text` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: UuidBloomOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: UuidBloomOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/uuid_minmax_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/uuid_minmax_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -10,8 +9,8 @@ model A {
   @@index([a(ops: UuidMinMaxOps)], type: Brin)
 }
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `UuidMinMaxOps` does not support native type `Text` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: UuidMinMaxOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: UuidMinMaxOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/uuid_minmaxmulti_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/uuid_minmaxmulti_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `BitMinMaxOps` does not support native type `Text` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: UuidMinMaxMultiOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: UuidMinMaxMultiOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/varbit_minmax_no_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/varbit_minmax_no_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -10,8 +9,8 @@ model A {
   @@index([a(ops: VarBitMinMaxOps)], type: Brin)
 }
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `VarBitMinMaxOps` expects the field `a` to define a valid native type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: VarBitMinMaxOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: VarBitMinMaxOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/brin/varbit_minmax_wrong_native_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/brin/varbit_minmax_wrong_native_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `VarBitMinMaxOps` does not support native type `Bit` of field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: VarBitMinMaxOps)], type: Brin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: VarBitMinMaxOps)], type: Brin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/gin/array_ops_default_ops.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/gin/array_ops_default_ops.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url      = "dummy-url"
 }
 
 model A {

--- a/psl/psl/tests/validation/postgres_indexes/gin/array_ops_invalid_index_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/gin/array_ops_invalid_index_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `ArrayOps` is not supported with the `Gist` index type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: ArrayOps)], type: Gist)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: ArrayOps)], type: Gist)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/gin/on_mysql.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/gin/on_mysql.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given index type is not supported with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  @@index([a(ops: JsonbOps)], [1;91mtype: Gin[0m)
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  @@index([a(ops: JsonbOps)], [1;91mtype: Gin[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/inet_ops_with_wrong_index_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/inet_ops_with_wrong_index_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `InetOps` is not supported with the `Gin` index type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: InetOps)], type: Gin)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: InetOps)], type: Gin)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/inet_ops_with_wrong_prisma_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/inet_ops_with_wrong_prisma_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `InetOps` expects the field `a` to define a valid native type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: InetOps)], type: SpGist)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: InetOps)], type: SpGist)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/no_ops_weird_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/no_ops_weird_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The SpGist index type does not support the type of the field `a`.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a], type: SpGist)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a], type: SpGist)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/on_mysql.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/on_mysql.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given index type is not supported with the current connector[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  @@index([a(ops: raw("poly_ops"))], [1;91mtype: SpGist[0m)
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  @@index([a(ops: raw("poly_ops"))], [1;91mtype: SpGist[0m)
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/only_single_column_allowed.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/only_single_column_allowed.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -13,8 +12,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": SpGist does not support multi-column indices.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m
-// [1;94m11 | [0m  [1;91m@@index([a, b], type: SpGist)[0m
+// [1;94m 9 | [0m
+// [1;94m10 | [0m  [1;91m@@index([a, b], type: SpGist)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/text_ops_with_wrong_index_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/text_ops_with_wrong_index_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -12,8 +11,8 @@ model A {
 
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `TextOps` is not supported with the `Gist` index type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: TextOps)], type: Gist)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: TextOps)], type: Gist)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/postgres_indexes/spgist/text_ops_with_wrong_prisma_type.prisma
+++ b/psl/psl/tests/validation/postgres_indexes/spgist/text_ops_with_wrong_prisma_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url = "dummy-url"
 }
 
 model A {
@@ -11,8 +10,8 @@ model A {
 }
 
 // [1;91merror[0m: [1mError parsing attribute "@@index": The given operator class `TextOps` points to the field `a` that is not of String type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m
-// [1;94m10 | [0m  [1;91m@@index([a(ops: TextOps)], type: SpGist)[0m
+// [1;94m 8 | [0m
+// [1;94m 9 | [0m  [1;91m@@index([a(ops: TextOps)], type: SpGist)[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/preview_features/full_text_index/mongodb.prisma
+++ b/psl/psl/tests/validation/preview_features/full_text_index/mongodb.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/full_text_index/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/full_text_index/mysql.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgres.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/postgresql.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/mysql.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgres.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgres"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
+++ b/psl/psl/tests/validation/preview_features/old_full_text_search/postgresql.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model Blog {

--- a/psl/psl/tests/validation/preview_features/schema_engine_driver_adapters/postgres/url_is_still_required.prisma
+++ b/psl/psl/tests/validation/preview_features/schema_engine_driver_adapters/postgres/url_is_still_required.prisma
@@ -12,11 +12,3 @@ model Blog {
   content String
   title   String
 }
-// [1;91merror[0m: [1mArgument "url" is missing in data source block "db".[0m
-//   [1;94m-->[0m  [4mschema.prisma:6[0m
-// [1;94m   | [0m
-// [1;94m 5 | [0m
-// [1;94m 6 | [0m[1;91mdatasource db {[0m
-// [1;94m 7 | [0m  provider = "postgres"
-// [1;94m 8 | [0m}
-// [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/mongodb/relation_same_native_type_1.prisma
+++ b/psl/psl/tests/validation/relations/mongodb/relation_same_native_type_1.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url = "mongodb://"
 }
 
 model Parent {
@@ -16,9 +15,9 @@ model Child {
   parent   Parent?
 }
 // [1;93mwarning[0m: [1mWarning validating field `child` in model `Parent`: Field Parent.childId and Child.parentId must have the same native type for MongoDB to join those collections correctly. Consider either removing Child.parentId's native type attribute or adding '@db.ObjectId' to Parent.childId. Beware that this will become an error in the future.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m
-// [1;94m 9 | [0m  [1;93mchildId String @unique[0m
-// [1;94m10 | [0m  child   Child? @relation(fields: [childId], references: [parentId])
+// [1;94m 7 | [0m
+// [1;94m 8 | [0m  [1;93mchildId String @unique[0m
+// [1;94m 9 | [0m  child   Child? @relation(fields: [childId], references: [parentId])
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/mongodb/relation_same_native_type_2.prisma
+++ b/psl/psl/tests/validation/relations/mongodb/relation_same_native_type_2.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url = "mongodb://"
 }
 
 model Parent {
@@ -17,9 +16,9 @@ model Child {
 }
 
 // [1;93mwarning[0m: [1mWarning validating field `child` in model `Parent`: Field Parent.childId and Child.parentId must have the same native type for MongoDB to join those collections correctly. Consider either removing Parent.childId's native type attribute or adding '@db.ObjectId' to Child.parentId. Beware that this will become an error in the future.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m
-// [1;94m 9 | [0m  [1;93mchildId String @unique @db.ObjectId[0m
-// [1;94m10 | [0m  child   Child? @relation(fields: [childId], references: [parentId])
+// [1;94m 7 | [0m
+// [1;94m 8 | [0m  [1;93mchildId String @unique @db.ObjectId[0m
+// [1;94m 9 | [0m  child   Child? @relation(fields: [childId], references: [parentId])
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/mongodb/relation_same_native_type_3.prisma
+++ b/psl/psl/tests/validation/relations/mongodb/relation_same_native_type_3.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url = "mongodb://"
 }
 
 model Parent {
@@ -17,9 +16,9 @@ model Child {
 }
 
 // [1;93mwarning[0m: [1mWarning validating field `child` in model `Parent`: Field Parent.childId and Child.parentId must have the same native type for MongoDB to join those collections correctly. Consider updating those fields to either use '@db.ObjectId' or '@db.String'. Beware that this will become an error in the future.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m
-// [1;94m 9 | [0m  [1;93mchildId String @unique @db.ObjectId[0m
-// [1;94m10 | [0m  child   Child? @relation(fields: [childId], references: [parentId])
+// [1;94m 7 | [0m
+// [1;94m 8 | [0m  [1;93mchildId String @unique @db.ObjectId[0m
+// [1;94m 9 | [0m  child   Child? @relation(fields: [childId], references: [parentId])
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_mixed_fields_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_mixed_fields_when_relation_mode_prisma.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider     = "postgresql"
-  url          = env("DATABASE_URL")
   relationMode = "prisma"
 }
 
@@ -23,18 +22,18 @@ model Profile {
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
 // Either choose another referential action, or make the referenced fields optional.
 // [0m
-//   [1;94m-->[0m  [4mschema.prisma:17[0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
-// [1;94m16 | [0m  id       Int       @id
-// [1;94m17 | [0m  [1;91muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m18 | [0m  user_id  Int?
+// [1;94m15 | [0m  id       Int       @id
+// [1;94m16 | [0m  [1;91muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m17 | [0m  user_id  Int?
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
 // Either choose another referential action, or make the referenced fields optional.
 // [0m
-//   [1;94m-->[0m  [4mschema.prisma:17[0m
+//   [1;94m-->[0m  [4mschema.prisma:16[0m
 // [1;94m   | [0m
-// [1;94m16 | [0m  id       Int       @id
-// [1;94m17 | [0m  [1;91muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m18 | [0m  user_id  Int?
+// [1;94m15 | [0m  id       Int       @id
+// [1;94m16 | [0m  [1;91muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m17 | [0m  user_id  Int?
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_required_fields_when_relation_mode_prisma.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_is_not_valid_on_required_fields_when_relation_mode_prisma.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider     = "postgresql"
-  url          = env("DATABASE_URL")
   relationMode = "prisma"
 }
 
@@ -17,18 +16,18 @@ model Profile {
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onDelete` referential action of a relation must not be set to `SetNull` when a referenced field is required.
 // Either choose another referential action, or make the referenced fields optional.
 // [0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m  id      Int       @id
-// [1;94m14 | [0m  [1;91muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m15 | [0m  user_id Int       @unique
+// [1;94m12 | [0m  id      Int       @id
+// [1;94m13 | [0m  [1;91muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m14 | [0m  user_id Int       @unique
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError parsing attribute "@relation": The `onUpdate` referential action of a relation must not be set to `SetNull` when a referenced field is required.
 // Either choose another referential action, or make the referenced fields optional.
 // [0m
-//   [1;94m-->[0m  [4mschema.prisma:14[0m
+//   [1;94m-->[0m  [4mschema.prisma:13[0m
 // [1;94m   | [0m
-// [1;94m13 | [0m  id      Int       @id
-// [1;94m14 | [0m  [1;91muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m15 | [0m  user_id Int       @unique
+// [1;94m12 | [0m  id      Int       @id
+// [1;94m13 | [0m  [1;91muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m14 | [0m  user_id Int       @unique
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_mixed_fields.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model SomeUser {
@@ -20,16 +19,16 @@ model Profile {
   @@unique([user_id, user_ref])
 }
 // [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m  id       Int       @id
-// [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m17 | [0m  user_id  Int?
+// [1;94m14 | [0m  id       Int       @id
+// [1;94m15 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m16 | [0m  user_id  Int?
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m  id       Int       @id
-// [1;94m16 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m17 | [0m  user_id  Int?
+// [1;94m14 | [0m  id       Int       @id
+// [1;94m15 | [0m  [1;93muser     SomeUser? @relation(fields: [user_id, user_ref], references: [id, ref], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m16 | [0m  user_id  Int?
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
+++ b/psl/psl/tests/validation/relations/postgres/set_null_warns_on_required_fields.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 model SomeUser {
@@ -14,16 +13,16 @@ model Profile {
   user_id Int       @unique
 }
 // [1;93mwarning[0m: [1mThe `onDelete` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  id      Int       @id
-// [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m14 | [0m  user_id Int       @unique
+// [1;94m11 | [0m  id      Int       @id
+// [1;94m12 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m13 | [0m  user_id Int       @unique
 // [1;94m   | [0m
 // [1;93mwarning[0m: [1mThe `onUpdate` referential action of a relation should not be set to `SetNull` when a referenced field is required. We recommend either to choose another referential action, or to make the referenced fields optional. Read more at https://pris.ly/d/postgres-set-null [0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  id      Int       @id
-// [1;94m13 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
-// [1;94m14 | [0m  user_id Int       @unique
+// [1;94m11 | [0m  id      Int       @id
+// [1;94m12 | [0m  [1;93muser    SomeUser? @relation(fields: [user_id], references: [id], onUpdate: SetNull, onDelete: SetNull)[0m
+// [1;94m13 | [0m  user_id Int       @unique
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_bindata_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_bindata_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -13,38 +12,38 @@ model A {
   g  Int      @test.BinData
 }
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type BigInt, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  BigInt   [1;91m@test.BinData[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  BigInt   [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type Float, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  BigInt   @test.BinData
-// [1;94m 9 | [0m  b  Float    [1;91m@test.BinData[0m
+// [1;94m 7 | [0m  a  BigInt   @test.BinData
+// [1;94m 8 | [0m  b  Float    [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type Boolean, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.BinData
-// [1;94m10 | [0m  d  Boolean  [1;91m@test.BinData[0m
+// [1;94m 8 | [0m  b  Float    @test.BinData
+// [1;94m 9 | [0m  d  Boolean  [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type String, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Boolean  @test.BinData
-// [1;94m11 | [0m  e  String   [1;91m@test.BinData[0m
+// [1;94m 9 | [0m  d  Boolean  @test.BinData
+// [1;94m10 | [0m  e  String   [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type DateTime, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  String   @test.BinData
-// [1;94m12 | [0m  f  DateTime [1;91m@test.BinData[0m
+// [1;94m10 | [0m  e  String   @test.BinData
+// [1;94m11 | [0m  f  DateTime [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type Int, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  f  DateTime @test.BinData
-// [1;94m13 | [0m  g  Int      [1;91m@test.BinData[0m
+// [1;94m11 | [0m  f  DateTime @test.BinData
+// [1;94m12 | [0m  g  Int      [1;91m@test.BinData[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_bindata_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_bindata_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -17,38 +16,38 @@ model A {
   b  B
 }
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type BigInt, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  BigInt   [1;91m@test.BinData[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  BigInt   [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type Float, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  BigInt   @test.BinData
-// [1;94m 8 | [0m  b  Float    [1;91m@test.BinData[0m
+// [1;94m 6 | [0m  a  BigInt   @test.BinData
+// [1;94m 7 | [0m  b  Float    [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type Boolean, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.BinData
-// [1;94m 9 | [0m  d  Boolean  [1;91m@test.BinData[0m
+// [1;94m 7 | [0m  b  Float    @test.BinData
+// [1;94m 8 | [0m  d  Boolean  [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type String, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  d  Boolean  @test.BinData
-// [1;94m10 | [0m  e  String   [1;91m@test.BinData[0m
+// [1;94m 8 | [0m  d  Boolean  @test.BinData
+// [1;94m 9 | [0m  e  String   [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type DateTime, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  e  String   @test.BinData
-// [1;94m11 | [0m  f  DateTime [1;91m@test.BinData[0m
+// [1;94m 9 | [0m  e  String   @test.BinData
+// [1;94m10 | [0m  f  DateTime [1;91m@test.BinData[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type BinData is not compatible with declared field type Int, expected field type Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  f  DateTime @test.BinData
-// [1;94m12 | [0m  g  Int      [1;91m@test.BinData[0m
+// [1;94m10 | [0m  f  DateTime @test.BinData
+// [1;94m11 | [0m  g  Int      [1;91m@test.BinData[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_bool_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_bool_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -14,38 +13,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type BigInt, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  BigInt   [1;91m@test.Bool[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type Float, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  BigInt   @test.Bool
-// [1;94m 9 | [0m  b  Float    [1;91m@test.Bool[0m
+// [1;94m 7 | [0m  a  BigInt   @test.Bool
+// [1;94m 8 | [0m  b  Float    [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type Bytes, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.Bool
-// [1;94m10 | [0m  d  Bytes    [1;91m@test.Bool[0m
+// [1;94m 8 | [0m  b  Float    @test.Bool
+// [1;94m 9 | [0m  d  Bytes    [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type String, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Bytes    @test.Bool
-// [1;94m11 | [0m  e  String   [1;91m@test.Bool[0m
+// [1;94m 9 | [0m  d  Bytes    @test.Bool
+// [1;94m10 | [0m  e  String   [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type DateTime, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  String   @test.Bool
-// [1;94m12 | [0m  f  DateTime [1;91m@test.Bool[0m
+// [1;94m10 | [0m  e  String   @test.Bool
+// [1;94m11 | [0m  f  DateTime [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type Int, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  f  DateTime @test.Bool
-// [1;94m13 | [0m  g  Int      [1;91m@test.Bool[0m
+// [1;94m11 | [0m  f  DateTime @test.Bool
+// [1;94m12 | [0m  g  Int      [1;91m@test.Bool[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_bool_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_bool_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -18,38 +17,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type BigInt, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Bool[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  BigInt   [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type Float, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  BigInt   @test.Bool
-// [1;94m 8 | [0m  b  Float    [1;91m@test.Bool[0m
+// [1;94m 6 | [0m  a  BigInt   @test.Bool
+// [1;94m 7 | [0m  b  Float    [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type Bytes, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.Bool
-// [1;94m 9 | [0m  d  Bytes    [1;91m@test.Bool[0m
+// [1;94m 7 | [0m  b  Float    @test.Bool
+// [1;94m 8 | [0m  d  Bytes    [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type String, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  d  Bytes    @test.Bool
-// [1;94m10 | [0m  e  String   [1;91m@test.Bool[0m
+// [1;94m 8 | [0m  d  Bytes    @test.Bool
+// [1;94m 9 | [0m  e  String   [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type DateTime, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  e  String   @test.Bool
-// [1;94m11 | [0m  f  DateTime [1;91m@test.Bool[0m
+// [1;94m 9 | [0m  e  String   @test.Bool
+// [1;94m10 | [0m  f  DateTime [1;91m@test.Bool[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Bool is not compatible with declared field type Int, expected field type Boolean.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  f  DateTime @test.Bool
-// [1;94m12 | [0m  g  Int      [1;91m@test.Bool[0m
+// [1;94m10 | [0m  f  DateTime @test.Bool
+// [1;94m11 | [0m  g  Int      [1;91m@test.Bool[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_date_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_date_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -14,38 +13,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type BigInt, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  BigInt   [1;91m@test.Date[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Float, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  BigInt   @test.Date
-// [1;94m 9 | [0m  b  Float    [1;91m@test.Date[0m
+// [1;94m 7 | [0m  a  BigInt   @test.Date
+// [1;94m 8 | [0m  b  Float    [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Bytes, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.Date
-// [1;94m10 | [0m  d  Bytes    [1;91m@test.Date[0m
+// [1;94m 8 | [0m  b  Float    @test.Date
+// [1;94m 9 | [0m  d  Bytes    [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type String, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Bytes    @test.Date
-// [1;94m11 | [0m  e  String   [1;91m@test.Date[0m
+// [1;94m 9 | [0m  d  Bytes    @test.Date
+// [1;94m10 | [0m  e  String   [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Boolean, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  String   @test.Date
-// [1;94m12 | [0m  f  Boolean  [1;91m@test.Date[0m
+// [1;94m10 | [0m  e  String   @test.Date
+// [1;94m11 | [0m  f  Boolean  [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Int, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  f  Boolean  @test.Date
-// [1;94m13 | [0m  g  Int      [1;91m@test.Date[0m
+// [1;94m11 | [0m  f  Boolean  @test.Date
+// [1;94m12 | [0m  g  Int      [1;91m@test.Date[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_date_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_date_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -17,38 +16,38 @@ model A {
   b  B
 }
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type BigInt, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Date[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  BigInt   [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Float, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  BigInt   @test.Date
-// [1;94m 8 | [0m  b  Float    [1;91m@test.Date[0m
+// [1;94m 6 | [0m  a  BigInt   @test.Date
+// [1;94m 7 | [0m  b  Float    [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Bytes, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.Date
-// [1;94m 9 | [0m  d  Bytes    [1;91m@test.Date[0m
+// [1;94m 7 | [0m  b  Float    @test.Date
+// [1;94m 8 | [0m  d  Bytes    [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type String, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  d  Bytes    @test.Date
-// [1;94m10 | [0m  e  String   [1;91m@test.Date[0m
+// [1;94m 8 | [0m  d  Bytes    @test.Date
+// [1;94m 9 | [0m  e  String   [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Boolean, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  e  String   @test.Date
-// [1;94m11 | [0m  f  Boolean  [1;91m@test.Date[0m
+// [1;94m 9 | [0m  e  String   @test.Date
+// [1;94m10 | [0m  f  Boolean  [1;91m@test.Date[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Date is not compatible with declared field type Int, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  f  Boolean  @test.Date
-// [1;94m12 | [0m  g  Int      [1;91m@test.Date[0m
+// [1;94m10 | [0m  f  Boolean  @test.Date
+// [1;94m11 | [0m  g  Int      [1;91m@test.Date[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_double_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_double_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -13,38 +12,38 @@ model A {
   g  Bytes    @test.Double
 }
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type Int, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  Int      [1;91m@test.Double[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  Int      [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type BigInt, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  Int      @test.Double
-// [1;94m 9 | [0m  b  BigInt   [1;91m@test.Double[0m
+// [1;94m 7 | [0m  a  Int      @test.Double
+// [1;94m 8 | [0m  b  BigInt   [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type Boolean, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  BigInt   @test.Double
-// [1;94m10 | [0m  d  Boolean  [1;91m@test.Double[0m
+// [1;94m 8 | [0m  b  BigInt   @test.Double
+// [1;94m 9 | [0m  d  Boolean  [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type String, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Boolean  @test.Double
-// [1;94m11 | [0m  e  String   [1;91m@test.Double[0m
+// [1;94m 9 | [0m  d  Boolean  @test.Double
+// [1;94m10 | [0m  e  String   [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type DateTime, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  String   @test.Double
-// [1;94m12 | [0m  f  DateTime [1;91m@test.Double[0m
+// [1;94m10 | [0m  e  String   @test.Double
+// [1;94m11 | [0m  f  DateTime [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type Bytes, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  f  DateTime @test.Double
-// [1;94m13 | [0m  g  Bytes    [1;91m@test.Double[0m
+// [1;94m11 | [0m  f  DateTime @test.Double
+// [1;94m12 | [0m  g  Bytes    [1;91m@test.Double[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_double_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_double_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 type B {
   a  Int      @test.Double
@@ -17,38 +16,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type Int, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:6[0m
+//   [1;94m-->[0m  [4mschema.prisma:5[0m
 // [1;94m   | [0m
-// [1;94m 5 | [0mtype B {
-// [1;94m 6 | [0m  a  Int      [1;91m@test.Double[0m
+// [1;94m 4 | [0mtype B {
+// [1;94m 5 | [0m  a  Int      [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type BigInt, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0m  a  Int      @test.Double
-// [1;94m 7 | [0m  b  BigInt   [1;91m@test.Double[0m
+// [1;94m 5 | [0m  a  Int      @test.Double
+// [1;94m 6 | [0m  b  BigInt   [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type Boolean, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  b  BigInt   @test.Double
-// [1;94m 8 | [0m  d  Boolean  [1;91m@test.Double[0m
+// [1;94m 6 | [0m  b  BigInt   @test.Double
+// [1;94m 7 | [0m  d  Boolean  [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type String, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  d  Boolean  @test.Double
-// [1;94m 9 | [0m  e  String   [1;91m@test.Double[0m
+// [1;94m 7 | [0m  d  Boolean  @test.Double
+// [1;94m 8 | [0m  e  String   [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type DateTime, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  e  String   @test.Double
-// [1;94m10 | [0m  f  DateTime [1;91m@test.Double[0m
+// [1;94m 8 | [0m  e  String   @test.Double
+// [1;94m 9 | [0m  f  DateTime [1;91m@test.Double[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Double is not compatible with declared field type Bytes, expected field type Float.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  f  DateTime @test.Double
-// [1;94m11 | [0m  g  Bytes    [1;91m@test.Double[0m
+// [1;94m 9 | [0m  f  DateTime @test.Double
+// [1;94m10 | [0m  g  Bytes    [1;91m@test.Double[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_int_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_int_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -13,38 +12,38 @@ model A {
   g  Bytes    @test.Int
 }
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type BigInt, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  BigInt   [1;91m@test.Int[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type Float, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  BigInt   @test.Int
-// [1;94m 9 | [0m  b  Float    [1;91m@test.Int[0m
+// [1;94m 7 | [0m  a  BigInt   @test.Int
+// [1;94m 8 | [0m  b  Float    [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type Boolean, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.Int
-// [1;94m10 | [0m  d  Boolean  [1;91m@test.Int[0m
+// [1;94m 8 | [0m  b  Float    @test.Int
+// [1;94m 9 | [0m  d  Boolean  [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type String, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Boolean  @test.Int
-// [1;94m11 | [0m  e  String   [1;91m@test.Int[0m
+// [1;94m 9 | [0m  d  Boolean  @test.Int
+// [1;94m10 | [0m  e  String   [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type DateTime, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  String   @test.Int
-// [1;94m12 | [0m  f  DateTime [1;91m@test.Int[0m
+// [1;94m10 | [0m  e  String   @test.Int
+// [1;94m11 | [0m  f  DateTime [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type Bytes, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  f  DateTime @test.Int
-// [1;94m13 | [0m  g  Bytes    [1;91m@test.Int[0m
+// [1;94m11 | [0m  f  DateTime @test.Int
+// [1;94m12 | [0m  g  Bytes    [1;91m@test.Int[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_int_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_int_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -18,38 +17,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type BigInt, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Int[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  BigInt   [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type Float, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  BigInt   @test.Int
-// [1;94m 8 | [0m  b  Float    [1;91m@test.Int[0m
+// [1;94m 6 | [0m  a  BigInt   @test.Int
+// [1;94m 7 | [0m  b  Float    [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type Boolean, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.Int
-// [1;94m 9 | [0m  d  Boolean  [1;91m@test.Int[0m
+// [1;94m 7 | [0m  b  Float    @test.Int
+// [1;94m 8 | [0m  d  Boolean  [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type String, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  d  Boolean  @test.Int
-// [1;94m10 | [0m  e  String   [1;91m@test.Int[0m
+// [1;94m 8 | [0m  d  Boolean  @test.Int
+// [1;94m 9 | [0m  e  String   [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type DateTime, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  e  String   @test.Int
-// [1;94m11 | [0m  f  DateTime [1;91m@test.Int[0m
+// [1;94m 9 | [0m  e  String   @test.Int
+// [1;94m10 | [0m  f  DateTime [1;91m@test.Int[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Int is not compatible with declared field type Bytes, expected field type Int.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  f  DateTime @test.Int
-// [1;94m12 | [0m  g  Bytes    [1;91m@test.Int[0m
+// [1;94m10 | [0m  f  DateTime @test.Int
+// [1;94m11 | [0m  g  Bytes    [1;91m@test.Int[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_json_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_json_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -18,38 +17,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Json is not compatible with declared field type Int, expected field type Json.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  Int      [1;91m@test.Json[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  Int      [1;91m@test.Json[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Json is not compatible with declared field type Float, expected field type Json.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  Int      @test.Json
-// [1;94m 8 | [0m  b  Float    [1;91m@test.Json[0m
+// [1;94m 6 | [0m  a  Int      @test.Json
+// [1;94m 7 | [0m  b  Float    [1;91m@test.Json[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Json is not compatible with declared field type Bytes, expected field type Json.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.Json
-// [1;94m 9 | [0m  c  Bytes    [1;91m@test.Json[0m
+// [1;94m 7 | [0m  b  Float    @test.Json
+// [1;94m 8 | [0m  c  Bytes    [1;91m@test.Json[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Json is not compatible with declared field type Boolean, expected field type Json.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  c  Bytes    @test.Json
-// [1;94m10 | [0m  d  Boolean  [1;91m@test.Json[0m
+// [1;94m 8 | [0m  c  Bytes    @test.Json
+// [1;94m 9 | [0m  d  Boolean  [1;91m@test.Json[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Json is not compatible with declared field type DateTime, expected field type Json.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Boolean  @test.Json
-// [1;94m11 | [0m  e  DateTime [1;91m@test.Json[0m
+// [1;94m 9 | [0m  d  Boolean  @test.Json
+// [1;94m10 | [0m  e  DateTime [1;91m@test.Json[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Json is not compatible with declared field type Decimal, expected field type Json.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  DateTime @test.Json
-// [1;94m12 | [0m  f  Decimal  [1;91m@test.Json[0m
+// [1;94m10 | [0m  e  DateTime @test.Json
+// [1;94m11 | [0m  f  Decimal  [1;91m@test.Json[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_long_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_long_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 model A {
   id Int      @id          @map("_id")
@@ -12,32 +11,32 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type Float, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0m  id Int      @id          @map("_id")
-// [1;94m 7 | [0m  b  Float    [1;91m@test.Long[0m
+// [1;94m 5 | [0m  id Int      @id          @map("_id")
+// [1;94m 6 | [0m  b  Float    [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type Boolean, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  b  Float    @test.Long
-// [1;94m 8 | [0m  d  Boolean  [1;91m@test.Long[0m
+// [1;94m 6 | [0m  b  Float    @test.Long
+// [1;94m 7 | [0m  d  Boolean  [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type String, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  d  Boolean  @test.Long
-// [1;94m 9 | [0m  e  String   [1;91m@test.Long[0m
+// [1;94m 7 | [0m  d  Boolean  @test.Long
+// [1;94m 8 | [0m  e  String   [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type DateTime, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  e  String   @test.Long
-// [1;94m10 | [0m  f  DateTime [1;91m@test.Long[0m
+// [1;94m 8 | [0m  e  String   @test.Long
+// [1;94m 9 | [0m  f  DateTime [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type Bytes, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  f  DateTime @test.Long
-// [1;94m11 | [0m  g  Bytes    [1;91m@test.Long[0m
+// [1;94m 9 | [0m  f  DateTime @test.Long
+// [1;94m10 | [0m  g  Bytes    [1;91m@test.Long[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_long_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_long_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -16,32 +15,32 @@ model A {
   b  B
 }
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type Float, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  b  Float    [1;91m@test.Long[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  b  Float    [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type Boolean, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  b  Float    @test.Long
-// [1;94m 8 | [0m  d  Boolean  [1;91m@test.Long[0m
+// [1;94m 6 | [0m  b  Float    @test.Long
+// [1;94m 7 | [0m  d  Boolean  [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type String, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  d  Boolean  @test.Long
-// [1;94m 9 | [0m  e  String   [1;91m@test.Long[0m
+// [1;94m 7 | [0m  d  Boolean  @test.Long
+// [1;94m 8 | [0m  e  String   [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type DateTime, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  e  String   @test.Long
-// [1;94m10 | [0m  f  DateTime [1;91m@test.Long[0m
+// [1;94m 8 | [0m  e  String   @test.Long
+// [1;94m 9 | [0m  f  DateTime [1;91m@test.Long[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Long is not compatible with declared field type Bytes, expected field type Int or BigInt.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  f  DateTime @test.Long
-// [1;94m11 | [0m  g  Bytes    [1;91m@test.Long[0m
+// [1;94m 9 | [0m  f  DateTime @test.Long
+// [1;94m10 | [0m  g  Bytes    [1;91m@test.Long[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_object_id_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_object_id_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -13,32 +12,32 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type ObjectID is not supported for mongodb connector.[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
+// [1;94m   | [0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  BigInt   [1;91m@test.ObjectID[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mNative type ObjectID is not supported for mongodb connector.[0m
 //   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  BigInt   [1;91m@test.ObjectID[0m
+// [1;94m 7 | [0m  a  BigInt   @test.ObjectID
+// [1;94m 8 | [0m  b  Float    [1;91m@test.ObjectID[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectID is not supported for mongodb connector.[0m
 //   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  BigInt   @test.ObjectID
-// [1;94m 9 | [0m  b  Float    [1;91m@test.ObjectID[0m
+// [1;94m 8 | [0m  b  Float    @test.ObjectID
+// [1;94m 9 | [0m  d  Boolean  [1;91m@test.ObjectID[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectID is not supported for mongodb connector.[0m
 //   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.ObjectID
-// [1;94m10 | [0m  d  Boolean  [1;91m@test.ObjectID[0m
+// [1;94m 9 | [0m  d  Boolean  @test.ObjectID
+// [1;94m10 | [0m  f  DateTime [1;91m@test.ObjectID[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectID is not supported for mongodb connector.[0m
 //   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Boolean  @test.ObjectID
-// [1;94m11 | [0m  f  DateTime [1;91m@test.ObjectID[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mNative type ObjectID is not supported for mongodb connector.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
-// [1;94m   | [0m
-// [1;94m11 | [0m  f  DateTime @test.ObjectID
-// [1;94m12 | [0m  g  Int      [1;91m@test.ObjectID[0m
+// [1;94m10 | [0m  f  DateTime @test.ObjectID
+// [1;94m11 | [0m  g  Int      [1;91m@test.ObjectID[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_object_id_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_object_id_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
     
 type B {
@@ -16,32 +15,32 @@ model A {
   b  B
 }
 // [1;91merror[0m: [1mNative type ObjectId is not compatible with declared field type BigInt, expected field type String or Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  BigInt   [1;91m@test.ObjectId[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  BigInt   [1;91m@test.ObjectId[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectId is not compatible with declared field type Float, expected field type String or Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  BigInt   @test.ObjectId
-// [1;94m 8 | [0m  b  Float    [1;91m@test.ObjectId[0m
+// [1;94m 6 | [0m  a  BigInt   @test.ObjectId
+// [1;94m 7 | [0m  b  Float    [1;91m@test.ObjectId[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectId is not compatible with declared field type Boolean, expected field type String or Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.ObjectId
-// [1;94m 9 | [0m  d  Boolean  [1;91m@test.ObjectId[0m
+// [1;94m 7 | [0m  b  Float    @test.ObjectId
+// [1;94m 8 | [0m  d  Boolean  [1;91m@test.ObjectId[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectId is not compatible with declared field type DateTime, expected field type String or Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  d  Boolean  @test.ObjectId
-// [1;94m10 | [0m  f  DateTime [1;91m@test.ObjectId[0m
+// [1;94m 8 | [0m  d  Boolean  @test.ObjectId
+// [1;94m 9 | [0m  f  DateTime [1;91m@test.ObjectId[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type ObjectId is not compatible with declared field type Int, expected field type String or Bytes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  f  DateTime @test.ObjectId
-// [1;94m11 | [0m  g  Int      [1;91m@test.ObjectId[0m
+// [1;94m 9 | [0m  f  DateTime @test.ObjectId
+// [1;94m10 | [0m  g  Int      [1;91m@test.ObjectId[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_string_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_string_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -13,32 +12,32 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Int, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  Int      [1;91m@test.String[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  Int      [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Float, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  Int      @test.String
-// [1;94m 9 | [0m  b  Float    [1;91m@test.String[0m
+// [1;94m 7 | [0m  a  Int      @test.String
+// [1;94m 8 | [0m  b  Float    [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Bytes, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.String
-// [1;94m10 | [0m  c  Bytes    [1;91m@test.String[0m
+// [1;94m 8 | [0m  b  Float    @test.String
+// [1;94m 9 | [0m  c  Bytes    [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Boolean, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  c  Bytes    @test.String
-// [1;94m11 | [0m  d  Boolean  [1;91m@test.String[0m
+// [1;94m 9 | [0m  c  Bytes    @test.String
+// [1;94m10 | [0m  d  Boolean  [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type DateTime, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  d  Boolean  @test.String
-// [1;94m12 | [0m  e  DateTime [1;91m@test.String[0m
+// [1;94m10 | [0m  d  Boolean  @test.String
+// [1;94m11 | [0m  e  DateTime [1;91m@test.String[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_string_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_string_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -17,32 +16,32 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Int, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  Int      [1;91m@test.String[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  Int      [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Float, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  Int      @test.String
-// [1;94m 8 | [0m  b  Float    [1;91m@test.String[0m
+// [1;94m 6 | [0m  a  Int      @test.String
+// [1;94m 7 | [0m  b  Float    [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Bytes, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.String
-// [1;94m 9 | [0m  c  Bytes    [1;91m@test.String[0m
+// [1;94m 7 | [0m  b  Float    @test.String
+// [1;94m 8 | [0m  c  Bytes    [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type Boolean, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  c  Bytes    @test.String
-// [1;94m10 | [0m  d  Boolean  [1;91m@test.String[0m
+// [1;94m 8 | [0m  c  Bytes    @test.String
+// [1;94m 9 | [0m  d  Boolean  [1;91m@test.String[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type String is not compatible with declared field type DateTime, expected field type String.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Boolean  @test.String
-// [1;94m11 | [0m  e  DateTime [1;91m@test.String[0m
+// [1;94m 9 | [0m  d  Boolean  @test.String
+// [1;94m10 | [0m  e  DateTime [1;91m@test.String[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_timestamp_usage_in_model.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_timestamp_usage_in_model.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 model A {
@@ -14,38 +13,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type BigInt, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int      @id          @map("_id")
-// [1;94m 8 | [0m  a  BigInt   [1;91m@test.Timestamp[0m
+// [1;94m 6 | [0m  id Int      @id          @map("_id")
+// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Float, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  a  BigInt   @test.Timestamp
-// [1;94m 9 | [0m  b  Float    [1;91m@test.Timestamp[0m
+// [1;94m 7 | [0m  a  BigInt   @test.Timestamp
+// [1;94m 8 | [0m  b  Float    [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Bytes, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  b  Float    @test.Timestamp
-// [1;94m10 | [0m  d  Bytes    [1;91m@test.Timestamp[0m
+// [1;94m 8 | [0m  b  Float    @test.Timestamp
+// [1;94m 9 | [0m  d  Bytes    [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type String, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  d  Bytes    @test.Timestamp
-// [1;94m11 | [0m  e  String   [1;91m@test.Timestamp[0m
+// [1;94m 9 | [0m  d  Bytes    @test.Timestamp
+// [1;94m10 | [0m  e  String   [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Boolean, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  e  String   @test.Timestamp
-// [1;94m12 | [0m  f  Boolean  [1;91m@test.Timestamp[0m
+// [1;94m10 | [0m  e  String   @test.Timestamp
+// [1;94m11 | [0m  f  Boolean  [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Int, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  f  Boolean  @test.Timestamp
-// [1;94m13 | [0m  g  Int      [1;91m@test.Timestamp[0m
+// [1;94m11 | [0m  f  Boolean  @test.Timestamp
+// [1;94m12 | [0m  g  Int      [1;91m@test.Timestamp[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/types/mongodb/invalid_timestamp_usage_in_type.prisma
+++ b/psl/psl/tests/validation/types/mongodb/invalid_timestamp_usage_in_type.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "mongodb"
-  url = "dummy-url"
 }
 
 type B {
@@ -18,38 +17,38 @@ model A {
 }
 
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type BigInt, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mtype B {
-// [1;94m 7 | [0m  a  BigInt   [1;91m@test.Timestamp[0m
+// [1;94m 5 | [0mtype B {
+// [1;94m 6 | [0m  a  BigInt   [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Float, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  a  BigInt   @test.Timestamp
-// [1;94m 8 | [0m  b  Float    [1;91m@test.Timestamp[0m
+// [1;94m 6 | [0m  a  BigInt   @test.Timestamp
+// [1;94m 7 | [0m  b  Float    [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Bytes, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:9[0m
+//   [1;94m-->[0m  [4mschema.prisma:8[0m
 // [1;94m   | [0m
-// [1;94m 8 | [0m  b  Float    @test.Timestamp
-// [1;94m 9 | [0m  d  Bytes    [1;91m@test.Timestamp[0m
+// [1;94m 7 | [0m  b  Float    @test.Timestamp
+// [1;94m 8 | [0m  d  Bytes    [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type String, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:10[0m
+//   [1;94m-->[0m  [4mschema.prisma:9[0m
 // [1;94m   | [0m
-// [1;94m 9 | [0m  d  Bytes    @test.Timestamp
-// [1;94m10 | [0m  e  String   [1;91m@test.Timestamp[0m
+// [1;94m 8 | [0m  d  Bytes    @test.Timestamp
+// [1;94m 9 | [0m  e  String   [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Boolean, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:11[0m
+//   [1;94m-->[0m  [4mschema.prisma:10[0m
 // [1;94m   | [0m
-// [1;94m10 | [0m  e  String   @test.Timestamp
-// [1;94m11 | [0m  f  Boolean  [1;91m@test.Timestamp[0m
+// [1;94m 9 | [0m  e  String   @test.Timestamp
+// [1;94m10 | [0m  f  Boolean  [1;91m@test.Timestamp[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mNative type Timestamp is not compatible with declared field type Int, expected field type DateTime.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0m  f  Boolean  @test.Timestamp
-// [1;94m12 | [0m  g  Int      [1;91m@test.Timestamp[0m
+// [1;94m10 | [0m  f  Boolean  @test.Timestamp
+// [1;94m11 | [0m  g  Int      [1;91m@test.Timestamp[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/basic_view.prisma
+++ b/psl/psl/tests/validation/views/basic_view.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {

--- a/psl/psl/tests/validation/views/duplicate_field.prisma
+++ b/psl/psl/tests/validation/views/duplicate_field.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -14,8 +13,8 @@ view Mountain {
 }
 
 // [1;91merror[0m: [1mField "id" is already defined on view "Mountain".[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  id Int @unique
-// [1;94m13 | [0m  [1;91mid[0m Int
+// [1;94m11 | [0m  id Int @unique
+// [1;94m12 | [0m  [1;91mid[0m Int
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/duplicate_view_model_names.prisma
+++ b/psl/psl/tests/validation/views/duplicate_view_model_names.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -18,8 +17,8 @@ model Mountain {
   val String
 }
 // [1;91merror[0m: [1mThe model "Mountain" cannot be defined because a view with that name already exists.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m
-// [1;94m16 | [0mmodel [1;91mMountain[0m {
+// [1;94m14 | [0m
+// [1;94m15 | [0mmodel [1;91mMountain[0m {
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/duplicate_view_model_names_2.prisma
+++ b/psl/psl/tests/validation/views/duplicate_view_model_names_2.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -19,8 +18,8 @@ view Mountain {
 }
 
 // [1;91merror[0m: [1mThe view "Mountain" cannot be defined because a model with that name already exists.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m
-// [1;94m16 | [0mview [1;91mMountain[0m {
+// [1;94m14 | [0m
+// [1;94m15 | [0mview [1;91mMountain[0m {
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/duplicate_view_names.prisma
+++ b/psl/psl/tests/validation/views/duplicate_view_names.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -18,8 +17,8 @@ view Mountain {
   val String
 }
 // [1;91merror[0m: [1mThe view "Mountain" cannot be defined because a view with that name already exists.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0m
-// [1;94m16 | [0mview [1;91mMountain[0m {
+// [1;94m14 | [0m
+// [1;94m15 | [0mview [1;91mMountain[0m {
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/field_name_starts_with_number.prisma
+++ b/psl/psl/tests/validation/views/field_name_starts_with_number.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 view foo {
@@ -8,8 +7,8 @@ view foo {
 }
 
 // [1;91merror[0m: [1mError validating: The name of a field must not start with a number.[0m
-//   [1;94m-->[0m  [4mschema.prisma:7[0m
+//   [1;94m-->[0m  [4mschema.prisma:6[0m
 // [1;94m   | [0m
-// [1;94m 6 | [0mview foo {
-// [1;94m 7 | [0m  [1;91m1id[0m Int @unique
+// [1;94m 5 | [0mview foo {
+// [1;94m 6 | [0m  [1;91m1id[0m Int @unique
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/garbage_field_definition.prisma
+++ b/psl/psl/tests/validation/views/garbage_field_definition.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -13,9 +12,9 @@ view Mountain {
   val
 }
 // [1;91merror[0m: [1mError validating view "Mountain": This field declaration is invalid. It is either missing a name or a type.[0m
-//   [1;94m-->[0m  [4mschema.prisma:13[0m
+//   [1;94m-->[0m  [4mschema.prisma:12[0m
 // [1;94m   | [0m
-// [1;94m12 | [0m  id Int @unique
-// [1;94m13 | [0m  [1;91mval[0m
-// [1;94m14 | [0m}
+// [1;94m11 | [0m  id Int @unique
+// [1;94m12 | [0m  [1;91mval[0m
+// [1;94m13 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/multi_schema.prisma
+++ b/psl/psl/tests/validation/views/multi_schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
   schemas  = ["A", "B"]
 }
 

--- a/psl/psl/tests/validation/views/multi_schema_no_schema_declaration.prisma
+++ b/psl/psl/tests/validation/views/multi_schema_no_schema_declaration.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
   schemas  = ["A", "B"]
 }
 
@@ -19,10 +18,10 @@ view Mountain {
   id Int
 }
 // [1;91merror[0m: [1mError validating view "Mountain": This view is missing an `@@schema` attribute.[0m
-//   [1;94m-->[0m  [4mschema.prisma:18[0m
+//   [1;94m-->[0m  [4mschema.prisma:17[0m
 // [1;94m   | [0m
-// [1;94m17 | [0m
-// [1;94m18 | [0m[1;91mview Mountain {[0m
-// [1;94m19 | [0m  id Int
-// [1;94m20 | [0m}
+// [1;94m16 | [0m
+// [1;94m17 | [0m[1;91mview Mountain {[0m
+// [1;94m18 | [0m  id Int
+// [1;94m19 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/name_starts_with_number.prisma
+++ b/psl/psl/tests/validation/views/name_starts_with_number.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 view 1foo {
@@ -8,8 +7,8 @@ view 1foo {
 }
 
 // [1;91merror[0m: [1mError validating: The name of a view must not start with a number.[0m
-//   [1;94m-->[0m  [4mschema.prisma:6[0m
+//   [1;94m-->[0m  [4mschema.prisma:5[0m
 // [1;94m   | [0m
-// [1;94m 5 | [0m
-// [1;94m 6 | [0mview [1;91m1foo[0m {
+// [1;94m 4 | [0m
+// [1;94m 5 | [0mview [1;91m1foo[0m {
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/no_preview_feature.prisma
+++ b/psl/psl/tests/validation/views/no_preview_feature.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 view Mountain {
@@ -10,11 +9,11 @@ view Mountain {
 
 
 // [1;91merror[0m: [1mError validating: View definitions are only available with the `views` preview feature.[0m
-//   [1;94m-->[0m  [4mschema.prisma:6[0m
+//   [1;94m-->[0m  [4mschema.prisma:5[0m
 // [1;94m   | [0m
-// [1;94m 5 | [0m
-// [1;94m 6 | [0m[1;91mview Mountain {[0m
-// [1;94m 7 | [0m  id  Int
-// [1;94m 8 | [0m  val String
-// [1;94m 9 | [0m}
+// [1;94m 4 | [0m
+// [1;94m 5 | [0m[1;91mview Mountain {[0m
+// [1;94m 6 | [0m  id  Int
+// [1;94m 7 | [0m  val String
+// [1;94m 8 | [0m}
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/reserved_name.prisma
+++ b/psl/psl/tests/validation/views/reserved_name.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 view Cat {
@@ -9,8 +8,8 @@ view Cat {
 }
 
 // [1;91merror[0m: [1mField "id" is already defined on view "Cat".[0m
-//   [1;94m-->[0m  [4mschema.prisma:8[0m
+//   [1;94m-->[0m  [4mschema.prisma:7[0m
 // [1;94m   | [0m
-// [1;94m 7 | [0m  id Int @unique
-// [1;94m 8 | [0m  [1;91mid[0m Int
+// [1;94m 6 | [0m  id Int @unique
+// [1;94m 7 | [0m  [1;91mid[0m Int
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/view_with_indexes.prisma
+++ b/psl/psl/tests/validation/views/view_with_indexes.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -21,20 +20,20 @@ view Mountain {
 }
 
 // [1;91merror[0m: [1mError validating: @@unique annotations on views are not backed by unique indexes in the database and cannot specify a mapped database name.[0m
-//   [1;94m-->[0m  [4mschema.prisma:16[0m
+//   [1;94m-->[0m  [4mschema.prisma:15[0m
 // [1;94m   | [0m
-// [1;94m15 | [0mview Mountain {
-// [1;94m16 | [0m  name   String [1;91m@unique(map: "name_idx")[0m
+// [1;94m14 | [0mview Mountain {
+// [1;94m15 | [0m  name   String [1;91m@unique(map: "name_idx")[0m
 // [1;94m   | [0m
 // [1;91merror[0m: [1mError validating: Views cannot have indexes.[0m
-//   [1;94m-->[0m  [4mschema.prisma:20[0m
-// [1;94m   | [0m
-// [1;94m19 | [0m  @@unique([region(length: 10)])
-// [1;94m20 | [0m  [1;91m@@index([name, region], type: Gin)[0m
-// [1;94m   | [0m
-// [1;91merror[0m: [1mError parsing attribute "@@unique": Scalar fields in @@unique attributes in views cannot have arguments.[0m
 //   [1;94m-->[0m  [4mschema.prisma:19[0m
 // [1;94m   | [0m
-// [1;94m18 | [0m
-// [1;94m19 | [0m  [1;91m@@unique([region(length: 10)])[0m
+// [1;94m18 | [0m  @@unique([region(length: 10)])
+// [1;94m19 | [0m  [1;91m@@index([name, region], type: Gin)[0m
+// [1;94m   | [0m
+// [1;91merror[0m: [1mError parsing attribute "@@unique": Scalar fields in @@unique attributes in views cannot have arguments.[0m
+//   [1;94m-->[0m  [4mschema.prisma:18[0m
+// [1;94m   | [0m
+// [1;94m17 | [0m
+// [1;94m18 | [0m  [1;91m@@unique([region(length: 10)])[0m
 // [1;94m   | [0m

--- a/psl/psl/tests/validation/views/view_with_pkey.prisma
+++ b/psl/psl/tests/validation/views/view_with_pkey.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
 }
 
 generator js {
@@ -12,8 +11,8 @@ view Mountain {
   id Int @id
 }
 // [1;91merror[0m: [1mError validating: Views cannot have primary keys.[0m
-//   [1;94m-->[0m  [4mschema.prisma:12[0m
+//   [1;94m-->[0m  [4mschema.prisma:11[0m
 // [1;94m   | [0m
-// [1;94m11 | [0mview Mountain {
-// [1;94m12 | [0m  id Int [1;91m@id[0m
+// [1;94m10 | [0mview Mountain {
+// [1;94m11 | [0m  id Int [1;91m@id[0m
 // [1;94m   | [0m

--- a/query-compiler/core-tests/tests/query_validation_tests/composites/schema.prisma
+++ b/query-compiler/core-tests/tests/query_validation_tests/composites/schema.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url      = "dummy-url"
 }
 
 model TestModel {

--- a/query-compiler/core-tests/tests/query_validation_tests/create/schema.prisma
+++ b/query-compiler/core-tests/tests/query_validation_tests/create/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgres"
-  url      = env("SOME_DB")
 }
 
 // / User model comment

--- a/query-compiler/core-tests/tests/query_validation_tests/postgres_basic/schema.prisma
+++ b/query-compiler/core-tests/tests/query_validation_tests/postgres_basic/schema.prisma
@@ -1,6 +1,5 @@
 datasource test {
   provider = "postgresql"
-  url      = "dummy-url"
 }
 
 model User {

--- a/query-compiler/dmmf/src/tests/test-schemas/mongo.prisma
+++ b/query-compiler/dmmf/src/tests/test-schemas/mongo.prisma
@@ -6,7 +6,6 @@ generator client {
 
 datasource db {
   provider = "mongodb"
-  url      = "file:dev.db"
 }
 
 /// User model comment

--- a/query-compiler/dmmf/src/tests/test-schemas/postgres.prisma
+++ b/query-compiler/dmmf/src/tests/test-schemas/postgres.prisma
@@ -6,7 +6,6 @@ generator client {
 
 datasource db {
   provider = "postgres"
-  url      = "file:dev.db"
 }
 
 /// User model comment

--- a/query-compiler/dmmf/src/tests/test-schemas/sqlite_ignore.prisma
+++ b/query-compiler/dmmf/src/tests/test-schemas/sqlite_ignore.prisma
@@ -6,7 +6,6 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = "file:dev.db"
 }
 
 /// User model comment

--- a/query-compiler/dmmf/src/tests/test-schemas/views_ignore.prisma
+++ b/query-compiler/dmmf/src/tests/test-schemas/views_ignore.prisma
@@ -6,7 +6,6 @@ generator client {
 
 datasource db {
   provider = "sqlite"
-  url      = "file:dev.db"
 }
 
 model User {

--- a/query-compiler/dmmf/test_files/general.prisma
+++ b/query-compiler/dmmf/test_files/general.prisma
@@ -1,6 +1,5 @@
 datasource pg1 {
   provider = "postgresql"
-  url      = "postgresql://"
 }
 
 generator foo {

--- a/query-compiler/dmmf/test_files/indexes_mongodb.prisma
+++ b/query-compiler/dmmf/test_files/indexes_mongodb.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator client {

--- a/query-compiler/dmmf/test_files/indexes_mysql.prisma
+++ b/query-compiler/dmmf/test_files/indexes_mysql.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mysql"
-  url      = "mysql://"
 }
 
 model Post {

--- a/query-compiler/dmmf/test_files/indexes_postgres.prisma
+++ b/query-compiler/dmmf/test_files/indexes_postgres.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://"
 }
 
 model Example {

--- a/query-compiler/dmmf/test_files/indexes_sqlserver.prisma
+++ b/query-compiler/dmmf/test_files/indexes_sqlserver.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "sqlserver"
-  url      = "sqlserver://"
 }
 
 model Example {

--- a/query-compiler/dmmf/test_files/schemas.prisma
+++ b/query-compiler/dmmf/test_files/schemas.prisma
@@ -1,6 +1,5 @@
 datasource pg {
   provider = "postgresql"
-  url      = "postgresql://"
   schemas  = ["public", "test"]
 }
 

--- a/query-compiler/dmmf/test_files/source.prisma
+++ b/query-compiler/dmmf/test_files/source.prisma
@@ -1,4 +1,3 @@
 datasource pg1 {
   provider = "postgresql"
-  url      = "postgresql://"
 }

--- a/query-compiler/dmmf/test_files/source_with_comments.prisma
+++ b/query-compiler/dmmf/test_files/source_with_comments.prisma
@@ -1,7 +1,6 @@
 /// Super cool postgres source.
 datasource pg1 {
   provider = "postgresql"
-  url      = "postgresql://"
 }
 
 /// My author model.

--- a/query-compiler/query-compiler-playground/src/schema.prisma
+++ b/query-compiler/query-compiler-playground/src/schema.prisma
@@ -4,7 +4,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = "postgresql://postgres:prisma@localhost:5438"
 }
 
 model User {

--- a/query-compiler/query-compiler/tests/data/schema.prisma
+++ b/query-compiler/query-compiler/tests/data/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("TEST_POSTGRES_URI")
 }
 
 enum Role {

--- a/query-compiler/schema/test-schemas/noalyss_folder.prisma
+++ b/query-compiler/schema/test-schemas/noalyss_folder.prisma
@@ -1,7 +1,6 @@
 
 datasource db {
   provider = "postgresql"
-  url      = env("DB_URL")
 }
 
 model action {

--- a/query-compiler/schema/test-schemas/odoo.prisma
+++ b/query-compiler/schema/test-schemas/odoo.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "postgres"
-  url      = env("DB_URL")
 }
 
 model base_import_import {

--- a/query-compiler/schema/test-schemas/standupbot.prisma
+++ b/query-compiler/schema/test-schemas/standupbot.prisma
@@ -1,7 +1,6 @@
 
 datasource db {
   provider = "postgresql"
-  url      = env("DB_URL")
 }
 
 model eventids {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_changed_from_descending_to_ascending/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_changed_from_descending_to_ascending/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 type Address {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_created/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_created/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_created_descending/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_created_descending/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 type Address {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_dropped/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_dropped/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_renamed/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_can_be_renamed/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_work_on_arrays/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/composite_indexes_work_on_arrays/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/index_keys_can_be_changed/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/index_keys_can_be_changed/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 type Address {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/index_to_unique/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/index_to_unique/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 type Ip {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/map_annotations/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/map_annotations/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 type Embed {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/multi_column_fulltext_indexes_can_be_created/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/multi_column_fulltext_indexes_can_be_created/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/multi_column_mixed_fulltext_indexes_can_be_changed/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/multi_column_mixed_fulltext_indexes_can_be_changed/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/multi_column_mixed_fulltext_indexes_can_be_created/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/multi_column_mixed_fulltext_indexes_can_be_created/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/single_column_fulltext_indexes_can_be_created/schema.prisma
+++ b/schema-engine/connectors/mongodb-schema-connector/tests/migrations/scenarios/single_column_fulltext_indexes_can_be_created/schema.prisma
@@ -1,6 +1,5 @@
 datasource db {
   provider = "mongodb"
-  url      = "mongodb://"
 }
 
 generator js {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/mysql/create_constraint_name_tests_w_explicit_names.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/mysql/create_constraint_name_tests_w_explicit_names.prisma
@@ -2,7 +2,6 @@
 
 datasource mydb {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/mysql/create_constraint_name_tests_w_implicit_names.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/mysql/create_constraint_name_tests_w_implicit_names.prisma
@@ -2,7 +2,6 @@
 
 datasource mydb {
     provider = "mysql"
-    url = "dummy-url"
     relationMode = "prisma"
 }
 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/mysql/enums/enum_fields.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/mysql/enums/enum_fields.prisma
@@ -2,7 +2,6 @@
 
 datasource mydb {
     provider = "mysql"
-    url = "dummy-url"
 }
 
 model MyTable {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_dbgenerated.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_dbgenerated.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url      = "dummy-url"
 }
 
 model table {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_unsupported_dbgenerated.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/empty_unsupported_dbgenerated.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url      = "dummy-url"
 }
 
 model table {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_basic.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_basic.prisma
@@ -3,7 +3,6 @@
 
 datasource pg {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model Test {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_fields.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/enum_fields.prisma
@@ -3,7 +3,6 @@
 
 datasource mydb {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model MyTable {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/mapped_basic.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/enums/mapped_basic.prisma
@@ -3,7 +3,6 @@
 
 datasource pg {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model Avocado {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/multi_schema_basic.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/multi_schema_basic.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public", "security", "users"]
 }
 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/multi_schema_implicit_many_to_many_join_table_is_in_first_model_schema.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/multi_schema_implicit_many_to_many_join_table_is_in_first_model_schema.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["veggies", "roots"]
 }
 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/multi_schema_unused_namespace.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/multi_schema_unused_namespace.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
     schemas = ["public", "security", "users", "unused"]
 }
 

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/scalar_lists_with_enum_and_int_id.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/postgres/scalar_lists_with_enum_and_int_id.prisma
@@ -3,7 +3,6 @@
 
 datasource testds {
     provider = "postgresql"
-    url = "dummy-url"
 }
 
 model A {

--- a/schema-engine/sql-migration-tests/tests/single_migration_tests/sqlite/constraint_names_basic.prisma
+++ b/schema-engine/sql-migration-tests/tests/single_migration_tests/sqlite/constraint_names_basic.prisma
@@ -2,7 +2,6 @@
 
 datasource db {
     provider = "sqlite"
-    url = "dummy-url"
 }
 
 model A {


### PR DESCRIPTION
Just for ease of review, to create a base commit for https://github.com/prisma/prisma-engines/pull/5683 to review from. Will be actually be merged as part of that PR.

The added lines come from updated stored inline in psl schema files. It was unfortunately too much effort to split them off into a separate commit retroactively, since all changes started as one commit, and updating the schema files was actually done after the code changes.

Ref: https://linear.app/prisma-company/issue/TML-1545/remove-url-datasource-attribute-from-psl
