### PR TITLE
fix: temporarily rename `QC_WASM_VERSION` back to `QE_WASM_VERSION`

### DIFF
--- a/.github/workflows/publish-query-compiler-wasm.yml
+++ b/.github/workflows/publish-query-compiler-wasm.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build @prisma/query-compiler-wasm
         run: make build-qc-wasm
         env:
-          QC_WASM_VERSION: ${{ github.event.inputs.packageVersion }}
+          QE_WASM_VERSION: ${{ github.event.inputs.packageVersion }}
 
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ CONFIG_FILE = .test_config
 DEV_SCHEMA_FILE = dev_datamodel.prisma
 PRISMA_BRANCH ?= main
 ENGINE_SIZE_OUTPUT ?= /dev/stdout
-QC_WASM_VERSION ?= 0.0.0
+QE_WASM_VERSION ?= 0.0.0
 SCHEMA_WASM_VERSION ?= 0.0.0
 
 LIBRARY_EXT := $(shell                            \
@@ -60,7 +60,7 @@ build-se-wasm:
 
 build-qc-wasm:
 	cd query-compiler/query-compiler-wasm && \
-	./build.sh $(QC_WASM_VERSION) query-compiler/query-compiler-wasm/pkg
+	./build.sh $(QE_WASM_VERSION) query-compiler/query-compiler-wasm/pkg
 
 build-qc-wasm-gz: build-qc-wasm
 	@cd query-compiler/query-compiler-wasm/pkg && \


### PR DESCRIPTION
`prisma/engines-wrapper` dispatches the version of the workflow file from the main branch with the code from the next branch. Since the workflow on the main branch still uses `QE_WASM_VERSION`, this breaks publishing the integration versions of `query-compiler-wasm`.

/prisma-branch next