### PR TITLE
chore: remove unneeded targets

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,15 +5,6 @@ targets = [
     # Wasm target for serverless and edge environments.
     "wasm32-unknown-unknown",
 
-    # React Native targets we support.
-    "x86_64-apple-ios",
-    "aarch64-apple-ios",
-    "aarch64-apple-ios-sim",
-    "aarch64-linux-android",
-    "x86_64-linux-android",
-    "armv7-linux-androideabi",
-    "i686-linux-android",
-
     # Server targets we support.
     "x86_64-unknown-linux-musl",
     "aarch64-unknown-linux-gnu",


### PR DESCRIPTION
React-native related target triples are unused since the removal of the query engine.

/prisma-branch next