### PR TITLE
chore: update Rust to 1.91.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.0"
+channel = "1.91.1"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # Wasm target for serverless and edge environments.


### PR DESCRIPTION
1.91.1 fixes a Wasm-related regression. It doesn't seem to affect us (since we're not linking multiple Wasm modules) but it's still a good idea to upgrade.

https://blog.rust-lang.org/2025/11/10/Rust-1.91.1/