### PR TITLE
fix: add missing repo URLs for OIDC

### DIFF
--- a/query-compiler/query-compiler-wasm/package.json
+++ b/query-compiler/query-compiler-wasm/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@prisma/query-compiler-wasm",
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma-engines",
+    "directory": "query-compiler/query-compiler-wasm"
+  }
 }

--- a/query-engine/query-engine-wasm/package.json
+++ b/query-engine/query-engine-wasm/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@prisma/query-engine-wasm",
   "version": "0.0.0",
-  "type": "module"
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/prisma/prisma-engines",
+    "directory": "query-engine/query-engine-wasm"
+  }
 }


### PR DESCRIPTION
Fixing https://github.com/prisma/prisma-engines/actions/runs/19970896507