### PR TITLE
fix: do not render timestamp precision when unspecified

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql/renderer.rs
@@ -511,14 +511,11 @@ fn render_default<'a>(column: TableColumnWalker<'a>, default: &'a DefaultValue) 
         DefaultKind::Value(PrismaValue::String(val)) | DefaultKind::Value(PrismaValue::Enum(val)) => {
             Quoted::mysql_string(escape_string_literal(val)).to_string().into()
         }
-        DefaultKind::Now => {
-            let precision = column
-                .column_native_type()
-                .and_then(MySqlType::timestamp_precision)
-                .unwrap_or(3);
-
-            format!("CURRENT_TIMESTAMP({precision})").into()
-        }
+        DefaultKind::Now => column
+            .column_native_type()
+            .and_then(MySqlType::timestamp_precision)
+            .map(|p| format!("CURRENT_TIMESTAMP({p})").into())
+            .unwrap_or_else(|| "CURRENT_TIMESTAMP".into()),
         DefaultKind::Value(PrismaValue::DateTime(dt)) if column.column_type_family().is_datetime() => {
             Quoted::mysql_string(dt.to_rfc3339()).to_string().into()
         }


### PR DESCRIPTION
[TML-1647](https://linear.app/prisma-company/issue/TML-1647/fix-broken-citext-integration-test)

[MySQL docs state](https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html):
> If a [TIMESTAMP](https://dev.mysql.com/doc/refman/5.7/en/datetime.html) or [DATETIME](https://dev.mysql.com/doc/refman/5.7/en/datetime.html) column definition includes an explicit fractional seconds precision value anywhere, the same value must be used throughout the column definition. This is permitted:
```
CREATE TABLE t1 (
  ts TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
);
```
> This is not permitted:
```
CREATE TABLE t1 (
  ts TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP(3)
);
```

Fixes https://github.com/prisma/prisma/issues/28873