### PR TITLE
chore: update Rust to 1.92.0

### DIFF
--- a/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/indexes.rs
@@ -355,10 +355,12 @@ pub(crate) fn composite_type_in_compound_unique_index(index: IndexWalker<'_>, ct
         .fields()
         .find(|f| f.scalar_field_type().as_composite_type().is_some());
 
-    if index.fields().len() > 1 && composite_type.is_some() {
+    if index.fields().len() > 1
+        && let Some(composite_type) = composite_type
+    {
         let message = format!(
             "Prisma does not currently support composite types in compound unique indices, please remove {:?} from the index. See https://pris.ly/d/mongodb-composite-compound-indices for more details",
-            composite_type.unwrap().name()
+            composite_type.name()
         );
         ctx.push_error(DatamodelError::new_attribute_validation_error(
             &message,

--- a/quaint/src/visitor/mssql.rs
+++ b/quaint/src/visitor/mssql.rs
@@ -856,7 +856,6 @@ impl<'a> Visitor<'a> for Mssql<'a> {
 mod tests {
     use crate::{
         ast::*,
-        val,
         visitor::{Mssql, Visitor},
     };
     use indoc::indoc;
@@ -922,8 +921,6 @@ mod tests {
 
     #[test]
     fn test_in_values() {
-        use crate::{col, values};
-
         let expected_sql =
             "SELECT [test].* FROM [test] WHERE (([id1] = @P1 AND [id2] = @P2) OR ([id1] = @P3 AND [id2] = @P4))";
 
@@ -941,8 +938,6 @@ mod tests {
 
     #[test]
     fn test_not_in_values() {
-        use crate::{col, values};
-
         let expected_sql =
             "SELECT [test].* FROM [test] WHERE NOT (([id1] = @P1 AND [id2] = @P2) OR ([id1] = @P3 AND [id2] = @P4))";
 

--- a/quaint/src/visitor/mysql.rs
+++ b/quaint/src/visitor/mysql.rs
@@ -804,8 +804,6 @@ mod tests {
 
     #[test]
     fn test_in_values_2_tuple() {
-        use crate::{col, values};
-
         let expected_sql = "SELECT `test`.* FROM `test` WHERE (`id1`,`id2`) IN ((?,?),(?,?))";
         let query = Select::from_table("test")
             .so_that(Row::from((col!("id1"), col!("id2"))).in_selection(values!((1, 2), (3, 4))));

--- a/quaint/src/visitor/sqlite.rs
+++ b/quaint/src/visitor/sqlite.rs
@@ -570,7 +570,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{val, visitor::*};
+    use crate::visitor::*;
 
     fn expected_values<'a, T>(sql: &'static str, params: Vec<T>) -> (String, Vec<Value<'a>>)
     where
@@ -633,8 +633,6 @@ mod tests {
 
     #[test]
     fn test_select_from_values() {
-        use crate::values;
-
         let expected_sql = "SELECT `vals`.* FROM (VALUES (?,?),(?,?)) AS `vals`";
         let values = Table::from(values!((1, 2), (3, 4))).alias("vals");
         let query = Select::from_table(values);
@@ -649,8 +647,6 @@ mod tests {
 
     #[test]
     fn test_in_values() {
-        use crate::{col, values};
-
         let expected_sql = "SELECT `test`.* FROM `test` WHERE (`id1`,`id2`) IN (VALUES (?,?),(?,?))";
         let query = Select::from_table("test")
             .so_that(Row::from((col!("id1"), col!("id2"))).in_selection(values!((1, 2), (3, 4))));

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/filter_regression.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/filter_regression.rs
@@ -4,7 +4,6 @@ use query_engine_tests::*;
 /// Basic filter regression 1:m relation tests.
 #[test_suite(schema(schema))]
 mod fr_one_to_m {
-    use indoc::indoc;
     use query_engine_tests::run_query;
 
     fn schema() -> String {
@@ -77,7 +76,6 @@ mod fr_one_to_m {
 /// Filter regression 1:m relation tests with compound ids.
 #[test_suite(schema(schema), capabilities(CompoundIds))]
 mod fr_compound_one_to_m {
-    use indoc::indoc;
     use query_engine_tests::run_query;
 
     fn schema() -> String {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.92.0"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # Wasm target for serverless and edge environments.


### PR DESCRIPTION
Update Rust to 1.92.0 and fix the new compiler and clippy lints:
- better unused imports detection in nested modules/scopes when the same path is made visible in multiple ways at the same time
- `is_some`+`unwrap` pattern detection