### PR TITLE
fix(ci): migrate off the retired macos-13 runner

### DIFF
--- a/.github/workflows/build-engines-apple-intel-template.yml
+++ b/.github/workflows/build-engines-apple-intel-template.yml
@@ -17,7 +17,7 @@ jobs:
 
       # minimum supported version of macOS
       MACOSX_DEPLOYMENT_TARGET: 10.15
-    runs-on: macos-13
+    runs-on: macos-15-intel
 
     steps:
       - name: Output link to real commit

--- a/.github/workflows/build-engines-apple-silicon-template.yml
+++ b/.github/workflows/build-engines-apple-silicon-template.yml
@@ -14,7 +14,7 @@ jobs:
     env:
       SQLITE_MAX_VARIABLE_NUMBER: 250000
       SQLITE_MAX_EXPR_DEPTH: 10000
-    runs-on: macos-13
+    runs-on: macos-15
 
     steps:
       - name: Output link to real commit

--- a/.github/workflows/test-compilation.yml
+++ b/.github/workflows/test-compilation.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-15
         crate:
           - schema-engine-cli
           - prisma-fmt


### PR DESCRIPTION
`macos-13` runner is being retired, and jobs using it are beginning to fail with these errors:

```
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.
The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046
```

(for example, see https://github.com/prisma/prisma-engines/actions/runs/20172373777/job/57911402339).

This commit migrates our macOS CI jobs to use the `macos-15` and `macos-15-intel` runners.