### PR TITLE
perf: compile qc optimizing for performance and not size

### DIFF
--- a/query-compiler/query-compiler-wasm/build.sh
+++ b/query-compiler/query-compiler-wasm/build.sh
@@ -13,7 +13,7 @@ OUT_FOLDER="${2:-"query-compiler/query-compiler-wasm/pkg"}"
 OUT_TARGET="bundler"
 # wasm-opt pass
 WASM_OPT_ARGS=(
-    "-Os"                                 # execute size-focused optimization passes (-Oz actually increases size by 1KB)
+    "-O4"                                 # execute size-focused optimization passes (-Oz actually increases size by 1KB)
     "--vacuum"                            # removes obviously unneeded code
     "--duplicate-function-elimination"    # removes duplicate functions
     "--duplicate-import-elimination"      # removes duplicate imports
@@ -63,7 +63,7 @@ build() {
     CARGO_TARGET_DIR=$(cargo metadata --format-version 1 | jq -r .target_directory)
 
     echo "🔨 Building $CONNECTOR"
-    CARGO_PROFILE_RELEASE_OPT_LEVEL="z" cargo build \
+    CARGO_PROFILE_RELEASE_OPT_LEVEL="3" cargo build \
         -p query-compiler-wasm \
         --profile "$WASM_BUILD_PROFILE" \
         --features "$CONNECTOR" \


### PR DESCRIPTION
Update the build script to tell rustc, LLVM and wasm-opt to optimize for performance and not size. This improves the query compilation performance by 35% (as measured from JavaScript).

This increases the size quite a bit. Notably, it won't fit in the free tier of Vercel Edge Functions anymore.

As discussed, we want to:
- Build two separate QC packages, one optimized for size and another for performance and bundle both in `@prisma/client`
- Add a new client generator option that allows to choose which QC build to use (e.g. something like `compiler = "fast"`/`compiler = "small"`.
- Use the small slow build by default if we generate the client for `vercel-edge` target runtime (but allow to override it with the option above). Conversely, use the fast build by default for all other target runtimes.