### PR TITLE
fix: fix measure-qc-wasm issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -438,7 +438,7 @@ measure-qc-wasm-%: build-qc-gz-%
 	@cd query-compiler/query-compiler-wasm/pkg; \
 	for provider in postgresql mysql sqlite sqlserver cockroachdb; do \
 		echo "$${provider}_$*_qc_size=$$(cat $$provider/query_compiler_$*_bg.wasm | wc -c | tr -d ' ')" >> $(ENGINE_SIZE_OUTPUT); \
-		echo "$${provider}_$*_qc_size_gz=$$(cat $$provider_$*.gz | wc -c | tr -d ' ')" >> $(ENGINE_SIZE_OUTPUT); \
+		echo "$${provider}_$*_qc_size_gz=$$(cat $${provider}_$*.gz | wc -c | tr -d ' ')" >> $(ENGINE_SIZE_OUTPUT); \
 	done;
 
 install-driver-adapters-kit-deps: build-driver-adapters


### PR DESCRIPTION
Another issue with variable interpolation. Broke the WASM size reports for gzipped files.