### PR TITLE
fix(mongodb): skip $$REMOVE check for required fields to enable index usage

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -272,7 +272,10 @@ impl MongoFilterVisitor {
             ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
         };
 
-        let filter_doc = if !is_set_cond {
+        // Only add $$REMOVE check for optional fields. Required fields and _id cannot
+        // be missing by definition, and adding this check prevents MongoDB from using indexes.
+        // See: https://github.com/prisma/prisma/issues/29000
+        let filter_doc = if !is_set_cond && !field.is_required() {
             exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
         } else {
             filter_doc
@@ -413,7 +416,10 @@ impl MongoFilterVisitor {
             )),
         }?;
 
-        let filter_doc = if !is_set_cond {
+        // Only add $$REMOVE check for optional fields. Required fields and _id cannot
+        // be missing by definition, and adding this check prevents MongoDB from using indexes.
+        // See: https://github.com/prisma/prisma/issues/29000
+        let filter_doc = if !is_set_cond && !field.is_required() {
             exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
         } else {
             filter_doc


### PR DESCRIPTION
## Description

Fixes prisma/prisma#29000

This PR fixes a critical performance issue where **all MongoDB queries bypass indexes** due to unconditional `$$REMOVE` checks.

### Problem

Previously, every scalar filter in `mongodb-query-connector` was wrapped with:

```javascript
{ $and: [<filter>, { $ne: ["$field", "$$REMOVE"] }] }
```

This forces MongoDB to use `$expr` (aggregation expressions), which **cannot use indexes**, causing full collection scans (COLLSCAN) on every query—including `_id` and `@unique` field lookups.

### Root Cause

The `exclude_undefineds()` function was designed to handle optional fields that might be `undefined` in MongoDB documents. However, it was being called **unconditionally** for all fields, including:

- `_id` primary key (impossible to be missing)
- `@unique` required fields (have indexes that should be used)
- Required fields (Prisma enforces on create, cannot be missing)

### Solution

Only add the `$$REMOVE` check for **optional fields**. Required fields and `_id` cannot be undefined by definition.

Added `!field.is_required()` condition before calling `exclude_undefineds()` in:
- `default_scalar_filter()` (line 278)
- `insensitive_scalar_filter()` (line 421)

### Related Issues

- prisma/prisma#29000 (main issue)
- prisma/prisma#22878
- prisma/prisma#23775 
- prisma/prisma#17396
