### PR TITLE
fix(postgresql): parsing bug with expression based unique indexes on postgres

### DIFF
--- a/quaint/src/connector/postgres/error.rs
+++ b/quaint/src/connector/postgres/error.rs
@@ -53,7 +53,7 @@ impl From<PostgresError> for Error {
                     .detail
                     .as_ref()
                     .and_then(|d| d.split(")=(").next())
-                    .and_then(|d| d.splitn(2, " (").nth(1).map(|s| s.replace('"', "")))
+                    .and_then(|d| d.split_once(" (").map(|(_, rest)| rest.replace('"', "")))
                     .map(|s| DatabaseConstraint::fields(s.split(", ")))
                     .unwrap_or(DatabaseConstraint::CannotParse);
 


### PR DESCRIPTION
Fixes a bug where the unique key violation parsing incorrectly returns extra "comma" characters for expression based unique indexes such as:

```
CREATE UNIQUE INDEX "unique_idx" ON "table_name"(
  "column_1",
  (column_2->>'field'),
);
```

In which case the columns affected would previously be returned as `["column_1,"]` instead of `["column_1"]`

