### PR TITLE
feat(qc): support parameterizing `orderBy._relevance.search`

### DIFF
--- a/quaint/src/ast/function/search.rs
+++ b/quaint/src/ast/function/search.rs
@@ -1,5 +1,4 @@
 use crate::prelude::*;
-use std::borrow::Cow;
 
 #[derive(Debug, Clone, PartialEq)]
 /// Holds the expressions on which to perform a full-text search
@@ -39,7 +38,7 @@ where
 /// Holds the expressions & query on which to perform a text-search ranking compute
 pub struct TextSearchRelevance<'a> {
     pub(crate) exprs: Vec<Expression<'a>>,
-    pub(crate) query: Cow<'a, str>,
+    pub(crate) query: Expression<'a>,
 }
 
 /// Computes the relevance score of a full-text search query against some expressions.
@@ -63,7 +62,7 @@ pub struct TextSearchRelevance<'a> {
 pub fn text_search_relevance<'a, E, Q>(exprs: &[E], query: Q) -> super::Function<'a>
 where
     E: Clone + Into<Expression<'a>>,
-    Q: Into<Cow<'a, str>>,
+    Q: Into<Expression<'a>>,
 {
     let exprs: Vec<Expression> = exprs.iter().map(|c| c.clone().into()).collect();
     let fun = TextSearchRelevance {

--- a/quaint/src/visitor/mysql.rs
+++ b/quaint/src/visitor/mysql.rs
@@ -593,7 +593,8 @@ impl<'a> Visitor<'a> for Mysql<'a> {
 
         let text_search = TextSearch { exprs };
 
-        self.visit_matches(text_search.into(), query, false)?;
+        self.visit_expression(text_search.into())?;
+        self.surround_with("AGAINST (", " IN BOOLEAN MODE)", |s| s.visit_expression(query))?;
 
         Ok(())
     }

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -667,7 +667,7 @@ impl<'a> Visitor<'a> for Postgres<'a> {
             Ok(())
         })?;
         self.write(", ")?;
-        self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(query)))?;
+        self.surround_with("to_tsquery(", ")", |s| s.visit_expression(query))?;
         self.write(")")?;
 
         Ok(())

--- a/query-compiler/core/src/query_graph_builder/extractors/query_arguments.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/query_arguments.rs
@@ -179,7 +179,6 @@ fn extract_order_by_relevance(
 ) -> QueryGraphBuilderResult<Option<OrderBy>> {
     let (sort_order, _) = extract_order_by_args(object.get(ordering::SORT).unwrap().clone())?;
     let search: PrismaValue = object.get(ordering::SEARCH).unwrap().clone().try_into()?;
-    let search = search.into_string().unwrap();
     let fields: PrismaValue = object.get(ordering::FIELDS).unwrap().clone().try_into()?;
 
     let fields = match fields {

--- a/query-compiler/query-structure/src/order_by.rs
+++ b/query-compiler/query-structure/src/order_by.rs
@@ -1,4 +1,5 @@
 use crate::{CompositeFieldRef, RelationFieldRef, ScalarFieldRef};
+use prisma_value::PrismaValue;
 use std::fmt::Display;
 
 #[derive(Clone, Copy, PartialEq, Debug, Eq, Hash)]
@@ -101,7 +102,7 @@ impl OrderBy {
 
     pub fn relevance(
         fields: Vec<ScalarFieldRef>,
-        search: String,
+        search: PrismaValue,
         sort_order: SortOrder,
         path: Vec<OrderByHop>,
     ) -> Self {
@@ -206,7 +207,7 @@ impl OrderByToManyAggregation {
 pub struct OrderByRelevance {
     pub fields: Vec<ScalarFieldRef>,
     pub sort_order: SortOrder,
-    pub search: String,
+    pub search: PrismaValue,
     pub path: Vec<OrderByHop>,
 }
 

--- a/query-compiler/schema/src/build/input_types/objects/order_by_objects.rs
+++ b/query-compiler/schema/src/build/input_types/objects/order_by_objects.rs
@@ -268,7 +268,7 @@ fn order_by_object_type_text_search<'a>(
                 None,
             ),
             simple_input_field(ordering::SORT, InputType::Enum(sort_order_enum), None),
-            simple_input_field(ordering::SEARCH, InputType::string(), None),
+            simple_input_field(ordering::SEARCH, InputType::string(), None).parameterizable(),
         ]
     });
     input_object


### PR DESCRIPTION
Don't parse the exact string value out of `orderBy._relevance.search` and forward it all the way to `quaint` as an opaque value.

This PR also marks the field as parameterizable in the query schema and DMMF.