### PR TITLE
refactor(qc): remove `ScalarCondition::[Not]InTemplate`

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -454,6 +454,13 @@ impl PrismaValue {
         }
     }
 
+    pub fn into_placeholder(self) -> Option<Placeholder> {
+        match self {
+            PrismaValue::Placeholder(p) => Some(p),
+            _ => None,
+        }
+    }
+
     pub fn new_float(float: f64) -> PrismaValue {
         PrismaValue::Float(BigDecimal::from_f64(float).unwrap())
     }
@@ -583,6 +590,12 @@ impl From<Uuid> for PrismaValue {
 impl From<PrismaListValue> for PrismaValue {
     fn from(s: PrismaListValue) -> Self {
         PrismaValue::List(s)
+    }
+}
+
+impl From<Placeholder> for PrismaValue {
+    fn from(p: Placeholder) -> Self {
+        PrismaValue::Placeholder(p)
     }
 }
 

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -94,8 +94,8 @@ impl<'a> ScalarFilterParser<'a> {
                         PrismaValue::Null => field.equals(value),
                         PrismaValue::List(values) => field.is_in(values),
 
-                        pv @ PrismaValue::Placeholder(_) if self.reverse() => field.not_in_template(pv),
-                        pv @ PrismaValue::Placeholder(_) => field.is_in_template(pv),
+                        PrismaValue::Placeholder(p) if self.reverse() => field.not_in(p),
+                        PrismaValue::Placeholder(p) => field.is_in(p),
 
                         _ => unreachable!(), // Validation guarantees this.
                     },
@@ -118,8 +118,8 @@ impl<'a> ScalarFilterParser<'a> {
                         PrismaValue::Null => field.not_equals(value),
                         PrismaValue::List(values) => field.not_in(values),
 
-                        pv @ PrismaValue::Placeholder(_) if self.reverse() => field.is_in_template(pv), // not not in => in
-                        pv @ PrismaValue::Placeholder(_) => field.not_in_template(pv),
+                        PrismaValue::Placeholder(p) if self.reverse() => field.is_in(p), // not not in => in
+                        PrismaValue::Placeholder(p) => field.not_in(p),
 
                         _ => unreachable!(), // Validation guarantees this.
                     },

--- a/query-compiler/query-structure/src/filter/compare.rs
+++ b/query-compiler/query-structure/src/filter/compare.rs
@@ -9,14 +9,6 @@ pub trait ScalarCompare {
     where
         T: Into<ConditionListValue>;
 
-    fn is_in_template<T>(&self, val: T) -> Filter
-    where
-        T: Into<ConditionValue>;
-
-    fn not_in_template<T>(&self, val: T) -> Filter
-    where
-        T: Into<ConditionValue>;
-
     fn not_in<T>(&self, val: T) -> Filter
     where
         T: Into<ConditionListValue>;

--- a/query-compiler/query-structure/src/filter/scalar/compare.rs
+++ b/query-compiler/query-structure/src/filter/scalar/compare.rs
@@ -14,30 +14,6 @@ impl ScalarCompare for ScalarFieldRef {
         })
     }
 
-    /// Field is in a given template value
-    fn is_in_template<T>(&self, value: T) -> Filter
-    where
-        T: Into<ConditionValue>,
-    {
-        Filter::from(ScalarFilter {
-            projection: ScalarProjection::Single(self.clone()),
-            condition: ScalarCondition::InTemplate(value.into()),
-            mode: QueryMode::Default,
-        })
-    }
-
-    /// Field is not in a given template value
-    fn not_in_template<T>(&self, value: T) -> Filter
-    where
-        T: Into<ConditionValue>,
-    {
-        Filter::from(ScalarFilter {
-            projection: ScalarProjection::Single(self.clone()),
-            condition: ScalarCondition::NotInTemplate(value.into()),
-            mode: QueryMode::Default,
-        })
-    }
-
     /// Field is not in a given value
     fn not_in<T>(&self, values: T) -> Filter
     where
@@ -238,30 +214,6 @@ impl ScalarCompare for ModelProjection {
         })
     }
 
-    /// Field is in a given template
-    fn is_in_template<T>(&self, value: T) -> Filter
-    where
-        T: Into<ConditionValue>,
-    {
-        Filter::from(ScalarFilter {
-            projection: ScalarProjection::Compound(self.scalar_fields().collect()),
-            condition: ScalarCondition::InTemplate(value.into()),
-            mode: QueryMode::Default,
-        })
-    }
-
-    /// Field is not in a given template
-    fn not_in_template<T>(&self, value: T) -> Filter
-    where
-        T: Into<ConditionValue>,
-    {
-        Filter::from(ScalarFilter {
-            projection: ScalarProjection::Compound(self.scalar_fields().collect()),
-            condition: ScalarCondition::NotInTemplate(value.into()),
-            mode: QueryMode::Default,
-        })
-    }
-
     /// Field is not in a given value
     fn not_in<T>(&self, values: T) -> Filter
     where
@@ -458,30 +410,6 @@ impl ScalarCompare for FieldSelection {
         Filter::from(ScalarFilter {
             projection: ScalarProjection::Compound(self.as_scalar_fields().expect("Todo composites in filters.")),
             condition: ScalarCondition::In(values.into()),
-            mode: QueryMode::Default,
-        })
-    }
-
-    /// Field is in a given template
-    fn is_in_template<T>(&self, value: T) -> Filter
-    where
-        T: Into<ConditionValue>,
-    {
-        Filter::from(ScalarFilter {
-            projection: ScalarProjection::Compound(self.as_scalar_fields().expect("Todo composites in filters.")),
-            condition: ScalarCondition::InTemplate(value.into()),
-            mode: QueryMode::Default,
-        })
-    }
-
-    /// Field is not in a given template
-    fn not_in_template<T>(&self, value: T) -> Filter
-    where
-        T: Into<ConditionValue>,
-    {
-        Filter::from(ScalarFilter {
-            projection: ScalarProjection::Compound(self.as_scalar_fields().expect("Todo composites in filters.")),
-            condition: ScalarCondition::NotInTemplate(value.into()),
             mode: QueryMode::Default,
         })
     }

--- a/query-compiler/query-structure/src/filter/scalar/condition/mod.rs
+++ b/query-compiler/query-structure/src/filter/scalar/condition/mod.rs
@@ -21,8 +21,6 @@ pub enum ScalarCondition {
     GreaterThanOrEquals(ConditionValue),
     In(ConditionListValue),
     NotIn(ConditionListValue),
-    InTemplate(ConditionValue),
-    NotInTemplate(ConditionValue),
     JsonCompare(JsonCondition),
     Search(ConditionValue, Vec<ScalarProjection>),
     NotSearch(ConditionValue, Vec<ScalarProjection>),
@@ -54,8 +52,6 @@ impl ScalarCondition {
                 Self::GreaterThanOrEquals(v) => Self::LessThan(v),
                 Self::In(v) => Self::NotIn(v),
                 Self::NotIn(v) => Self::In(v),
-                Self::InTemplate(v) => Self::NotInTemplate(v),
-                Self::NotInTemplate(v) => Self::InTemplate(v),
                 Self::JsonCompare(json_compare) => {
                     let inverted_cond = json_compare.condition.invert(true);
 
@@ -90,8 +86,6 @@ impl ScalarCondition {
             ScalarCondition::GreaterThanOrEquals(v) => v.as_field_ref(),
             ScalarCondition::In(v) => v.as_field_ref(),
             ScalarCondition::NotIn(v) => v.as_field_ref(),
-            ScalarCondition::InTemplate(v) => v.as_field_ref(),
-            ScalarCondition::NotInTemplate(v) => v.as_field_ref(),
             ScalarCondition::JsonCompare(json_cond) => json_cond.condition.as_field_ref(),
             ScalarCondition::Search(v, _) => v.as_field_ref(),
             ScalarCondition::NotSearch(v, _) => v.as_field_ref(),

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -224,6 +224,9 @@ impl MongoFilterVisitor {
                     // In this context, `field_ref` refers to an array field, so we actually need an `$in` operator.
                     doc! { "$in": [&field_name, coerce_as_array(self.prefixed_field_ref(&field_ref)?)] }
                 }
+                ConditionListValue::Placeholder(_) => {
+                    unimplemented!("query compiler not supported with mongodb yet")
+                }
             },
             ScalarCondition::NotIn(vals) => match vals {
                 ConditionListValue::List(vals) => {
@@ -245,9 +248,10 @@ impl MongoFilterVisitor {
                     // In this context, `field_ref` refers to an array field, so we actually need an `$in` operator.
                     doc! { "$not": { "$in": [&field_name, coerce_as_array(self.prefixed_field_ref(&field_ref)?)] } }
                 }
+                ConditionListValue::Placeholder(_) => {
+                    unimplemented!("query compiler not supported with mongodb yet")
+                }
             },
-            ScalarCondition::InTemplate(_) => unimplemented!("query compiler not supported with mongodb yet"),
-            ScalarCondition::NotInTemplate(_) => unimplemented!("query compiler not supported with mongodb yet"),
             ScalarCondition::JsonCompare(jc) => match *jc.condition {
                 ScalarCondition::Equals(value) => {
                     let bson = match value {
@@ -381,6 +385,9 @@ impl MongoFilterVisitor {
                     self.regex_match(&Bson::from("$$elem"), field, "^", field, "$", true)?,
                     true,
                 )),
+                ConditionListValue::Placeholder(_) => {
+                    unimplemented!("query compiler not supported with mongodb yet")
+                }
             },
             ScalarCondition::NotIn(vals) => match vals {
                 ConditionListValue::List(vals) => {
@@ -401,9 +408,10 @@ impl MongoFilterVisitor {
                         .map(|rgx_doc| doc! { "$not": rgx_doc })?,
                     true,
                 )),
+                ConditionListValue::Placeholder(_) => {
+                    unimplemented!("query compiler not supported with mongodb yet")
+                }
             },
-            ScalarCondition::InTemplate(_) => unimplemented!("query compiler not supported with mongodb yet"),
-            ScalarCondition::NotInTemplate(_) => unimplemented!("query compiler not supported with mongodb yet"),
             ScalarCondition::IsSet(is_set) => Ok(render_is_set(&field_name, is_set)),
             ScalarCondition::JsonCompare(_) => Err(MongoError::Unsupported(
                 "JSON filtering is not yet supported on MongoDB".to_string(),
@@ -470,6 +478,9 @@ impl MongoFilterVisitor {
                 doc! { "$in": ["$$elem", coerce_as_array((self.prefix(), &field_ref).into_bson()?)] },
                 true,
             ),
+            ScalarListCondition::ContainsEvery(ConditionListValue::Placeholder(_)) => {
+                unimplemented!("query compiler not supported with mongodb yet")
+            }
 
             ScalarListCondition::ContainsSome(vals) if vals.is_empty() => {
                 // Empty hasSome: Return no records.
@@ -493,6 +504,9 @@ impl MongoFilterVisitor {
                 doc! { "$in": ["$$elem", coerce_as_array((self.prefix(), &field_ref).into_bson()?)] },
                 true,
             ),
+            ScalarListCondition::ContainsSome(ConditionListValue::Placeholder(_)) => {
+                unimplemented!("query compiler not supported with mongodb yet")
+            }
 
             ScalarListCondition::IsEmpty(true) => {
                 doc! { "$eq": [render_size(&field_name, true), 0] }


### PR DESCRIPTION
Remove `ScalarCondition::InTemplate` and `ScalarCondition::NotInTemplate` and instead add placeholders as the third variant in `ConditionListValue`. This simplifies the implementation and makes some illegal states unrepresentable (previously it was possible to construct `ScalarCondition::InTemplate`/`ScalarCondition::NotInTemplate` with arbitrary `PrismaValue`s and with field references).