### PR TITLE
feat(qc): support `hasSome`/`hasEvery` parameterization

### DIFF
--- a/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -535,6 +535,9 @@ impl<'a> ScalarFilterParser<'a> {
                     ))),
                 }
             }
+
+            ParsedInputValue::Single(PrismaValue::Placeholder(p)) => Ok(ConditionListValue::Placeholder(p)),
+
             _ => {
                 let vals: Vec<PrismaValue> = input.try_into()?;
 

--- a/query-compiler/query-builders/sql-query-builder/src/filter/visitor.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/filter/visitor.rs
@@ -598,12 +598,13 @@ impl FilterVisitorExt for FilterVisitor {
             ScalarListCondition::ContainsSome(ConditionListValue::FieldRef(field_ref)) => {
                 comparable.compare_raw("&&", field_ref.aliased_col(alias, ctx))
             }
-            // TODO: Implement placeholder support for scalar list filters (follow-up work)
-            ScalarListCondition::ContainsEvery(ConditionListValue::Placeholder(_)) => {
-                unimplemented!("Placeholder support for hasSome/hasEvery not yet implemented")
+            ScalarListCondition::ContainsEvery(ConditionListValue::Placeholder(placeholder)) => {
+                let param: Expression = field.value(placeholder.into(), ctx).into();
+                comparable.compare_raw("@>", param)
             }
-            ScalarListCondition::ContainsSome(ConditionListValue::Placeholder(_)) => {
-                unimplemented!("Placeholder support for hasSome/hasEvery not yet implemented")
+            ScalarListCondition::ContainsSome(ConditionListValue::Placeholder(placeholder)) => {
+                let param: Expression = field.value(placeholder.into(), ctx).into();
+                comparable.compare_raw("&&", param)
             }
             ScalarListCondition::IsEmpty(true) => comparable.compare_raw("=", ValueType::Array(Some(vec![])).raw()),
             ScalarListCondition::IsEmpty(false) => comparable.compare_raw("<>", ValueType::Array(Some(vec![])).raw()),

--- a/query-compiler/schema/src/build/input_types/fields/field_filter_types.rs
+++ b/query-compiler/schema/src/build/input_types/fields/field_filter_types.rs
@@ -197,8 +197,16 @@ fn scalar_list_filter_type(ctx: &'_ QuerySchema, sf: ScalarFieldRef) -> InputObj
         );
 
         let mapped_list_type_with_field_ref_input = mapped_list_type.with_field_ref_input();
-        fields.push(input_field(filters::HAS_EVERY, mapped_list_type_with_field_ref_input.clone(), None).optional());
-        fields.push(input_field(filters::HAS_SOME, mapped_list_type_with_field_ref_input, None).optional());
+        fields.push(
+            input_field(filters::HAS_EVERY, mapped_list_type_with_field_ref_input.clone(), None)
+                .optional()
+                .parameterizable(),
+        );
+        fields.push(
+            input_field(filters::HAS_SOME, mapped_list_type_with_field_ref_input, None)
+                .optional()
+                .parameterizable(),
+        );
         fields.push(simple_input_field(filters::IS_EMPTY, InputType::boolean(), None).optional());
         fields
     });


### PR DESCRIPTION
Implement `ScalarListCondition::ContainsEvery` and `ScalarListCondition::ContainsSome` support for placeholders in `sql-query-builder` and mark `hasSome`/`hasEvery` as parameterizable in the DMMF.