### PR TITLE
refactor(qc): remove unused `ScalarType::Param` variant

### DIFF
--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -442,8 +442,6 @@ impl QueryDocumentParser {
             // UUID coercion matchers
             (PrismaValue::Uuid(uuid), ScalarType::String) => Ok(PrismaValue::String(uuid.to_string())),
 
-            (pv @ PrismaValue::Placeholder { .. }, ScalarType::Param) => Ok(pv),
-
             // All other combinations are value type mismatches.
             (_, _) => Err(ValidationError::invalid_argument_type(
                 selection_path.segments(),

--- a/query-compiler/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
+++ b/query-compiler/dmmf/src/ast_builders/schema_ast_builder/type_renderer.rs
@@ -46,7 +46,6 @@ pub(super) fn render_output_type<'a>(output_type: &OutputType<'a>, ctx: &mut Ren
                 ScalarType::UUID => "UUID",
                 ScalarType::JsonList => "Json",
                 ScalarType::Bytes => "Bytes",
-                ScalarType::Param => unreachable!("output type must not be Param"),
             };
 
             DmmfTypeReference {

--- a/query-compiler/schema/src/query_schema.rs
+++ b/query-compiler/schema/src/query_schema.rs
@@ -373,7 +373,6 @@ pub enum ScalarType {
     JsonList,
     UUID,
     Bytes,
-    Param,
 }
 
 impl fmt::Display for ScalarType {
@@ -391,7 +390,6 @@ impl fmt::Display for ScalarType {
             ScalarType::UUID => "UUID",
             ScalarType::JsonList => "Json",
             ScalarType::Bytes => "Bytes",
-            ScalarType::Param => "Param",
         };
 
         f.write_str(typ)


### PR DESCRIPTION
Remove unused `ScalarType::Param`.

This was intended to be used for schema-driver parameterization in the initial prototype but it would not have been an adequate representation, and we have now chosen a better way to mark fields as parameterizable.