### PR TITLE
feat(qc): make placeholders typed at JSON protocol level

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -129,6 +129,7 @@ impl std::fmt::Display for PrismaValueType {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, PartialOrd, Ord)]
 pub struct Placeholder {
     pub name: Cow<'static, str>,
+    #[serde(flatten)]
     pub r#type: PrismaValueType,
 }
 

--- a/query-compiler/query-compiler-playground/src/main.rs
+++ b/query-compiler/query-compiler-playground/src/main.rs
@@ -45,7 +45,10 @@ pub fn main() -> anyhow::Result<()> {
                 "where": {
                     "email": {
                         "$type": "Param",
-                        "value": "userEmail"
+                        "value": {
+                            "name": "userEmail",
+                            "type": "String"
+                        }
                     }
                 }
             },


### PR DESCRIPTION
Require placeholder types to be specified in the JSON
protocol representation of the placholders and parse them in
`JsonProtocolAdapter`.