### PR TITLE
fix(qc): fix a typo in invalid argument value validation error

### DIFF
--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -203,7 +203,7 @@ impl ValidationError {
         let (message, meta) = if let Some(err) = underlying_err {
             let err_msg = err.to_string();
             let message = format!(
-                "Invalid argument agument value. `{}` is not a valid `{}`. Underlying error: {}",
+                "Invalid argument value. `{}` is not a valid `{}`. Underlying error: {}",
                 value, expected_argument_type, &err_msg
             );
             let argument = ArgumentDescription::new(*argument_name, vec![Cow::Borrowed(expected_argument_type)]);
@@ -211,7 +211,7 @@ impl ValidationError {
             (message, Some(meta))
         } else {
             let message = format!(
-                "Invalid argument agument value. `{}` is not a valid `{}`",
+                "Invalid argument value. `{}` is not a valid `{}`",
                 value, &expected_argument_type
             );
             let argument = ArgumentDescription::new(*argument_name, vec![Cow::Borrowed(expected_argument_type)]);

--- a/query-compiler/core-tests/tests/query_validation_tests/invalid_argument_value.expected.json
+++ b/query-compiler/core-tests/tests/query_validation_tests/invalid_argument_value.expected.json
@@ -1,6 +1,6 @@
 {
   "is_panic": false,
-  "message": "Unable to match input value to any allowed input type for the field. Parse errors: [Unable to match input value to any allowed input type for the field. Parse errors: [Invalid argument agument value. `1983-10-31R10:20:00.000Z` is not a valid `ISO-8601 DateTime`. Underlying error: input contains invalid characters, Invalid argument type. `dob` should be of any of the following types: `Null`], Unable to match input value to any allowed input type for the field. Parse errors: [Invalid argument agument value. `1983-10-31R10:20:00.000Z` is not a valid `ISO-8601 DateTime`. Underlying error: input contains invalid characters, Invalid argument type. `dob` should be of any of the following types: `Null`]]",
+  "message": "Unable to match input value to any allowed input type for the field. Parse errors: [Unable to match input value to any allowed input type for the field. Parse errors: [Invalid argument value. `1983-10-31R10:20:00.000Z` is not a valid `ISO-8601 DateTime`. Underlying error: input contains invalid characters, Invalid argument type. `dob` should be of any of the following types: `Null`], Unable to match input value to any allowed input type for the field. Parse errors: [Invalid argument value. `1983-10-31R10:20:00.000Z` is not a valid `ISO-8601 DateTime`. Underlying error: input contains invalid characters, Invalid argument type. `dob` should be of any of the following types: `Null`]]",
   "meta": {
     "kind": "Union",
     "errors": [


### PR DESCRIPTION
Fix a typo in invalid argument value validation error: remove a
duplicate "argument" word that also had a typo in it.