### PR TITLE
fix(quaint): cast BigInt to text in JSON aggregation

### DIFF
--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -33,7 +33,7 @@ impl<'a> Postgres<'a> {
                 }
                 // Cast BigInt to text to preserve precision when parsed by JavaScript.
                 // JavaScript's JSON.parse loses precision for integers > 2^53-1.
-                (Some(TypeFamily::Int), Some("BigInt")) => {
+                (Some(TypeFamily::Int), Some("BIGINT")) => {
                     self.visit_expression(expr)?;
                     self.write("::text")?;
 


### PR DESCRIPTION
## Problem

When using `relationJoins` with BigInt fields in Prisma 7, JavaScript's `JSON.parse` loses precision for integers larger than `Number.MAX_SAFE_INTEGER` (2^53 - 1).

This happens because PostgreSQL's `JSONB_BUILD_OBJECT` returns BigInt values as JSON numbers, which JavaScript cannot represent precisely.

Example:
```
// Original BigInt ID: 312590077454712834
// After JSON.parse: 312590077454712830 (corrupted!)
```

## Solution

Cast BigInt columns to `::text` inside `JSONB_BUILD_OBJECT` calls, similar to how MONEY is already cast to `::numeric`.

```sql
-- Before
JSONB_BUILD_OBJECT('id', "id")

-- After  
JSONB_BUILD_OBJECT('id', "id"::text)
```

This ensures BigInt values are returned as JSON strings, preserving full precision when parsed in JavaScript.

## Changes

- Added BigInt → `::text` cast in `visit_json_build_obj_expr` (quaint/src/visitor/postgres.rs)
- Added test case for BigInt casting

## Related

- prisma/prisma#29009 (TypeScript-level workaround in prisma fork)

## Test plan

- [x] Added unit test for BigInt casting in `test_json_build_object`
- [ ] CI tests pass