### PR TITLE
fix(qc): don't panic on placeholders in full text search

### DIFF
--- a/quaint/src/ast/compare.rs
+++ b/quaint/src/ast/compare.rs
@@ -39,9 +39,9 @@ pub enum Compare<'a> {
     /// All json related comparators
     JsonCompare(JsonCompare<'a>),
     /// `left` @@ to_tsquery(`value`)
-    Matches(Box<Expression<'a>>, Cow<'a, str>),
+    Matches(Box<Expression<'a>>, Box<Expression<'a>>),
     /// (NOT `left` @@ to_tsquery(`value`))
-    NotMatches(Box<Expression<'a>>, Cow<'a, str>),
+    NotMatches(Box<Expression<'a>>, Box<Expression<'a>>),
     /// ANY (`left`)
     Any(Box<Expression<'a>>),
     /// ALL (`left`)
@@ -750,7 +750,7 @@ pub trait Comparable<'a> {
     /// ```
     fn matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>;
+        T: Into<Expression<'a>>;
 
     /// Tests if a full-text search does not match a certain query. Use it in combination with the `text_search()` function
     ///
@@ -773,7 +773,7 @@ pub trait Comparable<'a> {
     /// ```
     fn not_matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>;
+        T: Into<Expression<'a>>;
 
     /// Matches at least one elem of a list of values.
     ///
@@ -1047,7 +1047,7 @@ where
 
     fn matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>,
+        T: Into<Expression<'a>>,
     {
         let col: Column<'a> = self.into();
         let val: Expression<'a> = col.into();
@@ -1057,7 +1057,7 @@ where
 
     fn not_matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>,
+        T: Into<Expression<'a>>,
     {
         let col: Column<'a> = self.into();
         let val: Expression<'a> = col.into();

--- a/quaint/src/ast/expression.rs
+++ b/quaint/src/ast/expression.rs
@@ -532,16 +532,16 @@ impl<'a> Comparable<'a> for Expression<'a> {
 
     fn matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>,
+        T: Into<Expression<'a>>,
     {
-        Compare::Matches(Box::new(self), query.into())
+        Compare::Matches(Box::new(self), Box::new(query.into()))
     }
 
     fn not_matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>,
+        T: Into<Expression<'a>>,
     {
-        Compare::NotMatches(Box::new(self), query.into())
+        Compare::NotMatches(Box::new(self), Box::new(query.into()))
     }
 
     fn any(self) -> Compare<'a> {

--- a/quaint/src/ast/row.rs
+++ b/quaint/src/ast/row.rs
@@ -385,7 +385,7 @@ impl<'a> Comparable<'a> for Row<'a> {
 
     fn matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>,
+        T: Into<Expression<'a>>,
     {
         let value: Expression<'a> = self.into();
 
@@ -394,7 +394,7 @@ impl<'a> Comparable<'a> for Row<'a> {
 
     fn not_matches<T>(self, query: T) -> Compare<'a>
     where
-        T: Into<Cow<'a, str>>,
+        T: Into<Expression<'a>>,
     {
         let value: Expression<'a> = self.into();
 

--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -157,7 +157,7 @@ pub trait Visitor<'a> {
 
     fn visit_text_search(&mut self, text_search: TextSearch<'a>) -> Result;
 
-    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> Result;
+    fn visit_matches(&mut self, left: Expression<'a>, right: Expression<'a>, not: bool) -> Result;
 
     fn visit_text_search_relevance(&mut self, text_search_relevance: TextSearchRelevance<'a>) -> Result;
 
@@ -1058,8 +1058,8 @@ pub trait Visitor<'a> {
                 JsonCompare::TypeEquals(left, json_type) => self.visit_json_type_equals(*left, json_type, false),
                 JsonCompare::TypeNotEquals(left, json_type) => self.visit_json_type_equals(*left, json_type, true),
             },
-            Compare::Matches(left, right) => self.visit_matches(*left, right, false),
-            Compare::NotMatches(left, right) => self.visit_matches(*left, right, true),
+            Compare::Matches(left, right) => self.visit_matches(*left, *right, false),
+            Compare::NotMatches(left, right) => self.visit_matches(*left, *right, true),
             Compare::Any(left) => {
                 self.write("ANY")?;
                 self.surround_with("(", ")", |s| s.visit_expression(*left))

--- a/quaint/src/visitor/mssql.rs
+++ b/quaint/src/visitor/mssql.rs
@@ -821,12 +821,7 @@ impl<'a> Visitor<'a> for Mssql<'a> {
         unimplemented!("Full-text search is not yet supported on MSSQL")
     }
 
-    fn visit_matches(
-        &mut self,
-        _left: Expression<'a>,
-        _right: std::borrow::Cow<'a, str>,
-        _not: bool,
-    ) -> visitor::Result {
+    fn visit_matches(&mut self, _left: Expression<'a>, _right: Expression<'a>, _not: bool) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on MSSQL")
     }
 

--- a/quaint/src/visitor/mysql.rs
+++ b/quaint/src/visitor/mysql.rs
@@ -570,15 +570,13 @@ impl<'a> Visitor<'a> for Mysql<'a> {
         })
     }
 
-    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> visitor::Result {
+    fn visit_matches(&mut self, left: Expression<'a>, right: Expression<'a>, not: bool) -> visitor::Result {
         if not {
             self.write("(NOT ")?;
         }
 
         self.visit_expression(left)?;
-        self.surround_with("AGAINST (", " IN BOOLEAN MODE)", |s| {
-            s.visit_parameterized(Value::text(right))
-        })?;
+        self.surround_with("AGAINST (", " IN BOOLEAN MODE)", |s| s.visit_expression(right))?;
 
         if not {
             self.write(")")?;

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -633,14 +633,14 @@ impl<'a> Visitor<'a> for Postgres<'a> {
         })
     }
 
-    fn visit_matches(&mut self, left: Expression<'a>, right: std::borrow::Cow<'a, str>, not: bool) -> visitor::Result {
+    fn visit_matches(&mut self, left: Expression<'a>, right: Expression<'a>, not: bool) -> visitor::Result {
         if not {
             self.write("(NOT ")?;
         }
 
         self.visit_expression(left)?;
         self.write(" @@ ")?;
-        self.surround_with("to_tsquery(", ")", |s| s.visit_parameterized(Value::text(right)))?;
+        self.surround_with("to_tsquery(", ")", |s| s.visit_expression(right))?;
 
         if not {
             self.write(")")?;

--- a/quaint/src/visitor/sqlite.rs
+++ b/quaint/src/visitor/sqlite.rs
@@ -392,12 +392,7 @@ impl<'a> Visitor<'a> for Sqlite<'a> {
         unimplemented!("Full-text search is not yet supported on SQLite")
     }
 
-    fn visit_matches(
-        &mut self,
-        _left: Expression<'a>,
-        _right: std::borrow::Cow<'a, str>,
-        _not: bool,
-    ) -> visitor::Result {
+    fn visit_matches(&mut self, _left: Expression<'a>, _right: Expression<'a>, _not: bool) -> visitor::Result {
         unimplemented!("Full-text search is not yet supported on SQLite")
     }
 


### PR DESCRIPTION
`matches`/`not_matches` operations needed to be adjusted to accept
placeholders. The corresponding fields in DMMF were already marked as
parameterizable so QC panicked in Client tests here.