### PR TITLE
fix(quaint): add url decode for non-ascii db names

### DIFF
--- a/quaint/src/connector/connection_info.rs
+++ b/quaint/src/connector/connection_info.rs
@@ -111,7 +111,7 @@ impl ConnectionInfo {
     }
 
     /// The provided database name. This will be `None` on SQLite.
-    pub fn dbname(&self) -> Option<&str> {
+    pub fn dbname(&self) -> Option<Cow<'_, str>> {
         match self {
             #[cfg(any(
                 feature = "sqlite-native",
@@ -123,9 +123,9 @@ impl ConnectionInfo {
                 #[cfg(feature = "postgresql-native")]
                 NativeConnectionInfo::Postgres(url) => Some(url.dbname()),
                 #[cfg(feature = "mysql-native")]
-                NativeConnectionInfo::Mysql(url) => url.dbname(),
+                NativeConnectionInfo::Mysql(url) => url.dbname().map(Cow::Borrowed),
                 #[cfg(feature = "mssql-native")]
-                NativeConnectionInfo::Mssql(url) => Some(url.dbname()),
+                NativeConnectionInfo::Mssql(url) => Some(Cow::Borrowed(url.dbname())),
                 #[cfg(feature = "sqlite-native")]
                 NativeConnectionInfo::Sqlite { .. } | NativeConnectionInfo::InMemorySqlite { .. } => None,
             },

--- a/quaint/src/connector/postgres/native/mod.rs
+++ b/quaint/src/connector/postgres/native/mod.rs
@@ -207,7 +207,7 @@ impl PostgresNativeUrl {
         config.password(self.password().as_ref());
         config.host(self.host());
         config.port(self.port());
-        config.dbname(self.dbname());
+        config.dbname(self.dbname().as_ref());
         config.pgbouncer_mode(self.query_params.pg_bouncer);
 
         if let Some(options) = self.options() {

--- a/query-engine/connector-test-kit-rs/qe-setup/src/cockroachdb.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/cockroachdb.rs
@@ -21,7 +21,7 @@ pub(crate) async fn cockroach_setup(url: String, prisma_schema: &str) -> Connect
 
     conn.raw_cmd(&query).await.unwrap();
 
-    drop_db_when_thread_exits(parsed_url, db_name);
+    drop_db_when_thread_exits(parsed_url, &db_name);
     let params = ConnectorParams::new(url, Default::default(), None);
     let mut connector = sql_schema_connector::SqlSchemaConnector::new_cockroach(params)?;
     crate::diff_and_apply(prisma_schema, &mut connector).await

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -166,7 +166,7 @@ impl MigratePostgresUrl {
         Ok(Self(postgres_url))
     }
 
-    pub(super) fn dbname(&self) -> &str {
+    pub(super) fn dbname(&self) -> Cow<'_, str> {
         self.0.dbname()
     }
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/native/mod.rs
@@ -260,7 +260,7 @@ pub async fn create_database(state: &State) -> ConnectorResult<String> {
 
     conn.close().await;
 
-    Ok(db_name.to_owned())
+    Ok(db_name.into_owned())
 }
 
 pub async fn drop_database(state: &State) -> ConnectorResult<()> {


### PR DESCRIPTION
 Description                                                                                                                                        
                                                                                                                                                     
  ## Summary                                                                                                                                         
  Fix connection failure when using databases with non-ASCII names (e.g., Chinese characters like `测试库`).                                         
                                                                                                                                                     
  ## Problem                                                                                                                                         
  When connecting to a PostgreSQL database with a non-ASCII name, the URL must be percent-encoded:                                                   
  postgresql://user:pass@localhost:5432/%E6%B5%8B%E8%AF%95%E5%BA%93                                                                                  
                                                                                                                                                     
  Previously, `dbname()` returned the encoded string `%E6%B5%8B%E8%AF%95%E5%BA%93` as-is, causing:                                                   
  Error: Database does not exist: %E6%B5%8B%E8%AF%95%E5%BA%93
  
  for Example
  my database
![2026-01-18_15-23-24](https://github.com/user-attachments/assets/78b2a7f1-83e4-46d3-a47b-f581735eed7e)

  
<img width="1765" height="452" alt="스크린샷 2026-01-25 20-24-00" src="https://github.com/user-attachments/assets/9b049e61-b223-49f8-9c6a-cd23e1cbddf3" />
                                                                  
                                                                                                                                                     
  ## Solution                                                                                                                                        
  - Decode percent-encoded path segment in `PostgresNativeUrl::dbname()` using `percent_decode`                                                      
  - Change return type from `&str` to `Cow<'_, str>` to handle decoded strings                                                                       
  - Update dependent code in connection_info, schema-engine, and qe-setup                                                                            
                                                                                                                                                     
  ## Test Plan                                                                                                                                       
  - [x] Unit tests for percent-decoding logic (Chinese, spaces, special characters)                                                                  
  - [x] Integration test connecting to real PostgreSQL with Chinese database name                                                                    
                                                                                                                                                     
  ## Before/After                                                                                                                                    
                                                                                                                                                     
  **Before (bug exists):**                                                                                                                           
  Connecting to: postgresql://.../%E6%B5%8B%E8%AF%95%E5%BA%93                                                                                        
  ❌ Connection FAILED                                                                                                                               
  Error: Database does not exist: %E6%B5%8B%E8%AF%95%E5%BA%93                                                                                        
                                                                                                                                                     
  **After (fixed):**                                                                                                                                 
  Connecting to: postgresql://.../%E6%B5%8B%E8%AF%95%E5%BA%93                                                                                        
  ✅ Connection SUCCESS  


**Relation**
https://github.com/prisma/prisma/issues/26886