### PR TITLE
fix(quaint): recognize json placeholders as json values

### DIFF
--- a/quaint/src/ast/expression.rs
+++ b/quaint/src/ast/expression.rs
@@ -50,10 +50,20 @@ impl<'a> Expression<'a> {
                 ..
             }) => true,
 
+            ExpressionKind::Parameterized(Value {
+                typed: ValueType::Opaque(opaque),
+                ..
+            }) => matches!(opaque.typ(), OpaqueType::Json),
+
             ExpressionKind::ParameterizedRow(Value {
                 typed: ValueType::Json(_),
                 ..
             }) => true,
+
+            ExpressionKind::ParameterizedRow(Value {
+                typed: ValueType::Opaque(opaque),
+                ..
+            }) => matches!(opaque.typ(), OpaqueType::Json),
 
             ExpressionKind::Value(expr) => expr.is_json_value(),
 
@@ -70,12 +80,44 @@ impl<'a> Expression<'a> {
                 ..
             }) => true,
 
+            ExpressionKind::Parameterized(Value {
+                typed: ValueType::Opaque(opaque),
+                ..
+            }) => matches!(opaque.typ(), OpaqueType::Json),
+
             ExpressionKind::ParameterizedRow(Value {
                 typed: ValueType::Json(_),
                 ..
             }) => true,
 
+            ExpressionKind::ParameterizedRow(Value {
+                typed: ValueType::Opaque(opaque),
+                ..
+            }) => matches!(opaque.typ(), OpaqueType::Json),
+
             ExpressionKind::Value(expr) => expr.is_json_value(),
+            _ => false,
+        }
+    }
+
+    /// Returns true if this expression contains an extractable JSON value.
+    /// Unlike `is_json_value()`, this returns false for opaque JSON placeholders
+    /// which are typed as JSON but don't contain actual JSON data to extract.
+    #[allow(dead_code)]
+    #[cfg(feature = "mysql")]
+    pub(crate) fn is_extractable_json_value(&self) -> bool {
+        match &self.kind {
+            ExpressionKind::Parameterized(Value {
+                typed: ValueType::Json(_),
+                ..
+            }) => true,
+
+            ExpressionKind::ParameterizedRow(Value {
+                typed: ValueType::Json(_),
+                ..
+            }) => true,
+
+            ExpressionKind::Value(expr) => expr.is_extractable_json_value(),
             _ => false,
         }
     }

--- a/quaint/src/visitor/mysql.rs
+++ b/quaint/src/visitor/mysql.rs
@@ -65,7 +65,7 @@ impl<'a> Mysql<'a> {
         }
 
         match (left, right) {
-            (left, right) if left.is_json_value() && right.is_fun_retuning_json() => {
+            (left, right) if left.is_extractable_json_value() && right.is_fun_retuning_json() => {
                 let quaint_value = json_to_quaint_value(left.into_json_value().unwrap())?;
 
                 self.visit_parameterized(quaint_value)?;
@@ -73,7 +73,7 @@ impl<'a> Mysql<'a> {
                 self.visit_expression(right)?;
             }
 
-            (left, right) if left.is_fun_retuning_json() && right.is_json_value() => {
+            (left, right) if left.is_fun_retuning_json() && right.is_extractable_json_value() => {
                 let quaint_value = json_to_quaint_value(right.into_json_value().unwrap())?;
 
                 self.visit_expression(left)?;


### PR DESCRIPTION
Fixes some JSON tests failing for MySQL with parameterization enabled.