### PR TITLE
fix(qc): support placeholders for LIKE queries

### DIFF
--- a/query-compiler/query-compiler/tests/data/filter-contains-param-insensitive.json
+++ b/query-compiler/query-compiler/tests/data/filter-contains-param-insensitive.json
@@ -1,0 +1,23 @@
+{
+  "modelName": "User",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "where": {
+        "email": {
+          "contains": {
+            "$type": "Param",
+            "value": {
+              "name": "searchTerm",
+              "type": "String"
+            }
+          },
+          "mode": "insensitive"
+        }
+      }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/filter-contains-param.json
+++ b/query-compiler/query-compiler/tests/data/filter-contains-param.json
@@ -1,0 +1,22 @@
+{
+  "modelName": "User",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "where": {
+        "email": {
+          "contains": {
+            "$type": "Param",
+            "value": {
+              "name": "searchTerm",
+              "type": "String"
+            }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/filter-endswith-param.json
+++ b/query-compiler/query-compiler/tests/data/filter-endswith-param.json
@@ -1,0 +1,22 @@
+{
+  "modelName": "User",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "where": {
+        "email": {
+          "endsWith": {
+            "$type": "Param",
+            "value": {
+              "name": "suffix",
+              "type": "String"
+            }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/filter-not-contains-param.json
+++ b/query-compiler/query-compiler/tests/data/filter-not-contains-param.json
@@ -1,0 +1,24 @@
+{
+  "modelName": "User",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "where": {
+        "NOT": {
+          "email": {
+            "contains": {
+              "$type": "Param",
+              "value": {
+                "name": "excludeTerm",
+                "type": "String"
+              }
+            }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/filter-startswith-param.json
+++ b/query-compiler/query-compiler/tests/data/filter-startswith-param.json
@@ -1,0 +1,22 @@
+{
+  "modelName": "User",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "where": {
+        "email": {
+          "startsWith": {
+            "$type": "Param",
+            "value": {
+              "name": "prefix",
+              "type": "String"
+            }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-contains-param-insensitive.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-contains-param-insensitive.json.snap
@@ -1,0 +1,19 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/filter-contains-param-insensitive.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+query «SELECT "t0"."id", "t0"."email", "t0"."role"::text FROM "public"."User" AS
+       "t0" WHERE "t0"."email" ILIKE ('%' || $1 || '%')»
+params [var(searchTerm as String)]

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-contains-param.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-contains-param.json.snap
@@ -1,0 +1,19 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/filter-contains-param.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+query «SELECT "t0"."id", "t0"."email", "t0"."role"::text FROM "public"."User" AS
+       "t0" WHERE "t0"."email"::text LIKE ('%' || $1 || '%')»
+params [var(searchTerm as String)]

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-endswith-param.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-endswith-param.json.snap
@@ -1,0 +1,19 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/filter-endswith-param.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+query «SELECT "t0"."id", "t0"."email", "t0"."role"::text FROM "public"."User" AS
+       "t0" WHERE "t0"."email"::text LIKE ('%' || $1)»
+params [var(suffix as String)]

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-not-contains-param.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-not-contains-param.json.snap
@@ -1,0 +1,19 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/filter-not-contains-param.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+query «SELECT "t0"."id", "t0"."email", "t0"."role"::text FROM "public"."User" AS
+       "t0" WHERE (NOT "t0"."email"::text LIKE ('%' || $1 || '%'))»
+params [var(excludeTerm as String)]

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-startswith-param.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@filter-startswith-param.json.snap
@@ -1,0 +1,19 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/filter-startswith-param.json
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    role: Enum<Role> (role)
+}
+enums {
+    Role: {
+        admin: ADMIN
+        user: USER
+    }
+}
+query «SELECT "t0"."id", "t0"."email", "t0"."role"::text FROM "public"."User" AS
+       "t0" WHERE "t0"."email"::text LIKE ($1 || '%')»
+params [var(prefix as String)]


### PR DESCRIPTION
In `LIKE '%...%'` expressions, placeholders were incorrectly stringified as their names and interpolated into strings. This change makes such queries fully support placeholders by concatenating the parts of the pattern with a SQL parameter via CONCAT function in SQL instead of concatenating the strings in Rust and putting them into a single SQL parameter.