### PR TITLE
fix: support where argument on field-level @unique for partial indexes

### DIFF
--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -271,7 +271,7 @@ fn visit_scalar_field_attributes(
 
     // @unique
     if ctx.visit_optional_single_attr("unique") {
-        visit_field_unique(scalar_field_id, model_data, ctx);
+        visit_field_unique(scalar_field_id, model_id, model_data, ctx);
         ctx.validate_visited_arguments();
     }
 
@@ -284,7 +284,12 @@ fn visit_scalar_field_attributes(
     ctx.validate_visited_attributes();
 }
 
-fn visit_field_unique(scalar_field_id: ScalarFieldId, model_data: &mut ModelAttributes, ctx: &mut Context<'_>) {
+fn visit_field_unique(
+    scalar_field_id: ScalarFieldId,
+    model_id: crate::ModelId,
+    model_data: &mut ModelAttributes,
+    ctx: &mut Context<'_>,
+) {
     let mapped_name = match ctx
         .visit_optional_arg("map")
         .and_then(|arg| coerce::string(arg, ctx.diagnostics))
@@ -318,6 +323,7 @@ fn visit_field_unique(scalar_field_id: ScalarFieldId, model_data: &mut ModelAttr
     };
 
     let clustered = validate_clustering_setting(ctx);
+    let where_clause = parse_where_clause(model_id, ctx);
 
     let attribute_id = ctx.current_attribute_id();
     model_data.ast_indexes.push((
@@ -333,6 +339,7 @@ fn visit_field_unique(scalar_field_id: ScalarFieldId, model_data: &mut ModelAttr
             source_field: Some(scalar_field_id),
             mapped_name,
             clustered,
+            where_clause,
             ..Default::default()
         },
     ))


### PR DESCRIPTION
## fix: support `where` argument on field-level `@unique` for partial indexes

### Summary

- Add `where` clause parsing to field-level `@unique`, fixing "No such argument" validation error when `db pull` generates `@unique(where: raw("..."))` for single-column partial unique indexes.

### Changes

- `psl/parser-database/src/attributes.rs`: Call `parse_where_clause()` in `visit_field_unique`, matching the existing behavior in `model_unique` / `model_index`.
- `psl/psl/tests/attributes/partial_index.rs`: 4 new tests covering raw syntax, object syntax, missing preview feature error, and `map` + `where` combination.

### Test plan

- [x] All existing partial index tests pass (52 total)
- [x] `make test-unit` passes
- [x] Verified with reproduction repo from prisma/prisma#29172. `prisma generate` succeeds after fix

Closes prisma/prisma-engines#5773