### PR TITLE
ci: remove broken docker cache step

### DIFF
--- a/.github/workflows/test-query-compiler-template.yml
+++ b/.github/workflows/test-query-compiler-template.yml
@@ -76,11 +76,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ inputs.setup_task }}-${{hashFiles('docker-compose.yaml')}}
-
       - name: Set Prisma branch
         id: set-prisma-branch
         run: |

--- a/.github/workflows/test-schema-engine-linux-template.yml
+++ b/.github/workflows/test-schema-engine-linux-template.yml
@@ -44,11 +44,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ inputs.database_name }}-${{ hashFiles('docker-compose.yaml') }}
-
       #
       # Multithreaded tests
       #

--- a/.github/workflows/test-schema-engine.yml
+++ b/.github/workflows/test-schema-engine.yml
@@ -46,11 +46,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Cache Docker images.
-        uses: ScribeMD/docker-cache@0.5.0
-        with:
-          key: docker-${{ matrix.database.name }}-${{hashFiles('docker-compose.yaml')}}
-
       - name: 'Start ${{ matrix.database.name }}'
         run: make start-${{ matrix.database.name }}-single
 


### PR DESCRIPTION
Removes a broken docker cache step. I'm not sure if it ever worked, all recent actions report `Failed to restore: Cache service responded with 400`. The `Post Cache Docker images` step also causes [CI failures for some images ](https://github.com/prisma/prisma-engines/actions/runs/22143613049/job/64014401975?pr=5777)when it runs `docker save`.