### PR TITLE
fix: implement a workaround for JSON list equality

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -140,6 +140,13 @@ impl Placeholder {
             r#type,
         }
     }
+
+    pub fn with_type(self, r#type: PrismaValueType) -> Self {
+        Self {
+            name: self.name,
+            r#type,
+        }
+    }
 }
 
 /// Stringify a date to the following format

--- a/quaint/src/ast/expression.rs
+++ b/quaint/src/ast/expression.rs
@@ -180,6 +180,14 @@ impl<'a> Expression<'a> {
     }
 
     #[allow(dead_code)]
+    pub(crate) fn as_column(&self) -> Option<&Column<'a>> {
+        match &self.kind {
+            ExpressionKind::Column(column) => Some(column),
+            _ => None,
+        }
+    }
+
+    #[allow(dead_code)]
     pub(crate) fn into_column(self) -> Option<Column<'a>> {
         match self.kind {
             ExpressionKind::Column(column) => Some(*column),

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -415,47 +415,23 @@ impl<'a> Visitor<'a> for Postgres<'a> {
     }
 
     fn visit_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        // LHS must be cast to json/xml-text if the right is a json/xml-text value and vice versa.
-        let right_cast = match left {
-            _ if left.is_json_value() => "::jsonb",
-            _ if left.is_xml_value() => "::text",
-            _ => "",
-        };
+        let lhs_conv = EqualsOperandConversion::infer(&left, &right);
+        let rhs_conv = EqualsOperandConversion::infer(&right, &left);
 
-        let left_cast = match right {
-            _ if right.is_json_value() => "::jsonb",
-            _ if right.is_xml_value() => "::text",
-            _ => "",
-        };
-
-        self.visit_expression(left)?;
-        self.write(left_cast)?;
+        lhs_conv.write(left, self)?;
         self.write(" = ")?;
-        self.visit_expression(right)?;
-        self.write(right_cast)?;
+        rhs_conv.write(right, self)?;
 
         Ok(())
     }
 
     fn visit_not_equals(&mut self, left: Expression<'a>, right: Expression<'a>) -> visitor::Result {
-        // LHS must be cast to json/xml-text if the right is a json/xml-text value and vice versa.
-        let right_cast = match left {
-            _ if left.is_json_value() => "::jsonb",
-            _ if left.is_xml_value() => "::text",
-            _ => "",
-        };
+        let lhs_conv = EqualsOperandConversion::infer(&left, &right);
+        let rhs_conv = EqualsOperandConversion::infer(&right, &left);
 
-        let left_cast = match right {
-            _ if right.is_json_value() => "::jsonb",
-            _ if right.is_xml_value() => "::text",
-            _ => "",
-        };
-
-        self.visit_expression(left)?;
-        self.write(left_cast)?;
+        lhs_conv.write(left, self)?;
         self.write(" <> ")?;
-        self.visit_expression(right)?;
-        self.write(right_cast)?;
+        rhs_conv.write(right, self)?;
 
         Ok(())
     }
@@ -816,6 +792,48 @@ fn get_column_cast_target(column: &Column<'_>) -> Option<&'static str> {
         Some("numeric")
     } else {
         None
+    }
+}
+
+/// Utility type for equality and inequality expressions to determine if and how operands should
+/// be converted before comparison.
+#[derive(Debug, Clone, Copy)]
+enum EqualsOperandConversion {
+    JsonbCast,
+    TextCast,
+    ToJsonb,
+    Identity,
+}
+
+impl EqualsOperandConversion {
+    fn infer(this: &Expression<'_>, other: &Expression<'_>) -> Self {
+        // If we reference a JSON list column, we have to convert it to a JSON array
+        // (rather than a PostgreSQL list) before comparing it to a JSON value,
+        // otherwise the comparison would fail with a type error.
+        if other.is_json_value() && this.as_column().is_some_and(|c| c.is_list) {
+            Self::ToJsonb
+        } else if other.is_json_value() {
+            Self::JsonbCast
+        } else if other.is_xml_value() {
+            Self::TextCast
+        } else {
+            Self::Identity
+        }
+    }
+
+    fn write<'a>(self, expr: Expression<'a>, v: &mut Postgres<'a>) -> visitor::Result {
+        match self {
+            Self::JsonbCast => {
+                v.visit_expression(expr)?;
+                v.write("::jsonb")
+            }
+            Self::TextCast => {
+                v.visit_expression(expr)?;
+                v.write("::text")
+            }
+            Self::ToJsonb => v.surround_with("TO_JSONB(", ")", |v| v.visit_expression(expr)),
+            Self::Identity => v.visit_expression(expr),
+        }
     }
 }
 

--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -717,6 +717,22 @@ impl QueryDocumentParser {
             )
         };
 
+        if placeholder.r#type == PrismaValueType::Json
+            && matches!(element_input_type, InputType::Scalar(ScalarType::Json))
+        {
+            // Allow handling a JSON placeholder as a list. This is needed to support the equality
+            // operator for JSON arrays.
+            // JSON array arguments are treated as scalars rather than arrays by default, since the
+            // code that infers their type cannot differentiate between a value that's meant to be
+            // a database-level array versus a JSON-level array. This would normally lead to a type
+            // mismatch, hence this workaround is needed.
+            return Ok(ParsedInputValue::Single(
+                placeholder
+                    .with_type(PrismaValueType::List(PrismaValueType::Json.into()))
+                    .into(),
+            ));
+        }
+
         let PrismaValueType::List(inner_type) = &placeholder.r#type else {
             return Err(error());
         };

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/list_filters.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/filters/list_filters.rs
@@ -900,33 +900,32 @@ mod json_lists {
         schema.to_owned()
     }
 
-    // Uncomment this test when TML-2177 is fixed
-    // #[connector_test]
-    // async fn equality(runner: Runner) -> TestResult<()> {
-    //     test_data(&runner).await?;
+    #[connector_test]
+    async fn equality(runner: Runner) -> TestResult<()> {
+        test_data(&runner).await?;
 
-    //     // equals json
-    //     insta::assert_snapshot!(
-    //       list_query(&runner, "json", "equals", r#"["{}", "{\"int\":5}", "[1, 2, 3]"]"#).await?,
-    //       @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
-    //     );
-    //     insta::assert_snapshot!(
-    //       list_query(&runner, "json", "equals", r#"["null", "\"test\""]"#).await?,
-    //       @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
-    //     );
+        // equals json
+        insta::assert_snapshot!(
+          list_query(&runner, "json", "equals", r#"["{}", "{\"int\":5}", "[1, 2, 3]"]"#).await?,
+          @r###"{"data":{"findManyTestModel":[{"id":1}]}}"###
+        );
+        insta::assert_snapshot!(
+          list_query(&runner, "json", "equals", r#"["null", "\"test\""]"#).await?,
+          @r###"{"data":{"findManyTestModel":[{"id":3}]}}"###
+        );
 
-    //     // NOT equals json
-    //     insta::assert_snapshot!(
-    //       not_list_query(&runner, "json", "equals", r#"["{}", "{\"int\":5}", "[1, 2, 3]"]"#).await?,
-    //       @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
-    //     );
-    //     insta::assert_snapshot!(
-    //       not_list_query(&runner, "json", "equals", r#"["null", "\"test\""]"#).await?,
-    //       @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
-    //     );
+        // NOT equals json
+        insta::assert_snapshot!(
+          not_list_query(&runner, "json", "equals", r#"["{}", "{\"int\":5}", "[1, 2, 3]"]"#).await?,
+          @r###"{"data":{"findManyTestModel":[{"id":2},{"id":3}]}}"###
+        );
+        insta::assert_snapshot!(
+          not_list_query(&runner, "json", "equals", r#"["null", "\"test\""]"#).await?,
+          @r###"{"data":{"findManyTestModel":[{"id":1},{"id":2}]}}"###
+        );
 
-    //     Ok(())
-    // }
+        Ok(())
+    }
 
     #[connector_test]
     async fn has(runner: Runner) -> TestResult<()> {


### PR DESCRIPTION
[TML-2177](https://linear.app/prisma-company/issue/TML-2177/fix-list-filtersjson-listsequality)

Fixes the only remaining test that was broken due to the parameterisation changes. The issue boils down to two problems present in the JSON list equality test, one is that we get a `Json[]` versus `Json` type mismatch when parsing and second is that we would currently insert an invalid `::jsonb` cast in `visit_equals`. I've tried a number of different fixes, my main idea was to tag the `Json` array parameters as `List(Json)` instead, which seems the cleanest option, but that causes a huge fallout breaking lots of other tests and I couldn't find an easy way to fix them without implementing multiple other workarounds due to the `Json` type already receiving special treatment in multiple places, so I ended up patching `parse_parameterized_list` and `visit_equals` to handle this case specifically.