### PR TITLE
Issue 5755 change advisory lock to try advisory lock

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -28,14 +28,11 @@ use std::{
     future::{self, Future},
     str::FromStr,
     sync::LazyLock,
-    time,
 };
 use url::Url;
 use user_facing_errors::schema_engine::DatabaseSchemaInconsistent;
 
 use super::{SqlConnector, SqlDialect, UsingExternalShadowDb};
-
-const ADVISORY_LOCK_TIMEOUT: time::Duration = time::Duration::from_secs(10);
 
 /// Connection settings applied to every new connection on CockroachDB.
 ///
@@ -370,19 +367,42 @@ impl SqlConnector for PostgresConnector {
         self.with_connection(|connection, params| async {
             // https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS
 
+            // We use `pg_try_advisory_lock` rather than `pg_advisory_lock` so that the
+            // call returns immediately instead of blocking. Blocking on an advisory
+            // lock can cause deadlocks when another session is running operations such
+            // as `CREATE INDEX CONCURRENTLY`, which require waiting for any open
+            // transactions/locks to finish (see issue #5755).
+            //
             // 72707369 is a unique number we chose to identify Migrate. It does not
             // have any meaning, but it should not be used by any other tool.
-            crosstarget_utils::time::timeout(
-                ADVISORY_LOCK_TIMEOUT,
-                connection.raw_cmd("SELECT pg_advisory_lock(72707369)"),
-            )
-            .await
-            .map_err(|_| ConnectorError::user_facing(user_facing_errors::common::DatabaseTimeout {
-                context: format!(
-                    "Timed out trying to acquire a postgres advisory lock (SELECT pg_advisory_lock(72707369)). Timeout: {}ms. See https://pris.ly/d/migrate-advisory-locking for details.", ADVISORY_LOCK_TIMEOUT.as_millis()
-                ),
-            }))?
-            .map_err(imp::quaint_error_mapper(params))?;
+const MIGRATE_ADVISORY_LOCK_ID: i64 = 72707369;
+
+            let result = connection
+                .query_raw(
+                    &format!("SELECT pg_try_advisory_lock({MIGRATE_ADVISORY_LOCK_ID})"),
+                    &[],
+                )
+                .await
+                .map_err(imp::quaint_error_mapper(params))?;
+
+            let acquired = result
+                .first()
+                .and_then(|row| row.at(0).and_then(|v| v.as_bool()))
+                .ok_or_else(|| {
+                    ConnectorError::from_msg(
+                        "Unexpected result from pg_try_advisory_lock(72707369): \
+                         expected a single boolean column."
+                            .to_owned(),
+                    )
+                })?;
+
+            if !acquired {
+                return Err(ConnectorError::from_msg(format!(
+                    "Could not acquire the postgres advisory lock (SELECT pg_try_advisory_lock({MIGRATE_ADVISORY_LOCK_ID})). \
+                     Another instance is likely running migrations against this database. \
+                     See https://pris.ly/d/migrate-advisory-locking for details."
+                )));
+            }
 
             Ok(())
         })

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/wasm/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/wasm/mod.rs
@@ -3,7 +3,7 @@
 pub mod shadow_db;
 
 use crate::BitFlags;
-use crate::flavour::postgres::{ADVISORY_LOCK_TIMEOUT, Circumstances, PostgresProvider};
+use crate::flavour::postgres::{Circumstances, PostgresProvider};
 use crate::flavour::quaint_error_to_connector_error;
 use psl::PreviewFeature;
 use quaint::connector::{ExternalConnector, Queryable};

--- a/schema-engine/sql-migration-tests/tests/migrations/advisory_locking.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/advisory_locking.rs
@@ -1,3 +1,4 @@
+use quaint::prelude::Queryable;
 use sql_migration_tests::multi_engine_test_api::*;
 use std::sync::Arc;
 use test_macros::test_connector;
@@ -37,45 +38,101 @@ fn advisory_locking_works(mut api: TestApi) {
                     .apply_migrations(&migrations_directory)
                     .send()
                     .await
-                    .unwrap()
-                    .into_output()
+                    .map(|r| r.into_output())
             },
             async move {
                 first_me
                     .apply_migrations(&migrations_directory_2)
                     .send()
                     .await
-                    .unwrap()
-                    .into_output()
+                    .map(|r| r.into_output())
             },
             async move {
                 third_me
                     .apply_migrations(&migrations_directory_3)
                     .send()
                     .await
-                    .unwrap()
-                    .into_output()
+                    .map(|r| r.into_output())
             },
         )
     });
 
-    let results = &[&result_1, &result_2, &result_3];
+    let results = [&result_1, &result_2, &result_3];
 
     let applied_results_count = results
         .iter()
-        .filter(|result| {
-            let applied_migration_names = &result.applied_migration_names;
-
-            applied_migration_names.len() == 1 && applied_migration_names[0] == migration_name
+        .filter(|result| match result {
+            Ok(out) => {
+                out.applied_migration_names.len() == 1 && out.applied_migration_names[0] == migration_name
+            }
+            Err(_) => false,
         })
         .count();
 
     assert_eq!(applied_results_count, 1);
 
-    let empty_results_count = results
+    // The other two engines either succeeded with nothing to apply (lock acquired
+    // after the first engine was done) or, on Postgres, failed fast with an
+    // advisory-lock contention error (`pg_try_advisory_lock` returned false).
+    let other_results = results
         .iter()
-        .filter(|result| result.applied_migration_names.is_empty())
-        .count();
+        .filter(|result| match result {
+            Ok(out) => {
+                !(out.applied_migration_names.len() == 1 && out.applied_migration_names[0] == migration_name)
+            }
+            Err(_) => true,
+        })
+        .collect::<Vec<_>>();
 
-    assert_eq!(empty_results_count, 2);
+    assert_eq!(other_results.len(), 2);
+
+    for result in other_results {
+        match result {
+            Ok(out) => assert!(out.applied_migration_names.is_empty()),
+            Err(err) => assert!(
+                err.to_string().contains("advisory lock"),
+                "unexpected error: {err}"
+            ),
+        }
+    }
+}
+
+// Regression test for https://github.com/prisma/prisma-engines/issues/5755.
+// We hold a session-level advisory lock on `72707369` from an external
+// connection, then try to apply a migration. The schema engine must fail fast
+// with an advisory-lock error instead of blocking (and potentially deadlocking
+// against concurrent operations such as `CREATE INDEX CONCURRENTLY`).
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+fn postgres_advisory_lock_contention_fails_fast(mut api: TestApi) {
+    let mut me = api.new_engine();
+    let migrations_directory = api.create_migrations_directory();
+
+    let dm = api.datamodel_with_provider(
+        r#"
+        model Cat {
+            id Int @id
+            inBox Boolean
+        }
+    "#,
+    );
+
+    me.create_migration("01initial", &dm, &migrations_directory)
+        .draft(true)
+        .send_sync();
+
+    // Acquire a dedicated connection (separate from the engine's connection)
+    // and grab the same advisory lock the schema engine uses.
+    let lock_holder = tok(quaint::single::Quaint::new(api.connection_string())).unwrap();
+    tok(lock_holder.raw_cmd("SELECT pg_advisory_lock(72707369)")).unwrap();
+
+    let err = tok(async { me.apply_migrations(&migrations_directory).send().await }).unwrap_err();
+
+    // Release the lock so the test database teardown is not blocked.
+    tok(lock_holder.raw_cmd("SELECT pg_advisory_unlock(72707369)")).unwrap();
+
+    let msg = err.to_string();
+    assert!(
+        msg.contains("pg_try_advisory_lock") && msg.contains("Another instance"),
+        "unexpected error: {msg}"
+    );
 }


### PR DESCRIPTION
**Full disclosure: This is very AI assisted code but given my detailed description, it would have ended up in a similar state.** 

------------

I noticed that sometimes migrations using Prisma can result in deadlocks when more than one instance is trying to run the migrations at a time. This is attempted to be mitigated through the use of advisory locks as can be seen https://github.com/prisma/prisma-engines/blob/a09903a14c97c90b4fa191ca42b02ec9a7809451/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs#L375-L378. 

Unfortunately the `ADVISORY_LOCK_TIMEOUT` https://github.com/prisma/prisma-engines/blob/a09903a14c97c90b4fa191ca42b02ec9a7809451/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs#L38  still leaves the opportunity for a race condition to occur because the 2nd instance of a service holds on the advisory lock leading to a deadlock scenario. 

As per the documentation of Postgres: https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS there are two types of advisory locks that can be obtained here, one that is currently in use `pg_advisory_lock` and one that (IMHO) is the better one since it would return instantly with a boolean `f` if it fails to obtain the lock. Essentially mitigating the risk of race conditions and deadlocks altogether. 

Proposal would be to change from `pg_advisory_lock` to `pg_try_advisory_lock` and handle the change from a timeout error type of scenario to a simple boolean shortcircuit of the failure to obtain the lock as observed here: https://github.com/prisma/prisma-engines/blob/a09903a14c97c90b4fa191ca42b02ec9a7809451/schema-engine/commands/src/commands/apply_migrations.rs#L20-L24 and log and return that another instance must be running the migration instead at that point.  

```
pg_advisory_lock ( key bigint ) → void
pg_advisory_lock ( key1 integer, key2 integer ) → void
Obtains an exclusive session-level advisory lock, waiting if necessary.
...
pg_try_advisory_lock ( key bigint ) → boolean
pg_try_advisory_lock ( key1 integer, key2 integer ) → boolean
Obtains an exclusive session-level advisory lock if available. This will either obtain the lock immediately and return true, or return false without waiting if the lock cannot be acquired immediately.
```

One can mimic the failure on a local Postgres quite easily by following below steps:
```sql
-- Shell 1:
CREATE TABLE derp (fname text);

-- Shell 1:
SELECT pg_advisory_lock(72707369);

-- Shell 2:
SELECT pg_advisory_lock(72707369); -- This will hang

-- Shell 1:
CREATE INDEX CONCURRENTLY idx_fname_derp ON derp (fname);
```

Produces following logs:
```
2026-02-05 10:42:23.375 UTC [18224] ERROR:  deadlock detected
2026-02-05 10:42:23.375 UTC [18224] DETAIL:  Process 18224 waits for ShareLock on virtual transaction 6/1259; blocked by process 18225.
	Process 18225 waits for ExclusiveLock on advisory lock [13757,0,72707369,1]; blocked by process 18224.
	Process 18224: CREATE INDEX CONCURRENTLY idx_fname_derp ON derp (fname);
	Process 18225: SELECT pg_advisory_lock(72707369);
2026-02-05 10:42:23.375 UTC [18224] HINT:  See server log for query details.
2026-02-05 10:42:23.375 UTC [18224] STATEMENT:  CREATE INDEX CONCURRENTLY idx_fname_derp ON derp (fname);
```