### PR TITLE
fix(psl): preserve schema line endings during reformat

### DIFF
--- a/psl/psl/tests/reformat/reformat.rs
+++ b/psl/psl/tests/reformat/reformat.rs
@@ -16,6 +16,22 @@ fn must_add_new_line_to_end_of_schema() {
 }
 
 #[test]
+fn must_preserve_lf_line_endings() {
+    let input = "model User {\n  id Int @id\n}";
+    let expected = "model User {\n  id Int @id\n}\n";
+
+    assert_eq!(expected, reformat(input));
+}
+
+#[test]
+fn must_preserve_crlf_line_endings() {
+    let input = "model User {\r\n  id Int @id\r\n}";
+    let expected = "model User {\r\n  id Int @id\r\n}\r\n";
+
+    assert_eq!(expected, reformat(input));
+}
+
+#[test]
 fn test_reformat_model_complex() {
     let input = indoc! {r#"
         /// model doc comment

--- a/psl/psl/tests/reformat/reformat_implicit_relations.rs
+++ b/psl/psl/tests/reformat/reformat_implicit_relations.rs
@@ -1103,5 +1103,8 @@ fn reformat_missing_forward_relation_arguments_with_crln() {
         }
     "#]];
 
-    expected.assert_eq(&reformat(&schema.replace('\n', "\r\n")));
+    let reformatted = reformat(&schema.replace('\n', "\r\n"));
+    expected.assert_eq(&reformatted.replace("\r\n", "\n"));
+    assert!(reformatted.ends_with("\r\n"));
+    assert!(!reformatted.replace("\r\n", "").contains('\r'));
 }

--- a/psl/psl/tests/reformat_tests.rs
+++ b/psl/psl/tests/reformat_tests.rs
@@ -106,5 +106,18 @@ mod reformat_multi_file {
             })
     }
 
+    #[test]
+    fn reformat_multiple_preserves_line_endings_per_file() {
+        let schemas = vec![
+            ("lf.prisma".to_owned(), "model A {\n  id Int @id\n}".into()),
+            ("crlf.prisma".to_owned(), "model B {\r\n  id Int @id\r\n}".into()),
+        ];
+
+        let result: HashMap<_, _> = reformat_multiple(schemas, 2).into_iter().collect();
+
+        assert_eq!("model A {\n  id Int @id\n}\n", result["lf.prisma"]);
+        assert_eq!("model B {\r\n  id Int @id\r\n}\r\n", result["crlf.prisma"]);
+    }
+
     include!(concat!(env!("OUT_DIR"), "/reformat_multi_file_tests.rs"));
 }

--- a/psl/schema-ast/src/reformat.rs
+++ b/psl/schema-ast/src/reformat.rs
@@ -9,6 +9,7 @@ type Pair<'a> = pest::iterators::Pair<'a, Rule>;
 
 /// Reformat a PSL string.
 pub fn reformat(input: &str, indent_width: usize) -> Option<String> {
+    let line_ending = detect_line_ending(input);
     let mut ast = PrismaDatamodelParser::parse(Rule::schema, input).ok()?;
     let mut renderer = Renderer::new(indent_width);
     renderer.stream.reserve(input.len() / 2);
@@ -21,7 +22,24 @@ pub fn reformat(input: &str, indent_width: usize) -> Option<String> {
 
     // TODO: why do we need to use a `Some` here?
     // Also: if we really want to return an `Option<String>`, why do unwrap in `ast.next()`?
-    Some(renderer.stream)
+    Some(normalize_line_endings(renderer.stream, line_ending))
+}
+
+fn detect_line_ending(input: &str) -> &'static str {
+    match input.find('\n') {
+        Some(idx) if idx > 0 && input.as_bytes()[idx - 1] == b'\r' => "\r\n",
+        _ => "\n",
+    }
+}
+
+fn normalize_line_endings(output: String, line_ending: &str) -> String {
+    let normalized = output.replace("\r\n", "\n");
+
+    if line_ending == "\r\n" {
+        normalized.replace('\n', "\r\n")
+    } else {
+        normalized
+    }
 }
 
 fn reformat_top(target: &mut Renderer, pair: Pair<'_>) {


### PR DESCRIPTION
Fixes prisma/prisma#8548.

/claim https://github.com/prisma/prisma/issues/8548

Per the maintainer guidance in prisma/prisma#8548, this fixes the issue in `prisma-engines` instead of post-processing formatter output in the CLI layer. The implementation follows the accepted direction of preserving the original file line endings in the Rust formatter path.

`schema-ast` currently renders formatted schemas with one newline style. This change detects the source schema's line ending style before rendering, keeps the renderer output normalized internally, then applies the source line ending style to the final formatter output. That preserves LF-only schemas and CRLF schemas without unconditionally forcing either style for all users.

Changes:

- detect the first line ending style from the input schema
- keep the renderer's internal output normalized to LF
- normalize the final formatter output to LF or CRLF to match the input
- add coverage for single-file and multi-file reformatting
- update the existing CRLF relation reformat test to assert CRLF preservation

This intentionally differs from earlier closed CLI-side attempts by putting the behavior in `psl/schema-ast/src/reformat.rs`.

Verification:

```text
docker run --rm -v "C:\Users\fires\Documents\Codex\2026-05-19\20-goal\prisma-engines:/work" -w /work rust:1.92.0 cargo test -p psl --all-features line_endings
docker run --rm -v "C:\Users\fires\Documents\Codex\2026-05-19\20-goal\prisma-engines:/work" -w /work rust:1.92.0 cargo test -p psl --all-features reformat
docker run --rm -v "C:\Users\fires\Documents\Codex\2026-05-19\20-goal\prisma-engines:/work" -w /work rust:1.92.0 cargo test -p prisma-fmt format
docker run --rm -v "C:\Users\fires\Documents\Codex\2026-05-19\20-goal\prisma-engines:/work" -w /work rust:1.92.0 cargo fmt --check
```

All commands passed.

Additional clean-check: generated `prisma_8548.patch`, applied it to a fresh Linux clone of `prisma/prisma-engines`, then ran:

```text
CLICOLOR_FORCE=1 FORCE_COLOR=1 cargo test -p psl --all-features
```

Result: `1065` datamodel tests, `20` reformat tests, `215` validation tests, and doc tests passed.
