### PR TITLE
fix(schema-engine): use allowlist in pg constraints query to handle PostgreSQL 18 NOT NULL contype

### DIFF
--- a/schema-engine/sql-schema-describer/src/postgres/constraints_query.sql
+++ b/schema-engine/sql-schema-describer/src/postgres/constraints_query.sql
@@ -12,5 +12,5 @@ JOIN pg_class AS tableinfo
 JOIN pg_namespace AS schemainfo
 	ON schemainfo.oid = tableinfo.relnamespace
 WHERE schemainfo.nspname = ANY ( $1 )
-	AND contype NOT IN ('p', 'u', 'f')
+	AND contype IN ('c', 'x')
 ORDER BY namespace, table_name, constr.contype, constraint_name;


### PR DESCRIPTION
## What

Change the PostgreSQL constraint introspection query from a denylist to an allowlist.

**Before:**
```sql
AND contype NOT IN ('p', 'u', 'f')
```

**After:**
```sql
AND contype IN ('c', 'x')
```

## Why

PostgreSQL 18 introduces NOT NULL constraints as first-class `pg_constraint` rows with `contype = 'n'` ([PG 18 docs](https://www.postgresql.org/docs/18/catalog-pg-constraint.html)). The previous denylist allowed these rows through to `get_constraints`, where `row.get_expect_char("constraint_type")` panics when the value arrives as `Text("n")` rather than a `char` — which is the case for all driver-adapter paths, since values cross the JS boundary as strings.

The practical impact: any PostgreSQL 18 database with at least one `NOT NULL` column (i.e. effectively all of them) breaks `db push` diffing, `db pull`, and `migrate dev`/`deploy` when going through the WASM engine with a driver adapter (`@prisma/adapter-pg`, PGlite, etc.). The promise returned by `schemaPush` never settles because the panic has no registered handler.

The fix uses an allowlist restricted to `'c'` (check) and `'x'` (exclusion) — the only two `contype` values `get_constraints` actually handles. Column nullability is already read from `pg_attribute.attnotnull`, so `NOT-NULL-as-constraint` rows carry no information Prisma needs. This also future-proofs the query against any new `contype` values PostgreSQL might introduce (PG 18 also added `'t'` for trigger constraints upstream).

Fixes prisma/prisma#29635