### PR TITLE
perf(query-compiler): Prisma Client performance groundwork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3679,6 +3679,7 @@ dependencies = [
  "schema",
  "serde",
  "serde_json",
+ "smallvec",
  "sql-query-builder",
  "thiserror 2.0.17",
 ]

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -9,7 +9,6 @@ use chrono::prelude::*;
 use serde::de::Unexpected;
 use serde::ser::{SerializeMap, SerializeTuple};
 use serde::{Deserialize, Deserializer, Serialize, ser::Serializer};
-use serde_json::json;
 use std::{borrow::Cow, convert::TryFrom, fmt, str::FromStr};
 use uuid::Uuid;
 
@@ -358,24 +357,31 @@ where
 fn serialize_generator_call<S>(
     name: &str,
     args: &[PrismaValue],
-    return_type: &PrismaValueType,
+    _return_type: &PrismaValueType,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let mut map = serializer.serialize_map(Some(2))?;
+    struct CompactGeneratorCall<'a> {
+        name: &'a str,
+        args: &'a [PrismaValue],
+    }
 
-    map.serialize_entry("prisma__type", "generatorCall")?;
-    map.serialize_entry(
-        "prisma__value",
-        &json!({
-            "name": name,
-            "args": args,
-            "returnType": return_type,
-        }),
-    )?;
+    impl Serialize for CompactGeneratorCall<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(self.name)?;
+            tuple.serialize_element(self.args)?;
+            tuple.end()
+        }
+    }
 
+    let mut map = serializer.serialize_map(Some(1))?;
+    map.serialize_entry("$g", &CompactGeneratorCall { name, args })?;
     map.end()
 }
 

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -7,7 +7,7 @@ use base64::prelude::*;
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use chrono::prelude::*;
 use serde::de::Unexpected;
-use serde::ser::SerializeMap;
+use serde::ser::{SerializeMap, SerializeTuple};
 use serde::{Deserialize, Deserializer, Serialize, ser::Serializer};
 use serde_json::json;
 use std::{borrow::Cow, convert::TryFrom, fmt, str::FromStr};
@@ -327,17 +327,31 @@ fn serialize_placeholder<S>(Placeholder { name, r#type }: &Placeholder, serializ
 where
     S: Serializer,
 {
-    let mut map = serializer.serialize_map(Some(2))?;
+    struct CompactPlaceholderValue<'a> {
+        name: &'a Cow<'static, str>,
+        r#type: String,
+    }
 
-    map.serialize_entry("prisma__type", "param")?;
+    impl Serialize for CompactPlaceholderValue<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(self.name)?;
+            tuple.serialize_element(&self.r#type)?;
+            tuple.end()
+        }
+    }
+
+    let mut map = serializer.serialize_map(Some(1))?;
     map.serialize_entry(
-        "prisma__value",
-        &json!({
-            "name": name,
-            "type": r#type.to_string(),
-        }),
+        "$p",
+        &CompactPlaceholderValue {
+            name,
+            r#type: r#type.to_string(),
+        },
     )?;
-
     map.end()
 }
 

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -328,7 +328,7 @@ where
 {
     struct CompactPlaceholderValue<'a> {
         name: &'a Cow<'static, str>,
-        r#type: String,
+        r#type: &'a PrismaValueType,
     }
 
     impl Serialize for CompactPlaceholderValue<'_> {
@@ -338,19 +338,38 @@ where
         {
             let mut tuple = serializer.serialize_tuple(2)?;
             tuple.serialize_element(self.name)?;
-            tuple.serialize_element(&self.r#type)?;
+            tuple.serialize_element(&CompactPlaceholderType(self.r#type))?;
             tuple.end()
         }
     }
 
+    struct CompactPlaceholderType<'a>(&'a PrismaValueType);
+
+    impl Serialize for CompactPlaceholderType<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match self.0 {
+                PrismaValueType::String => serializer.serialize_str("String"),
+                PrismaValueType::Boolean => serializer.serialize_str("Boolean"),
+                PrismaValueType::Enum => serializer.serialize_str("Enum"),
+                PrismaValueType::Int => serializer.serialize_str("Int"),
+                PrismaValueType::Uuid => serializer.serialize_str("Uuid"),
+                PrismaValueType::Json => serializer.serialize_str("Json"),
+                PrismaValueType::Object => serializer.serialize_str("Object"),
+                PrismaValueType::DateTime => serializer.serialize_str("DateTime"),
+                PrismaValueType::Float => serializer.serialize_str("Float"),
+                PrismaValueType::BigInt => serializer.serialize_str("BigInt"),
+                PrismaValueType::Bytes => serializer.serialize_str("Bytes"),
+                PrismaValueType::Any => serializer.serialize_str("Any"),
+                PrismaValueType::List(_) => self.0.to_string().serialize(serializer),
+            }
+        }
+    }
+
     let mut map = serializer.serialize_map(Some(1))?;
-    map.serialize_entry(
-        "$p",
-        &CompactPlaceholderValue {
-            name,
-            r#type: r#type.to_string(),
-        },
-    )?;
+    map.serialize_entry("$p", &CompactPlaceholderValue { name, r#type })?;
     map.end()
 }
 
@@ -646,5 +665,23 @@ impl TryFrom<PrismaValue> for String {
             PrismaValue::String(s) => Ok(s),
             _ => Err(ConversionFailure::new("PrismaValue", "String")),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn serializes_compact_placeholders() {
+        let scalar = PrismaValue::placeholder("%1", PrismaValueType::Int);
+        let list = PrismaValue::placeholder("%2", PrismaValueType::List(PrismaValueType::String.into()));
+
+        assert_eq!(serde_json::to_value(scalar).unwrap(), json!({ "$p": ["%1", "Int"] }));
+        assert_eq!(
+            serde_json::to_value(list).unwrap(),
+            json!({ "$p": ["%2", "List<String>"] })
+        );
     }
 }

--- a/quaint/src/ast.rs
+++ b/quaint/src/ast.rs
@@ -34,6 +34,7 @@ pub use column::{Column, DefaultValue, TypeDataLength, TypeFamily};
 pub use compare::{Comparable, Compare, JsonCompare, JsonType};
 pub use conditions::ConditionTree;
 pub use conjunctive::Conjunctive;
+pub(crate) use cte::CommonTableExpressionBody;
 pub use cte::{CommonTableExpression, IntoCommonTableExpression};
 pub use delete::Delete;
 pub use enums::{EnumName, EnumVariant};

--- a/quaint/src/ast/cte.rs
+++ b/quaint/src/ast/cte.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::SelectQuery;
+use super::{Insert, Select, SelectQuery, Union};
 
 /// A builder for a common table expression (CTE) statement, to be used in the
 /// `WITH` block of a `SELECT` statement.
@@ -12,7 +12,13 @@ use super::SelectQuery;
 pub struct CommonTableExpression<'a> {
     pub(crate) identifier: Cow<'a, str>,
     pub(crate) columns: Vec<Cow<'a, str>>,
-    pub(crate) selection: SelectQuery<'a>,
+    pub(crate) body: CommonTableExpressionBody<'a>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) enum CommonTableExpressionBody<'a> {
+    Selection(SelectQuery<'a>),
+    Insert(Insert<'a>),
 }
 
 impl<'a> CommonTableExpression<'a> {
@@ -30,14 +36,40 @@ impl<'a> CommonTableExpression<'a> {
 ///
 /// [`Select#with`]: struct.Select.html#method.with
 pub trait IntoCommonTableExpression<'a> {
-    fn into_cte(self, identifier: impl Into<Cow<'a, str>>) -> CommonTableExpression<'a>
-    where
-        Self: Into<SelectQuery<'a>>,
-    {
-        CommonTableExpression {
-            identifier: identifier.into(),
-            columns: Vec::new(),
-            selection: self.into(),
-        }
+    fn into_cte(self, identifier: impl Into<Cow<'a, str>>) -> CommonTableExpression<'a>;
+}
+
+fn common_table_expression<'a>(
+    identifier: impl Into<Cow<'a, str>>,
+    body: CommonTableExpressionBody<'a>,
+) -> CommonTableExpression<'a> {
+    CommonTableExpression {
+        identifier: identifier.into(),
+        columns: Vec::new(),
+        body,
+    }
+}
+
+impl<'a> IntoCommonTableExpression<'a> for Select<'a> {
+    fn into_cte(self, identifier: impl Into<Cow<'a, str>>) -> CommonTableExpression<'a> {
+        common_table_expression(identifier, CommonTableExpressionBody::Selection(self.into()))
+    }
+}
+
+impl<'a> IntoCommonTableExpression<'a> for Union<'a> {
+    fn into_cte(self, identifier: impl Into<Cow<'a, str>>) -> CommonTableExpression<'a> {
+        common_table_expression(identifier, CommonTableExpressionBody::Selection(self.into()))
+    }
+}
+
+impl<'a> IntoCommonTableExpression<'a> for SelectQuery<'a> {
+    fn into_cte(self, identifier: impl Into<Cow<'a, str>>) -> CommonTableExpression<'a> {
+        common_table_expression(identifier, CommonTableExpressionBody::Selection(self))
+    }
+}
+
+impl<'a> IntoCommonTableExpression<'a> for Insert<'a> {
+    fn into_cte(self, identifier: impl Into<Cow<'a, str>>) -> CommonTableExpression<'a> {
+        common_table_expression(identifier, CommonTableExpressionBody::Insert(self))
     }
 }

--- a/quaint/src/ast/query.rs
+++ b/quaint/src/ast/query.rs
@@ -1,8 +1,6 @@
 use crate::ast::{Delete, Insert, Merge, Select, Union, Update};
 use std::borrow::Cow;
 
-use super::IntoCommonTableExpression;
-
 /// A database query
 #[derive(Debug, PartialEq)]
 pub enum Query<'a> {
@@ -107,5 +105,3 @@ impl<'a> From<SelectQuery<'a>> for Query<'a> {
         }
     }
 }
-
-impl<'a> IntoCommonTableExpression<'a> for SelectQuery<'a> {}

--- a/quaint/src/ast/select.rs
+++ b/quaint/src/ast/select.rs
@@ -722,8 +722,6 @@ impl<'a> Select<'a> {
     }
 }
 
-impl<'a> IntoCommonTableExpression<'a> for Select<'a> {}
-
 impl<'a> Extend<Expression<'a>> for Select<'a> {
     fn extend<T: IntoIterator<Item = Expression<'a>>>(&mut self, iter: T) {
         self.columns.extend(iter);

--- a/quaint/src/ast/union.rs
+++ b/quaint/src/ast/union.rs
@@ -2,7 +2,6 @@ use crate::ast::{Expression, Query, Select};
 use std::{collections::BTreeSet, fmt};
 
 use super::CommonTableExpression;
-use super::IntoCommonTableExpression;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub(crate) enum UnionType {
@@ -145,5 +144,3 @@ impl<'a> Union<'a> {
         }
     }
 }
-
-impl<'a> IntoCommonTableExpression<'a> for Union<'a> {}

--- a/quaint/src/visitor.rs
+++ b/quaint/src/visitor.rs
@@ -1350,8 +1350,11 @@ pub trait Visitor<'a> {
 
         self.write(" AS ")?;
 
-        let selection = cte.selection;
-        self.surround_with("(", ")", |ref mut s| s.visit_selection(selection))
+        let body = cte.body;
+        self.surround_with("(", ")", |ref mut s| match body {
+            CommonTableExpressionBody::Selection(selection) => s.visit_selection(selection),
+            CommonTableExpressionBody::Insert(insert) => s.visit_insert(insert),
+        })
     }
 
     fn visit_comment(&mut self, comment: Cow<'a, str>) -> Result {

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -936,6 +936,28 @@ mod tests {
 
     #[test]
     #[cfg(feature = "postgresql")]
+    fn test_insert_common_table_expression() {
+        let expected = expected_values(
+            "WITH \"inserted\" AS (INSERT INTO \"relations\" (\"parent_id\",\"child_id\") SELECT \"parent_id\", \"child_id\" FROM \"children\" WHERE \"child_id\" = $1 ON CONFLICT DO NOTHING RETURNING \"child_id\") SELECT \"child_id\" FROM \"inserted\"",
+            vec![10],
+        );
+        let selection = Select::from_table("children")
+            .columns(vec!["parent_id", "child_id"])
+            .so_that("child_id".equals(10));
+        let insert = Insert::expression_into("relations", vec!["parent_id", "child_id"], selection)
+            .on_conflict(OnConflict::DoNothing)
+            .returning(vec!["child_id"]);
+        let query = Select::from_table("inserted")
+            .column("child_id")
+            .with(insert.into_cte("inserted"));
+        let (sql, params) = Postgres::build(query).unwrap();
+
+        assert_eq!(expected.0, sql);
+        assert_eq!(expected.1, params);
+    }
+
+    #[test]
+    #[cfg(feature = "postgresql")]
     fn test_insert_on_conflict_update() {
         let expected = expected_values(
             "INSERT INTO \"users\" (\"foo\") VALUES ($1) ON CONFLICT (\"foo\") DO UPDATE SET \"foo\" = $2 WHERE \"users\".\"foo\" = $3 RETURNING \"foo\"",

--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -378,6 +378,24 @@ impl<'a> Visitor<'a> for Postgres<'a> {
                     }
                 }
             }
+            Expression {
+                kind: ExpressionKind::Selection(selection),
+                ..
+            } => {
+                let columns = insert.columns.len();
+
+                self.write(" (")?;
+                for (i, c) in insert.columns.into_iter().enumerate() {
+                    self.visit_column(c.name.into_owned().into())?;
+
+                    if i < (columns - 1) {
+                        self.write(",")?;
+                    }
+                }
+
+                self.write(") ")?;
+                self.visit_sub_selection(selection)?;
+            }
             expr => self.surround_with("(", ")", |ref mut s| s.visit_expression(expr))?,
         }
 
@@ -892,6 +910,25 @@ mod tests {
         );
         let query = Insert::single_into("users").value("foo", 10);
         let (sql, params) = Postgres::build(Insert::from(query).returning(vec!["foo"])).unwrap();
+
+        assert_eq!(expected.0, sql);
+        assert_eq!(expected.1, params);
+    }
+
+    #[test]
+    #[cfg(feature = "postgresql")]
+    fn test_insert_from_selection() {
+        let expected = expected_values(
+            "INSERT INTO \"relations\" (\"parent_id\",\"child_id\") SELECT \"parent_id\", \"child_id\" FROM \"children\" WHERE \"child_id\" = $1 ON CONFLICT DO NOTHING RETURNING \"child_id\"",
+            vec![10],
+        );
+        let selection = Select::from_table("children")
+            .columns(vec!["parent_id", "child_id"])
+            .so_that("child_id".equals(10));
+        let query = Insert::expression_into("relations", vec!["parent_id", "child_id"], selection)
+            .on_conflict(OnConflict::DoNothing)
+            .returning(vec!["child_id"]);
+        let (sql, params) = Postgres::build(query).unwrap();
 
         assert_eq!(expected.0, sql);
         assert_eq!(expected.1, params);

--- a/query-compiler/core/src/query_ast/write.rs
+++ b/query-compiler/core/src/query_ast/write.rs
@@ -14,6 +14,7 @@ pub enum WriteQuery {
     DeleteManyRecords(DeleteManyRecords),
     ConnectRecords(ConnectRecords),
     DisconnectRecords(DisconnectRecords),
+    DisconnectAllRecords(DisconnectAllRecords),
     ExecuteRaw(RawQuery),
     QueryRaw(RawQuery),
     Upsert(NativeUpsert),
@@ -29,6 +30,7 @@ impl WriteQuery {
             | Self::DeleteManyRecords(_)
             | Self::ConnectRecords(_)
             | Self::DisconnectRecords(_)
+            | Self::DisconnectAllRecords(_)
             | Self::ExecuteRaw(_)
             | Self::QueryRaw(_) => false,
         }
@@ -79,6 +81,7 @@ impl WriteQuery {
             Self::DeleteManyRecords(_) => None,
             Self::ConnectRecords(_) => None,
             Self::DisconnectRecords(_) => None,
+            Self::DisconnectAllRecords(_) => None,
             Self::ExecuteRaw(_) => None,
             Self::QueryRaw(_) => None,
             Self::Upsert(upsert) => Some(&upsert.selected_fields),
@@ -110,6 +113,7 @@ impl WriteQuery {
             Self::DeleteManyRecords(_) => (),
             Self::ConnectRecords(_) => (),
             Self::DisconnectRecords(_) => (),
+            Self::DisconnectAllRecords(_) => (),
             Self::ExecuteRaw(_) => (),
             Self::QueryRaw(_) => (),
             Self::Upsert(_) => (),
@@ -127,6 +131,7 @@ impl WriteQuery {
             Self::DeleteManyRecords(q) => q.model.clone(),
             Self::ConnectRecords(q) => q.relation_field.model(),
             Self::DisconnectRecords(q) => q.relation_field.model(),
+            Self::DisconnectAllRecords(q) => q.relation_field.model(),
             Self::ExecuteRaw(_) => unimplemented!(),
             Self::QueryRaw(_) => unimplemented!(),
         }
@@ -198,6 +203,7 @@ impl std::fmt::Display for WriteQuery {
             Self::DeleteManyRecords(q) => write!(f, "DeleteManyRecords: {}", q.model.name()),
             Self::ConnectRecords(_) => write!(f, "ConnectRecords"),
             Self::DisconnectRecords(_) => write!(f, "DisconnectRecords"),
+            Self::DisconnectAllRecords(_) => write!(f, "DisconnectAllRecords"),
             Self::ExecuteRaw(r) => write!(f, "ExecuteRaw: {:?}", r.inputs),
             Self::QueryRaw(r) => write!(f, "QueryRaw: {:?}", r.inputs),
             Self::Upsert(q) => write!(
@@ -236,6 +242,7 @@ impl ToGraphviz for WriteQuery {
             Self::DeleteManyRecords(q) => format!("DeleteManyRecords: {}", q.model.name()),
             Self::ConnectRecords(_) => "ConnectRecords".to_string(),
             Self::DisconnectRecords(_) => "DisconnectRecords".to_string(),
+            Self::DisconnectAllRecords(_) => "DisconnectAllRecords".to_string(),
             Self::ExecuteRaw(r) => format!("ExecuteRaw: {:#?}", r.inputs),
             Self::QueryRaw(r) => format!("QueryRaw: {:#?}", r.inputs),
             Self::Upsert(q) => format!("Upsert(model: {}", q.model().name()),
@@ -401,6 +408,12 @@ pub struct ConnectRecords {
 pub struct DisconnectRecords {
     pub parent_id: Option<SelectionResult>,
     pub child_ids: Vec<SelectionResult>,
+    pub relation_field: RelationFieldRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct DisconnectAllRecords {
+    pub parent_id: Option<SelectionResult>,
     pub relation_field: RelationFieldRef,
 }
 

--- a/query-compiler/core/src/query_document/mod.rs
+++ b/query-compiler/core/src/query_document/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use parser::*;
 
 use crate::{
     query_ast::{QueryOption, QueryOptions},
-    query_graph_builder::resolve_compound_field,
+    query_graph_builder::is_compound_field,
 };
 use itertools::Itertools;
 use query_structure::Model;
@@ -91,7 +91,7 @@ impl BatchDocument {
 
         where_obj.iter().any(|(key, val)| match val {
             // If it's a compound, then it's still considered as scalar
-            ArgumentValue::Object(_) if resolve_compound_field(key, &model).is_some() => false,
+            ArgumentValue::Object(_) if is_compound_field(key, &model) => false,
             // Otherwise, we just look for a scalar field inside the model. If it's not one, then we break.
             val => match model.fields().find_from_scalar(key) {
                 Ok(sf) => match val {
@@ -319,7 +319,7 @@ fn extract_filter(where_obj: ArgumentValueObject, model: &Model) -> Vec<Selectio
         .into_iter()
         .flat_map(|(key, val)| match val {
             // This means our query has a compound field in the form of: {co1_col2: { col1_col2: { col1: <val>, col2: <val> } }}
-            ArgumentValue::Object(obj) if resolve_compound_field(&key, model).is_some() => obj.into_iter().collect(),
+            ArgumentValue::Object(obj) if is_compound_field(&key, model) => obj.into_iter().collect(),
             // This means our query has a scalar filter in the form of {col1: { equals: <val> }}
             ArgumentValue::Object(obj) => {
                 // This is safe because it's been validated before in the `.can_compact` method.

--- a/query-compiler/core/src/query_document/parse_ast.rs
+++ b/query-compiler/core/src/query_document/parse_ast.rs
@@ -123,8 +123,7 @@ impl<'a> ParsedField<'a> {
     fn look_arg(&mut self, arg_name: &str) -> QueryParserResult<Option<ParsedInputMap<'a>>> {
         self.arguments
             .lookup(arg_name)
-            .as_ref()
-            .map(|arg| arg.value.clone().try_into())
+            .map(|arg| arg.value.try_into())
             .transpose()
     }
 }

--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -267,13 +267,13 @@ impl QueryDocumentParser {
         }
 
         for input_type in possible_input_types {
-            match (value.clone(), input_type) {
+            match (&value, input_type) {
                 // With the JSON protocol, JSON values are sent as deserialized values.
                 // This means JSON can match with pretty much anything. A string, an int, an object, an array.
                 // This is an early catch-all.
                 // We do not get into this catch-all if the value is already Json, or if it's a FieldRef,
                 // Enum or Placeholder, because they've already been disambiguated at the procotol level.
-                (value, InputType::<'a>::Scalar(ScalarType::Json))
+                (_, InputType::<'a>::Scalar(ScalarType::Json))
                     if value.should_be_parsed_as_json() && get_engine_protocol().is_json() =>
                 {
                     return Ok(ParsedInputValue::Single(self.to_json(
@@ -285,14 +285,14 @@ impl QueryDocumentParser {
                 // With the JSON protocol, JSON values are sent as deserialized values.
                 // This means that a JsonList([1, 2]) will be coerced as an `ArgumentValue::List([1, 2])`.
                 // We need this early matcher to make sure we coerce this array back to JSON.
-                (list @ ArgumentValue::List(_), InputType::Scalar(ScalarType::JsonList))
+                (ArgumentValue::List(_), InputType::Scalar(ScalarType::JsonList))
                     if get_engine_protocol().is_json() =>
                 {
-                    let json_val = serde_json::to_value(list.clone()).map_err(|err| {
+                    let json_val = serde_json::to_value(&value).map_err(|err| {
                         ValidationError::invalid_argument_value(
                             selection_path.segments(),
                             argument_path.segments(),
-                            format!("{list:?}"),
+                            format!("{value:?}"),
                             "JSON array",
                             Some(Box::new(err)),
                         )
@@ -313,26 +313,33 @@ impl QueryDocumentParser {
                     ))),
                     // Scalar handling
                     (pv, InputType::Scalar(st)) => try_this!(
-                        self.parse_scalar(&selection_path, &argument_path, pv, *st, &value, is_parameterizable)
-                            .map(ParsedInputValue::Single)
+                        self.parse_scalar(
+                            &selection_path,
+                            &argument_path,
+                            pv.clone(),
+                            *st,
+                            &value,
+                            is_parameterizable
+                        )
+                        .map(ParsedInputValue::Single)
                     ),
 
                     // Enum handling
                     (pv @ PrismaValue::Enum(_), InputType::Enum(et)) => {
-                        try_this!(self.parse_enum(&selection_path, &argument_path, pv, et))
+                        try_this!(self.parse_enum(&selection_path, &argument_path, pv.clone(), et))
                     }
                     (pv @ PrismaValue::String(_), InputType::Enum(et)) => {
-                        try_this!(self.parse_enum(&selection_path, &argument_path, pv, et))
+                        try_this!(self.parse_enum(&selection_path, &argument_path, pv.clone(), et))
                     }
                     (pv @ PrismaValue::Boolean(_), InputType::Enum(et)) => {
-                        try_this!(self.parse_enum(&selection_path, &argument_path, pv, et))
+                        try_this!(self.parse_enum(&selection_path, &argument_path, pv.clone(), et))
                     }
                     (PrismaValue::Placeholder(placeholder), InputType::Enum(et)) => {
                         try_this!(self.parse_parameterized_enum(
                             &selection_path,
                             &argument_path,
                             &value,
-                            placeholder,
+                            placeholder.clone(),
                             et,
                             is_parameterizable
                         ))
@@ -344,7 +351,7 @@ impl QueryDocumentParser {
                             &selection_path,
                             &argument_path,
                             &value,
-                            placeholder,
+                            placeholder.clone(),
                             elem_type,
                             is_parameterizable
                         ))
@@ -364,7 +371,7 @@ impl QueryDocumentParser {
                     self.parse_list(
                         &selection_path,
                         &argument_path,
-                        values.clone(),
+                        values.to_vec(),
                         l,
                         query_schema,
                         is_parameterizable

--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -3,7 +3,6 @@ use crate::{request_context::get_engine_protocol, schema::*};
 use bigdecimal::{BigDecimal, ToPrimitive};
 use chrono::prelude::*;
 use core::fmt;
-use indexmap::{IndexMap, IndexSet};
 use query_structure::{DefaultKind, Placeholder, PrismaValue, PrismaValueType};
 use std::{borrow::Cow, convert::TryFrom, rc::Rc, str::FromStr};
 use user_facing_errors::query_engine::validation::ValidationError;
@@ -848,18 +847,17 @@ impl QueryDocumentParser {
         schema_object: &InputObjectType<'a>,
         query_schema: &'a QuerySchema,
     ) -> QueryParserResult<ParsedInputMap<'a>> {
-        let fields = schema_object.get_fields().iter();
-        let valid_field_names: IndexSet<Cow<'_, str>> = fields.clone().map(|field| field.name.clone()).collect();
-        let given_field_names: IndexSet<Cow<'_, str>> = object.iter().map(|(k, _)| Cow::Borrowed(k.as_str())).collect();
-        let missing_field_names = valid_field_names.difference(&given_field_names);
-        let schema_fields: IndexMap<Cow<'_, str>, InputField<'_>> =
-            fields.map(|f| (f.name.clone(), f.clone())).collect();
+        let fields = schema_object.get_fields();
 
         // First, filter-in those fields that are not given but have a default value in the schema.
         // As in practise, it is like if they were given with said default value.
-        let defaults = missing_field_names
-            .filter_map(|unset_field_name| {
-                let field = schema_fields.get(unset_field_name.as_ref()).unwrap();
+        let defaults = fields
+            .iter()
+            .filter_map(|field| {
+                if object.contains_key(field.name.as_ref()) {
+                    return None;
+                }
+
                 let argument_path = argument_path.add(field.name.clone().into_owned());
 
                 // If the input field has a default, add the default to the result.
@@ -898,13 +896,16 @@ impl QueryDocumentParser {
         let mut map = object
             .into_iter()
             .map(|(field_name, value)| {
-                let field = schema_fields.get(field_name.as_str()).ok_or_else(|| {
-                    ValidationError::unknown_input_field(
-                        selection_path.segments(),
-                        argument_path.add(field_name.clone()).segments(),
-                        conversions::schema_input_object_type_to_input_type_description(schema_object),
-                    )
-                })?;
+                let field = fields
+                    .iter()
+                    .find(|field| field.name.as_ref() == field_name)
+                    .ok_or_else(|| {
+                        ValidationError::unknown_input_field(
+                            selection_path.segments(),
+                            argument_path.add(field_name.clone()).segments(),
+                            conversions::schema_input_object_type_to_input_type_description(schema_object),
+                        )
+                    })?;
 
                 let argument_path = argument_path.add(field.name.clone().into_owned());
                 let parsed = self.parse_input_value(

--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -262,6 +262,17 @@ impl QueryDocumentParser {
         query_schema: &'a QuerySchema,
         is_parameterizable: bool,
     ) -> QueryParserResult<ParsedInputValue<'a>> {
+        if let [input_type] = possible_input_types {
+            return self.parse_input_value_single(
+                selection_path,
+                argument_path,
+                value,
+                input_type,
+                query_schema,
+                is_parameterizable,
+            );
+        }
+
         let mut failures = Vec::new();
 
         macro_rules! try_this {
@@ -322,15 +333,8 @@ impl QueryDocumentParser {
                     ))),
                     // Scalar handling
                     (pv, InputType::Scalar(st)) => try_this!(
-                        self.parse_scalar(
-                            selection_path,
-                            &*argument_path,
-                            pv.clone(),
-                            *st,
-                            &value,
-                            is_parameterizable
-                        )
-                        .map(ParsedInputValue::Single)
+                        self.parse_scalar(selection_path, &*argument_path, pv.clone(), *st, is_parameterizable)
+                            .map(ParsedInputValue::Single)
                     ),
 
                     // Enum handling
@@ -347,7 +351,6 @@ impl QueryDocumentParser {
                         try_this!(self.parse_parameterized_enum(
                             selection_path,
                             &*argument_path,
-                            &value,
                             placeholder.clone(),
                             et,
                             is_parameterizable
@@ -359,7 +362,6 @@ impl QueryDocumentParser {
                         try_this!(self.parse_parameterized_list(
                             selection_path,
                             &*argument_path,
-                            &value,
                             placeholder.clone(),
                             elem_type,
                             is_parameterizable
@@ -411,6 +413,128 @@ impl QueryDocumentParser {
         }
     }
 
+    fn parse_input_value_single<'a>(
+        &self,
+        selection_path: &Path,
+        argument_path: &mut Path,
+        value: ArgumentValue,
+        input_type: &InputType<'a>,
+        query_schema: &'a QuerySchema,
+        is_parameterizable: bool,
+    ) -> QueryParserResult<ParsedInputValue<'a>> {
+        if matches!(input_type, InputType::Scalar(ScalarType::Json))
+            && value.should_be_parsed_as_json()
+            && get_engine_protocol().is_json()
+        {
+            return Ok(ParsedInputValue::Single(self.to_json(
+                selection_path,
+                &*argument_path,
+                &value,
+            )?));
+        }
+
+        if matches!(input_type, InputType::Scalar(ScalarType::JsonList))
+            && matches!(value, ArgumentValue::List(_))
+            && get_engine_protocol().is_json()
+        {
+            let json_val = serde_json::to_value(&value).map_err(|err| {
+                ValidationError::invalid_argument_value(
+                    selection_path.segments(),
+                    argument_path.segments(),
+                    format!("{value:?}"),
+                    "JSON array",
+                    Some(Box::new(err)),
+                )
+            })?;
+            let json_list = self.parse_json_list_from_value(selection_path, &*argument_path, json_val)?;
+
+            return Ok(ParsedInputValue::Single(json_list));
+        }
+
+        match value {
+            ArgumentValue::Scalar(pv) => match (pv, input_type) {
+                (PrismaValue::Null, InputType::Scalar(ScalarType::Null)) => {
+                    Ok(ParsedInputValue::Single(PrismaValue::Null))
+                }
+                (PrismaValue::Null, input_type) => Err(ValidationError::required_argument_missing(
+                    selection_path.segments(),
+                    argument_path.segments(),
+                    &conversions::input_types_to_input_type_descriptions(std::slice::from_ref(input_type)),
+                )),
+                (pv, InputType::Scalar(st)) => self
+                    .parse_scalar(selection_path, &*argument_path, pv, *st, is_parameterizable)
+                    .map(ParsedInputValue::Single),
+                (pv @ PrismaValue::Enum(_), InputType::Enum(et))
+                | (pv @ PrismaValue::String(_), InputType::Enum(et))
+                | (pv @ PrismaValue::Boolean(_), InputType::Enum(et)) => {
+                    self.parse_enum(selection_path, &*argument_path, pv, et)
+                }
+                (PrismaValue::Placeholder(placeholder), InputType::Enum(et)) => {
+                    self.parse_parameterized_enum(selection_path, &*argument_path, placeholder, et, is_parameterizable)
+                }
+                (PrismaValue::Placeholder(placeholder), InputType::List(elem_type)) => self.parse_parameterized_list(
+                    selection_path,
+                    &*argument_path,
+                    placeholder,
+                    elem_type,
+                    is_parameterizable,
+                ),
+                (pv, input_type) => Err(invalid_prisma_value_type_error(
+                    selection_path,
+                    &*argument_path,
+                    input_type,
+                    pv,
+                )),
+            },
+            ArgumentValue::List(values) => match input_type {
+                InputType::List(l) => self
+                    .parse_list(
+                        selection_path,
+                        argument_path,
+                        values,
+                        l,
+                        query_schema,
+                        is_parameterizable,
+                    )
+                    .map(ParsedInputValue::List),
+                input_type => Err(invalid_argument_type_error_owned(
+                    selection_path,
+                    &*argument_path,
+                    input_type,
+                    ArgumentValue::List(values),
+                )),
+            },
+            ArgumentValue::Object(o) => match input_type {
+                InputType::Object(obj) => self
+                    .parse_input_object(selection_path, argument_path, o, obj, query_schema)
+                    .map(ParsedInputValue::Map),
+                input_type => Err(invalid_argument_type_error_owned(
+                    selection_path,
+                    &*argument_path,
+                    input_type,
+                    ArgumentValue::Object(o),
+                )),
+            },
+            ArgumentValue::FieldRef(o) => match input_type {
+                InputType::Object(obj) => self
+                    .parse_input_object(selection_path, argument_path, o, obj, query_schema)
+                    .map(ParsedInputValue::Map),
+                input_type => Err(invalid_argument_type_error_owned(
+                    selection_path,
+                    &*argument_path,
+                    input_type,
+                    ArgumentValue::FieldRef(o),
+                )),
+            },
+            value => Err(invalid_argument_type_error_owned(
+                selection_path,
+                &*argument_path,
+                input_type,
+                value,
+            )),
+        }
+    }
+
     /// Attempts to parse given query value into a concrete PrismaValue based on given scalar type.
     fn parse_scalar(
         &self,
@@ -418,7 +542,6 @@ impl QueryDocumentParser {
         argument_path: &Path,
         value: PrismaValue,
         scalar_type: ScalarType,
-        argument_value: &ArgumentValue,
         is_parameterizable: bool,
     ) -> QueryParserResult<PrismaValue> {
         match (value, scalar_type) {
@@ -514,11 +637,11 @@ impl QueryDocumentParser {
             }
 
             // All other combinations are value type mismatches.
-            (_, _) => Err(invalid_argument_type_error(
+            (pv, scalar_type) => Err(invalid_prisma_value_type_error(
                 selection_path,
                 argument_path,
                 &InputType::Scalar(scalar_type),
-                argument_value,
+                pv,
             )),
         }
     }
@@ -704,7 +827,6 @@ impl QueryDocumentParser {
         &self,
         selection_path: &Path,
         argument_path: &Path,
-        argument_value: &ArgumentValue,
         placeholder: Placeholder,
         element_input_type: &InputType<'a>,
         is_parameterizable: bool,
@@ -718,12 +840,12 @@ impl QueryDocumentParser {
             ));
         }
 
-        let error = || {
-            invalid_argument_type_error(
+        let error = |placeholder| {
+            invalid_prisma_value_type_error(
                 selection_path,
                 argument_path,
                 &InputType::List(element_input_type.to_owned().into()),
-                argument_value,
+                PrismaValue::Placeholder(placeholder),
             )
         };
 
@@ -744,7 +866,7 @@ impl QueryDocumentParser {
         }
 
         let PrismaValueType::List(inner_type) = &placeholder.r#type else {
-            return Err(error());
+            return Err(error(placeholder));
         };
 
         let element_type_matches = match element_input_type {
@@ -760,7 +882,7 @@ impl QueryDocumentParser {
         if element_type_matches {
             Ok(ParsedInputValue::Single(placeholder.into()))
         } else {
-            Err(error())
+            Err(error(placeholder))
         }
     }
 
@@ -816,7 +938,6 @@ impl QueryDocumentParser {
         &self,
         selection_path: &Path,
         argument_path: &Path,
-        argument_value: &ArgumentValue,
         placeholder: Placeholder,
         enum_type: &EnumType,
         is_parameterizable: bool,
@@ -833,11 +954,11 @@ impl QueryDocumentParser {
         if matches!(placeholder.r#type, PrismaValueType::Enum) {
             Ok(ParsedInputValue::Single(placeholder.into()))
         } else {
-            Err(invalid_argument_type_error(
+            Err(invalid_prisma_value_type_error(
                 selection_path,
                 argument_path,
                 &InputType::Enum(enum_type.to_owned()),
-                argument_value,
+                PrismaValue::Placeholder(placeholder),
             ))
         }
     }
@@ -1017,6 +1138,26 @@ fn invalid_argument_type_error(
         conversions::input_type_to_argument_description(argument_path.last().unwrap_or_default(), input_type),
         conversions::argument_value_to_type_name(argument_value),
     )
+}
+
+#[inline(never)]
+fn invalid_argument_type_error_owned(
+    selection_path: &Path,
+    argument_path: &Path,
+    input_type: &InputType<'_>,
+    argument_value: ArgumentValue,
+) -> ValidationError {
+    invalid_argument_type_error(selection_path, argument_path, input_type, &argument_value)
+}
+
+#[inline(never)]
+fn invalid_prisma_value_type_error(
+    selection_path: &Path,
+    argument_path: &Path,
+    input_type: &InputType<'_>,
+    value: PrismaValue,
+) -> ValidationError {
+    invalid_argument_type_error_owned(selection_path, argument_path, input_type, ArgumentValue::Scalar(value))
 }
 
 #[inline(never)]

--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -4,6 +4,7 @@ use bigdecimal::{BigDecimal, ToPrimitive};
 use chrono::prelude::*;
 use core::fmt;
 use query_structure::{DefaultKind, Placeholder, PrismaValue, PrismaValueType};
+use smallvec::SmallVec;
 use std::{borrow::Cow, convert::TryFrom, str::FromStr};
 use user_facing_errors::query_engine::validation::ValidationError;
 use uuid::Uuid;
@@ -1180,7 +1181,7 @@ pub(crate) mod conversions {
 }
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Path {
-    segments: Vec<String>,
+    segments: SmallVec<[String; 8]>,
 }
 
 impl Path {

--- a/query-compiler/core/src/query_document/parser.rs
+++ b/query-compiler/core/src/query_document/parser.rs
@@ -4,7 +4,7 @@ use bigdecimal::{BigDecimal, ToPrimitive};
 use chrono::prelude::*;
 use core::fmt;
 use query_structure::{DefaultKind, Placeholder, PrismaValue, PrismaValueType};
-use std::{borrow::Cow, convert::TryFrom, rc::Rc, str::FromStr};
+use std::{borrow::Cow, convert::TryFrom, str::FromStr};
 use user_facing_errors::query_engine::validation::ValidationError;
 use uuid::Uuid;
 
@@ -26,9 +26,12 @@ impl QueryDocumentParser {
         fields: ResolveField<'a, '_>,
         query_schema: &'a QuerySchema,
     ) -> QueryParserResult<ParsedObject<'a>> {
+        let mut selection_path = Path::default();
+        let mut argument_path = Path::default();
+
         self.parse_object(
-            Path::default(),
-            Path::default(),
+            &mut selection_path,
+            &mut argument_path,
             selections,
             exclusions,
             schema_object,
@@ -45,8 +48,8 @@ impl QueryDocumentParser {
     #[allow(clippy::too_many_arguments)]
     fn parse_object<'a>(
         &self,
-        selection_path: Path,
-        argument_path: Path,
+        selection_path: &mut Path,
+        argument_path: &mut Path,
         selections: &[Selection],
         exclusions: Option<&[Exclusion]>,
         schema_object: &ObjectType<'a>,
@@ -67,144 +70,141 @@ impl QueryDocumentParser {
             for exclusion in exclusions {
                 if resolve_field(&exclusion.name).is_none() {
                     return Err(ValidationError::unknown_selection_field(
-                        selection_path.add(exclusion.name.to_owned()).segments(),
+                        selection_path.segments_with(&exclusion.name),
                         conversions::schema_object_to_output_type_description(schema_object),
                     ));
                 }
             }
         }
 
-        selections
-            .iter()
-            .map(|selection| {
-                let field_name = selection.name();
-                match resolve_field(field_name) {
-                    Some(field) => self.parse_field(
-                        selection_path.clone(),
-                        argument_path.clone(),
-                        selection,
-                        field,
-                        query_schema,
-                    ),
-                    None => Err(ValidationError::unknown_selection_field(
-                        selection_path.add(field_name.to_owned()).segments(),
-                        conversions::schema_object_to_output_type_description(schema_object),
-                    )),
+        let mut fields = Vec::with_capacity(selections.len());
+
+        for selection in selections {
+            let field_name = selection.name();
+            match resolve_field(field_name) {
+                Some(field) => {
+                    fields.push(self.parse_field(selection_path, argument_path, selection, field, query_schema)?)
                 }
-            })
-            .collect::<QueryParserResult<Vec<_>>>()
-            .map(|fields| ParsedObject { fields })
+                None => {
+                    return Err(ValidationError::unknown_selection_field(
+                        selection_path.segments_with(field_name),
+                        conversions::schema_object_to_output_type_description(schema_object),
+                    ));
+                }
+            }
+        }
+
+        Ok(ParsedObject { fields })
     }
 
     /// Parses and validates a selection against a schema (output) field.
     fn parse_field<'a>(
         &self,
-        selection_path: Path,
-        argument_path: Path,
+        selection_path: &mut Path,
+        argument_path: &mut Path,
         selection: &Selection,
         schema_field: OutputField<'a>,
         query_schema: &'a QuerySchema,
     ) -> QueryParserResult<FieldPair<'a>> {
-        let selection_path = selection_path.add(schema_field.name().clone().into_owned());
+        selection_path.push(schema_field.name().clone().into_owned());
 
         // Parse and validate all provided arguments for the field
-        self.parse_arguments(
-            selection_path.clone(),
-            argument_path.clone(),
+        let result = match self.parse_arguments(
+            selection_path,
+            argument_path,
             &schema_field,
             selection.arguments(),
             query_schema,
-        )
-        .and_then(move |arguments| {
-            if !selection.nested_selections().is_empty() && schema_field.field_type().is_scalar() {
-                Err(ValidationError::selection_set_on_scalar(
-                    selection.name().to_string(),
-                    selection_path.segments(),
-                ))
-            } else {
-                // If the output type of the field is an object type of any form, validate the sub selection as well.
-                let nested_fields = schema_field.field_type().as_object_type().map(|obj| {
-                    self.parse_object(
-                        selection_path.clone(),
-                        argument_path.clone(),
-                        selection.nested_selections(),
-                        selection.nested_exclusions(),
-                        obj,
-                        None,
-                        query_schema,
-                    )
-                });
+        ) {
+            Ok(arguments) => {
+                if !selection.nested_selections().is_empty() && schema_field.field_type().is_scalar() {
+                    Err(ValidationError::selection_set_on_scalar(
+                        selection.name().to_string(),
+                        selection_path.segments(),
+                    ))
+                } else {
+                    (|| -> QueryParserResult<FieldPair<'a>> {
+                        // If the output type of the field is an object type of any form, validate the sub selection as well.
+                        let nested_fields = match schema_field.field_type().as_object_type() {
+                            Some(obj) => Some(self.parse_object(
+                                selection_path,
+                                argument_path,
+                                selection.nested_selections(),
+                                selection.nested_exclusions(),
+                                obj,
+                                None,
+                                query_schema,
+                            )?),
+                            None => None,
+                        };
 
-                let nested_fields = match nested_fields {
-                    Some(sub) => Some(sub?),
-                    None => None,
-                };
+                        let parsed_field = ParsedField {
+                            name: selection.name().to_string(),
+                            alias: selection.alias().clone(),
+                            arguments,
+                            nested_fields,
+                        };
 
-                let parsed_field = ParsedField {
-                    name: selection.name().to_string(),
-                    alias: selection.alias().clone(),
-                    arguments,
-                    nested_fields,
-                };
-
-                Ok(FieldPair {
-                    parsed_field,
-                    schema_field,
-                })
+                        Ok(FieldPair {
+                            parsed_field,
+                            schema_field,
+                        })
+                    })()
+                }
             }
-        })
+            Err(err) => Err(err),
+        };
+
+        selection_path.pop();
+        result
     }
 
     /// Parses and validates selection arguments against a schema defined field.
     fn parse_arguments<'a>(
         &self,
-        selection_path: Path,
-        argument_path: Path,
+        selection_path: &Path,
+        argument_path: &mut Path,
         schema_field: &OutputField<'a>,
         given_arguments: &[(String, ArgumentValue)],
         query_schema: &'a QuerySchema,
     ) -> QueryParserResult<Vec<ParsedArgument<'a>>> {
         for (name, _) in given_arguments {
             if !schema_field.arguments().iter().any(|arg| arg.name == name.as_str()) {
-                let argument_path = argument_path.add(name.clone());
                 return Err(ValidationError::unknown_argument(
                     selection_path.segments(),
-                    argument_path.segments(),
+                    argument_path.segments_with(name),
                     conversions::schema_arguments_to_argument_description_vec(schema_field.arguments().iter().cloned()),
                 ));
             }
         }
 
+        let mut parsed_arguments = Vec::new();
+
         // Check remaining arguments
-        schema_field
-            .arguments()
-            .iter()
-            .filter_map(|input_field| {
-                // Match schema argument field to an argument field in the incoming document.
-                let selection_arg = given_arguments
-                    .iter()
-                    .find(|given_argument| given_argument.0 == input_field.name)
-                    .map(|(_, value)| value)
-                    .cloned();
+        for input_field in schema_field.arguments() {
+            // Match schema argument field to an argument field in the incoming document.
+            let selection_arg = given_arguments
+                .iter()
+                .find(|given_argument| given_argument.0 == input_field.name)
+                .map(|(_, value)| value)
+                .cloned();
 
-                let argument_path = argument_path.add(input_field.name.clone().into_owned());
+            argument_path.push(input_field.name.clone().into_owned());
 
-                let validate_other_required_args = || {
-                    for req_name in input_field.requires_other_fields() {
-                        if !given_arguments.iter().any(|(name, _)| name == req_name) {
-                            let Some(req_field) = schema_field.arguments().iter().find(|f| f.name == *req_name) else {
-                                panic!("argument {} requires unknown argument {req_name}", input_field.name)
-                            };
-                            return Err(ValidationError::conditionally_required_argument_missing(
-                                &selection_path.segments(),
-                                &argument_path.parent().add(req_name.to_string()).segments(),
-                                &argument_path.segments(),
-                                &conversions::input_types_to_input_type_descriptions(req_field.field_types()),
-                            ));
-                        }
+            let parsed_argument = (|| -> QueryParserResult<Option<ParsedArgument<'a>>> {
+                for req_name in input_field.requires_other_fields() {
+                    if !given_arguments.iter().any(|(name, _)| name == req_name) {
+                        let Some(req_field) = schema_field.arguments().iter().find(|f| f.name == *req_name) else {
+                            panic!("argument {} requires unknown argument {req_name}", input_field.name)
+                        };
+                        return Err(ValidationError::conditionally_required_argument_missing(
+                            &selection_path.segments(),
+                            &argument_path.parent_segments_with(req_name),
+                            &argument_path.segments(),
+                            &conversions::input_types_to_input_type_descriptions(req_field.field_types()),
+                        ));
                     }
-                    Ok(())
-                };
+                }
 
                 // If optional and not present ignore the field.
                 // If present or has a default, process the value.
@@ -216,37 +216,46 @@ impl QueryDocumentParser {
                         .and_then(DefaultKind::get)
                         .map(ArgumentValue::from)
                 }) {
-                    Some(value) => Some(validate_other_required_args().and_then(|_| {
-                        self.parse_input_value(
-                            selection_path.clone(),
+                    Some(value) => self
+                        .parse_input_value(
+                            selection_path,
                             argument_path,
                             value,
                             input_field.field_types(),
                             query_schema,
                             input_field.is_parameterizable(),
                         )
-                        .map(|value| ParsedArgument {
-                            name: input_field.name.clone().into_owned(),
-                            value,
-                        })
-                    })),
-                    None if !input_field.is_required() => None,
-                    _ => Some(Err(ValidationError::required_argument_missing(
+                        .map(|value| {
+                            Some(ParsedArgument {
+                                name: input_field.name.clone().into_owned(),
+                                value,
+                            })
+                        }),
+                    None if !input_field.is_required() => Ok(None),
+                    _ => Err(ValidationError::required_argument_missing(
                         selection_path.segments(),
                         argument_path.segments(),
                         &conversions::input_types_to_input_type_descriptions(input_field.field_types()),
-                    ))),
+                    )),
                 }
-            })
-            .collect()
+            })();
+
+            argument_path.pop();
+
+            if let Some(parsed_argument) = parsed_argument? {
+                parsed_arguments.push(parsed_argument);
+            }
+        }
+
+        Ok(parsed_arguments)
     }
 
     /// Parses and validates an ArgumentValue against possible input types.
     /// Matching is done in order of definition on the input type. First matching type wins.
     fn parse_input_value<'a>(
         &self,
-        selection_path: Path,
-        argument_path: Path,
+        selection_path: &Path,
+        argument_path: &mut Path,
         value: ArgumentValue,
         possible_input_types: &[InputType<'a>],
         query_schema: &'a QuerySchema,
@@ -276,8 +285,8 @@ impl QueryDocumentParser {
                     if value.should_be_parsed_as_json() && get_engine_protocol().is_json() =>
                 {
                     return Ok(ParsedInputValue::Single(self.to_json(
-                        &selection_path,
-                        &argument_path,
+                        selection_path,
+                        &*argument_path,
                         &value,
                     )?));
                 }
@@ -296,7 +305,7 @@ impl QueryDocumentParser {
                             Some(Box::new(err)),
                         )
                     })?;
-                    let json_list = self.parse_json_list_from_value(&selection_path, &argument_path, json_val)?;
+                    let json_list = self.parse_json_list_from_value(selection_path, &*argument_path, json_val)?;
 
                     return Ok(ParsedInputValue::Single(json_list));
                 }
@@ -313,8 +322,8 @@ impl QueryDocumentParser {
                     // Scalar handling
                     (pv, InputType::Scalar(st)) => try_this!(
                         self.parse_scalar(
-                            &selection_path,
-                            &argument_path,
+                            selection_path,
+                            &*argument_path,
                             pv.clone(),
                             *st,
                             &value,
@@ -325,18 +334,18 @@ impl QueryDocumentParser {
 
                     // Enum handling
                     (pv @ PrismaValue::Enum(_), InputType::Enum(et)) => {
-                        try_this!(self.parse_enum(&selection_path, &argument_path, pv.clone(), et))
+                        try_this!(self.parse_enum(selection_path, &*argument_path, pv.clone(), et))
                     }
                     (pv @ PrismaValue::String(_), InputType::Enum(et)) => {
-                        try_this!(self.parse_enum(&selection_path, &argument_path, pv.clone(), et))
+                        try_this!(self.parse_enum(selection_path, &*argument_path, pv.clone(), et))
                     }
                     (pv @ PrismaValue::Boolean(_), InputType::Enum(et)) => {
-                        try_this!(self.parse_enum(&selection_path, &argument_path, pv.clone(), et))
+                        try_this!(self.parse_enum(selection_path, &*argument_path, pv.clone(), et))
                     }
                     (PrismaValue::Placeholder(placeholder), InputType::Enum(et)) => {
                         try_this!(self.parse_parameterized_enum(
-                            &selection_path,
-                            &argument_path,
+                            selection_path,
+                            &*argument_path,
                             &value,
                             placeholder.clone(),
                             et,
@@ -347,8 +356,8 @@ impl QueryDocumentParser {
                     // Parameterized list handling
                     (PrismaValue::Placeholder(placeholder), InputType::List(elem_type)) => {
                         try_this!(self.parse_parameterized_list(
-                            &selection_path,
-                            &argument_path,
+                            selection_path,
+                            &*argument_path,
                             &value,
                             placeholder.clone(),
                             elem_type,
@@ -358,8 +367,8 @@ impl QueryDocumentParser {
 
                     // Invalid combinations
                     (_, input_type) => try_this!(Err(invalid_argument_type_error(
-                        &selection_path,
-                        &argument_path,
+                        selection_path,
+                        &*argument_path,
                         input_type,
                         &value,
                     ))),
@@ -368,8 +377,8 @@ impl QueryDocumentParser {
                 // Non-parameterized list handling
                 (ArgumentValue::List(values), InputType::List(l)) => try_this!(
                     self.parse_list(
-                        &selection_path,
-                        &argument_path,
+                        selection_path,
+                        argument_path,
                         values.to_vec(),
                         l,
                         query_schema,
@@ -380,20 +389,14 @@ impl QueryDocumentParser {
 
                 // Object handling
                 (ArgumentValue::Object(o) | ArgumentValue::FieldRef(o), InputType::Object(obj)) => try_this!(
-                    self.parse_input_object(
-                        selection_path.clone(),
-                        argument_path.clone(),
-                        o.clone(),
-                        obj,
-                        query_schema,
-                    )
-                    .map(ParsedInputValue::Map)
+                    self.parse_input_object(selection_path, argument_path, o.clone(), obj, query_schema,)
+                        .map(ParsedInputValue::Map)
                 ),
 
                 // Invalid combinations
                 (_, input_type) => try_this!(Err(invalid_argument_type_error(
-                    &selection_path,
-                    &argument_path,
+                    selection_path,
+                    &*argument_path,
                     input_type,
                     &value,
                 ))),
@@ -675,7 +678,7 @@ impl QueryDocumentParser {
     fn parse_list<'a>(
         &self,
         selection_path: &Path,
-        argument_path: &Path,
+        argument_path: &mut Path,
         values: Vec<ArgumentValue>,
         value_type: &InputType<'a>,
         query_schema: &'a QuerySchema,
@@ -685,8 +688,8 @@ impl QueryDocumentParser {
             .into_iter()
             .map(|val| {
                 self.parse_input_value(
-                    selection_path.clone(),
-                    argument_path.clone(),
+                    selection_path,
+                    argument_path,
                     val,
                     std::slice::from_ref(value_type),
                     query_schema,
@@ -841,8 +844,8 @@ impl QueryDocumentParser {
     /// Parses and validates an input object recursively.
     fn parse_input_object<'a>(
         &self,
-        selection_path: Path,
-        argument_path: Path,
+        selection_path: &Path,
+        argument_path: &mut Path,
         object: ArgumentValueObject,
         schema_object: &InputObjectType<'a>,
         query_schema: &'a QuerySchema,
@@ -851,75 +854,74 @@ impl QueryDocumentParser {
 
         // First, filter-in those fields that are not given but have a default value in the schema.
         // As in practise, it is like if they were given with said default value.
-        let defaults = fields
-            .iter()
-            .filter_map(|field| {
-                if object.contains_key(field.name.as_ref()) {
-                    return None;
-                }
+        let mut defaults = Vec::new();
 
-                let argument_path = argument_path.add(field.name.clone().into_owned());
+        for field in fields {
+            if object.contains_key(field.name.as_ref()) {
+                continue;
+            }
 
+            argument_path.push(field.name.clone().into_owned());
+
+            let default = (|| -> QueryParserResult<Option<(Cow<'a, str>, ParsedInputValue<'a>)>> {
                 // If the input field has a default, add the default to the result.
                 // If it's not optional and has no default, a required field has not been provided.
                 match &field.default_value {
-                    Some(default_value) => {
-                        match self.parse_input_value(
-                            selection_path.clone(),
-                            argument_path,
-                            default_value.get()?.into(),
-                            field.field_types(),
-                            query_schema,
-                            field.is_parameterizable(),
-                        ) {
-                            Ok(value) => Some(Ok((field.name.clone(), value))),
-                            Err(err) => Some(Err(err)),
-                        }
-                    }
-                    None => {
-                        if field.is_required() {
-                            Some(Err(ValidationError::required_argument_missing(
-                                selection_path.segments(),
-                                argument_path.segments(),
-                                &conversions::input_types_to_input_type_descriptions(field.field_types()),
-                            )))
-                        } else {
-                            None
-                        }
-                    }
+                    Some(default_value) => match default_value.get() {
+                        Some(default_value) => self
+                            .parse_input_value(
+                                selection_path,
+                                argument_path,
+                                default_value.into(),
+                                field.field_types(),
+                                query_schema,
+                                field.is_parameterizable(),
+                            )
+                            .map(|value| Some((field.name.clone(), value))),
+                        None => Ok(None),
+                    },
+                    None if field.is_required() => Err(ValidationError::required_argument_missing(
+                        selection_path.segments(),
+                        argument_path.segments(),
+                        &conversions::input_types_to_input_type_descriptions(field.field_types()),
+                    )),
+                    None => Ok(None),
                 }
-            })
-            .collect::<QueryParserResult<Vec<(_, ParsedInputValue<'a>)>>>()?;
+            })();
+
+            argument_path.pop();
+
+            if let Some(default) = default? {
+                defaults.push(default);
+            }
+        }
 
         // Checks all fields on the provided input object. This will catch extra
         // or unknown fields and parsing errors.
-        let mut map = object
-            .into_iter()
-            .map(|(field_name, value)| {
-                let field = fields
-                    .iter()
-                    .find(|field| field.name.as_ref() == field_name)
-                    .ok_or_else(|| {
-                        ValidationError::unknown_input_field(
-                            selection_path.segments(),
-                            argument_path.add(field_name.clone()).segments(),
-                            conversions::schema_input_object_type_to_input_type_description(schema_object),
-                        )
-                    })?;
+        let mut map = ParsedInputMap::default();
 
-                let argument_path = argument_path.add(field.name.clone().into_owned());
-                let parsed = self.parse_input_value(
-                    selection_path.clone(),
-                    argument_path,
-                    value,
-                    field.field_types(),
-                    query_schema,
-                    field.is_parameterizable(),
-                )?;
+        for (field_name, value) in object {
+            let Some(field) = fields.iter().find(|field| field.name.as_ref() == field_name) else {
+                return Err(ValidationError::unknown_input_field(
+                    selection_path.segments(),
+                    argument_path.segments_with(&field_name),
+                    conversions::schema_input_object_type_to_input_type_description(schema_object),
+                ));
+            };
 
-                Ok((Cow::Owned(field_name), parsed))
-            })
-            .collect::<QueryParserResult<ParsedInputMap<'a>>>()?;
+            argument_path.push(field.name.clone().into_owned());
+            let parsed = self.parse_input_value(
+                selection_path,
+                argument_path,
+                value,
+                field.field_types(),
+                query_schema,
+                field.is_parameterizable(),
+            );
+            argument_path.pop();
+
+            map.insert(Cow::Owned(field_name), parsed?);
+        }
 
         map.extend(defaults);
 
@@ -1178,36 +1180,53 @@ pub(crate) mod conversions {
 }
 #[derive(Debug, Clone, Default)]
 pub(crate) struct Path {
-    next: Rc<Option<(String, Path)>>,
+    segments: Vec<String>,
 }
 
 impl Path {
+    pub(crate) fn push(&mut self, segment: String) {
+        self.segments.push(segment);
+    }
+
+    pub(crate) fn pop(&mut self) {
+        self.segments.pop().expect("path stack underflow");
+    }
+
+    #[cfg(test)]
     pub(crate) fn add(&self, segment: String) -> Self {
-        Path {
-            next: Rc::new(Some((segment, self.clone()))),
-        }
+        let mut path = self.clone();
+        path.push(segment);
+        path
     }
 
     pub(crate) fn last(&self) -> Option<&str> {
-        Some(&self.next()?.0)
+        self.segments.last().map(String::as_str)
     }
 
+    #[cfg(test)]
     pub(crate) fn parent(&self) -> Self {
-        self.next().map(|(_, p)| p.clone()).unwrap_or_default()
-    }
-
-    fn next(&self) -> Option<&(String, Path)> {
-        (*self.next).as_ref()
+        let mut path = self.clone();
+        path.segments.pop();
+        path
     }
 
     pub(crate) fn segments(&self) -> Vec<&str> {
-        let mut out = Vec::new();
-        let mut cur = &self.next;
-        while let Some((segment, next)) = cur.as_ref() {
-            out.push(segment.as_str());
-            cur = &next.next;
-        }
-        out.reverse();
+        self.segments.iter().map(String::as_str).collect()
+    }
+
+    pub(crate) fn segments_with<'a>(&'a self, segment: &'a str) -> Vec<&'a str> {
+        let mut out = self.segments();
+        out.push(segment);
+        out
+    }
+
+    pub(crate) fn parent_segments_with<'a>(&'a self, segment: &'a str) -> Vec<&'a str> {
+        let parent_len = self.segments.len().saturating_sub(1);
+        let mut out = self.segments[..parent_len]
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
+        out.push(segment);
         out
     }
 }

--- a/query-compiler/core/src/query_graph/formatters.rs
+++ b/query-compiler/core/src/query_graph/formatters.rs
@@ -66,6 +66,7 @@ impl Display for Computation {
         match self {
             Self::DiffLeftToRight(_) => write!(f, "DiffLeftToRight"),
             Self::DiffRightToLeft(_) => write!(f, "DiffRightToLeft"),
+            Self::RequiredOneToManySet(_) => write!(f, "RequiredOneToManySet"),
         }
     }
 }

--- a/query-compiler/core/src/query_graph/formatters.rs
+++ b/query-compiler/core/src/query_graph/formatters.rs
@@ -57,6 +57,7 @@ impl Display for Flow {
         match self {
             Self::If { rule, .. } => write!(f, "If {rule:?}"),
             Self::Return(_) => write!(f, "Return"),
+            Self::ReturnPreservingResult(_) => write!(f, "ReturnPreservingResult"),
         }
     }
 }

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -68,8 +68,13 @@ impl From<Flow> for Node {
 
 pub enum Flow {
     /// Expresses a conditional control flow in the graph.
-    /// Possible outgoing edges are `then` and `else`, each at most once, with `then` required to be present.
-    If { rule: DataRule, data: Option<Placeholder> },
+    /// Possible outgoing edges are `then` and `else`, each at most once.
+    /// `then` is required unless `then_returns_condition` is set, in which case the condition input is also the then-branch result.
+    If {
+        rule: DataRule,
+        data: Option<Placeholder>,
+        then_returns_condition: bool,
+    },
 
     /// Returns a fixed set of results at runtime.
     Return(Option<Placeholder>),
@@ -80,6 +85,15 @@ impl Flow {
         Self::If {
             rule: DataRule::RowCountNeq(0),
             data: None,
+            then_returns_condition: false,
+        }
+    }
+
+    pub fn if_non_empty_returning_condition() -> Self {
+        Self::If {
+            rule: DataRule::RowCountNeq(0),
+            data: None,
+            then_returns_condition: true,
         }
     }
 
@@ -87,6 +101,7 @@ impl Flow {
         Self::If {
             rule: DataRule::Never,
             data: None,
+            then_returns_condition: false,
         }
     }
 }

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -847,19 +847,15 @@ impl QueryGraph {
 
         for return_node in return_nodes {
             let out_edges = self.outgoing_edges(&return_node);
-            let dependencies: Vec<FieldSelection> = out_edges
-                .into_iter()
-                .filter_map(|edge| {
-                    if let QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _) =
-                        self.edge_content(&edge).unwrap()
-                    {
-                        Some(requested_selection.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let dependencies = FieldSelection::union(dependencies);
+            let dependencies = FieldSelection::union_iter(out_edges.into_iter().filter_map(|edge| {
+                if let QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _) =
+                    self.edge_content(&edge).unwrap()
+                {
+                    Some(requested_selection.clone())
+                } else {
+                    None
+                }
+            }));
 
             // Assumption: We currently always have at most one single incoming ProjectedDataDependency edge
             // connected to return nodes. This will break if we ever have more.
@@ -1085,23 +1081,23 @@ impl QueryGraph {
 
                 if let Node::Query(q) = self.node_content(&node).unwrap() {
                     let edges = self.outgoing_edges(&node);
-                    let unsatisfied_dependencies: Vec<_> = edges
-                        .into_iter()
-                        .filter_map(|edge| match self.edge_content(&edge).unwrap() {
-                            QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)
-                                if !q.satisfies(requested_selection) =>
-                            {
-                                Some(requested_selection.clone())
-                            }
-                            _ => None,
-                        })
-                        .collect();
+                    let mut unsatisfied_dependencies =
+                        edges
+                            .into_iter()
+                            .filter_map(|edge| match self.edge_content(&edge).unwrap() {
+                                QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)
+                                    if !q.satisfies(requested_selection) =>
+                                {
+                                    Some(requested_selection.clone())
+                                }
+                                _ => None,
+                            });
 
-                    if unsatisfied_dependencies.is_empty() {
-                        None
-                    } else {
-                        Some((node, FieldSelection::union(unsatisfied_dependencies)))
-                    }
+                    let first = unsatisfied_dependencies.next()?;
+                    Some((
+                        node,
+                        FieldSelection::union_iter(std::iter::once(first).chain(unsatisfied_dependencies)),
+                    ))
                 } else {
                     None
                 }

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -131,6 +131,11 @@ impl NodeRef {
     pub fn id(&self) -> String {
         self.node_ix.index().to_string()
     }
+
+    /// Returns the raw index of the Node.
+    pub fn index(&self) -> usize {
+        self.node_ix.index()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -401,8 +401,8 @@ impl QueryGraph {
         if !self.finalized {
             self.swap_marked()?;
             self.ensure_return_nodes_have_parent_dependency()?;
-            self.normalize_data_dependencies(capabilities)?;
-            self.insert_reloads()?;
+            let reloads = self.normalize_data_dependencies(capabilities)?;
+            self.insert_reloads(reloads)?;
             self.normalize_if_nodes()?;
             self.finalized = true;
         }
@@ -952,9 +952,7 @@ impl QueryGraph {
     ///
     /// The `Reload` node is always a "find many" query.
     /// Unwraps are safe because we're operating on the unprocessed state of the graph (`Expressionista` changes that).
-    fn insert_reloads(&mut self) -> QueryGraphResult<()> {
-        let reloads = self.find_unsatisfied_dependencies();
-
+    fn insert_reloads(&mut self, reloads: Vec<(NodeRef, FieldSelection)>) -> QueryGraphResult<()> {
         for (node, identifiers) in reloads {
             let query = self.node_content(&node).and_then(|node| node.as_query()).unwrap();
 
@@ -1043,8 +1041,12 @@ impl QueryGraph {
     /// This is only possible when the parent node _can_ fulfill the selection set.
     /// In the case of updates and inserts, for instance, only connectors supporting `InsertReturning` and `UpdateReturning` can do it,
     /// or else they're only able to return the primary identifier of the model inserted or updated.
-    fn normalize_data_dependencies(&mut self, capabilities: ConnectorCapabilities) -> QueryGraphResult<()> {
+    fn normalize_data_dependencies(
+        &mut self,
+        capabilities: ConnectorCapabilities,
+    ) -> QueryGraphResult<Vec<(NodeRef, FieldSelection)>> {
         let unsatisfied_deps = self.find_unsatisfied_dependencies();
+        let mut reloads = Vec::new();
 
         for (node, identifiers) in unsatisfied_deps {
             let query = self
@@ -1055,18 +1057,21 @@ impl QueryGraph {
             // If the connector does not support returning more than the primary identifier for an update,
             // do not update the selection set.
             if query.is_update_one() && !capabilities.contains(ConnectorCapability::UpdateReturning) {
+                reloads.push((node, identifiers));
                 continue;
             }
 
             // If the connector does not support returning more than the primary identifier for a create,
             // do not update the selection set.
             if query.is_create_one() && !capabilities.contains(ConnectorCapability::InsertReturning) {
+                reloads.push((node, identifiers));
                 continue;
             }
 
             // If the connector does not support returning more than the primary identifier for a delete,
             // do not update the selection set.
             if query.is_delete_one() && !capabilities.contains(ConnectorCapability::DeleteReturning) {
+                reloads.push((node, identifiers));
                 continue;
             }
 
@@ -1079,7 +1084,7 @@ impl QueryGraph {
             query.satisfy_dependency(identifiers);
         }
 
-        Ok(())
+        Ok(reloads)
     }
 
     /// Traverses the query graph and finds the query nodes that don't fulfill their children data dependencies.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -541,6 +541,13 @@ impl QueryGraph {
         self.collect_edges(node, Direction::Incoming)
     }
 
+    /// Returns parent nodes without allocating or sorting edge refs.
+    pub fn parent_nodes(&self, node: &NodeRef) -> impl Iterator<Item = NodeRef> + '_ {
+        self.graph
+            .edges_directed(node.node_ix, Direction::Incoming)
+            .map(|edge| NodeRef { node_ix: edge.source() })
+    }
+
     /// Removes the edge from the graph but leaves the graph intact by keeping the empty
     /// edge in the graph by plucking the content of the edge, but not the edge itself.
     /// Panics if the edge has been already been taken or plucked.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -22,7 +22,7 @@ use petgraph::{
     *,
 };
 use query_structure::{
-    FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, SelectionResult, WriteArgs,
+    FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, Relation, SelectionResult, WriteArgs,
 };
 
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
@@ -304,35 +304,35 @@ pub trait NodeInputField<R: ?Sized>: Send + Sync + fmt::Debug {
 /// An expectation for a data dependency.
 pub struct DataExpectation {
     rules: SmallVec<[DataRule; 1]>,
-    error: Box<dyn DataDependencyError>,
+    error: DataDependencyError,
 }
 
 impl DataExpectation {
-    pub fn non_empty_rows(error: impl DataDependencyError + 'static) -> Self {
+    pub fn non_empty_rows(error: impl Into<DataDependencyError>) -> Self {
         Self {
             rules: smallvec![DataRule::RowCountNeq(0)],
-            error: Box::new(error),
+            error: error.into(),
         }
     }
 
-    pub fn empty_rows(error: impl DataDependencyError + 'static) -> Self {
+    pub fn empty_rows(error: impl Into<DataDependencyError>) -> Self {
         Self {
             rules: smallvec![DataRule::RowCountEq(0)],
-            error: Box::new(error),
+            error: error.into(),
         }
     }
 
-    pub fn exact_row_count(expected: usize, error: impl DataDependencyError + 'static) -> Self {
+    pub fn exact_row_count(expected: usize, error: impl Into<DataDependencyError>) -> Self {
         Self {
             rules: smallvec![DataRule::RowCountEq(expected)],
-            error: Box::new(error),
+            error: error.into(),
         }
     }
 
-    pub fn affected_row_count(expected: usize, error: impl DataDependencyError + 'static) -> Self {
+    pub fn affected_row_count(expected: usize, error: impl Into<DataDependencyError>) -> Self {
         Self {
             rules: smallvec![DataRule::AffectedRowCountEq(expected)],
-            error: Box::new(error),
+            error: error.into(),
         }
     }
 
@@ -340,8 +340,8 @@ impl DataExpectation {
         &self.rules
     }
 
-    pub fn error(&self) -> &dyn DataDependencyError {
-        &*self.error
+    pub fn error(&self) -> &DataDependencyError {
+        &self.error
     }
 }
 
@@ -393,12 +393,306 @@ impl fmt::Display for DataRule {
     }
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "String")]
+pub enum DataOperation {
+    Query,
+    Update,
+    Upsert,
+    Delete,
+    Disconnect,
+    Connect,
+    NestedCreate,
+    NestedUpdate,
+    NestedUpsert,
+    NestedDelete,
+    NestedSet,
+    NestedConnect,
+    NestedConnectOrCreate,
+}
+
+impl fmt::Display for DataOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl DataOperation {
+    pub fn as_str(&self) -> &'static str {
+        let str = match self {
+            Self::Query => "a query",
+            Self::Update => "an update",
+            Self::Upsert => "an upsert",
+            Self::Delete => "a delete",
+            Self::Disconnect => "a disconnect",
+            Self::Connect => "a connect",
+            Self::NestedCreate => "a nested create",
+            Self::NestedUpdate => "a nested update",
+            Self::NestedUpsert => "a nested upsert",
+            Self::NestedDelete => "a nested delete",
+            Self::NestedSet => "a nested set",
+            Self::NestedConnect => "a nested connect",
+            Self::NestedConnectOrCreate => "a nested connect or create",
+        };
+        str
+    }
+}
+
+impl From<DataOperation> for String {
+    fn from(operation: DataOperation) -> Self {
+        operation.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "String")]
+pub enum DependentOperation {
+    NestedUpdate,
+    DisconnectRecords,
+    FindRecords { model: String },
+    InlineRelation { model: String },
+    UpdateInlinedRelation { model: String },
+    CreateInlinedRelation { model: String },
+    ConnectOrCreateInlinedRelation { model: String },
+}
+
+impl DependentOperation {
+    pub fn nested_update() -> Self {
+        Self::NestedUpdate
+    }
+
+    pub fn disconnect_records() -> Self {
+        Self::DisconnectRecords
+    }
+
+    pub fn find_records(model: &Model) -> Self {
+        Self::FindRecords {
+            model: model.name().to_owned(),
+        }
+    }
+
+    pub fn inline_relation(model: &Model) -> Self {
+        Self::InlineRelation {
+            model: model.name().to_owned(),
+        }
+    }
+
+    pub fn update_inlined_relation(model: &Model) -> Self {
+        Self::UpdateInlinedRelation {
+            model: model.name().to_owned(),
+        }
+    }
+
+    pub fn create_inlined_relation(model: &Model) -> Self {
+        Self::CreateInlinedRelation {
+            model: model.name().to_owned(),
+        }
+    }
+
+    pub fn connect_or_create_inlined_relation(model: &Model) -> Self {
+        Self::ConnectOrCreateInlinedRelation {
+            model: model.name().to_owned(),
+        }
+    }
+}
+
+impl fmt::Display for DependentOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NestedUpdate => write!(f, "perform a nested update"),
+            Self::DisconnectRecords => write!(f, "disconnect existing child records"),
+            Self::FindRecords { model } => write!(f, "find '{model}' record(s)"),
+            Self::InlineRelation { model } => write!(f, "inline the relation on '{model}' record(s)"),
+            Self::UpdateInlinedRelation { model } => {
+                write!(f, "update inlined relation for '{model}' record(s)")
+            }
+            Self::CreateInlinedRelation { model } => {
+                write!(f, "create inlined relation for '{model}' record(s)")
+            }
+            Self::ConnectOrCreateInlinedRelation { model } => {
+                write!(f, "create or connect inlined relation for '{model}' record(s)")
+            }
+        }
+    }
+}
+
+impl From<DependentOperation> for String {
+    fn from(operation: DependentOperation) -> Self {
+        operation.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(into = "String")]
+pub enum RelationType {
+    OneToOne,
+    OneToMany,
+    ManyToMany,
+}
+
+impl From<&Relation> for RelationType {
+    fn from(relation: &Relation) -> Self {
+        if relation.is_one_to_one() {
+            Self::OneToOne
+        } else if relation.is_one_to_many() {
+            Self::OneToMany
+        } else {
+            Self::ManyToMany
+        }
+    }
+}
+
+impl fmt::Display for RelationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl RelationType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RelationType::OneToOne => "one-to-one",
+            RelationType::OneToMany => "one-to-many",
+            RelationType::ManyToMany => "many-to-many",
+        }
+    }
+}
+
+impl From<RelationType> for String {
+    fn from(relation_type: RelationType) -> Self {
+        relation_type.to_string()
+    }
+}
+
 /// An error that can occur during data dependency validation.
-pub trait DataDependencyError: Send + Sync {
-    /// A unique identifier for the error.
-    fn id(&self) -> &'static str;
-    /// Context with additional information used to provide more context for the error.
-    fn context(&self) -> serde_json::Value;
+#[derive(Debug, Clone)]
+pub enum DataDependencyError {
+    RelationViolation {
+        relation: String,
+        model_a: String,
+        model_b: String,
+    },
+    MissingRecord {
+        operation: DataOperation,
+    },
+    MissingRelatedRecord {
+        model: String,
+        relation: String,
+        relation_type: RelationType,
+        operation: DataOperation,
+        needed_for: Option<DependentOperation>,
+    },
+    IncompleteConnectInput {
+        expected_rows: usize,
+    },
+    IncompleteConnectOutput {
+        expected_rows: usize,
+        relation: String,
+        relation_type: RelationType,
+    },
+    RecordsNotConnected {
+        relation: String,
+        parent: String,
+        child: String,
+    },
+}
+
+impl DataDependencyError {
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::RelationViolation { .. } => "RELATION_VIOLATION",
+            Self::MissingRecord { .. } => "MISSING_RECORD",
+            Self::MissingRelatedRecord { .. } => "MISSING_RELATED_RECORD",
+            Self::IncompleteConnectInput { .. } => "INCOMPLETE_CONNECT_INPUT",
+            Self::IncompleteConnectOutput { .. } => "INCOMPLETE_CONNECT_OUTPUT",
+            Self::RecordsNotConnected { .. } => "RECORDS_NOT_CONNECTED",
+        }
+    }
+
+    pub fn compact_id(&self) -> &'static str {
+        match self {
+            Self::RelationViolation { .. } => "r",
+            Self::MissingRelatedRecord { .. } => "m",
+            Self::MissingRecord { .. } => "M",
+            Self::IncompleteConnectInput { .. } => "i",
+            Self::IncompleteConnectOutput { .. } => "o",
+            Self::RecordsNotConnected { .. } => "n",
+        }
+    }
+
+    pub fn serialize_compact_context<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::RelationViolation {
+                relation,
+                model_a,
+                model_b,
+            } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element(relation)?;
+                tuple.serialize_element(model_a)?;
+                tuple.serialize_element(model_b)?;
+                tuple.end()
+            }
+            Self::MissingRelatedRecord {
+                model,
+                relation,
+                relation_type,
+                operation,
+                needed_for,
+            } => {
+                let mut tuple = serializer.serialize_tuple(if needed_for.is_some() { 5 } else { 4 })?;
+                tuple.serialize_element(model)?;
+                tuple.serialize_element(relation)?;
+                tuple.serialize_element(relation_type.as_str())?;
+                tuple.serialize_element(operation.as_str())?;
+                if let Some(needed_for) = needed_for {
+                    tuple.serialize_element(&DisplayValue(needed_for))?;
+                }
+                tuple.end()
+            }
+            Self::MissingRecord { operation } => serializer.serialize_str(operation.as_str()),
+            Self::IncompleteConnectInput { expected_rows } => expected_rows.serialize(serializer),
+            Self::IncompleteConnectOutput {
+                expected_rows,
+                relation,
+                relation_type,
+            } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element(expected_rows)?;
+                tuple.serialize_element(relation)?;
+                tuple.serialize_element(relation_type.as_str())?;
+                tuple.end()
+            }
+            Self::RecordsNotConnected {
+                relation,
+                parent,
+                child,
+            } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element(relation)?;
+                tuple.serialize_element(parent)?;
+                tuple.serialize_element(child)?;
+                tuple.end()
+            }
+        }
+    }
+}
+
+struct DisplayValue<'a, T>(&'a T);
+
+impl<T> Serialize for DisplayValue<'_, T>
+where
+    T: fmt::Display,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(self.0)
+    }
 }
 
 /// A graph representing an abstract view of queries and their execution dependencies.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -21,7 +21,9 @@ use petgraph::{
     visit::{EdgeRef as PEdgeRef, NodeIndexable},
     *,
 };
-use query_structure::{FieldSelection, Filter, Placeholder, QueryArguments, SelectionResult, WriteArgs};
+use query_structure::{
+    FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, SelectionResult, WriteArgs,
+};
 
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
 
@@ -93,6 +95,7 @@ impl Flow {
 pub enum Computation {
     DiffLeftToRight(DiffNode),
     DiffRightToLeft(DiffNode),
+    RequiredOneToManySet(RequiredOneToManySetNode),
 }
 
 impl Computation {
@@ -102,6 +105,28 @@ impl Computation {
 
     pub fn empty_diff_right_to_left(fields: FieldSelection) -> Self {
         Self::DiffRightToLeft(DiffNode::new_empty(fields))
+    }
+
+    pub fn required_one_to_many_set(
+        fields: FieldSelection,
+        parent_node: NodeRef,
+        parent_link: FieldSelection,
+        child_link: FieldSelection,
+        child_model: Model,
+        parent_expectation: DataExpectation,
+        relation_expectation: DataExpectation,
+        request_now: PrismaValue,
+    ) -> Self {
+        Self::RequiredOneToManySet(RequiredOneToManySetNode::new(
+            fields,
+            parent_node,
+            parent_link,
+            child_link,
+            child_model,
+            parent_expectation,
+            relation_expectation,
+            request_now,
+        ))
     }
 }
 
@@ -117,6 +142,45 @@ impl DiffNode {
             left: None,
             right: None,
             fields,
+        }
+    }
+}
+
+pub struct RequiredOneToManySetNode {
+    pub old_children: Option<Placeholder>,
+    pub new_children: Option<Placeholder>,
+    pub fields: FieldSelection,
+    pub parent_node: NodeRef,
+    pub parent_link: FieldSelection,
+    pub child_link: FieldSelection,
+    pub child_model: Model,
+    pub parent_expectation: DataExpectation,
+    pub relation_expectation: DataExpectation,
+    pub request_now: PrismaValue,
+}
+
+impl RequiredOneToManySetNode {
+    pub fn new(
+        fields: FieldSelection,
+        parent_node: NodeRef,
+        parent_link: FieldSelection,
+        child_link: FieldSelection,
+        child_model: Model,
+        parent_expectation: DataExpectation,
+        relation_expectation: DataExpectation,
+        request_now: PrismaValue,
+    ) -> Self {
+        Self {
+            old_children: None,
+            new_children: None,
+            fields,
+            parent_node,
+            parent_link,
+            child_link,
+            child_model,
+            parent_expectation,
+            relation_expectation,
+            request_now,
         }
     }
 }
@@ -559,7 +623,9 @@ impl QueryGraph {
         self.graph
             .edges_directed(node.node_ix, Direction::Outgoing)
             .filter_map(|edge| match edge.weight().borrow() {
-                Some(QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)) => Some(requested_selection),
+                Some(QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)) => {
+                    Some(requested_selection)
+                }
                 _ => None,
             })
     }
@@ -567,7 +633,12 @@ impl QueryGraph {
     fn incoming_projected_data_dependency_edge(&self, node: &NodeRef) -> Option<EdgeRef> {
         self.graph
             .edges_directed(node.node_ix, Direction::Incoming)
-            .find(|edge| matches!(edge.weight().borrow(), Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))))
+            .find(|edge| {
+                matches!(
+                    edge.weight().borrow(),
+                    Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))
+                )
+            })
             .map(|edge| EdgeRef { edge_ix: edge.id() })
     }
 
@@ -855,12 +926,14 @@ impl QueryGraph {
     }
 
     fn has_incoming_then_or_else_edge(&self, node: &NodeRef) -> bool {
-        self.graph.edges_directed(node.node_ix, Direction::Incoming).any(|edge| {
-            matches!(
-                edge.weight().borrow(),
-                Some(QueryGraphDependency::Then | QueryGraphDependency::Else)
-            )
-        })
+        self.graph
+            .edges_directed(node.node_ix, Direction::Incoming)
+            .any(|edge| {
+                matches!(
+                    edge.weight().borrow(),
+                    Some(QueryGraphDependency::Then | QueryGraphDependency::Else)
+                )
+            })
     }
 
     /// Traverses the graph and ensures that return nodes have correct `ProjectedDataDependency`s on their incoming edges.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -830,10 +830,7 @@ impl QueryGraph {
 
                     for (_, sibling) in siblings {
                         let possible_edge = self.graph.find_edge(node.node_ix, sibling.node_ix);
-                        let is_if_node_child = self.incoming_edges(&sibling).into_iter().any(|edge| {
-                            let content = self.edge_content(&edge).unwrap();
-                            matches!(content, QueryGraphDependency::Then | QueryGraphDependency::Else)
-                        });
+                        let is_if_node_child = self.has_incoming_then_or_else_edge(&sibling);
 
                         if sibling != node
                             && possible_edge.is_none()
@@ -848,6 +845,15 @@ impl QueryGraph {
         }
 
         Ok(())
+    }
+
+    fn has_incoming_then_or_else_edge(&self, node: &NodeRef) -> bool {
+        self.graph.edges_directed(node.node_ix, Direction::Incoming).any(|edge| {
+            matches!(
+                edge.weight().borrow(),
+                Some(QueryGraphDependency::Then | QueryGraphDependency::Else)
+            )
+        })
     }
 
     /// Traverses the graph and ensures that return nodes have correct `ProjectedDataDependency`s on their incoming edges.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -78,6 +78,9 @@ pub enum Flow {
 
     /// Returns a fixed set of results at runtime.
     Return(Option<Placeholder>),
+
+    /// Runs child nodes, then returns the same fixed set of results.
+    ReturnPreservingResult(Option<Placeholder>),
 }
 
 impl Flow {
@@ -103,6 +106,10 @@ impl Flow {
             data: None,
             then_returns_condition: false,
         }
+    }
+
+    pub fn return_preserving_result() -> Self {
+        Self::ReturnPreservingResult(None)
     }
 }
 
@@ -1262,7 +1269,7 @@ impl QueryGraph {
                 let node = NodeRef { node_ix: ix };
 
                 match self.node_content(&node).unwrap() {
-                    Node::Flow(Flow::Return(_)) => Some(node),
+                    Node::Flow(Flow::Return(_) | Flow::ReturnPreservingResult(_)) => Some(node),
                     _ => None,
                 }
             })

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -21,7 +21,7 @@ use petgraph::{
     visit::{EdgeRef as PEdgeRef, NodeIndexable},
     *,
 };
-use query_structure::{FieldSelection, Filter, QueryArguments, SelectionResult, WriteArgs};
+use query_structure::{FieldSelection, Filter, Placeholder, QueryArguments, SelectionResult, WriteArgs};
 
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
 
@@ -67,24 +67,24 @@ impl From<Flow> for Node {
 pub enum Flow {
     /// Expresses a conditional control flow in the graph.
     /// Possible outgoing edges are `then` and `else`, each at most once, with `then` required to be present.
-    If { rule: DataRule, data: Vec<SelectionResult> },
+    If { rule: DataRule, data: Option<Placeholder> },
 
     /// Returns a fixed set of results at runtime.
-    Return(Vec<SelectionResult>),
+    Return(Option<Placeholder>),
 }
 
 impl Flow {
     pub fn if_non_empty() -> Self {
         Self::If {
             rule: DataRule::RowCountNeq(0),
-            data: Vec::new(),
+            data: None,
         }
     }
 
     pub fn if_false() -> Self {
         Self::If {
             rule: DataRule::Never,
-            data: Vec::new(),
+            data: None,
         }
     }
 }
@@ -106,16 +106,16 @@ impl Computation {
 }
 
 pub struct DiffNode {
-    pub left: Vec<SelectionResult>,
-    pub right: Vec<SelectionResult>,
+    pub left: Option<Placeholder>,
+    pub right: Option<Placeholder>,
     pub fields: FieldSelection,
 }
 
 impl DiffNode {
     pub fn new_empty(fields: FieldSelection) -> Self {
         Self {
-            left: Vec::new(),
-            right: Vec::new(),
+            left: None,
+            right: None,
             fields,
         }
     }
@@ -187,6 +187,8 @@ pub enum RowSink {
     AtMostOne(&'static dyn NodeInputField<Vec<SelectionResult>>),
     /// Store an array of exactly one row to the node input field.
     ExactlyOne(&'static dyn NodeInputField<Vec<SelectionResult>>),
+    /// Store a projected placeholder directly to the node input field.
+    ProjectedPlaceholder(&'static dyn NodeInputField<Option<Placeholder>>),
     /// Store a filter representing all rows to the node input field.
     AllFilter(&'static dyn NodeInputField<Filter>),
     /// Store a filter representing exactly one row to the node input field.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -426,6 +426,11 @@ impl QueryGraph {
         }
     }
 
+    pub fn reserve_visited_capacity(&mut self) {
+        self.visited
+            .reserve_exact(self.graph.node_count().saturating_sub(self.visited.len()));
+    }
+
     /// Checks if the given node is marked as one of the result nodes in the graph.
     pub fn is_result_node(&self, node: &NodeRef) -> bool {
         self.result_nodes.contains(&node.node_ix)

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -275,6 +275,8 @@ pub enum RowSink {
     ExactlyOne(&'static dyn NodeInputField<Vec<SelectionResult>>),
     /// Store a projected placeholder directly to the node input field.
     ProjectedPlaceholder(&'static dyn NodeInputField<Option<Placeholder>>),
+    /// Store a single source-field placeholder directly to the node input field.
+    ProjectedFieldPlaceholder(&'static dyn NodeInputField<Option<Placeholder>>),
     /// Store a filter representing all rows to the node input field.
     AllFilter(&'static dyn NodeInputField<Filter>),
     /// Store a filter representing exactly one row to the node input field.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -548,6 +548,22 @@ impl QueryGraph {
             .map(|edge| NodeRef { node_ix: edge.source() })
     }
 
+    fn outgoing_projected_data_dependencies(&self, node: &NodeRef) -> impl Iterator<Item = &FieldSelection> {
+        self.graph
+            .edges_directed(node.node_ix, Direction::Outgoing)
+            .filter_map(|edge| match edge.weight().borrow() {
+                Some(QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)) => Some(requested_selection),
+                _ => None,
+            })
+    }
+
+    fn incoming_projected_data_dependency_edge(&self, node: &NodeRef) -> Option<EdgeRef> {
+        self.graph
+            .edges_directed(node.node_ix, Direction::Incoming)
+            .find(|edge| matches!(edge.weight().borrow(), Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))))
+            .map(|edge| EdgeRef { edge_ix: edge.id() })
+    }
+
     /// Removes the edge from the graph but leaves the graph intact by keeping the empty
     /// edge in the graph by plucking the content of the edge, but not the edge itself.
     /// Panics if the edge has been already been taken or plucked.
@@ -858,26 +874,12 @@ impl QueryGraph {
             .collect();
 
         for return_node in return_nodes {
-            let out_edges = self.outgoing_edges(&return_node);
-            let dependencies = FieldSelection::union_iter(out_edges.into_iter().filter_map(|edge| {
-                if let QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _) =
-                    self.edge_content(&edge).unwrap()
-                {
-                    Some(requested_selection.clone())
-                } else {
-                    None
-                }
-            }));
+            let dependencies =
+                FieldSelection::union_iter(self.outgoing_projected_data_dependencies(&return_node).cloned());
 
             // Assumption: We currently always have at most one single incoming ProjectedDataDependency edge
             // connected to return nodes. This will break if we ever have more.
-            let in_edges = self.incoming_edges(&return_node);
-            let incoming_dep_edge = in_edges.into_iter().find(|edge| {
-                matches!(
-                    self.edge_content(edge),
-                    Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))
-                )
-            });
+            let incoming_dep_edge = self.incoming_projected_data_dependency_edge(&return_node);
 
             if let Some(incoming_edge) = incoming_dep_edge {
                 let source = self.edge_source(&incoming_edge);
@@ -1097,18 +1099,10 @@ impl QueryGraph {
                 let node = NodeRef { node_ix: ix };
 
                 if let Node::Query(q) = self.node_content(&node).unwrap() {
-                    let edges = self.outgoing_edges(&node);
-                    let mut unsatisfied_dependencies =
-                        edges
-                            .into_iter()
-                            .filter_map(|edge| match self.edge_content(&edge).unwrap() {
-                                QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)
-                                    if !q.satisfies(requested_selection) =>
-                                {
-                                    Some(requested_selection.clone())
-                                }
-                                _ => None,
-                            });
+                    let mut unsatisfied_dependencies = self
+                        .outgoing_projected_data_dependencies(&node)
+                        .filter(|requested_selection| !q.satisfies(requested_selection))
+                        .cloned();
 
                     let first = unsatisfied_dependencies.next()?;
                     Some((

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 pub use error::*;
 use psl::datamodel_connector::{ConnectorCapabilities, ConnectorCapability};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeTuple};
 use smallvec::{SmallVec, smallvec};
 use tracing::trace;
 
@@ -260,8 +260,7 @@ impl DataExpectation {
 }
 
 /// A rule a data dependency needs to fulfill to be considered valid.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", content = "args", rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub enum DataRule {
     /// Expect the data dependency to contain an exact number of rows.
     RowCountEq(usize),
@@ -271,6 +270,30 @@ pub enum DataRule {
     AffectedRowCountEq(usize),
     /// Expect the edge to not be taken and never match any data.
     Never,
+}
+
+impl Serialize for DataRule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::RowCountEq(count) => serialize_rule_tuple("=", count, serializer),
+            Self::RowCountNeq(count) => serialize_rule_tuple("!", count, serializer),
+            Self::AffectedRowCountEq(count) => serialize_rule_tuple("a", count, serializer),
+            Self::Never => serializer.serialize_str("n"),
+        }
+    }
+}
+
+fn serialize_rule_tuple<S>(tag: &'static str, count: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut tuple = serializer.serialize_tuple(2)?;
+    tuple.serialize_element(tag)?;
+    tuple.serialize_element(count)?;
+    tuple.end()
 }
 
 impl fmt::Display for DataRule {

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -969,7 +969,7 @@ impl QueryGraph {
             let primary_model_id = model.shard_aware_primary_identifier();
 
             let read_query = ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
-                name: "reload".into(),
+                name: String::new(),
                 alias: None,
                 model: model.clone(),
                 args: QueryArguments::new(model),

--- a/query-compiler/core/src/query_graph_builder/error.rs
+++ b/query-compiler/core/src/query_graph_builder/error.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::{DataDependencyError, QueryGraphError};
+use crate::{DataDependencyError, DataOperation, DependentOperation, QueryGraphError, RelationType};
 use bon::bon;
 use query_structure::{DomainError, Model, Relation, RelationFieldRef};
 use serde::Serialize;
@@ -100,13 +100,13 @@ impl From<QueryGraphError> for QueryGraphBuilderError {
     }
 }
 
-impl DataDependencyError for RelationViolation {
-    fn id(&self) -> &'static str {
-        "RELATION_VIOLATION"
-    }
-
-    fn context(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap()
+impl From<RelationViolation> for DataDependencyError {
+    fn from(error: RelationViolation) -> Self {
+        Self::RelationViolation {
+            relation: error.relation,
+            model_a: error.model_a,
+            model_b: error.model_b,
+        }
     }
 }
 
@@ -130,13 +130,11 @@ impl fmt::Display for MissingRecord {
     }
 }
 
-impl DataDependencyError for MissingRecord {
-    fn id(&self) -> &'static str {
-        "MISSING_RECORD"
-    }
-
-    fn context(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap()
+impl From<MissingRecord> for DataDependencyError {
+    fn from(error: MissingRecord) -> Self {
+        Self::MissingRecord {
+            operation: error.operation,
+        }
     }
 }
 
@@ -192,13 +190,15 @@ impl fmt::Display for MissingRelatedRecord {
     }
 }
 
-impl DataDependencyError for MissingRelatedRecord {
-    fn id(&self) -> &'static str {
-        "MISSING_RELATED_RECORD"
-    }
-
-    fn context(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap()
+impl From<MissingRelatedRecord> for DataDependencyError {
+    fn from(error: MissingRelatedRecord) -> Self {
+        Self::MissingRelatedRecord {
+            model: error.model,
+            relation: error.relation,
+            relation_type: error.relation_type,
+            operation: error.operation,
+            needed_for: error.needed_for,
+        }
     }
 }
 
@@ -216,13 +216,11 @@ impl IncompleteConnectInput {
     }
 }
 
-impl DataDependencyError for IncompleteConnectInput {
-    fn id(&self) -> &'static str {
-        "INCOMPLETE_CONNECT_INPUT"
-    }
-
-    fn context(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap()
+impl From<IncompleteConnectInput> for DataDependencyError {
+    fn from(error: IncompleteConnectInput) -> Self {
+        Self::IncompleteConnectInput {
+            expected_rows: error.expected_rows,
+        }
     }
 }
 
@@ -246,13 +244,13 @@ impl IncompleteConnectOutput {
     }
 }
 
-impl DataDependencyError for IncompleteConnectOutput {
-    fn id(&self) -> &'static str {
-        "INCOMPLETE_CONNECT_OUTPUT"
-    }
-
-    fn context(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap()
+impl From<IncompleteConnectOutput> for DataDependencyError {
+    fn from(error: IncompleteConnectOutput) -> Self {
+        Self::IncompleteConnectOutput {
+            expected_rows: error.expected_rows,
+            relation: error.relation,
+            relation_type: error.relation_type,
+        }
     }
 }
 
@@ -275,171 +273,12 @@ impl RecordsNotConnected {
     }
 }
 
-impl DataDependencyError for RecordsNotConnected {
-    fn id(&self) -> &'static str {
-        "RECORDS_NOT_CONNECTED"
-    }
-
-    fn context(&self) -> serde_json::Value {
-        serde_json::to_value(self).unwrap()
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(into = "String")]
-pub enum DataOperation {
-    Query,
-    Update,
-    Upsert,
-    Delete,
-    Disconnect,
-    Connect,
-    NestedCreate,
-    NestedUpdate,
-    NestedUpsert,
-    NestedDelete,
-    NestedSet,
-    NestedConnect,
-    NestedConnectOrCreate,
-}
-
-impl fmt::Display for DataOperation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let str = match self {
-            Self::Query => "a query",
-            Self::Update => "an update",
-            Self::Upsert => "an upsert",
-            Self::Delete => "a delete",
-            Self::Disconnect => "a disconnect",
-            Self::Connect => "a connect",
-            Self::NestedCreate => "a nested create",
-            Self::NestedUpdate => "a nested update",
-            Self::NestedUpsert => "a nested upsert",
-            Self::NestedDelete => "a nested delete",
-            Self::NestedSet => "a nested set",
-            Self::NestedConnect => "a nested connect",
-            Self::NestedConnectOrCreate => "a nested connect or create",
-        };
-        write!(f, "{str}")
-    }
-}
-
-impl From<DataOperation> for String {
-    fn from(operation: DataOperation) -> Self {
-        operation.to_string()
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(into = "String")]
-pub(crate) enum DependentOperation {
-    NestedUpdate,
-    DisconnectRecords,
-    FindRecords { model: String },
-    InlineRelation { model: String },
-    UpdateInlinedRelation { model: String },
-    CreateInlinedRelation { model: String },
-    ConnectOrCreateInlinedRelation { model: String },
-}
-
-impl DependentOperation {
-    pub fn nested_update() -> Self {
-        Self::NestedUpdate
-    }
-
-    pub fn disconnect_records() -> Self {
-        Self::DisconnectRecords
-    }
-
-    pub fn find_records(model: &Model) -> Self {
-        Self::FindRecords {
-            model: model.name().to_owned(),
+impl From<RecordsNotConnected> for DataDependencyError {
+    fn from(error: RecordsNotConnected) -> Self {
+        Self::RecordsNotConnected {
+            relation: error.relation,
+            parent: error.parent,
+            child: error.child,
         }
-    }
-
-    pub fn inline_relation(model: &Model) -> Self {
-        Self::InlineRelation {
-            model: model.name().to_owned(),
-        }
-    }
-
-    pub fn update_inlined_relation(model: &Model) -> Self {
-        Self::UpdateInlinedRelation {
-            model: model.name().to_owned(),
-        }
-    }
-
-    pub fn create_inlined_relation(model: &Model) -> Self {
-        Self::CreateInlinedRelation {
-            model: model.name().to_owned(),
-        }
-    }
-
-    pub fn connect_or_create_inlined_relation(model: &Model) -> Self {
-        Self::ConnectOrCreateInlinedRelation {
-            model: model.name().to_owned(),
-        }
-    }
-}
-
-impl fmt::Display for DependentOperation {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NestedUpdate => write!(f, "perform a nested update"),
-            Self::DisconnectRecords => write!(f, "disconnect existing child records"),
-            Self::FindRecords { model } => write!(f, "find '{model}' record(s)"),
-            Self::InlineRelation { model } => write!(f, "inline the relation on '{model}' record(s)"),
-            Self::UpdateInlinedRelation { model } => {
-                write!(f, "update inlined relation for '{model}' record(s)")
-            }
-            Self::CreateInlinedRelation { model } => {
-                write!(f, "create inlined relation for '{model}' record(s)")
-            }
-            Self::ConnectOrCreateInlinedRelation { model } => {
-                write!(f, "create or connect inlined relation for '{model}' record(s)")
-            }
-        }
-    }
-}
-
-impl From<DependentOperation> for String {
-    fn from(operation: DependentOperation) -> Self {
-        operation.to_string()
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(into = "String")]
-enum RelationType {
-    OneToOne,
-    OneToMany,
-    ManyToMany,
-}
-
-impl From<&Relation> for RelationType {
-    fn from(relation: &Relation) -> Self {
-        if relation.is_one_to_one() {
-            Self::OneToOne
-        } else if relation.is_one_to_many() {
-            Self::OneToMany
-        } else {
-            Self::ManyToMany
-        }
-    }
-}
-
-impl fmt::Display for RelationType {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            RelationType::OneToOne => write!(f, "one-to-one"),
-            RelationType::OneToMany => write!(f, "one-to-many"),
-            RelationType::ManyToMany => write!(f, "many-to-many"),
-        }
-    }
-}
-
-impl From<RelationType> for String {
-    fn from(relation_type: RelationType) -> Self {
-        relation_type.to_string()
     }
 }

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -242,7 +242,7 @@ fn merge_search_filters(filter: Filter) -> Filter {
 fn fold_search_filters(filters: &[Filter]) -> Vec<Filter> {
     let mut filters_by_val: HashMap<PrismaValue, &Filter> = HashMap::new();
     let mut projections_by_val: HashMap<PrismaValue, Vec<ScalarProjection>> = HashMap::new();
-    let mut output: Vec<Filter> = vec![];
+    let mut output: Vec<Filter> = Vec::with_capacity(filters.len());
 
     // Gather search filters that have the same condition
     for filter in filters.iter() {

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -23,7 +23,7 @@ pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> Qu
             .fields()
             .find_from_scalar(field_name)
             .is_ok_and(|field| field.unique())
-            || utils::resolve_compound_field(field_name, model).is_some()
+            || utils::is_compound_field(field_name, model)
     }) {
         return internal_extract_unique_filter(value_map, model);
     }
@@ -36,7 +36,7 @@ pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> Qu
             .into_iter()
             .partition(|(field_name, _)| match model.fields().find_from_scalar(field_name) {
                 Ok(field) => field.unique(),
-                Err(_) => utils::resolve_compound_field(field_name, model).is_some(),
+                Err(_) => utils::is_compound_field(field_name, model),
             });
     let mut unique_map = ParsedInputMap::from(unique_map);
     let mut rest_map = ParsedInputMap::from(rest_map);

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -228,6 +228,10 @@ where
 /// 3. We reconstruct the filter tree and merge the search filters that have the same query along the way
 ///    eg: `Filter(And([SearchFilter("query", [FieldA]), SearchFilter("query", [FieldB])]))` -> `Filter(And([SearchFilter("query", [FieldA, FieldB])]))`
 fn merge_search_filters(filter: Filter) -> Filter {
+    if matches!(filter, Filter::And(_) | Filter::Or(_) | Filter::Not(_)) && !contains_search_filter(&filter) {
+        return filter;
+    }
+
     // The filter tree _needs_ to be flattened for the merge to work properly
     let flattened = fold_filter(filter);
 
@@ -236,6 +240,19 @@ fn merge_search_filters(filter: Filter) -> Filter {
         Filter::Or(or) => Filter::Or(fold_search_filters(&or)),
         Filter::Not(not) => Filter::Not(fold_search_filters(&not)),
         _ => flattened,
+    }
+}
+
+fn contains_search_filter(filter: &Filter) -> bool {
+    match filter {
+        Filter::Scalar(sf) => matches!(
+            sf.condition,
+            ScalarCondition::Search(..) | ScalarCondition::NotSearch(..)
+        ),
+        Filter::And(filters) | Filter::Or(filters) | Filter::Not(filters) => {
+            filters.iter().any(contains_search_filter)
+        }
+        _ => false,
     }
 }
 

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -18,6 +18,16 @@ use std::{borrow::Cow, collections::HashMap, convert::TryInto, str::FromStr};
 
 /// Extracts a filter for a unique selector, i.e. a filter that selects exactly one record.
 pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> QueryGraphBuilderResult<Filter> {
+    if value_map.iter().all(|(field_name, _)| {
+        model
+            .fields()
+            .find_from_scalar(field_name)
+            .is_ok_and(|field| field.unique())
+            || utils::resolve_compound_field(field_name, model).is_some()
+    }) {
+        return internal_extract_unique_filter(value_map, model);
+    }
+
     let tag = value_map.tag.clone();
     // Partition the input into a map containing only the unique fields and one containing all the other filters
     // so that we can parse them separately and ensure we AND both filters
@@ -42,29 +52,48 @@ pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> Qu
 /// Extracts a filter for a unique selector, i.e. a filter that selects exactly one record.
 /// The input map must only contain unique & compound unique fields.
 fn internal_extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> QueryGraphBuilderResult<Filter> {
-    let filters = value_map
-        .into_iter()
-        .map(|(field_name, value): (Cow<'_, str>, ParsedInputValue<'_>)| {
-            // Always try to resolve regular fields first. If that fails, try to resolve compound fields.
-            match model.fields().find_from_scalar(&field_name) {
-                Ok(field) => {
-                    let value: PrismaValue = value.try_into()?;
-                    Ok(field.equals(value))
-                }
-                Err(_) => utils::resolve_compound_field(&field_name, model)
-                    .ok_or_else(|| {
-                        QueryGraphBuilderError::AssertionError(format!(
-                            "Unable to resolve field {} to a field or set of scalar fields on model {}",
-                            field_name,
-                            model.name()
-                        ))
-                    })
-                    .and_then(|fields| handle_compound_field(fields, value)),
-            }
-        })
-        .collect::<QueryGraphBuilderResult<Vec<Filter>>>()?;
+    let mut input = value_map.into_iter();
+    let Some((field_name, value)) = input.next() else {
+        return Ok(Filter::And(Vec::new()));
+    };
+
+    let first = extract_unique_filter_field(field_name, value, model)?;
+
+    if input.len() == 0 {
+        return Ok(first);
+    }
+
+    let mut filters = Vec::with_capacity(input.len() + 1);
+    filters.push(first);
+
+    for (field_name, value) in input {
+        filters.push(extract_unique_filter_field(field_name, value, model)?);
+    }
 
     Ok(Filter::and(filters))
+}
+
+fn extract_unique_filter_field(
+    field_name: Cow<'_, str>,
+    value: ParsedInputValue<'_>,
+    model: &Model,
+) -> QueryGraphBuilderResult<Filter> {
+    // Always try to resolve regular fields first. If that fails, try to resolve compound fields.
+    match model.fields().find_from_scalar(&field_name) {
+        Ok(field) => {
+            let value: PrismaValue = value.try_into()?;
+            Ok(field.equals(value))
+        }
+        Err(_) => utils::resolve_compound_field(&field_name, model)
+            .ok_or_else(|| {
+                QueryGraphBuilderError::AssertionError(format!(
+                    "Unable to resolve field {} to a field or set of scalar fields on model {}",
+                    field_name,
+                    model.name()
+                ))
+            })
+            .and_then(|fields| handle_compound_field(fields, value)),
+    }
 }
 
 fn handle_compound_field(fields: Vec<ScalarFieldRef>, value: ParsedInputValue<'_>) -> QueryGraphBuilderResult<Filter> {

--- a/query-compiler/core/src/query_graph_builder/extractors/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/mod.rs
@@ -6,6 +6,6 @@ mod utils;
 pub(crate) use filters::*;
 pub(crate) use query_arguments::*;
 pub(crate) use rel_aggregations::*;
-pub(crate) use utils::resolve_compound_field;
+pub(crate) use utils::is_compound_field;
 
 use crate::query_document::*;

--- a/query-compiler/core/src/query_graph_builder/extractors/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/utils.rs
@@ -1,5 +1,10 @@
 use query_structure::{Model, ScalarFieldRef};
 
+/// Checks whether a field name resolves to a compound field without materializing the fields.
+pub fn is_compound_field(name: &str, model: &Model) -> bool {
+    is_compound_id(name, model) || is_index_field(name, model)
+}
+
 /// Attempts to resolve a field name to a compound field.
 pub fn resolve_compound_field(name: &str, model: &Model) -> Option<Vec<ScalarFieldRef>> {
     resolve_compound_id(name, model).or_else(|| resolve_index_fields(name, model))
@@ -7,20 +12,63 @@ pub fn resolve_compound_field(name: &str, model: &Model) -> Option<Vec<ScalarFie
 
 /// Attempts to match a given name to the (schema) name of a compound id field on the model.
 pub fn resolve_compound_id(name: &str, model: &Model) -> Option<Vec<ScalarFieldRef>> {
-    model.fields().compound_id().and_then(|pk| {
-        (name == schema::compound_id_field_name(model.walker().primary_key().unwrap())).then(|| pk.collect())
-    })
+    model
+        .fields()
+        .compound_id()
+        .and_then(|pk| is_compound_id(name, model).then(|| pk.collect()))
 }
 
 /// Attempts to match a given name to the (schema) name of a compound indexes on the model and returns the first match.
 pub fn resolve_index_fields(name: &str, model: &Model) -> Option<Vec<ScalarFieldRef>> {
     model
         .unique_indexes()
-        .find(|index| schema::compound_index_field_name(*index) == name)
+        .find(|index| index_field_name_matches(name, *index))
         .map(|index| {
             index
                 .fields()
                 .map(|f| ScalarFieldRef::from((model.dm.clone(), f)))
                 .collect()
         })
+}
+
+fn is_compound_id(name: &str, model: &Model) -> bool {
+    model.fields().compound_id().is_some()
+        && model.walker().primary_key().is_some_and(|pk| match pk.name() {
+            Some(pk_name) => name == pk_name,
+            None => compound_field_name_matches(name, pk.fields().map(|field| field.name())),
+        })
+}
+
+fn is_index_field(name: &str, model: &Model) -> bool {
+    model
+        .unique_indexes()
+        .any(|index| index_field_name_matches(name, index))
+}
+
+fn index_field_name_matches(name: &str, index: psl::parser_database::walkers::IndexWalker<'_>) -> bool {
+    match index.name() {
+        Some(index_name) => name == index_name,
+        None => compound_field_name_matches(name, index.fields().map(|field| field.name())),
+    }
+}
+
+fn compound_field_name_matches<'a>(mut name: &str, fields: impl Iterator<Item = &'a str>) -> bool {
+    let mut first = true;
+
+    for field in fields {
+        if first {
+            first = false;
+        } else if let Some(rest) = name.strip_prefix('_') {
+            name = rest;
+        } else {
+            return false;
+        }
+
+        let Some(rest) = name.strip_prefix(field) else {
+            return false;
+        };
+        name = rest;
+    }
+
+    !first && name.is_empty()
 }

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -1,6 +1,6 @@
 use std::slice;
 
-use query_structure::{Filter, SelectionResult, WriteArgs};
+use query_structure::{Filter, Placeholder, SelectionResult, WriteArgs};
 
 use crate::{Computation, Flow, Node, NodeInputField, Query, ReadQuery, WriteQuery};
 
@@ -84,25 +84,25 @@ node_input_field!(
 
 node_input_field!(
     LeftSideDiffInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Computation(Computation::DiffLeftToRight(diff_node) | Computation::DiffRightToLeft(diff_node)) => &mut diff_node.left
 );
 
 node_input_field!(
     RightSideDiffInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Computation(Computation::DiffLeftToRight(diff_node) | Computation::DiffRightToLeft(diff_node)) => &mut diff_node.right
 );
 
 node_input_field!(
     IfInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Flow(Flow::If { data, .. }) => data
 );
 
 node_input_field!(
     ReturnInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Flow(Flow::Return(data)) => data
 );
 

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -115,7 +115,7 @@ node_input_field!(
 node_input_field!(
     ReturnInput,
     Option<Placeholder>,
-    Node::Flow(Flow::Return(data)) => data
+    Node::Flow(Flow::Return(data) | Flow::ReturnPreservingResult(data)) => data
 );
 
 node_input_field!(

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -143,6 +143,12 @@ node_input_field!(
 );
 
 node_input_field!(
+    DisconnectAllParentInput,
+    Option<SelectionResult>,
+    Node::Query(Query::Write(WriteQuery::DisconnectAllRecords(dr))) => &mut dr.parent_id
+);
+
+node_input_field!(
     DisconnectChildrenInput,
     Vec<SelectionResult>,
     Node::Query(Query::Write(WriteQuery::DisconnectRecords(dr))) => &mut dr.child_ids

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -95,6 +95,18 @@ node_input_field!(
 );
 
 node_input_field!(
+    RequiredOneToManySetOldInput,
+    Option<Placeholder>,
+    Node::Computation(Computation::RequiredOneToManySet(set_node)) => &mut set_node.old_children
+);
+
+node_input_field!(
+    RequiredOneToManySetNewInput,
+    Option<Placeholder>,
+    Node::Computation(Computation::RequiredOneToManySet(set_node)) => &mut set_node.new_children
+);
+
+node_input_field!(
     IfInput,
     Option<Placeholder>,
     Node::Flow(Flow::If { data, .. }) => data

--- a/query-compiler/core/src/query_graph_builder/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod inputs;
 pub(crate) mod read;
 pub(crate) mod write;
 pub(crate) use extractors::*;
+pub(crate) use crate::{DataOperation, DependentOperation};
 
 pub use builder::QueryGraphBuilder;
 pub use error::*;

--- a/query-compiler/core/src/query_graph_builder/read/aggregations/aggregate.rs
+++ b/query-compiler/core/src/query_graph_builder/read/aggregations/aggregate.rs
@@ -7,7 +7,6 @@ pub(crate) fn aggregate(field: ParsedField<'_>, model: Model) -> QueryGraphBuild
     let alias = field.alias;
     let model = model;
     let nested_fields = field.nested_fields.unwrap().fields;
-    let selection_order = collect_selection_tree(&nested_fields);
     let args = extractors::extract_query_args(field.arguments, &model)?;
 
     // Reject any inmemory-requiring operation for aggregations, we don't have an in-memory aggregator yet.
@@ -20,10 +19,7 @@ pub(crate) fn aggregate(field: ParsedField<'_>, model: Model) -> QueryGraphBuild
         ));
     }
 
-    let selectors: Vec<_> = nested_fields
-        .into_iter()
-        .map(|field| resolve_query(field, &model, true))
-        .collect::<QueryGraphBuilderResult<_>>()?;
+    let (selection_order, selectors) = collect_selection_tree_and_selectors(nested_fields, &model, true)?;
 
     Ok(ReadQuery::AggregateRecordsQuery(AggregateRecordsQuery {
         name,

--- a/query-compiler/core/src/query_graph_builder/read/aggregations/group_by.rs
+++ b/query-compiler/core/src/query_graph_builder/read/aggregations/group_by.rs
@@ -18,12 +18,7 @@ pub(crate) fn group_by(mut field: ParsedField<'_>, model: Model) -> QueryGraphBu
 
     let args = extractors::extract_query_args(field.arguments, &model)?;
     let nested_fields = field.nested_fields.unwrap().fields;
-    let selection_order = collect_selection_tree(&nested_fields);
-
-    let selectors: Vec<_> = nested_fields
-        .into_iter()
-        .map(|field| resolve_query(field, &model, false))
-        .collect::<QueryGraphBuilderResult<_>>()?;
+    let (selection_order, selectors) = collect_selection_tree_and_selectors(nested_fields, &model, false)?;
 
     verify_selections(&selectors, &group_by)
         .and_then(|_| verify_orderings(&args.order_by, &group_by))

--- a/query-compiler/core/src/query_graph_builder/read/aggregations/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/read/aggregations/mod.rs
@@ -5,107 +5,137 @@ pub(crate) use aggregate::*;
 pub(crate) use group_by::*;
 
 use super::*;
-use crate::FieldPair;
-use itertools::Itertools;
+use crate::{FieldPair, ParsedObject};
 use query_structure::{AggregationSelection, Model, ScalarFieldRef};
 use schema::constants::aggregations::*;
 
-/// Resolves the given field as a aggregation query.
-fn resolve_query(
+fn collect_selection_tree_and_selectors(
+    fields: Vec<FieldPair<'_>>,
+    model: &Model,
+    allow_deprecated: bool,
+) -> QueryGraphBuilderResult<(Vec<(String, Option<Vec<String>>)>, Vec<AggregationSelection>)> {
+    let mut selection_order = Vec::with_capacity(fields.len());
+    let mut selectors = Vec::with_capacity(fields.len());
+
+    for field in fields {
+        let (selection, selector) = resolve_query_and_selection(field, model, allow_deprecated)?;
+        selection_order.push(selection);
+        selectors.push(selector);
+    }
+
+    Ok((selection_order, selectors))
+}
+
+/// Resolves the given field as an aggregation query.
+fn resolve_query_and_selection(
     field: FieldPair<'_>,
     model: &Model,
     allow_deprecated: bool,
-) -> QueryGraphBuilderResult<AggregationSelection> {
-    let count_resolver = |mut field: FieldPair<'_>, model: &Model| {
-        let nested_fields = field
-            .parsed_field
-            .nested_fields
-            .as_mut()
-            .expect("Expected at least one selection for aggregate");
+) -> QueryGraphBuilderResult<((String, Option<Vec<String>>), AggregationSelection)> {
+    let name = field.parsed_field.name;
+    let nested_fields = field.parsed_field.nested_fields;
 
-        let all_position = nested_fields
-            .fields
-            .iter()
-            .find_position(|f| f.parsed_field.name == "_all");
-
-        match all_position {
-            Some((pos, _)) => {
-                nested_fields.fields.remove(pos);
-
+    let (nested_selection, query) = match name.as_str() {
+        COUNT if allow_deprecated => {
+            let (nested_selection, has_count_all, fields) = resolve_fields(model, nested_fields);
+            (
+                nested_selection,
                 AggregationSelection::Count {
-                    all: Some(model.into()),
-                    fields: resolve_fields(model, field),
-                }
-            }
-            None => AggregationSelection::Count {
-                all: None,
-                fields: resolve_fields(model, field),
-            },
+                    all: has_count_all.then(|| model.into()),
+                    fields,
+                },
+            )
         }
+        AVG if allow_deprecated => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Average(fields))
+        }
+        SUM if allow_deprecated => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Sum(fields))
+        }
+        MIN if allow_deprecated => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Min(fields))
+        }
+        MAX if allow_deprecated => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Max(fields))
+        }
+
+        UNDERSCORE_COUNT => {
+            let (nested_selection, has_count_all, fields) = resolve_fields(model, nested_fields);
+            (
+                nested_selection,
+                AggregationSelection::Count {
+                    all: has_count_all.then(|| model.into()),
+                    fields,
+                },
+            )
+        }
+        UNDERSCORE_AVG => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Average(fields))
+        }
+        UNDERSCORE_SUM => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Sum(fields))
+        }
+        UNDERSCORE_MIN => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Min(fields))
+        }
+        UNDERSCORE_MAX => {
+            let (nested_selection, _, fields) = resolve_fields(model, nested_fields);
+            (nested_selection, AggregationSelection::Max(fields))
+        }
+
+        name => (
+            None,
+            AggregationSelection::Field(model.fields().find_from_scalar(name).unwrap()),
+        ),
     };
 
-    let query = match field.parsed_field.name.as_str() {
-        COUNT if allow_deprecated => count_resolver(field, model),
-        AVG if allow_deprecated => AggregationSelection::Average(resolve_fields(model, field)),
-        SUM if allow_deprecated => AggregationSelection::Sum(resolve_fields(model, field)),
-        MIN if allow_deprecated => AggregationSelection::Min(resolve_fields(model, field)),
-        MAX if allow_deprecated => AggregationSelection::Max(resolve_fields(model, field)),
-
-        UNDERSCORE_COUNT => count_resolver(field, model),
-        UNDERSCORE_AVG => AggregationSelection::Average(resolve_fields(model, field)),
-        UNDERSCORE_SUM => AggregationSelection::Sum(resolve_fields(model, field)),
-        UNDERSCORE_MIN => AggregationSelection::Min(resolve_fields(model, field)),
-        UNDERSCORE_MAX => AggregationSelection::Max(resolve_fields(model, field)),
-
-        name => AggregationSelection::Field(model.fields().find_from_scalar(name).unwrap()),
-    };
-
-    Ok(query)
+    Ok(((name, nested_selection), query))
 }
 
-fn resolve_fields(model: &Model, field: FieldPair<'_>) -> Vec<ScalarFieldRef> {
+fn resolve_fields(
+    model: &Model,
+    nested_fields: Option<ParsedObject<'_>>,
+) -> (Option<Vec<String>>, bool, Vec<ScalarFieldRef>) {
     let scalars = model.fields().scalar();
-    let fields = field
-        .parsed_field
-        .nested_fields
+    let fields = nested_fields
         .expect("Expected at least one selection for aggregate")
         .fields;
+    let mut selection_order = Vec::with_capacity(fields.len());
+    let mut has_count_all = false;
+    let mut selected_fields = Vec::with_capacity(fields.len());
 
-    fields
-        .into_iter()
-        .filter_map(|f| {
-            if f.parsed_field.name == "_all" {
-                None
-            } else {
-                scalars.clone().find_map(|sf| {
-                    if sf.name() == f.parsed_field.name {
-                        Some(sf)
-                    } else {
-                        None
-                    }
-                })
-            }
-        })
-        .collect()
-}
+    for field in fields {
+        let name = field.parsed_field.name;
 
-fn collect_selection_tree(fields: &[FieldPair<'_>]) -> Vec<(String, Option<Vec<String>>)> {
-    fields
-        .iter()
-        .map(|field| {
-            let field = &field.parsed_field;
-            (
-                field.name.clone(),
-                field.nested_fields.as_ref().and_then(|nested_object| {
-                    let nested: Vec<_> = nested_object
-                        .fields
-                        .iter()
-                        .map(|f| f.parsed_field.name.clone())
-                        .collect();
+        if name == "_all" {
+            has_count_all = true;
+            selection_order.push(name);
+            continue;
+        }
 
-                    if nested.is_empty() { None } else { Some(nested) }
-                }),
-            )
-        })
-        .collect()
+        let scalar = scalars
+            .clone()
+            .find_map(|sf| if sf.name() == name.as_str() { Some(sf) } else { None });
+
+        selection_order.push(name);
+
+        if let Some(scalar) = scalar {
+            selected_fields.push(scalar);
+        }
+    }
+
+    let selection_order = if selection_order.is_empty() {
+        None
+    } else {
+        Some(selection_order)
+    };
+
+    (selection_order, has_count_all, selected_fields)
 }

--- a/query-compiler/core/src/query_graph_builder/read/many.rs
+++ b/query-compiler/core/src/query_graph_builder/read/many.rs
@@ -30,9 +30,9 @@ fn find_many_with_options(
     let name = field.name;
     let alias = field.alias;
     let nested_fields = field.nested_fields.unwrap().fields;
-    let selection_order: Vec<String> = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, args.distinct.clone(), &model, query_schema)?;
-    let nested = utils::collect_nested_queries(nested_fields, &model, query_schema)?;
+    let (selection_order, nested) =
+        utils::collect_selection_order_and_nested_queries(nested_fields, &model, query_schema)?;
 
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
     let selected_fields = utils::merge_cursor_fields(selected_fields, &args.cursor);

--- a/query-compiler/core/src/query_graph_builder/read/related.rs
+++ b/query-compiler/core/src/query_graph_builder/read/related.rs
@@ -13,9 +13,9 @@ pub(crate) fn find_related(
     let name = field.name;
     let alias = field.alias;
     let sub_selections = field.nested_fields.unwrap().fields;
-    let selection_order: Vec<String> = utils::collect_selection_order(&sub_selections);
     let selected_fields = utils::collect_selected_fields(&sub_selections, args.distinct.clone(), &model, query_schema)?;
-    let nested = utils::collect_nested_queries(sub_selections, &model, query_schema)?;
+    let (selection_order, nested) =
+        utils::collect_selection_order_and_nested_queries(sub_selections, &model, query_schema)?;
     let parent_field = parent;
 
     let selected_fields = utils::merge_relation_selections(selected_fields, Some(parent_field.clone()), &nested);

--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -322,9 +322,51 @@ pub(crate) fn extract_selected_fields(
     model: &Model,
     query_schema: &QuerySchema,
 ) -> crate::QueryGraphBuilderResult<(FieldSelection, Vec<String>, Vec<ReadQuery>)> {
-    let selected_fields = utils::collect_selected_fields(&nested_fields, None, model, query_schema)?;
-    let (selection_order, nested) =
-        utils::collect_selection_order_and_nested_queries(nested_fields, model, query_schema)?;
+    let should_collect_relation_selection = query_schema.can_resolve_relation_with_joins();
+    let model_id = model.shard_aware_primary_identifier();
+    let mut selections = Vec::with_capacity(nested_fields.len());
+    let mut selection_order = Vec::with_capacity(nested_fields.len());
+    let mut nested = Vec::new();
+
+    for pair in nested_fields {
+        if is_aggr_selection(&pair) {
+            selection_order.push(selection_order_name(&pair.parsed_field));
+            selections.extend(extract_relation_count_selections(pair.parsed_field, model)?);
+            continue;
+        }
+
+        let model_field = model.fields().find_from_all(&pair.parsed_field.name).unwrap();
+
+        match model_field {
+            Field::Scalar(sf) => {
+                selections.push(sf.into());
+                selection_order.push(into_selection_order_name(pair.parsed_field));
+            }
+            Field::Composite(cf) => {
+                selection_order.push(selection_order_name(&pair.parsed_field));
+                selections.push(extract_composite_selection(pair.parsed_field, cf, query_schema)?);
+            }
+            Field::Relation(rf) => {
+                let related_model = rf.related_model();
+                let parsed_field = pair.parsed_field;
+
+                selection_order.push(selection_order_name(&parsed_field));
+                selections.extend(rf.scalar_fields().into_iter().map(SelectedField::from));
+
+                if should_collect_relation_selection {
+                    selections.push(extract_relation_selection(
+                        parsed_field.clone(),
+                        rf.clone(),
+                        query_schema,
+                    )?);
+                }
+
+                nested.push(related::find_related(parsed_field, rf, related_model, query_schema)?);
+            }
+        }
+    }
+
+    let selected_fields = model_id.merge(FieldSelection::new(selections));
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
     Ok((selected_fields, selection_order, nested))

--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -230,6 +230,10 @@ pub(crate) fn merge_relation_selections(
         selected_fields
     };
 
+    if nested_queries.is_empty() {
+        return selected_fields;
+    }
+
     let nested: Vec<_> = nested_queries
         .iter()
         .map(|nested_query| {

--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -244,18 +244,13 @@ pub(crate) fn merge_relation_selections(
         return selected_fields;
     }
 
-    let nested: Vec<_> = nested_queries
-        .iter()
-        .map(|nested_query| {
-            if let ReadQuery::RelatedRecordsQuery(rq) = nested_query {
-                rq.parent_field.linking_fields()
-            } else {
-                unreachable!()
-            }
-        })
-        .collect();
-
-    selected_fields.merge(FieldSelection::union(nested))
+    selected_fields.merge(FieldSelection::union_iter(nested_queries.iter().map(|nested_query| {
+        if let ReadQuery::RelatedRecordsQuery(rq) = nested_query {
+            rq.parent_field.linking_fields()
+        } else {
+            unreachable!()
+        }
+    })))
 }
 
 /// Ensures that if a cursor is provided, its fields are also selected.

--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -9,15 +9,18 @@ use schema::{
     constants::{aggregations::*, args},
 };
 
-pub fn collect_selection_order(from: &[FieldPair<'_>]) -> Vec<String> {
-    from.iter()
-        .map(|pair| {
-            pair.parsed_field
-                .alias
-                .clone()
-                .unwrap_or_else(|| pair.parsed_field.name.clone())
-        })
+pub fn collect_selection_order_owned(from: Vec<FieldPair<'_>>) -> Vec<String> {
+    from.into_iter()
+        .map(|pair| into_selection_order_name(pair.parsed_field))
         .collect()
+}
+
+fn selection_order_name(field: &ParsedField<'_>) -> String {
+    field.alias.clone().unwrap_or_else(|| field.name.clone())
+}
+
+fn into_selection_order_name(field: ParsedField<'_>) -> String {
+    field.alias.unwrap_or(field.name)
 }
 
 /// Creates a `FieldSelection` from a query selection.
@@ -152,8 +155,8 @@ fn extract_relation_selection(
     Ok(SelectedField::Relation(RelationSelection {
         field: rf,
         args: extract_query_args(pf.arguments, &related_model)?,
-        result_fields: collect_selection_order(&object.fields),
         selections: pairs_to_selections(related_model, &object.fields, query_schema)?,
+        result_fields: collect_selection_order_owned(object.fields),
     }))
 }
 
@@ -186,31 +189,38 @@ fn extract_relation_count_selections(
         .collect()
 }
 
-pub(crate) fn collect_nested_queries(
+pub(crate) fn collect_selection_order_and_nested_queries(
     from: Vec<FieldPair<'_>>,
     model: &Model,
     query_schema: &QuerySchema,
-) -> QueryGraphBuilderResult<Vec<ReadQuery>> {
-    from.into_iter()
-        .filter_map(|pair| {
-            if is_aggr_selection(&pair) {
-                return None;
+) -> QueryGraphBuilderResult<(Vec<String>, Vec<ReadQuery>)> {
+    let mut selection_order = Vec::with_capacity(from.len());
+    let mut nested = Vec::new();
+
+    for pair in from {
+        if is_aggr_selection(&pair) {
+            selection_order.push(into_selection_order_name(pair.parsed_field));
+            continue;
+        }
+
+        let model_field = model.fields().find_from_all(&pair.parsed_field.name).unwrap();
+
+        match model_field {
+            Field::Scalar(_) | Field::Composite(_) => {
+                selection_order.push(into_selection_order_name(pair.parsed_field));
             }
+            Field::Relation(ref rf) => {
+                let model = rf.related_model();
+                let parent = rf.clone();
+                let parsed_field = pair.parsed_field;
 
-            let model_field = model.fields().find_from_all(&pair.parsed_field.name).unwrap();
-
-            match model_field {
-                Field::Scalar(_) => None,
-                Field::Composite(_) => None,
-                Field::Relation(ref rf) => {
-                    let model = rf.related_model();
-                    let parent = rf.clone();
-
-                    Some(related::find_related(pair.parsed_field, parent, model, query_schema))
-                }
+                selection_order.push(selection_order_name(&parsed_field));
+                nested.push(related::find_related(parsed_field, parent, model, query_schema)?);
             }
-        })
-        .collect::<QueryGraphBuilderResult<Vec<ReadQuery>>>()
+        }
+    }
+
+    Ok((selection_order, nested))
 }
 
 /// Performs a lookahead based on the nested queries and merges fields required
@@ -317,9 +327,9 @@ pub(crate) fn extract_selected_fields(
     model: &Model,
     query_schema: &QuerySchema,
 ) -> crate::QueryGraphBuilderResult<(FieldSelection, Vec<String>, Vec<ReadQuery>)> {
-    let selection_order = utils::collect_selection_order(&nested_fields);
     let selected_fields = utils::collect_selected_fields(&nested_fields, None, model, query_schema)?;
-    let nested = utils::collect_nested_queries(nested_fields, model, query_schema)?;
+    let (selection_order, nested) =
+        utils::collect_selection_order_and_nested_queries(nested_fields, model, query_schema)?;
     let selected_fields = utils::merge_relation_selections(selected_fields, None, &nested);
 
     Ok((selected_fields, selection_order, nested))

--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -78,7 +78,7 @@ where
 
     let parent = parent.into();
 
-    let mut selected_fields = Vec::new();
+    let mut selected_fields = Vec::with_capacity(pairs.len());
 
     for pair in pairs {
         let field = parent.find_field(&pair.parsed_field.name);

--- a/query-compiler/core/src/query_graph_builder/write/create.rs
+++ b/query-compiler/core/src/query_graph_builder/write/create.rs
@@ -5,8 +5,8 @@ use crate::{
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
-use psl::{datamodel_connector::ConnectorCapability, parser_database::RelationFieldId};
-use query_structure::{Model, WriteArgs, Zipper};
+use psl::datamodel_connector::ConnectorCapability;
+use query_structure::{Model, WriteArgs};
 use schema::{QuerySchema, constants::args};
 use std::convert::TryInto;
 use write_args_parser::*;
@@ -127,7 +127,7 @@ pub(crate) fn create_record_node_from_args(
     query_schema: &QuerySchema,
     model: Model,
     args: WriteArgs,
-    nested: Vec<(Zipper<RelationFieldId>, ParsedInputMap<'_>)>,
+    nested: NestedWriteOperations<'_>,
 ) -> QueryGraphBuilderResult<NodeRef> {
     let selected_fields = model.shard_aware_primary_identifier();
     let selection_order = selected_fields.db_names().collect();

--- a/query-compiler/core/src/query_graph_builder/write/create.rs
+++ b/query-compiler/core/src/query_graph_builder/write/create.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    ArgumentListLookup, DataExpectation, ParsedField, ParsedInputList, ParsedInputMap, RowSink,
+    ArgumentListLookup, DataExpectation, ParsedField, ParsedInputMap, RowSink,
     inputs::RecordQueryFilterInput,
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
@@ -63,9 +63,9 @@ pub(crate) fn create_many_records(
 ) -> QueryGraphBuilderResult<()> {
     graph.flag_transactional();
 
-    let data_list: ParsedInputList<'_> = match field.arguments.lookup(args::DATA) {
-        Some(data) => utils::coerce_vec(data.value),
-        None => vec![],
+    let data_list = match field.arguments.lookup(args::DATA) {
+        Some(data) => utils::coerce_values(data.value),
+        None => utils::CoercedParsedInputValues::empty(),
     };
 
     let skip_duplicates: bool = match field.arguments.lookup(args::SKIP_DUPLICATES) {

--- a/query-compiler/core/src/query_graph_builder/write/create.rs
+++ b/query-compiler/core/src/query_graph_builder/write/create.rs
@@ -192,8 +192,8 @@ fn atomic_create_record_node(
     let mut args = create_args.args;
 
     let nested_fields = field.nested_fields.unwrap().fields;
-    let selection_order: Vec<String> = read::utils::collect_selection_order(&nested_fields);
     let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
+    let selection_order = read::utils::collect_selection_order_owned(nested_fields);
 
     args.add_datetimes(&model);
 

--- a/query-compiler/core/src/query_graph_builder/write/delete.rs
+++ b/query-compiler/core/src/query_graph_builder/write/delete.rs
@@ -26,7 +26,7 @@ pub(crate) fn delete_record(
         // Database supports returning the deleted row, so just the delete node will suffice.
         let nested_fields = field.nested_fields.unwrap().fields;
         let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
-        let selection_order = read::utils::collect_selection_order(&nested_fields);
+        let selection_order = read::utils::collect_selection_order_owned(nested_fields);
 
         let delete_query = Query::Write(WriteQuery::DeleteRecord(DeleteRecord {
             name: field.name,

--- a/query-compiler/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-compiler/core/src/query_graph_builder/write/disconnect.rs
@@ -4,7 +4,7 @@ use crate::{
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
-use query_structure::RelationFieldRef;
+use query_structure::{RelationFieldRef, SelectionResult};
 
 /// Only for many to many relations.
 ///
@@ -74,6 +74,43 @@ pub(crate) fn disconnect_records_node(
         child_node,
         &disconnect_node,
         QueryGraphDependency::ProjectedDataDependency(child_model_id, RowSink::All(&DisconnectChildrenInput), None),
+    )?;
+
+    Ok(disconnect_node)
+}
+
+pub(crate) fn disconnect_records_node_with_child_ids(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+    child_ids: Vec<SelectionResult>,
+) -> QueryGraphBuilderResult<NodeRef> {
+    assert!(parent_relation_field.relation().is_many_to_many());
+
+    let parent_model_id = parent_relation_field.model().shard_aware_primary_identifier();
+
+    let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
+        parent_id: None,
+        child_ids,
+        relation_field: parent_relation_field.clone(),
+    });
+
+    let disconnect_node = graph.create_node(Query::Write(disconnect));
+
+    graph.create_edge(
+        parent_node,
+        &disconnect_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            parent_model_id,
+            RowSink::Single(&DisconnectParentInput),
+            Some(DataExpectation::non_empty_rows(
+                MissingRelatedRecord::builder()
+                    .model(&parent_relation_field.model())
+                    .relation(&parent_relation_field.relation())
+                    .operation(DataOperation::Disconnect)
+                    .build(),
+            )),
+        ),
     )?;
 
     Ok(disconnect_node)

--- a/query-compiler/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-compiler/core/src/query_graph_builder/write/disconnect.rs
@@ -1,6 +1,6 @@
 use crate::{
     DataExpectation, DataOperation, MissingRelatedRecord, QueryGraphBuilderResult, RowSink,
-    inputs::{DisconnectChildrenInput, DisconnectParentInput},
+    inputs::{DisconnectAllParentInput, DisconnectChildrenInput, DisconnectParentInput},
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
@@ -108,6 +108,41 @@ pub(crate) fn disconnect_records_node_with_child_ids(
                     .model(&parent_relation_field.model())
                     .relation(&parent_relation_field.relation())
                     .operation(DataOperation::Disconnect)
+                    .build(),
+            )),
+        ),
+    )?;
+
+    Ok(disconnect_node)
+}
+
+pub(crate) fn disconnect_all_records_node(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+) -> QueryGraphBuilderResult<NodeRef> {
+    assert!(parent_relation_field.relation().is_many_to_many());
+
+    let parent_model_id = parent_relation_field.model().shard_aware_primary_identifier();
+
+    let disconnect = WriteQuery::DisconnectAllRecords(DisconnectAllRecords {
+        parent_id: None,
+        relation_field: parent_relation_field.clone(),
+    });
+
+    let disconnect_node = graph.create_node(Query::Write(disconnect));
+
+    graph.create_edge(
+        parent_node,
+        &disconnect_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            parent_model_id,
+            RowSink::Single(&DisconnectAllParentInput),
+            Some(DataExpectation::non_empty_rows(
+                MissingRelatedRecord::builder()
+                    .model(&parent_relation_field.model())
+                    .relation(&parent_relation_field.relation())
+                    .operation(DataOperation::NestedSet)
                     .build(),
             )),
         ),

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -22,7 +22,7 @@ pub fn nested_connect(
     let relation = parent_relation_field.relation();
 
     // Build all filters upfront.
-    let filters: Vec<Filter> = utils::coerce_vec(value)
+    let filters: Vec<Filter> = utils::coerce_values(value)
         .into_iter()
         .map(|value: ParsedInputValue<'_>| {
             let value: ParsedInputMap<'_> = value.try_into()?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -117,7 +117,7 @@ fn handle_many_to_many(
 
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let if_node = graph.create_node(Flow::if_non_empty());
-        let return_existing = graph.create_node(Flow::Return(Vec::new()));
+        let return_existing = graph.create_node(Flow::Return(None));
 
         graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
         graph.create_edge(
@@ -125,7 +125,7 @@ fn handle_many_to_many(
             &if_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&IfInput),
+                RowSink::ProjectedPlaceholder(&IfInput),
                 None,
             ),
         )?;
@@ -137,7 +137,7 @@ fn handle_many_to_many(
             &return_existing,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&ReturnInput),
+                RowSink::ProjectedPlaceholder(&ReturnInput),
                 None,
             ),
         )?;
@@ -287,7 +287,11 @@ fn one_to_many_inlined_child(
         graph.create_edge(
             &read_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_link.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         graph.create_edge(
@@ -399,13 +403,17 @@ fn one_to_many_inlined_parent(
 
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
-    let return_existing = graph.create_node(Flow::Return(Vec::new()));
-    let return_create = graph.create_node(Flow::Return(Vec::new()));
+    let return_existing = graph.create_node(Flow::Return(None));
+    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
@@ -424,13 +432,17 @@ fn one_to_many_inlined_parent(
     graph.create_edge(
         &read_node,
         &return_existing,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
+            None,
+        ),
     )?;
 
     graph.create_edge(
         &create_node,
         &return_create,
-        QueryGraphDependency::ProjectedDataDependency(child_link, RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(child_link, RowSink::ProjectedPlaceholder(&ReturnInput), None),
     )?;
 
     Ok(())
@@ -528,13 +540,17 @@ fn one_to_one_inlined_parent(
 
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_data)?;
-    let return_existing = graph.create_node(Flow::Return(Vec::new()));
-    let return_create = graph.create_node(Flow::Return(Vec::new()));
+    let return_existing = graph.create_node(Flow::Return(None));
+    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // Then branch handling
@@ -551,7 +567,11 @@ fn one_to_one_inlined_parent(
     graph.create_edge(
         &read_node,
         &return_existing,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
+            None,
+        ),
     )?;
 
     // Else branch handling
@@ -559,7 +579,11 @@ fn one_to_one_inlined_parent(
     graph.create_edge(
         &create_node,
         &return_create,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
+            None,
+        ),
     )?;
 
     if utils::node_is_create(graph, &parent_node) {
@@ -708,7 +732,11 @@ fn one_to_one_inlined_child(
     graph.create_edge(
         &read_new_child_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // *** Else branch handling ***
@@ -800,7 +828,7 @@ fn one_to_one_inlined_child(
             &diff_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&LeftSideDiffInput),
+                RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
                 None,
             ),
         )?;
@@ -811,7 +839,7 @@ fn one_to_one_inlined_child(
             &diff_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&RightSideDiffInput),
+                RowSink::ProjectedPlaceholder(&RightSideDiffInput),
                 None,
             ),
         )?;
@@ -820,7 +848,11 @@ fn one_to_one_inlined_child(
         graph.create_edge(
             &diff_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         // update old child, set link to null

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -118,7 +118,6 @@ fn handle_many_to_many(
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let if_node = graph.create_node(Flow::if_non_empty());
         let return_existing = graph.create_node(Flow::Return(Vec::new()));
-        let return_create = graph.create_node(Flow::Return(Vec::new()));
 
         graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
         graph.create_edge(
@@ -141,11 +140,6 @@ fn handle_many_to_many(
                 RowSink::All(&ReturnInput),
                 None,
             ),
-        )?;
-        graph.create_edge(
-            &create_node,
-            &return_create,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier, RowSink::All(&ReturnInput), None),
         )?;
 
         connect::connect_records_node(graph, &parent_node, &if_node, parent_relation_field, 1)?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -116,8 +116,7 @@ fn handle_many_to_many(
         ));
 
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
-        let if_node = graph.create_node(Flow::if_non_empty());
-        let return_existing = graph.create_node(Flow::Return(None));
+        let if_node = graph.create_node(Flow::if_non_empty_returning_condition());
 
         graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
         graph.create_edge(
@@ -130,17 +129,7 @@ fn handle_many_to_many(
             ),
         )?;
 
-        graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
         graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
-        graph.create_edge(
-            &read_node,
-            &return_existing,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model_identifier.clone(),
-                RowSink::ProjectedPlaceholder(&ReturnInput),
-                None,
-            ),
-        )?;
 
         connect::connect_records_node(graph, &parent_node, &if_node, parent_relation_field, 1)?;
     }
@@ -401,9 +390,8 @@ fn one_to_many_inlined_parent(
     graph.mark_nodes(&parent_node, &read_node);
     graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
 
-    let if_node = graph.create_node(Flow::if_non_empty());
+    let if_node = graph.create_node(Flow::if_non_empty_returning_condition());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
-    let return_existing = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
@@ -415,7 +403,6 @@ fn one_to_many_inlined_parent(
         ),
     )?;
 
-    graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
     graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
 
     graph.create_edge(
@@ -424,16 +411,6 @@ fn one_to_many_inlined_parent(
         QueryGraphDependency::ProjectedDataDependency(
             child_link.clone(),
             RowSink::ExactlyOneWriteArgs(parent_link, &UpdateOrCreateArgsInput),
-            None,
-        ),
-    )?;
-
-    graph.create_edge(
-        &read_node,
-        &return_existing,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_link.clone(),
-            RowSink::ProjectedPlaceholder(&ReturnInput),
             None,
         ),
     )?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -108,9 +108,10 @@ fn handle_many_to_many(
         let create_map: ParsedInputMap<'_> = create_arg.try_into()?;
 
         let filter = extract_unique_filter(where_map, child_model)?;
+        let child_model_identifier = child_model.shard_aware_primary_identifier();
         let read_node = graph.create_node(utils::read_id_infallible(
             child_model.clone(),
-            child_model.shard_aware_primary_identifier(),
+            child_model_identifier.clone(),
             filter,
         ));
 
@@ -127,11 +128,7 @@ fn handle_many_to_many(
         graph.create_edge(
             &read_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model.shard_aware_primary_identifier(),
-                RowSink::All(&IfInput),
-                None,
-            ),
+            QueryGraphDependency::ProjectedDataDependency(child_model_identifier, RowSink::All(&IfInput), None),
         )?;
 
         graph.create_edge(&if_node, &connect_exists_node, QueryGraphDependency::Then)?;
@@ -713,11 +710,7 @@ fn one_to_one_inlined_child(
     graph.create_edge(
         &read_new_child_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model.shard_aware_primary_identifier(),
-            RowSink::All(&IfInput),
-            None,
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
     )?;
 
     // *** Else branch handling ***

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -404,7 +404,6 @@ fn one_to_many_inlined_parent(
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
     let return_existing = graph.create_node(Flow::Return(None));
-    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
@@ -437,12 +436,6 @@ fn one_to_many_inlined_parent(
             RowSink::ProjectedPlaceholder(&ReturnInput),
             None,
         ),
-    )?;
-
-    graph.create_edge(
-        &create_node,
-        &return_create,
-        QueryGraphDependency::ProjectedDataDependency(child_link, RowSink::ProjectedPlaceholder(&ReturnInput), None),
     )?;
 
     Ok(())
@@ -541,7 +534,6 @@ fn one_to_one_inlined_parent(
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_data)?;
     let return_existing = graph.create_node(Flow::Return(None));
-    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
@@ -576,16 +568,6 @@ fn one_to_one_inlined_parent(
 
     // Else branch handling
     graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
-    graph.create_edge(
-        &create_node,
-        &return_create,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_link.clone(),
-            RowSink::ProjectedPlaceholder(&ReturnInput),
-            None,
-        ),
-    )?;
-
     if utils::node_is_create(graph, &parent_node) {
         // No need to perform checks, a child can't exist if the parent is just getting created. Simply inject.
         graph.create_edge(

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -24,7 +24,7 @@ pub(crate) fn nested_connect_or_create(
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
-    let values = utils::coerce_vec(value);
+    let values = utils::coerce_values(value);
 
     if relation.is_many_to_many() {
         handle_many_to_many(
@@ -95,7 +95,7 @@ fn handle_many_to_many(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    values: Vec<ParsedInputValue<'_>>,
+    values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     for value in values {
@@ -144,7 +144,7 @@ fn handle_one_to_many(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    values: Vec<ParsedInputValue<'_>>,
+    values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     if parent_relation_field.is_inlined_on_enclosing_model() {
@@ -174,7 +174,7 @@ fn handle_one_to_one(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    mut values: Vec<ParsedInputValue<'_>>,
+    mut values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let value = values.pop().unwrap();
@@ -245,7 +245,7 @@ fn one_to_many_inlined_child(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    values: Vec<ParsedInputValue<'_>>,
+    values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     for value in values {
@@ -366,7 +366,7 @@ fn one_to_many_inlined_parent(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    mut values: Vec<ParsedInputValue<'_>>,
+    mut values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let parent_link = parent_relation_field.linking_fields();

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -277,11 +277,7 @@ fn one_to_many_inlined_child(
         graph.create_edge(
             &read_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model.shard_aware_primary_identifier(),
-                RowSink::All(&IfInput),
-                None,
-            ),
+            QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
         )?;
 
         graph.create_edge(
@@ -399,11 +395,7 @@ fn one_to_many_inlined_parent(
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model.shard_aware_primary_identifier(),
-            RowSink::All(&IfInput),
-            None,
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
     )?;
 
     graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
@@ -532,11 +524,7 @@ fn one_to_one_inlined_parent(
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model.shard_aware_primary_identifier(),
-            RowSink::All(&IfInput),
-            None,
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
     )?;
 
     // Then branch handling
@@ -710,7 +698,7 @@ fn one_to_one_inlined_child(
     graph.create_edge(
         &read_new_child_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
     )?;
 
     // *** Else branch handling ***

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -117,22 +117,38 @@ fn handle_many_to_many(
 
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let if_node = graph.create_node(Flow::if_non_empty());
-
-        let connect_exists_node =
-            connect::connect_records_node(graph, &parent_node, &read_node, parent_relation_field, 1)?;
-
-        let _connect_create_node =
-            connect::connect_records_node(graph, &parent_node, &create_node, parent_relation_field, 1)?;
+        let return_existing = graph.create_node(Flow::Return(Vec::new()));
+        let return_create = graph.create_node(Flow::Return(Vec::new()));
 
         graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
         graph.create_edge(
             &read_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier, RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::All(&IfInput),
+                None,
+            ),
         )?;
 
-        graph.create_edge(&if_node, &connect_exists_node, QueryGraphDependency::Then)?;
+        graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
         graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
+        graph.create_edge(
+            &read_node,
+            &return_existing,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::All(&ReturnInput),
+                None,
+            ),
+        )?;
+        graph.create_edge(
+            &create_node,
+            &return_create,
+            QueryGraphDependency::ProjectedDataDependency(child_model_identifier, RowSink::All(&ReturnInput), None),
+        )?;
+
+        connect::connect_records_node(graph, &parent_node, &if_node, parent_relation_field, 1)?;
     }
 
     Ok(())

--- a/query-compiler/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -297,16 +297,16 @@ fn handle_one_to_many(
             ),
         )?;
     } else {
-        for create_node in create_nodes {
-            let parent_link = parent_relation_field.linking_fields();
-            let child_link = parent_relation_field.related_field().linking_fields();
+        let parent_link = parent_relation_field.linking_fields();
+        let child_link = parent_relation_field.related_field().linking_fields();
 
+        for create_node in create_nodes {
             graph.create_edge(
                 &parent_node,
                 &create_node,
                 QueryGraphDependency::ProjectedDataDependency(
-                    parent_link,
-                    RowSink::ExactlyOneWriteArgs(child_link, &UpdateOrCreateArgsInput),
+                    parent_link.clone(),
+                    RowSink::ExactlyOneWriteArgs(child_link.clone(), &UpdateOrCreateArgsInput),
                     Some(DataExpectation::non_empty_rows(
                         MissingRelatedRecord::builder()
                             .model(&parent_relation_field.model())

--- a/query-compiler/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    DataExpectation, ParsedInputList, ParsedInputValue, RowSink,
+    DataExpectation, ParsedInputValue, RowSink,
     inputs::{UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput},
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
@@ -24,7 +24,7 @@ pub fn nested_create(
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
 
-    let data_maps = utils::coerce_vec(value)
+    let data_maps = utils::coerce_values(value)
         .into_iter()
         .map(|value| {
             let mut parser = WriteArgsParser::from(child_model, value.try_into()?)?;
@@ -537,7 +537,7 @@ pub fn nested_create_many(
     // Nested input is an object of { data: [...], skipDuplicates: bool }
     let mut obj: ParsedInputMap<'_> = value.try_into()?;
 
-    let data_list: ParsedInputList<'_> = utils::coerce_vec(obj.swap_remove(args::DATA).unwrap());
+    let data_list = utils::coerce_values(obj.swap_remove(args::DATA).unwrap());
     let skip_duplicates: bool = match obj.swap_remove(args::SKIP_DUPLICATES) {
         Some(val) => val.try_into()?,
         None => false,

--- a/query-compiler/core/src/query_graph_builder/write/nested/delete_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/delete_nested.rs
@@ -31,7 +31,7 @@ pub fn nested_delete(
     let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
     if parent_relation_field.is_list() {
-        let filters: Vec<Filter> = utils::coerce_vec(value)
+        let filters: Vec<Filter> = utils::coerce_values(value)
             .into_iter()
             .map(|value: ParsedInputValue<'_>| {
                 let value: ParsedInputMap<'_> = value.try_into()?;
@@ -129,7 +129,7 @@ pub fn nested_delete_many(
 ) -> QueryGraphBuilderResult<()> {
     let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
-    for value in utils::coerce_vec(value) {
+    for value in utils::coerce_values(value) {
         let as_map: ParsedInputMap<'_> = value.try_into()?;
         let filter = extract_filter(as_map, child_model)?;
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -23,7 +23,7 @@ pub fn nested_disconnect(
 
     if relation.is_many_to_many() {
         // Build all filters upfront.
-        let filters: Vec<Filter> = utils::coerce_vec(value)
+        let filters: Vec<Filter> = utils::coerce_values(value)
             .into_iter()
             .map(|value: ParsedInputValue<'_>| {
                 let value: ParsedInputMap<'_> = value.try_into()?;
@@ -53,7 +53,7 @@ pub fn nested_disconnect(
             // One-to-many specify a number of finders if the parent side is the to-one.
             // todo check if this if else is really still required.
             if parent_relation_field.is_list() {
-                let filters = utils::coerce_vec(value)
+                let filters = utils::coerce_values(value)
                     .into_iter()
                     .map(|value: ParsedInputValue<'_>| {
                         let value: ParsedInputMap<'_> = value.try_into()?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -5,7 +5,9 @@ use crate::{
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
 use itertools::Itertools;
-use query_structure::{Filter, Model, PrismaValue, RelationCompare, RelationFieldRef, SelectionResult, WriteArgs};
+use query_structure::{
+    Filter, Model, PrismaValue, RelationCompare, RelationFieldRef, ScalarFieldRef, SelectionResult, WriteArgs,
+};
 use std::convert::TryInto;
 
 /// Handles nested disconnect cases.
@@ -22,13 +24,34 @@ pub fn nested_disconnect(
     let relation = parent_relation_field.relation();
 
     if relation.is_many_to_many() {
-        // Build all filters upfront.
-        let filters: Vec<Filter> = utils::coerce_values(value)
+        let values = utils::coerce_values(value);
+        let mut selectors = Vec::with_capacity(values.len());
+
+        for value in values {
+            selectors.push(value.try_into()?);
+        }
+
+        if let Some(child_id_field) = child_model.single_primary_identifier_scalar() {
+            let mut child_ids = Vec::with_capacity(selectors.len());
+
+            for selector in &selectors {
+                let Some(child_id) = try_extract_child_primary_identifier(selector, &child_id_field)? else {
+                    child_ids.clear();
+                    break;
+                };
+
+                child_ids.push(child_id);
+            }
+
+            if child_ids.len() == selectors.len() {
+                let child_ids = child_ids.into_iter().unique().collect();
+                return handle_many_to_many_with_child_ids(graph, &parent_node, parent_relation_field, child_ids);
+            }
+        }
+
+        let filters: Vec<Filter> = selectors
             .into_iter()
-            .map(|value: ParsedInputValue<'_>| {
-                let value: ParsedInputMap<'_> = value.try_into()?;
-                extract_unique_filter(value, child_model)
-            })
+            .map(|value| extract_unique_filter(value, child_model))
             .collect::<QueryGraphBuilderResult<Vec<Filter>>>()?
             .into_iter()
             .unique()
@@ -74,6 +97,27 @@ pub fn nested_disconnect(
     }
 }
 
+fn try_extract_child_primary_identifier(
+    selector: &ParsedInputMap<'_>,
+    child_id_field: &ScalarFieldRef,
+) -> QueryGraphBuilderResult<Option<SelectionResult>> {
+    if selector.len() != 1 {
+        return Ok(None);
+    }
+
+    let Some((field_name, value)) = selector.iter().next() else {
+        return Ok(None);
+    };
+
+    if field_name.as_ref() != child_id_field.name() {
+        return Ok(None);
+    }
+
+    let value: PrismaValue = value.clone().try_into()?;
+
+    Ok(Some(SelectionResult::new(vec![(child_id_field.clone(), value)])))
+}
+
 /// Handles a nested many-to-many disconnect.
 ///
 /// Creates a disconnect node in the graph and creates edges to `parent_node` and `child_node`.
@@ -115,6 +159,20 @@ fn handle_many_to_many(
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, filter)?;
 
     disconnect::disconnect_records_node(graph, parent_node, &find_child_records_node, parent_relation_field)?;
+    Ok(())
+}
+
+fn handle_many_to_many_with_child_ids(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+    child_ids: Vec<SelectionResult>,
+) -> QueryGraphBuilderResult<()> {
+    if child_ids.is_empty() {
+        return Ok(());
+    }
+
+    disconnect::disconnect_records_node_with_child_ids(graph, parent_node, parent_relation_field, child_ids)?;
     Ok(())
 }
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -2,10 +2,9 @@ use super::*;
 use crate::{
     ParsedInputValue,
     inputs::{
-        DisconnectChildrenInput, DisconnectParentInput, IfInput, LeftSideDiffInput, RequiredOneToManySetNewInput,
-        RequiredOneToManySetOldInput, RightSideDiffInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
+        IfInput, LeftSideDiffInput, RequiredOneToManySetNewInput, RequiredOneToManySetOldInput, RightSideDiffInput,
+        UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
     },
-    query_ast::*,
     query_graph::*,
 };
 use query_structure::{Filter, Model, RelationFieldRef, SelectionResult, WriteArgs};
@@ -59,16 +58,9 @@ pub fn nested_set(
 /// │           │           │
 /// │           │           │         │
 /// │           ▼           │         ▼
-/// │  ┌─────────────────┐  │  ┌ ─ ─ ─ ─ ─ ─ ┐
-/// │  │Read old children│  │      Result
-/// │  └─────────────────┘  │  └ ─ ─ ─ ─ ─ ─ ┘
-/// │           │           │
-/// │           │           │
-/// │           │           │
-/// │           ▼           │
-/// │  ┌─────────────────┐  │
-/// │  │   Disconnect    │◀─┘
-/// │  └─────────────────┘
+/// │  ┌─────────────────┐     ┌ ─ ─ ─ ─ ─ ─ ┐
+/// │  │ Disconnect all  │        Result
+/// │  └─────────────────┘     └ ─ ─ ─ ─ ─ ─ ┘
 /// │           │
 /// │           │
 /// │           │
@@ -95,52 +87,13 @@ fn handle_many_to_many(
 ) -> QueryGraphBuilderResult<()> {
     let child_model = parent_relation_field.related_model();
 
+    let disconnect_node = disconnect::disconnect_all_records_node(graph, parent_node, parent_relation_field)?;
+
     if filter.size() == 0 {
-        disconnect::disconnect_all_records_node(graph, parent_node, parent_relation_field)?;
         return Ok(());
     }
 
-    let read_old_node =
-        utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
-
     let child_model_identifier = child_model.shard_aware_primary_identifier();
-    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
-
-    let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
-        parent_id: None,
-        child_ids: vec![],
-        relation_field: parent_relation_field.clone(),
-    });
-
-    let disconnect_node = graph.create_node(Query::Write(disconnect));
-
-    graph.create_edge(
-        parent_node,
-        &disconnect_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            parent_model_identifier,
-            RowSink::Single(&DisconnectParentInput),
-            Some(DataExpectation::non_empty_rows(
-                MissingRelatedRecord::builder()
-                    .model(&parent_relation_field.model())
-                    .relation(&parent_relation_field.relation())
-                    .needed_for(DependentOperation::disconnect_records())
-                    .operation(DataOperation::NestedSet)
-                    .build(),
-            )),
-        ),
-    )?;
-
-    graph.create_edge(
-        &read_old_node,
-        &disconnect_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model_identifier.clone(),
-            RowSink::All(&DisconnectChildrenInput),
-            None,
-        ),
-    )?;
-
     let expected_connects = filter.size();
     let read_new_query = utils::read_ids_infallible(child_model, child_model_identifier, filter);
     let read_new_node = graph.create_node(read_new_query);

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -8,7 +8,6 @@ use crate::{
     query_ast::*,
     query_graph::*,
 };
-use itertools::Itertools;
 use query_structure::{Filter, Model, RelationFieldRef, SelectionResult, WriteArgs};
 use std::convert::TryInto;
 
@@ -26,17 +25,17 @@ pub fn nested_set(
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
 
-    // Build all filters upfront.
-    let filters: Vec<Filter> = utils::coerce_vec(value)
-        .into_iter()
-        .map(|value: ParsedInputValue<'_>| {
-            let value: ParsedInputMap<'_> = value.try_into()?;
-            extract_unique_filter(value, child_model)
-        })
-        .collect::<QueryGraphBuilderResult<Vec<Filter>>>()?
-        .into_iter()
-        .unique()
-        .collect();
+    let values = utils::coerce_vec(value);
+    let mut filters = Vec::with_capacity(values.len());
+
+    for value in values {
+        let value: ParsedInputMap<'_> = value.try_into()?;
+        let filter = extract_unique_filter(value, child_model)?;
+
+        if !filters.iter().any(|existing| existing == &filter) {
+            filters.push(filter);
+        }
+    }
 
     let filter = Filter::or(filters);
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -230,7 +230,11 @@ fn handle_one_to_many(
         graph.create_edge(
             &read_old_node,
             &disconnect_if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         graph.create_edge(&disconnect_if_node, &update_disconnect_node, QueryGraphDependency::Then)?;
@@ -264,7 +268,7 @@ fn handle_one_to_many(
         &diff_left_to_right_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&LeftSideDiffInput),
+            RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
             None,
         ),
     )?;
@@ -273,7 +277,7 @@ fn handle_one_to_many(
         &diff_right_to_left_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&LeftSideDiffInput),
+            RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
             None,
         ),
     )?;
@@ -284,7 +288,7 @@ fn handle_one_to_many(
         &diff_left_to_right_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&RightSideDiffInput),
+            RowSink::ProjectedPlaceholder(&RightSideDiffInput),
             None,
         ),
     )?;
@@ -293,7 +297,7 @@ fn handle_one_to_many(
         &diff_right_to_left_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&RightSideDiffInput),
+            RowSink::ProjectedPlaceholder(&RightSideDiffInput),
             None,
         ),
     )?;
@@ -306,7 +310,11 @@ fn handle_one_to_many(
     graph.create_edge(
         &diff_left_to_right_node,
         &connect_if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // Connect to the if node, the parent node (for the inlining ID) and the diff node (to get the IDs to update)
@@ -354,7 +362,11 @@ fn handle_one_to_many(
     graph.create_edge(
         &diff_right_to_left_node,
         &disconnect_if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // Connect to the if node and the diff node (to get the IDs to update)

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -215,6 +215,39 @@ fn handle_one_to_many(
     let read_old_node =
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
 
+    if filter.size() == 0 {
+        let disconnect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
+        let write_args = WriteArgs::from_result(empty_child_link, crate::request_context::get_request_now());
+        let update_disconnect_node =
+            utils::update_records_node_placeholder_with_args(graph, Filter::empty(), child_model, write_args);
+
+        let child_side_required = parent_relation_field.related_field().is_required();
+        let rf = parent_relation_field.clone();
+
+        graph.create_edge(
+            &read_old_node,
+            &disconnect_if_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::All(&IfInput),
+                child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
+            ),
+        )?;
+
+        graph.create_edge(&disconnect_if_node, &update_disconnect_node, QueryGraphDependency::Then)?;
+        graph.create_edge(
+            &read_old_node,
+            &update_disconnect_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier,
+                RowSink::All(&UpdateManyRecordsSelectorsInput),
+                None,
+            ),
+        )?;
+
+        return Ok(());
+    }
+
     let read_new_query = utils::read_ids_infallible(child_model.clone(), child_model_identifier.clone(), filter);
     let read_new_node = graph.create_node(read_new_query);
     let diff_left_to_right_node = graph.create_node(Node::Computation(Computation::empty_diff_left_to_right(

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -93,11 +93,18 @@ fn handle_many_to_many(
     parent_relation_field: &RelationFieldRef,
     filter: Filter,
 ) -> QueryGraphBuilderResult<()> {
-    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
     let child_model = parent_relation_field.related_model();
-    let child_model_identifier = child_model.shard_aware_primary_identifier();
+
+    if filter.size() == 0 {
+        disconnect::disconnect_all_records_node(graph, parent_node, parent_relation_field)?;
+        return Ok(());
+    }
+
     let read_old_node =
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
+
+    let child_model_identifier = child_model.shard_aware_primary_identifier();
+    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
 
     let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
         parent_id: None,
@@ -107,7 +114,6 @@ fn handle_many_to_many(
 
     let disconnect_node = graph.create_node(Query::Write(disconnect));
 
-    // Edge from parent to disconnect
     graph.create_edge(
         parent_node,
         &disconnect_node,
@@ -125,7 +131,6 @@ fn handle_many_to_many(
         ),
     )?;
 
-    // Edge from read to disconnect.
     graph.create_edge(
         &read_old_node,
         &disconnect_node,
@@ -136,21 +141,19 @@ fn handle_many_to_many(
         ),
     )?;
 
-    if filter.size() > 0 {
-        let expected_connects = filter.size();
-        let read_new_query = utils::read_ids_infallible(child_model, child_model_identifier, filter);
-        let read_new_node = graph.create_node(read_new_query);
+    let expected_connects = filter.size();
+    let read_new_query = utils::read_ids_infallible(child_model, child_model_identifier, filter);
+    let read_new_node = graph.create_node(read_new_query);
 
-        graph.create_edge(&disconnect_node, &read_new_node, QueryGraphDependency::ExecutionOrder)?;
+    graph.create_edge(&disconnect_node, &read_new_node, QueryGraphDependency::ExecutionOrder)?;
 
-        connect::connect_records_node(
-            graph,
-            parent_node,
-            &read_new_node,
-            parent_relation_field,
-            expected_connects,
-        )?;
-    }
+    connect::connect_records_node(
+        graph,
+        parent_node,
+        &read_new_node,
+        parent_relation_field,
+        expected_connects,
+    )?;
 
     Ok(())
 }

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -209,29 +209,28 @@ fn handle_one_to_many(
     let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
     let child_link = parent_relation_field.related_field().linking_fields();
     let parent_link = parent_relation_field.linking_fields();
-    let empty_child_link = SelectionResult::from(&child_link);
+    let child_side_required = parent_relation_field.related_field().is_required();
 
     let child_model = parent_relation_field.related_model();
     let read_old_node =
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
 
     if filter.size() == 0 {
+        if child_side_required {
+            insert_required_relation_disconnect_check(graph, &read_old_node, parent_relation_field)?;
+            return Ok(());
+        }
+
         let disconnect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
+        let empty_child_link = SelectionResult::from(&child_link);
         let write_args = WriteArgs::from_result(empty_child_link, crate::request_context::get_request_now());
         let update_disconnect_node =
             utils::update_records_node_placeholder_with_args(graph, Filter::empty(), child_model, write_args);
 
-        let child_side_required = parent_relation_field.related_field().is_required();
-        let rf = parent_relation_field.clone();
-
         graph.create_edge(
             &read_old_node,
             &disconnect_if_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model_identifier.clone(),
-                RowSink::All(&IfInput),
-                child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
-            ),
+            QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
         )?;
 
         graph.create_edge(&disconnect_if_node, &update_disconnect_node, QueryGraphDependency::Then)?;
@@ -302,6 +301,7 @@ fn handle_one_to_many(
     // Update (connect) case: Check left diff IDs
     let connect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
     let update_connect_node = utils::update_records_node_placeholder(graph, Filter::empty(), child_model.clone());
+    let empty_child_link = (!child_side_required).then(|| SelectionResult::from(&child_link));
 
     graph.create_edge(
         &diff_left_to_right_node,
@@ -338,22 +338,23 @@ fn handle_one_to_many(
     )?;
 
     // Update (disconnect) case: Check right diff IDs.
+    if child_side_required {
+        insert_required_relation_disconnect_check(graph, &diff_right_to_left_node, parent_relation_field)?;
+        return Ok(());
+    }
+
     let disconnect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
-    let write_args = WriteArgs::from_result(empty_child_link, crate::request_context::get_request_now());
+    let write_args = WriteArgs::from_result(
+        empty_child_link.expect("optional child side needs null write args"),
+        crate::request_context::get_request_now(),
+    );
     let update_disconnect_node =
         utils::update_records_node_placeholder_with_args(graph, Filter::empty(), child_model, write_args);
-
-    let child_side_required = parent_relation_field.related_field().is_required();
-    let rf = parent_relation_field.clone();
 
     graph.create_edge(
         &diff_right_to_left_node,
         &disconnect_if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model_identifier.clone(),
-            RowSink::All(&IfInput),
-            child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
     )?;
 
     // Connect to the if node and the diff node (to get the IDs to update)
@@ -365,6 +366,27 @@ fn handle_one_to_many(
             child_model_identifier,
             RowSink::All(&UpdateManyRecordsSelectorsInput),
             None,
+        ),
+    )?;
+
+    Ok(())
+}
+
+fn insert_required_relation_disconnect_check(
+    graph: &mut QueryGraph,
+    node_providing_ids: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+) -> QueryGraphBuilderResult<()> {
+    let check_node = graph.create_node(Node::Empty);
+
+    graph.create_edge(
+        node_providing_ids,
+        &check_node,
+        QueryGraphDependency::DataDependency(
+            RowCountSink::Discard,
+            Some(DataExpectation::empty_rows(RelationViolation::from(
+                parent_relation_field.clone(),
+            ))),
         ),
     )?;
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -25,7 +25,7 @@ pub fn nested_set(
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
 
-    let values = utils::coerce_vec(value);
+    let values = utils::coerce_values(value);
     let mut filters = Vec::with_capacity(values.len());
 
     for value in values {

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::{
     ParsedInputValue,
     inputs::{
-        DisconnectChildrenInput, DisconnectParentInput, IfInput, LeftSideDiffInput, RightSideDiffInput,
-        UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
+        DisconnectChildrenInput, DisconnectParentInput, IfInput, LeftSideDiffInput, RequiredOneToManySetNewInput,
+        RequiredOneToManySetOldInput, RightSideDiffInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
     },
     query_ast::*,
     query_graph::*,
@@ -253,6 +253,53 @@ fn handle_one_to_many(
 
     let read_new_query = utils::read_ids_infallible(child_model.clone(), child_model_identifier.clone(), filter);
     let read_new_node = graph.create_node(read_new_query);
+
+    if child_side_required
+        && child_model_identifier.selections().len() == 1
+        && parent_link.selections().len() == 1
+        && child_link.selections().len() == 1
+    {
+        let set_node = graph.create_node(Node::Computation(Computation::required_one_to_many_set(
+            child_model_identifier.clone(),
+            *parent_node,
+            parent_link,
+            child_link,
+            child_model,
+            DataExpectation::non_empty_rows(
+                MissingRelatedRecord::builder()
+                    .model(&parent_relation_field.model())
+                    .relation(&parent_relation_field.relation())
+                    .operation(DataOperation::NestedSet)
+                    .build(),
+            ),
+            DataExpectation::empty_rows(RelationViolation::from(parent_relation_field.clone())),
+            crate::request_context::get_request_now(),
+        )));
+
+        graph.create_edge(&read_old_node, &read_new_node, QueryGraphDependency::ExecutionOrder)?;
+
+        graph.create_edge(
+            &read_old_node,
+            &set_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&RequiredOneToManySetOldInput),
+                None,
+            ),
+        )?;
+        graph.create_edge(
+            &read_new_node,
+            &set_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier,
+                RowSink::ProjectedPlaceholder(&RequiredOneToManySetNewInput),
+                None,
+            ),
+        )?;
+
+        return Ok(());
+    }
+
     let diff_left_to_right_node = graph.create_node(Node::Computation(Computation::empty_diff_left_to_right(
         child_model_identifier.clone(),
     )));

--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -94,14 +94,14 @@ pub fn nested_update(
         let update_args = WriteArgsParser::from(child_model, data_map)?;
 
         if update_args.args.is_empty() && !update_args.nested.is_empty() {
-            let return_node = graph.create_node(Flow::Return(Vec::new()));
+            let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
                 &find_child_records_node,
                 &return_node,
                 QueryGraphDependency::ProjectedDataDependency(
                     child_model_identifier,
-                    RowSink::All(&ReturnInput),
+                    RowSink::ProjectedPlaceholder(&ReturnInput),
                     Some(DataExpectation::non_empty_rows(
                         MissingRelatedRecord::builder()
                             .model(child_model)

--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -1,10 +1,11 @@
 use super::*;
-use crate::inputs::{UpdateManyRecordsSelectorsInput, UpdateRecordSelectorsInput};
+use crate::inputs::{ReturnInput, UpdateManyRecordsSelectorsInput, UpdateRecordSelectorsInput};
+use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::query_graph_builder::write::update::UpdateManyRecordNodeOptionals;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputValue,
-    query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
+    query_graph::{Flow, NodeRef, QueryGraph, QueryGraphDependency},
 };
 use query_structure::{Filter, Model, RelationFieldRef};
 use schema::constants::args;
@@ -89,8 +90,37 @@ pub fn nested_update(
         let find_child_records_node =
             utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter.clone())?;
 
-        let update_node = update::update_record_node(graph, query_schema, filter, child_model.clone(), data_map, None)?;
         let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
+        let update_args = WriteArgsParser::from(child_model, data_map)?;
+
+        if update_args.args.is_empty() && !update_args.nested.is_empty() {
+            let return_node = graph.create_node(Flow::Return(Vec::new()));
+
+            graph.create_edge(
+                &find_child_records_node,
+                &return_node,
+                QueryGraphDependency::ProjectedDataDependency(
+                    child_model_identifier,
+                    RowSink::All(&ReturnInput),
+                    Some(DataExpectation::non_empty_rows(
+                        MissingRelatedRecord::builder()
+                            .model(child_model)
+                            .relation(&parent_relation_field.relation())
+                            .operation(DataOperation::NestedUpdate)
+                            .build(),
+                    )),
+                ),
+            )?;
+
+            for (relation_field, data_map) in update_args.nested {
+                connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+            }
+
+            continue;
+        }
+
+        let update_node =
+            update::update_record_node_from_args(graph, query_schema, filter, child_model.clone(), update_args, None)?;
 
         graph.create_edge(
             &find_child_records_node,

--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -1,13 +1,13 @@
 use super::*;
 use crate::inputs::{ReturnInput, UpdateManyRecordsSelectorsInput, UpdateRecordSelectorsInput};
-use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::query_graph_builder::write::update::UpdateManyRecordNodeOptionals;
+use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputValue,
     query_graph::{Flow, NodeRef, QueryGraph, QueryGraphDependency},
 };
-use query_structure::{Filter, Model, RelationFieldRef};
+use query_structure::{FieldSelection, Filter, Model, RelationFieldRef, SelectedField};
 use schema::constants::args;
 use std::convert::TryInto;
 
@@ -87,13 +87,27 @@ pub fn nested_update(
             return Ok(());
         }
 
-        let find_child_records_node =
-            utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter.clone())?;
-
         let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
         let update_args = WriteArgsParser::from(child_model, data_map)?;
 
         if update_args.args.is_empty() && !update_args.nested.is_empty() {
+            if let Some(return_node) = insert_parent_link_return_node(
+                graph,
+                query_schema,
+                parent,
+                parent_relation_field,
+                &filter,
+                &child_model_identifier,
+            )? {
+                for (relation_field, data_map) in update_args.nested {
+                    connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+                }
+
+                continue;
+            }
+
+            let find_child_records_node =
+                utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter)?;
             let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
@@ -119,6 +133,8 @@ pub fn nested_update(
             continue;
         }
 
+        let find_child_records_node =
+            utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter.clone())?;
         let update_node =
             update::update_record_node_from_args(graph, query_schema, filter, child_model.clone(), update_args, None)?;
 
@@ -142,6 +158,47 @@ pub fn nested_update(
     }
 
     Ok(())
+}
+
+fn insert_parent_link_return_node(
+    graph: &mut QueryGraph,
+    query_schema: &QuerySchema,
+    parent: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+    filter: &Filter,
+    child_model_identifier: &FieldSelection,
+) -> QueryGraphBuilderResult<Option<NodeRef>> {
+    if query_schema.relation_mode().is_prisma()
+        || parent_relation_field.is_list()
+        || !parent_relation_field.is_required()
+        || !parent_relation_field.is_inlined_on_enclosing_model()
+        || !filter.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let parent_scalars = parent_relation_field.scalar_fields();
+    let child_link = parent_relation_field.related_field().linking_fields();
+
+    if parent_scalars.len() != 1 || child_link.selections().len() != 1 || child_link != *child_model_identifier {
+        return Ok(None);
+    }
+
+    let parent_link = FieldSelection::new(vec![SelectedField::Scalar(parent_scalars[0].clone())]);
+
+    let return_node = graph.create_node(Flow::Return(None));
+
+    graph.create_edge(
+        parent,
+        &return_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            parent_link,
+            RowSink::ProjectedFieldPlaceholder(&ReturnInput),
+            None,
+        ),
+    )?;
+
+    Ok(Some(return_node))
 }
 
 pub fn nested_update_many(

--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -46,7 +46,7 @@ pub fn nested_update(
     value: ParsedInputValue<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    for value in utils::coerce_vec(value) {
+    for value in utils::coerce_values(value) {
         let (data, filter) = if parent_relation_field.is_list() {
             // We have to have a single record filter in "where".
             // This is used to read the children first, to make sure they're actually connected.
@@ -122,7 +122,7 @@ pub fn nested_update_many(
     value: ParsedInputValue<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    for value in utils::coerce_vec(value) {
+    for value in utils::coerce_values(value) {
         let mut map: ParsedInputMap<'_> = value.try_into()?;
         let where_arg = map.swap_remove(args::WHERE).unwrap();
         let data_value = map.swap_remove(args::DATA).unwrap();

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -1,6 +1,9 @@
 use super::*;
-use crate::inputs::{IfInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput, UpdateRecordSelectorsInput};
+use crate::inputs::{
+    IfInput, ReturnInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput, UpdateRecordSelectorsInput,
+};
 use crate::query_graph_builder::write::utils::coerce_values;
+use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputMap, ParsedInputValue,
@@ -138,14 +141,9 @@ pub fn nested_upsert(
         let if_node = graph.create_node(Flow::if_non_empty());
         let create_node =
             create::create_record_node(graph, query_schema, child_model.clone(), create_input.try_into()?)?;
-        let update_node = update::update_record_node(
-            graph,
-            query_schema,
-            filter.clone(),
-            child_model.clone(),
-            update_input.try_into()?,
-            None,
-        )?;
+        let update_map: ParsedInputMap<'_> = update_input.try_into()?;
+        let update_args = WriteArgsParser::from(&child_model, update_map)?;
+        let is_nested_only_update = update_args.args.is_empty() && !update_args.nested.is_empty();
 
         graph.create_edge(
             &read_children_node,
@@ -153,41 +151,77 @@ pub fn nested_upsert(
             QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
         )?;
 
-        graph.create_edge(
-            &read_children_node,
-            &update_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model_identifier.clone(),
-                RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
-                Some(DataExpectation::non_empty_rows(
-                    MissingRelatedRecord::builder()
-                        .model(&child_model)
-                        .relation(&parent_relation_field.relation())
-                        .needed_for(DependentOperation::nested_update())
-                        .operation(DataOperation::NestedUpsert)
-                        .build(),
-                )),
-            ),
-        )?;
+        let then_node = if is_nested_only_update {
+            let return_node = graph.create_node(Flow::Return(Vec::new()));
 
-        // In case the connector doesn't support referential integrity, we add a subtree to the graph that emulates the ON_UPDATE referential action.
-        // When that's the case, we create an intermediary node to which we connect all the nodes reponsible for emulating the referential action
-        // Then, we connect the if node to that intermediary emulation node. This enables performing the emulation only in case the graph traverses
-        // the update path (if the children already exists and goes to the THEN node).
-        // It's only after we've executed the emulation that it'll traverse the update node, hence the ExecutionOrder between
-        // the emulation node and the update node.
-        let then_node = if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
-            graph,
-            query_schema,
-            &child_model,
-            &read_children_node,
-            &update_node,
-        )? {
-            graph.create_edge(&emulation_node, &update_node, QueryGraphDependency::ExecutionOrder)?;
+            graph.create_edge(
+                &read_children_node,
+                &return_node,
+                QueryGraphDependency::ProjectedDataDependency(
+                    child_model_identifier.clone(),
+                    RowSink::All(&ReturnInput),
+                    Some(DataExpectation::non_empty_rows(
+                        MissingRelatedRecord::builder()
+                            .model(&child_model)
+                            .relation(&parent_relation_field.relation())
+                            .needed_for(DependentOperation::nested_update())
+                            .operation(DataOperation::NestedUpsert)
+                            .build(),
+                    )),
+                ),
+            )?;
 
-            emulation_node
+            for (relation_field, data_map) in update_args.nested {
+                connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+            }
+
+            return_node
         } else {
-            update_node
+            let update_node = update::update_record_node_from_args(
+                graph,
+                query_schema,
+                filter.clone(),
+                child_model.clone(),
+                update_args,
+                None,
+            )?;
+
+            graph.create_edge(
+                &read_children_node,
+                &update_node,
+                QueryGraphDependency::ProjectedDataDependency(
+                    child_model_identifier.clone(),
+                    RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
+                    Some(DataExpectation::non_empty_rows(
+                        MissingRelatedRecord::builder()
+                            .model(&child_model)
+                            .relation(&parent_relation_field.relation())
+                            .needed_for(DependentOperation::nested_update())
+                            .operation(DataOperation::NestedUpsert)
+                            .build(),
+                    )),
+                ),
+            )?;
+
+            // In case the connector doesn't support referential integrity, we add a subtree to the graph that emulates the ON_UPDATE referential action.
+            // When that's the case, we create an intermediary node to which we connect all the nodes reponsible for emulating the referential action
+            // Then, we connect the if node to that intermediary emulation node. This enables performing the emulation only in case the graph traverses
+            // the update path (if the children already exists and goes to the THEN node).
+            // It's only after we've executed the emulation that it'll traverse the update node, hence the ExecutionOrder between
+            // the emulation node and the update node.
+            if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
+                graph,
+                query_schema,
+                &child_model,
+                &read_children_node,
+                &update_node,
+            )? {
+                graph.create_edge(&emulation_node, &update_node, QueryGraphDependency::ExecutionOrder)?;
+
+                emulation_node
+            } else {
+                update_node
+            }
         };
 
         graph.create_edge(&if_node, &then_node, QueryGraphDependency::Then)?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -148,18 +148,22 @@ pub fn nested_upsert(
         graph.create_edge(
             &read_children_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         let then_node = if is_nested_only_update {
-            let return_node = graph.create_node(Flow::Return(Vec::new()));
+            let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
                 &read_children_node,
                 &return_node,
                 QueryGraphDependency::ProjectedDataDependency(
                     child_model_identifier.clone(),
-                    RowSink::All(&ReturnInput),
+                    RowSink::ProjectedPlaceholder(&ReturnInput),
                     Some(DataExpectation::non_empty_rows(
                         MissingRelatedRecord::builder()
                             .model(&child_model)

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -9,9 +9,9 @@ use crate::{
     ParsedInputMap, ParsedInputValue,
     query_graph::{Flow, NodeRef, QueryGraph, QueryGraphDependency},
 };
-use query_structure::{Filter, RelationFieldRef};
-use schema::constants::args;
-use std::convert::TryInto;
+use query_structure::{Filter, Model, RelationFieldRef};
+use schema::constants::{args, operations};
+use std::{borrow::Cow, convert::TryInto};
 
 /// Handles a nested upsert.
 /// The constructed query graph can have different shapes based on the relation
@@ -114,6 +114,9 @@ pub fn nested_upsert(
         let create_input = as_map.swap_remove(args::CREATE).expect("create argument is missing");
         let update_input = as_map.swap_remove(args::UPDATE).expect("update argument is missing");
         let where_input = as_map.swap_remove(args::WHERE);
+        let mut create_map: ParsedInputMap<'_> = create_input.try_into()?;
+        let mut update_map: ParsedInputMap<'_> = update_input.try_into()?;
+        let shared_connect = extract_common_m2m_connect(&child_model, &mut create_map, &mut update_map);
 
         // Read child(ren) node
         let filter = match (where_input, parent_relation_field.is_list()) {
@@ -139,11 +142,11 @@ pub fn nested_upsert(
             utils::insert_find_children_by_parent_node(graph, &parent_node, parent_relation_field, filter.clone())?;
 
         let if_node = graph.create_node(Flow::if_non_empty());
-        let create_node =
-            create::create_record_node(graph, query_schema, child_model.clone(), create_input.try_into()?)?;
-        let update_map: ParsedInputMap<'_> = update_input.try_into()?;
+        let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let update_args = WriteArgsParser::from(&child_model, update_map)?;
         let is_nested_only_update = update_args.args.is_empty() && !update_args.nested.is_empty();
+        let is_shared_connect_only_update =
+            shared_connect.is_some() && update_args.args.is_empty() && update_args.nested.is_empty();
 
         graph.create_edge(
             &read_children_node,
@@ -155,7 +158,7 @@ pub fn nested_upsert(
             ),
         )?;
 
-        let then_node = if is_nested_only_update {
+        let then_node = if is_nested_only_update || is_shared_connect_only_update {
             let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
@@ -299,7 +302,71 @@ pub fn nested_upsert(
                 ),
             )?;
         }
+
+        if let Some((relation_field, connect_value)) = shared_connect {
+            connect_nested_query(
+                graph,
+                query_schema,
+                if_node,
+                relation_field,
+                [(Cow::Borrowed(operations::CONNECT), connect_value)]
+                    .into_iter()
+                    .collect(),
+            )?;
+        }
     }
 
     Ok(())
+}
+
+fn extract_common_m2m_connect<'a>(
+    child_model: &Model,
+    create_map: &mut ParsedInputMap<'a>,
+    update_map: &mut ParsedInputMap<'a>,
+) -> Option<(RelationFieldRef, ParsedInputValue<'a>)> {
+    if update_map.len() != 1 {
+        return None;
+    }
+
+    let (create_field_name, create_relation_field, create_connect) = single_m2m_connect(child_model, create_map)?;
+    let (update_field_name, _, update_connect) = single_m2m_connect(child_model, update_map)?;
+
+    if create_field_name != update_field_name || create_connect != update_connect {
+        return None;
+    }
+
+    create_map.shift_remove(create_field_name.as_ref())?;
+    update_map.shift_remove(update_field_name.as_ref())?;
+
+    Some((create_relation_field, update_connect))
+}
+
+fn single_m2m_connect<'a>(
+    model: &Model,
+    map: &ParsedInputMap<'a>,
+) -> Option<(Cow<'a, str>, RelationFieldRef, ParsedInputValue<'a>)> {
+    let mut connect = None;
+
+    for (field_name, value) in map.iter() {
+        let Ok(relation_field) = model.fields().find_from_relation_fields(field_name) else {
+            continue;
+        };
+
+        if connect.is_some() || !relation_field.relation().is_many_to_many() {
+            return None;
+        }
+
+        let ParsedInputValue::Map(envelope) = value else {
+            return None;
+        };
+
+        if envelope.len() != 1 {
+            return None;
+        }
+
+        let connect_value = envelope.get(operations::CONNECT)?.clone();
+        connect = Some((field_name.clone(), relation_field, connect_value));
+    }
+
+    connect
 }

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::inputs::{IfInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput, UpdateRecordSelectorsInput};
-use crate::query_graph_builder::write::utils::coerce_vec;
+use crate::query_graph_builder::write::utils::coerce_values;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputMap, ParsedInputValue,
@@ -103,7 +103,7 @@ pub fn nested_upsert(
     let child_model = parent_relation_field.related_model();
     let child_model_identifier = child_model.shard_aware_primary_identifier();
 
-    for value in coerce_vec(value) {
+    for value in coerce_values(value) {
         let parent_link = parent_relation_field.linking_fields();
         let child_link = parent_relation_field.related_field().linking_fields();
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -141,12 +141,16 @@ pub fn nested_upsert(
         let read_children_node =
             utils::insert_find_children_by_parent_node(graph, &parent_node, parent_relation_field, filter.clone())?;
 
-        let if_node = graph.create_node(Flow::if_non_empty());
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let update_args = WriteArgsParser::from(&child_model, update_map)?;
         let is_nested_only_update = update_args.args.is_empty() && !update_args.nested.is_empty();
         let is_shared_connect_only_update =
             shared_connect.is_some() && update_args.args.is_empty() && update_args.nested.is_empty();
+        let if_node = graph.create_node(if is_shared_connect_only_update {
+            Flow::if_non_empty_returning_condition()
+        } else {
+            Flow::if_non_empty()
+        });
 
         graph.create_edge(
             &read_children_node,
@@ -158,7 +162,9 @@ pub fn nested_upsert(
             ),
         )?;
 
-        let then_node = if is_nested_only_update || is_shared_connect_only_update {
+        let then_node = if is_shared_connect_only_update {
+            None
+        } else if is_nested_only_update {
             let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
@@ -182,7 +188,7 @@ pub fn nested_upsert(
                 connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
             }
 
-            return_node
+            Some(return_node)
         } else {
             let update_node = update::update_record_node_from_args(
                 graph,
@@ -228,10 +234,14 @@ pub fn nested_upsert(
                 emulation_node
             } else {
                 update_node
-            }
+            };
+
+            Some(update_node)
         };
 
-        graph.create_edge(&if_node, &then_node, QueryGraphDependency::Then)?;
+        if let Some(then_node) = then_node {
+            graph.create_edge(&if_node, &then_node, QueryGraphDependency::Then)?;
+        }
         graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
 
         // Specific handling based on relation type and inlining side.

--- a/query-compiler/core/src/query_graph_builder/write/update.rs
+++ b/query-compiler/core/src/query_graph_builder/write/update.rs
@@ -190,6 +190,21 @@ where
     T: Clone + Into<Filter>,
 {
     let update_args = WriteArgsParser::from(&model, data_map)?;
+
+    update_record_node_from_args(graph, query_schema, filter, model, update_args, field)
+}
+
+pub(crate) fn update_record_node_from_args<T>(
+    graph: &mut QueryGraph,
+    query_schema: &QuerySchema,
+    filter: T,
+    model: Model,
+    update_args: WriteArgsParser<'_>,
+    field: Option<&ParsedField<'_>>,
+) -> QueryGraphBuilderResult<NodeRef>
+where
+    T: Clone + Into<Filter>,
+{
     let mut args = update_args.args;
 
     args.update_datetimes(&model);

--- a/query-compiler/core/src/query_graph_builder/write/update.rs
+++ b/query-compiler/core/src/query_graph_builder/write/update.rs
@@ -203,8 +203,8 @@ where
         // If there's a selected field, fulfill the scalar selection set.
         if let Some(field) = field.cloned() {
             let nested_fields = field.nested_fields.unwrap().fields;
-            let selection_order: Vec<String> = read::utils::collect_selection_order(&nested_fields);
             let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
+            let selection_order = read::utils::collect_selection_order_owned(nested_fields);
 
             Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithSelection(
                 UpdateRecordWithSelection {

--- a/query-compiler/core/src/query_graph_builder/write/update.rs
+++ b/query-compiler/core/src/query_graph_builder/write/update.rs
@@ -206,6 +206,7 @@ where
     T: Clone + Into<Filter>,
 {
     let mut args = update_args.args;
+    let nested = update_args.nested;
 
     args.update_datetimes(&model);
 
@@ -217,9 +218,19 @@ where
     let update_parent = if query_schema.has_capability(ConnectorCapability::UpdateReturning) {
         // If there's a selected field, fulfill the scalar selection set.
         if let Some(field) = field.cloned() {
-            let nested_fields = field.nested_fields.unwrap().fields;
-            let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
-            let selection_order = read::utils::collect_selection_order_owned(nested_fields);
+            let (selected_fields, selection_order) =
+                if args.is_empty() && (field.has_nested_selection() || !nested.is_empty()) {
+                    let selected_fields = model.shard_aware_primary_identifier();
+                    let selection_order = selected_fields.db_names().collect();
+
+                    (selected_fields, selection_order)
+                } else {
+                    let nested_fields = field.nested_fields.unwrap().fields;
+                    let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
+                    let selection_order = read::utils::collect_selection_order_owned(nested_fields);
+
+                    (selected_fields, selection_order)
+                };
 
             Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithSelection(
                 UpdateRecordWithSelection {
@@ -259,7 +270,7 @@ where
 
     let update_node = graph.create_node(update_parent);
 
-    for (relation_field, data_map) in update_args.nested {
+    for (relation_field, data_map) in nested {
         nested::connect_nested_query(graph, query_schema, update_node, relation_field, data_map)?;
     }
 

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -99,10 +99,13 @@ pub(crate) fn upsert_record(
     let read_parent_records = utils::read_ids_infallible(model.clone(), model_id.clone(), filter.clone());
     let read_parent_records_node = graph.create_node(read_parent_records);
 
-    let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
-
     let update_args = WriteArgsParser::from(&model, update_argument)?;
     let is_noop_update = update_args.args.is_empty();
+    let update_has_nested = !update_args.nested.is_empty();
+    let can_share_result_read =
+        is_noop_update && !update_has_nested && !WriteArgsParser::has_nested_operation(&model, &create_argument);
+
+    let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
     let update_node = if is_noop_update {
         let return_node = graph.create_node(Flow::Return(None));
 
@@ -125,11 +128,26 @@ pub(crate) fn upsert_record(
         update::update_record_node_from_args(graph, query_schema, filter, model.clone(), update_args, Some(&field))?
     };
 
-    let read_node_create = graph.create_node(Query::Read(read_query.clone()));
-    let read_node_update = graph.create_node(Query::Read(read_query));
+    let mut read_query = Some(read_query);
+    let read_node_shared = if can_share_result_read {
+        let read_node = graph.create_node(Query::Read(read_query.take().unwrap()));
+        graph.add_result_node(&read_node);
+        Some(read_node)
+    } else {
+        None
+    };
+    let branch_read_nodes = if can_share_result_read {
+        None
+    } else {
+        let read_query = read_query.take().unwrap();
+        let read_node_create = graph.create_node(Query::Read(read_query.clone()));
+        let read_node_update = graph.create_node(Query::Read(read_query));
 
-    graph.add_result_node(&read_node_create);
-    graph.add_result_node(&read_node_update);
+        graph.add_result_node(&read_node_create);
+        graph.add_result_node(&read_node_update);
+
+        Some((read_node_create, read_node_update))
+    };
 
     let if_node = graph.create_node(Flow::if_non_empty());
 
@@ -175,29 +193,43 @@ pub(crate) fn upsert_record(
         )?;
     }
 
-    graph.create_edge(
-        &update_node,
-        &read_node_update,
-        QueryGraphDependency::ProjectedDataDependency(
-            model_id.clone(),
-            RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
-            Some(DataExpectation::non_empty_rows(
-                MissingRecord::builder().operation(DataOperation::Upsert).build(),
-            )),
-        ),
-    )?;
+    if let Some(read_node) = read_node_shared {
+        graph.create_edge(
+            &if_node,
+            &read_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id,
+                RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
+                Some(DataExpectation::non_empty_rows(
+                    MissingRecord::builder().operation(DataOperation::Upsert).build(),
+                )),
+            ),
+        )?;
+    } else if let Some((read_node_create, read_node_update)) = branch_read_nodes {
+        graph.create_edge(
+            &update_node,
+            &read_node_update,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id.clone(),
+                RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
+                Some(DataExpectation::non_empty_rows(
+                    MissingRecord::builder().operation(DataOperation::Upsert).build(),
+                )),
+            ),
+        )?;
 
-    graph.create_edge(
-        &create_node,
-        &read_node_create,
-        QueryGraphDependency::ProjectedDataDependency(
-            model_id,
-            RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
-            Some(DataExpectation::non_empty_rows(
-                MissingRecord::builder().operation(DataOperation::Upsert).build(),
-            )),
-        ),
-    )?;
+        graph.create_edge(
+            &create_node,
+            &read_node_create,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id,
+                RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
+                Some(DataExpectation::non_empty_rows(
+                    MissingRecord::builder().operation(DataOperation::Upsert).build(),
+                )),
+            ),
+        )?;
+    }
 
     Ok(())
 }

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -101,13 +101,20 @@ pub(crate) fn upsert_record(
 
     let update_args = WriteArgsParser::from(&model, update_argument)?;
     let is_noop_update = update_args.args.is_empty();
-    let update_has_nested = !update_args.nested.is_empty();
+    let update_nested_count = update_args.nested.len();
+    let update_has_nested = update_nested_count != 0;
+    let create_has_nested = WriteArgsParser::has_nested_operation(&model, &create_argument);
+    let can_preserve_update_result = update_nested_count == 1;
     let can_share_result_read =
-        is_noop_update && !update_has_nested && !WriteArgsParser::has_nested_operation(&model, &create_argument);
+        is_noop_update && !create_has_nested && (!update_has_nested || can_preserve_update_result);
 
     let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
     let update_node = if is_noop_update {
-        let return_node = graph.create_node(Flow::Return(None));
+        let return_node = if update_has_nested && can_share_result_read {
+            graph.create_node(Flow::return_preserving_result())
+        } else {
+            graph.create_node(Flow::Return(None))
+        };
 
         graph.create_edge(
             &read_parent_records_node,

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -104,12 +104,16 @@ pub(crate) fn upsert_record(
     let update_args = WriteArgsParser::from(&model, update_argument)?;
     let is_noop_update = update_args.args.is_empty();
     let update_node = if is_noop_update {
-        let return_node = graph.create_node(Flow::Return(Vec::new()));
+        let return_node = graph.create_node(Flow::Return(None));
 
         graph.create_edge(
             &read_parent_records_node,
             &return_node,
-            QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::All(&ReturnInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id.clone(),
+                RowSink::ProjectedPlaceholder(&ReturnInput),
+                None,
+            ),
         )?;
 
         for (relation_field, data_map) in update_args.nested {
@@ -132,7 +136,7 @@ pub(crate) fn upsert_record(
     graph.create_edge(
         &read_parent_records_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::ProjectedPlaceholder(&IfInput), None),
     )?;
 
     // In case the connector doesn't support referential integrity, we add a subtree to the graph that emulates the ON_UPDATE referential action.

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -232,7 +232,7 @@ fn can_use_connector_native_upsert<'a>(
 fn is_unique_field(field_name: &str, model: &Model) -> bool {
     match model.fields().find_from_scalar(field_name) {
         Ok(field) => field.unique(),
-        Err(_) => resolve_compound_field(field_name, model).is_some(),
+        Err(_) => is_compound_field(field_name, model),
     }
 }
 

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -1,7 +1,7 @@
 use super::{write_args_parser::WriteArgsParser, *};
 use crate::{
     DataExpectation, ParsedField, ParsedInputMap, ParsedInputValue, ParsedObject, RowSink,
-    inputs::{IfInput, RecordQueryFilterInput, UpdateRecordSelectorsInput},
+    inputs::{IfInput, RecordQueryFilterInput, ReturnInput, UpdateRecordSelectorsInput},
     query_ast::*,
     query_graph::{Flow, QueryGraph, QueryGraphDependency},
 };
@@ -101,14 +101,25 @@ pub(crate) fn upsert_record(
 
     let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
 
-    let update_node = update::update_record_node(
-        graph,
-        query_schema,
-        filter,
-        model.clone(),
-        update_argument,
-        Some(&field),
-    )?;
+    let update_args = WriteArgsParser::from(&model, update_argument)?;
+    let is_noop_update = update_args.args.is_empty();
+    let update_node = if is_noop_update {
+        let return_node = graph.create_node(Flow::Return(Vec::new()));
+
+        graph.create_edge(
+            &read_parent_records_node,
+            &return_node,
+            QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::All(&ReturnInput), None),
+        )?;
+
+        for (relation_field, data_map) in update_args.nested {
+            nested::connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+        }
+
+        return_node
+    } else {
+        update::update_record_node_from_args(graph, query_schema, filter, model.clone(), update_args, Some(&field))?
+    };
 
     let read_node_create = graph.create_node(Query::Read(read_query.clone()));
     let read_node_update = graph.create_node(Query::Read(read_query));
@@ -130,7 +141,9 @@ pub(crate) fn upsert_record(
     // the update path (if the children already exists and goes to the THEN node).
     // It's only after we've executed the emulation that it'll traverse the update node, hence the ExecutionOrder between
     // the emulation node and the update node.
-    if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
+    if is_noop_update {
+        graph.create_edge(&if_node, &update_node, QueryGraphDependency::Then)?;
+    } else if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
         graph,
         query_schema,
         &model,
@@ -145,16 +158,18 @@ pub(crate) fn upsert_record(
 
     graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
 
-    // Pass-in the read parent record result to the update node RecordFilter to avoid a redundant read.
-    graph.create_edge(
-        &read_parent_records_node,
-        &update_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            model_id.clone(),
-            RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
-            None,
-        ),
-    )?;
+    if !is_noop_update {
+        // Pass-in the read parent record result to the update node RecordFilter to avoid a redundant read.
+        graph.create_edge(
+            &read_parent_records_node,
+            &update_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id.clone(),
+                RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
+                None,
+            ),
+        )?;
+    }
 
     graph.create_edge(
         &update_node,

--- a/query-compiler/core/src/query_graph_builder/write/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/write/utils.rs
@@ -112,7 +112,7 @@ where
     let filter: Filter = filter.into();
 
     let read_query = ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
-        name: "read_ids_infallible".into(), // this name only eases debugging
+        name: String::new(),
         alias: None,
         model: model.clone(),
         args: (model, filter).into(),
@@ -135,7 +135,7 @@ where
     let filter: Filter = filter.into();
 
     let read_query = ReadQuery::RecordQuery(RecordQuery {
-        name: "read_ids_infallible".into(), // this name only eases debugging
+        name: String::new(),
         alias: None,
         model: model.clone(),
         filter: Some(filter),
@@ -206,7 +206,7 @@ where
     );
 
     let read_children_node = graph.create_node(Query::Read(ReadQuery::RelatedRecordsQuery(RelatedRecordsQuery {
-        name: "find_children_by_parent".to_owned(),
+        name: String::new(),
         alias: None,
         parent_field: parent_relation_field.clone(),
         parent_results: None,

--- a/query-compiler/core/src/query_graph_builder/write/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/write/utils.rs
@@ -245,7 +245,7 @@ pub fn insert_1to1_idempotent_connect_checks(
         &diff_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&LeftSideDiffInput),
+            RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
             Some(DataExpectation::non_empty_rows(
                 MissingRelatedRecord::builder()
                     .model(&child_model.clone())
@@ -263,7 +263,7 @@ pub fn insert_1to1_idempotent_connect_checks(
         &diff_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&RightSideDiffInput),
+            RowSink::ProjectedPlaceholder(&RightSideDiffInput),
             None,
         ),
     )?;
@@ -272,7 +272,11 @@ pub fn insert_1to1_idempotent_connect_checks(
     graph.create_edge(
         &diff_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_model_identifier, RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier,
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
     let empty_node = graph.create_node(Node::Empty);
 
@@ -392,7 +396,7 @@ pub fn insert_existing_1to1_related_model_checks(
         &if_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&IfInput),
+            RowSink::ProjectedPlaceholder(&IfInput),
             // If the other side ("child") requires the connection, we need to make sure that there isn't a child already connected
             // to the parent, as that would violate the other childs relation side.
             if child_side_required {
@@ -992,14 +996,14 @@ pub fn insert_emulated_on_update_with_intermediary_node(
     let internal_model = &model_to_update.dm;
     let relation_fields = internal_model.fields_pointing_to_model(model_to_update);
 
-    let join_node = graph.create_node(Flow::Return(Vec::new()));
+    let join_node = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         parent_node,
         &join_node,
         QueryGraphDependency::ProjectedDataDependency(
             model_to_update.shard_aware_primary_identifier(),
-            RowSink::All(&ReturnInput),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
             None,
         ),
     )?;

--- a/query-compiler/core/src/query_graph_builder/write/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/write/utils.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Computation, DataExpectation, DataOperation, MissingRelatedRecord, ParsedInputValue, QueryGraphBuilderResult,
-    RelationViolation, RowSink,
+    Computation, DataExpectation, DataOperation, MissingRelatedRecord, ParsedInputList, ParsedInputValue,
+    QueryGraphBuilderResult, RelationViolation, RowSink,
     inputs::{
         DeleteManyRecordsSelectorsInput, IfInput, LeftSideDiffInput, RelatedRecordsSelectorsInput, ReturnInput,
         RightSideDiffInput, UpdateManyRecordsSelectorsInput,
@@ -16,13 +16,83 @@ use query_structure::{
 };
 use schema::QuerySchema;
 
-/// Coerces single values (`ParsedInputValue::Single` and `ParsedInputValue::Map`) into a vector.
+pub(crate) enum CoercedParsedInputValues<'a> {
+    List(ParsedInputList<'a>),
+    Single(Option<ParsedInputValue<'a>>),
+}
+
+impl<'a> CoercedParsedInputValues<'a> {
+    pub(crate) fn empty() -> Self {
+        Self::Single(None)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::List(values) => values.len(),
+            Self::Single(Some(_)) => 1,
+            Self::Single(None) => 0,
+        }
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<ParsedInputValue<'a>> {
+        match self {
+            Self::List(values) => values.pop(),
+            Self::Single(value) => value.take(),
+        }
+    }
+}
+
+pub(crate) enum CoercedParsedInputValuesIntoIter<'a> {
+    List(std::vec::IntoIter<ParsedInputValue<'a>>),
+    Single(std::option::IntoIter<ParsedInputValue<'a>>),
+}
+
+impl<'a> Iterator for CoercedParsedInputValuesIntoIter<'a> {
+    type Item = ParsedInputValue<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::List(values) => values.next(),
+            Self::Single(value) => value.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::List(values) => values.size_hint(),
+            Self::Single(value) => value.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for CoercedParsedInputValuesIntoIter<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::List(values) => values.len(),
+            Self::Single(value) => value.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for CoercedParsedInputValues<'a> {
+    type Item = ParsedInputValue<'a>;
+    type IntoIter = CoercedParsedInputValuesIntoIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::List(values) => CoercedParsedInputValuesIntoIter::List(values.into_iter()),
+            Self::Single(value) => CoercedParsedInputValuesIntoIter::Single(value.into_iter()),
+        }
+    }
+}
+
+/// Coerces single values (`ParsedInputValue::Single` and `ParsedInputValue::Map`) into an iterable collection.
 /// Simply unpacks `ParsedInputValue::List`.
-pub(crate) fn coerce_vec(val: ParsedInputValue<'_>) -> Vec<ParsedInputValue<'_>> {
+/// The singleton path intentionally avoids allocating a one-element `Vec`.
+pub(crate) fn coerce_values(val: ParsedInputValue<'_>) -> CoercedParsedInputValues<'_> {
     match val {
-        ParsedInputValue::List(l) => l,
-        m @ ParsedInputValue::Map(_) => vec![m],
-        single => vec![single],
+        ParsedInputValue::List(l) => CoercedParsedInputValues::List(l),
+        single => CoercedParsedInputValues::Single(Some(single)),
     }
 }
 

--- a/query-compiler/core/src/query_graph_builder/write/write_args_parser.rs
+++ b/query-compiler/core/src/query_graph_builder/write/write_args_parser.rs
@@ -5,12 +5,15 @@ use query_structure::{
     TypeIdentifier, WriteArgs, WriteOperation,
 };
 use schema::constants::{args, json_null, operations};
+use smallvec::SmallVec;
 use std::{borrow::Cow, convert::TryInto};
+
+pub(crate) type NestedWriteOperations<'a> = SmallVec<[(RelationFieldRef, ParsedInputMap<'a>); 1]>;
 
 #[derive(Debug)]
 pub struct WriteArgsParser<'a> {
     pub(crate) args: WriteArgs,
-    pub(crate) nested: Vec<(RelationFieldRef, ParsedInputMap<'a>)>,
+    pub(crate) nested: NestedWriteOperations<'a>,
 }
 
 impl<'a> WriteArgsParser<'a> {

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -311,6 +311,7 @@ pub enum DynamicArgType {
 pub struct ArgType {
     pub arity: Arity,
     pub scalar_type: ArgScalarType,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub db_type: Option<String>,
 }
 

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -413,13 +413,13 @@ impl Serialize for ArgType {
         S: Serializer,
     {
         if self.arity == Arity::Scalar && self.db_type.is_none() {
-            return serializer.serialize_str(self.scalar_type.as_str());
+            return serializer.serialize_str(self.scalar_type.compact_str());
         }
 
         if self.arity == Arity::Scalar {
             if let Some(db_type) = &self.db_type {
                 let mut tuple = serializer.serialize_tuple(2)?;
-                tuple.serialize_element(self.scalar_type.as_str())?;
+                tuple.serialize_element(self.scalar_type.compact_str())?;
                 tuple.serialize_element(db_type)?;
                 return tuple.end();
             }
@@ -486,6 +486,23 @@ impl ArgScalarType {
             Self::DateTime => "datetime",
             Self::Bytes => "bytes",
             Self::Unknown => "unknown",
+        }
+    }
+
+    fn compact_str(&self) -> &'static str {
+        match self {
+            Self::String => "s",
+            Self::Int => "i",
+            Self::BigInt => "I",
+            Self::Float => "f",
+            Self::Decimal => "d",
+            Self::Boolean => "b",
+            Self::Enum => "e",
+            Self::Uuid => "u",
+            Self::Json => "j",
+            Self::DateTime => "D",
+            Self::Bytes => "B",
+            Self::Unknown => "?",
         }
     }
 }

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -2,7 +2,7 @@ use query_structure::{
     AggregationSelection, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, RecordFilter,
     RelationField, RelationLoadStrategy, ScalarCondition, ScalarField, SelectedField, SelectionResult, WriteArgs,
 };
-use serde::{Serialize, Serializer, ser::SerializeSeq};
+use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct};
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::{collections::HashMap, fmt};
@@ -308,26 +308,53 @@ where
     seq.end()
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "arity", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum DynamicArgType {
-    Tuple {
-        elements: Vec<ArgType>,
-    },
-    #[serde(untagged)]
-    Single {
-        #[serde(flatten)]
-        r#type: ArgType,
-    },
+    Tuple { elements: Vec<ArgType> },
+    Single { r#type: ArgType },
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+impl Serialize for DynamicArgType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Tuple { elements } => {
+                let mut state = serializer.serialize_struct("DynamicArgType", 2)?;
+                state.serialize_field("arity", "tuple")?;
+                state.serialize_field("elements", elements)?;
+                state.end()
+            }
+            Self::Single { r#type } => r#type.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct ArgType {
     pub arity: Arity,
     pub scalar_type: ArgScalarType,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub db_type: Option<String>,
+}
+
+impl Serialize for ArgType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.arity == Arity::Scalar && self.db_type.is_none() {
+            return serializer.serialize_str(self.scalar_type.as_str());
+        }
+
+        let mut state = serializer.serialize_struct("ArgType", 3)?;
+        state.serialize_field("arity", &self.arity)?;
+        state.serialize_field("scalarType", self.scalar_type.as_str())?;
+        if let Some(db_type) = &self.db_type {
+            state.serialize_field("dbType", db_type)?;
+        }
+        state.end()
+    }
 }
 
 impl ArgType {
@@ -364,6 +391,25 @@ pub enum ArgScalarType {
     DateTime,
     Bytes,
     Unknown,
+}
+
+impl ArgScalarType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Int => "int",
+            Self::BigInt => "bigint",
+            Self::Float => "float",
+            Self::Decimal => "decimal",
+            Self::Boolean => "boolean",
+            Self::Enum => "enum",
+            Self::Uuid => "uuid",
+            Self::Json => "json",
+            Self::DateTime => "datetime",
+            Self::Bytes => "bytes",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 /// Indicates whether the parameters of this query can be chunked into smaller queries.

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -334,10 +334,22 @@ impl Serialize for SerializedFragments<'_> {
         for fragment in self.0 {
             match fragment {
                 Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
+                Fragment::Parameter => seq.serialize_element(&ParameterFragment)?,
                 fragment => seq.serialize_element(fragment)?,
             }
         }
         seq.end()
+    }
+}
+
+struct ParameterFragment;
+
+impl Serialize for ParameterFragment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_none()
     }
 }
 

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -2,7 +2,7 @@ use query_structure::{
     AggregationSelection, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, RecordFilter,
     RelationField, RelationLoadStrategy, ScalarCondition, ScalarField, SelectedField, SelectionResult, WriteArgs,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeSeq};
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::{collections::HashMap, fmt};
@@ -227,6 +227,7 @@ pub enum DbQuery {
     },
     #[serde(rename_all = "camelCase")]
     TemplateSql {
+        #[serde(serialize_with = "serialize_fragments")]
         fragments: Vec<Fragment>,
         args: Vec<PrismaValue>,
         arg_types: Vec<DynamicArgType>,
@@ -291,6 +292,20 @@ impl fmt::Display for DbQuery {
         }
         Ok(())
     }
+}
+
+fn serialize_fragments<S>(fragments: &Vec<Fragment>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(fragments.len()))?;
+    for fragment in fragments {
+        match fragment {
+            Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
+            fragment => seq.serialize_element(fragment)?,
+        }
+    }
+    seq.end()
 }
 
 #[derive(Debug, Serialize)]

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -2,7 +2,7 @@ use query_structure::{
     AggregationSelection, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, RecordFilter,
     RelationField, RelationLoadStrategy, ScalarCondition, ScalarField, SelectedField, SelectionResult, WriteArgs,
 };
-use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct};
+use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct, ser::SerializeTuple};
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::{collections::HashMap, fmt};
@@ -216,24 +216,53 @@ impl fmt::Display for RelationLinkage {
     }
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum DbQuery {
-    #[serde(rename_all = "camelCase")]
     RawSql {
         sql: String,
         args: Vec<PrismaValue>,
         arg_types: Vec<ArgType>,
     },
-    #[serde(rename_all = "camelCase")]
     TemplateSql {
-        #[serde(serialize_with = "serialize_fragments")]
         fragments: Vec<Fragment>,
         args: Vec<PrismaValue>,
         arg_types: Vec<DynamicArgType>,
         placeholder_format: PlaceholderFormat,
         chunkable: Chunkable,
     },
+}
+
+impl Serialize for DbQuery {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::RawSql { sql, args, arg_types } => {
+                let mut state = serializer.serialize_struct("DbQuery", 4)?;
+                state.serialize_field("type", "rawSql")?;
+                state.serialize_field("sql", sql)?;
+                state.serialize_field("args", args)?;
+                state.serialize_field("argTypes", arg_types)?;
+                state.end()
+            }
+            Self::TemplateSql {
+                fragments,
+                args,
+                arg_types,
+                placeholder_format,
+                chunkable,
+            } => {
+                let mut tuple = serializer.serialize_tuple(5)?;
+                tuple.serialize_element(&SerializedFragments(fragments))?;
+                tuple.serialize_element(&SerializedPlaceholderFormat(placeholder_format))?;
+                tuple.serialize_element(args)?;
+                tuple.serialize_element(arg_types)?;
+                tuple.serialize_element(chunkable)?;
+                tuple.end()
+            }
+        }
+    }
 }
 
 impl DbQuery {
@@ -294,18 +323,36 @@ impl fmt::Display for DbQuery {
     }
 }
 
-fn serialize_fragments<S>(fragments: &Vec<Fragment>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut seq = serializer.serialize_seq(Some(fragments.len()))?;
-    for fragment in fragments {
-        match fragment {
-            Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
-            fragment => seq.serialize_element(fragment)?,
+struct SerializedFragments<'a>(&'a Vec<Fragment>);
+
+impl Serialize for SerializedFragments<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for fragment in self.0 {
+            match fragment {
+                Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
+                fragment => seq.serialize_element(fragment)?,
+            }
         }
+        seq.end()
     }
-    seq.end()
+}
+
+struct SerializedPlaceholderFormat<'a>(&'a PlaceholderFormat);
+
+impl Serialize for SerializedPlaceholderFormat<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(self.0.prefix)?;
+        tuple.serialize_element(&self.0.has_numbering)?;
+        tuple.end()
+    }
 }
 
 #[derive(Debug)]

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -335,7 +335,17 @@ impl Serialize for SerializedFragments<'_> {
             match fragment {
                 Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
                 Fragment::Parameter => seq.serialize_element(&ParameterFragment)?,
-                fragment => seq.serialize_element(fragment)?,
+                Fragment::ParameterTuple {
+                    item_prefix,
+                    item_separator,
+                    item_suffix,
+                } => seq.serialize_element(&("T", item_prefix, item_separator, item_suffix))?,
+                Fragment::ParameterTupleList {
+                    item_prefix,
+                    item_separator,
+                    item_suffix,
+                    group_separator,
+                } => seq.serialize_element(&("L", item_prefix, item_separator, item_suffix, group_separator))?,
             }
         }
         seq.end()

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -95,6 +95,12 @@ pub trait QueryBuilder {
         child_ids: &[SelectionResult],
     ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>>;
 
+    fn build_m2m_disconnect_all(
+        &self,
+        field: RelationField,
+        parent_id: &SelectionResult,
+    ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>>;
+
     fn build_delete(
         &self,
         model: &Model,

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -416,6 +416,15 @@ impl Serialize for ArgType {
             return serializer.serialize_str(self.scalar_type.as_str());
         }
 
+        if self.arity == Arity::Scalar {
+            if let Some(db_type) = &self.db_type {
+                let mut tuple = serializer.serialize_tuple(2)?;
+                tuple.serialize_element(self.scalar_type.as_str())?;
+                tuple.serialize_element(db_type)?;
+                return tuple.end();
+            }
+        }
+
         let mut state = serializer.serialize_struct("ArgType", 3)?;
         state.serialize_field("arity", &self.arity)?;
         state.serialize_field("scalarType", self.scalar_type.as_str())?;

--- a/query-compiler/query-builders/sql-query-builder/src/lib.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/lib.rs
@@ -453,6 +453,17 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
         self.convert_query(query, chunkable)
     }
 
+    fn build_m2m_disconnect_all(
+        &self,
+        field: RelationField,
+        parent_id: &SelectionResult,
+    ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>> {
+        // Delete by parent id is always chunkable.
+        let chunkable = Chunkable::Yes;
+        let query = write::delete_relation_table_records_for_parent(&field, parent_id, &self.context);
+        self.convert_query(query, chunkable)
+    }
+
     fn build_delete(
         &self,
         model: &Model,

--- a/query-compiler/query-builders/sql-query-builder/src/model_extensions/column.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/model_extensions/column.rs
@@ -1,5 +1,4 @@
 use crate::{Context, model_extensions::ScalarFieldExt};
-use itertools::Itertools;
 use quaint::ast::{Column, NativeColumnType};
 use query_structure::{Field, ModelProjection, RelationField, ScalarField};
 
@@ -38,13 +37,28 @@ pub trait AsColumns {
 
 impl AsColumns for ModelProjection {
     fn as_columns(&self, ctx: &Context<'_>) -> ColumnIterator {
-        let cols: Vec<Column<'static>> = self
-            .fields()
-            .flat_map(|f| f.as_columns(ctx))
-            .unique_by(|c| c.name.clone())
-            .collect();
+        let mut cols = Vec::with_capacity(self.fields().size_hint().0);
+
+        for field in self.fields() {
+            match field {
+                Field::Scalar(sf) => push_unique_column(&mut cols, sf.as_column(ctx)),
+                Field::Relation(rf) => {
+                    for sf in rf.scalar_fields() {
+                        push_unique_column(&mut cols, sf.as_column(ctx));
+                    }
+                }
+                Field::Composite(_) => unimplemented!(),
+            }
+        }
 
         ColumnIterator::from(cols)
+    }
+}
+
+fn push_unique_column(cols: &mut Vec<Column<'static>>, col: Column<'static>) {
+    let name = col.name.clone();
+    if !cols.iter().any(|existing| existing.name == name) {
+        cols.push(col);
     }
 }
 

--- a/query-compiler/query-builders/sql-query-builder/src/write.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/write.rs
@@ -373,6 +373,21 @@ pub fn delete_relation_table_records(
         .add_traceparent(ctx.traceparent)
 }
 
+pub fn delete_relation_table_records_for_parent(
+    parent_field: &RelationFieldRef,
+    parent_id: &SelectionResult,
+    ctx: &Context<'_>,
+) -> Delete<'static> {
+    let relation = parent_field.relation();
+
+    let parent_column = parent_field.related_field().m2m_column(ctx);
+    let parent_id_values = parent_id.db_values(ctx);
+
+    Delete::from_table(relation.as_table(ctx))
+        .so_that(parent_column.equals(parent_id_values))
+        .add_traceparent(ctx.traceparent)
+}
+
 /// Generates a list of insert statements to execute. If `selected_fields` is set, insert statements
 /// will return the specified columns of inserted rows.
 pub fn generate_insert_statements(

--- a/query-compiler/query-compiler/Cargo.toml
+++ b/query-compiler/query-compiler/Cargo.toml
@@ -18,6 +18,7 @@ itertools.workspace = true
 bon.workspace = true
 pretty = { workspace = true, features = ["termcolor"] }
 indexmap = { workspace = true, features = ["serde"] }
+smallvec.workspace = true
 
 [dev-dependencies]
 codspeed-criterion-compat.workspace = true

--- a/query-compiler/query-compiler/examples/allocation_profile.rs
+++ b/query-compiler/query-compiler/examples/allocation_profile.rs
@@ -1,0 +1,337 @@
+//! Allocation profile for query compilation phases.
+//!
+//! This example counts heap allocation calls and requested bytes for the native
+//! query compiler path. It is intentionally separate from `profile_query` so
+//! the timing/flamegraph example does not pay counting-allocator overhead.
+//!
+//! ```bash
+//! cargo run -p query-compiler --example allocation_profile --release
+//! ALLOC_PROFILE_QUERIES=query-m2o,nested-pagination-query \
+//!   cargo run -p query-compiler --example allocation_profile --release
+//! ```
+
+use quaint::prelude::{ConnectionInfo, ExternalConnectionInfo, SqlFamily};
+use quaint::visitor;
+use query_compiler::{Expression, compile, translate};
+use query_core::{Operation, QueryDocument, QueryGraph, QueryGraphBuilder};
+use request_handlers::{JsonBody, JsonSingleQuery, RequestBody};
+use schema::QuerySchemaRef;
+use sql_query_builder::{Context, SqlQueryBuilder};
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::fs;
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[global_allocator]
+static GLOBAL: CountingAllocator = CountingAllocator;
+
+static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static DEALLOCATIONS: AtomicU64 = AtomicU64::new(0);
+static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
+static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
+
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = unsafe { System.alloc(layout) };
+        if !ptr.is_null() {
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if !ptr.is_null() {
+            DEALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES_DEALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        unsafe { System.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, old_layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = unsafe { System.realloc(ptr, old_layout, new_size) };
+        if !new_ptr.is_null() {
+            DEALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES_DEALLOCATED.fetch_add(old_layout.size() as u64, Ordering::Relaxed);
+            ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
+            BYTES_ALLOCATED.fetch_add(new_size as u64, Ordering::Relaxed);
+        }
+        new_ptr
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+struct AllocSnapshot {
+    allocations: u64,
+    deallocations: u64,
+    bytes_allocated: u64,
+    bytes_deallocated: u64,
+}
+
+impl AllocSnapshot {
+    fn reset() {
+        ALLOCATIONS.store(0, Ordering::Relaxed);
+        DEALLOCATIONS.store(0, Ordering::Relaxed);
+        BYTES_ALLOCATED.store(0, Ordering::Relaxed);
+        BYTES_DEALLOCATED.store(0, Ordering::Relaxed);
+    }
+
+    fn current() -> Self {
+        Self {
+            allocations: ALLOCATIONS.load(Ordering::Relaxed),
+            deallocations: DEALLOCATIONS.load(Ordering::Relaxed),
+            bytes_allocated: BYTES_ALLOCATED.load(Ordering::Relaxed),
+            bytes_deallocated: BYTES_DEALLOCATED.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[derive(Default)]
+struct AllocTotals {
+    samples: u64,
+    allocations: u64,
+    deallocations: u64,
+    bytes_allocated: u64,
+    bytes_deallocated: u64,
+}
+
+impl AllocTotals {
+    fn push(&mut self, snapshot: AllocSnapshot) {
+        self.samples += 1;
+        self.allocations += snapshot.allocations;
+        self.deallocations += snapshot.deallocations;
+        self.bytes_allocated += snapshot.bytes_allocated;
+        self.bytes_deallocated += snapshot.bytes_deallocated;
+    }
+
+    fn print(&self, phase: &str) {
+        let samples = self.samples as f64;
+        let allocations = self.allocations as f64 / samples;
+        let deallocations = self.deallocations as f64 / samples;
+        let bytes_allocated = self.bytes_allocated as f64 / samples;
+        let bytes_deallocated = self.bytes_deallocated as f64 / samples;
+        let net_bytes = bytes_allocated - bytes_deallocated;
+
+        println!(
+            "  {phase:<16} allocs/op={allocations:>8.1} deallocs/op={deallocations:>8.1} allocated/op={} deallocated/op={} net/op={}",
+            format_bytes(bytes_allocated),
+            format_bytes(bytes_deallocated),
+            format_bytes(net_bytes),
+        );
+    }
+}
+
+struct ProfileContext {
+    query_schema: QuerySchemaRef,
+    connection_info: ConnectionInfo,
+}
+
+impl ProfileContext {
+    fn new() -> Self {
+        let data_dir = get_test_data_dir();
+        let schema_path = data_dir.join("schema.prisma");
+        let schema = fs::read_to_string(&schema_path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", schema_path.display()));
+        let validated_schema = psl::parse_schema_without_extensions(&schema).unwrap();
+        let query_schema = Arc::new(schema::build(Arc::new(validated_schema), true));
+        let connection_info = ConnectionInfo::External(ExternalConnectionInfo::new(
+            SqlFamily::Postgres,
+            Some("public".to_string()),
+            None,
+            true,
+        ));
+
+        Self {
+            query_schema,
+            connection_info,
+        }
+    }
+
+    fn parse_query(&self, query_json: &str) -> JsonSingleQuery {
+        serde_json::from_str(query_json).unwrap()
+    }
+
+    fn query_to_operation(&self, query: JsonSingleQuery) -> Operation {
+        let request = RequestBody::Json(JsonBody::Single(query));
+        let doc = request.into_doc(&self.query_schema).unwrap();
+
+        let QueryDocument::Single(operation) = doc else {
+            panic!("expected single query");
+        };
+
+        operation
+    }
+
+    fn compile_operation(&self, operation: Operation) -> Expression {
+        compile(&self.query_schema, operation, &self.connection_info).unwrap()
+    }
+
+    fn build_graph(&self, operation: Operation) -> QueryGraph {
+        QueryGraphBuilder::new(&self.query_schema).build(operation).unwrap()
+    }
+
+    fn translate_graph(&self, graph: QueryGraph) -> Expression {
+        let ctx = Context::new(&self.connection_info, None);
+        translate(graph, &SqlQueryBuilder::<visitor::Postgres<'_>>::new(ctx)).unwrap()
+    }
+
+    fn compile_query(&self, query_json: &str) -> Expression {
+        let query = self.parse_query(query_json);
+        let operation = self.query_to_operation(query);
+        self.compile_operation(operation)
+    }
+}
+
+fn get_test_data_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/data")
+}
+
+fn default_query_names() -> Vec<String> {
+    [
+        "query-m2o",
+        "query-many-m2m",
+        "nested-pagination-query",
+        "filter-contains-param",
+        "create-nested-create",
+    ]
+    .into_iter()
+    .map(ToOwned::to_owned)
+    .collect()
+}
+
+fn query_names() -> Vec<String> {
+    std::env::var("ALLOC_PROFILE_QUERIES")
+        .ok()
+        .map(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .filter(|name| !name.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_else(default_query_names)
+}
+
+fn load_query(data_dir: &Path, name: &str) -> String {
+    let path = data_dir.join(format!("{name}.json"));
+    fs::read_to_string(&path).unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()))
+}
+
+fn measure_phase(iterations: usize, mut phase: impl FnMut() -> AllocSnapshot) -> AllocTotals {
+    let mut totals = AllocTotals::default();
+    for _ in 0..iterations {
+        totals.push(phase());
+    }
+    totals
+}
+
+fn measure_parse(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    AllocSnapshot::reset();
+    let query = ctx.parse_query(query_json);
+    black_box(&query);
+    AllocSnapshot::current()
+}
+
+fn measure_into_doc(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    let query = ctx.parse_query(query_json);
+    AllocSnapshot::reset();
+    let operation = ctx.query_to_operation(query);
+    black_box(&operation);
+    AllocSnapshot::current()
+}
+
+fn measure_compile(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    let operation = ctx.query_to_operation(ctx.parse_query(query_json));
+    AllocSnapshot::reset();
+    let expression = ctx.compile_operation(operation);
+    black_box(&expression);
+    AllocSnapshot::current()
+}
+
+fn measure_graph_build(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    let operation = ctx.query_to_operation(ctx.parse_query(query_json));
+    AllocSnapshot::reset();
+    let graph = ctx.build_graph(operation);
+    black_box(&graph);
+    AllocSnapshot::current()
+}
+
+fn measure_translate(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    let operation = ctx.query_to_operation(ctx.parse_query(query_json));
+    let graph = ctx.build_graph(operation);
+    AllocSnapshot::reset();
+    let expression = ctx.translate_graph(graph);
+    black_box(&expression);
+    AllocSnapshot::current()
+}
+
+fn measure_full(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    AllocSnapshot::reset();
+    let expression = ctx.compile_query(query_json);
+    black_box(&expression);
+    AllocSnapshot::current()
+}
+
+fn measure_serialize(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
+    let expression = ctx.compile_query(query_json);
+    AllocSnapshot::reset();
+    let serialized = serde_json::to_string(&expression).unwrap();
+    black_box(&serialized);
+    AllocSnapshot::current()
+}
+
+fn format_bytes(bytes: f64) -> String {
+    let sign = if bytes < 0.0 { "-" } else { "" };
+    let abs = bytes.abs();
+
+    if abs < 1024.0 {
+        format!("{sign}{abs:.0} B")
+    } else if abs < 1024.0 * 1024.0 {
+        format!("{sign}{:.1} KiB", abs / 1024.0)
+    } else {
+        format!("{sign}{:.2} MiB", abs / (1024.0 * 1024.0))
+    }
+}
+
+fn main() {
+    let iterations = std::env::var("ALLOC_PROFILE_ITERATIONS")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(100);
+    let warmup = std::env::var("ALLOC_PROFILE_WARMUP")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(10);
+    let data_dir = get_test_data_dir();
+    let ctx = ProfileContext::new();
+
+    println!("=== Query Compiler Allocation Profile ===");
+    println!("Iterations: {iterations}");
+    println!("Warmup: {warmup}");
+    println!("Queries: {}", query_names().join(", "));
+    println!();
+
+    for name in query_names() {
+        let query = load_query(&data_dir, &name);
+
+        for _ in 0..warmup {
+            black_box(ctx.compile_query(&query));
+        }
+
+        println!("--- {name} ---");
+        measure_phase(iterations, || measure_parse(&ctx, &query)).print("parse_json");
+        measure_phase(iterations, || measure_into_doc(&ctx, &query)).print("into_doc");
+        measure_phase(iterations, || measure_graph_build(&ctx, &query)).print("graph_build");
+        measure_phase(iterations, || measure_translate(&ctx, &query)).print("translate_ir");
+        measure_phase(iterations, || measure_compile(&ctx, &query)).print("compile_ir");
+        measure_phase(iterations, || measure_full(&ctx, &query)).print("full_compile");
+        measure_phase(iterations, || measure_serialize(&ctx, &query)).print("serialize_json");
+        println!();
+    }
+}

--- a/query-compiler/query-compiler/examples/allocation_profile.rs
+++ b/query-compiler/query-compiler/examples/allocation_profile.rs
@@ -8,6 +8,8 @@
 //! cargo run -p query-compiler --example allocation_profile --release
 //! ALLOC_PROFILE_QUERIES=query-m2o,nested-pagination-query \
 //!   cargo run -p query-compiler --example allocation_profile --release
+//! ALLOC_PROFILE_BUCKETS=1 ALLOC_PROFILE_QUERIES=create-nested-create \
+//!   cargo run -p query-compiler --example allocation_profile --release
 //! ```
 
 use quaint::prelude::{ConnectionInfo, ExternalConnectionInfo, SqlFamily};
@@ -31,6 +33,32 @@ static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
 static DEALLOCATIONS: AtomicU64 = AtomicU64::new(0);
 static BYTES_ALLOCATED: AtomicU64 = AtomicU64::new(0);
 static BYTES_DEALLOCATED: AtomicU64 = AtomicU64::new(0);
+const ALLOC_BUCKET_LIMITS: [usize; 21] = [
+    8,
+    16,
+    24,
+    32,
+    48,
+    64,
+    96,
+    128,
+    192,
+    256,
+    384,
+    512,
+    768,
+    1024,
+    1536,
+    2048,
+    4096,
+    8192,
+    16_384,
+    65_536,
+    usize::MAX,
+];
+const ALLOC_BUCKET_COUNT: usize = ALLOC_BUCKET_LIMITS.len();
+static BUCKET_ALLOCATIONS: [AtomicU64; ALLOC_BUCKET_COUNT] = [const { AtomicU64::new(0) }; ALLOC_BUCKET_COUNT];
+static BUCKET_BYTES_ALLOCATED: [AtomicU64; ALLOC_BUCKET_COUNT] = [const { AtomicU64::new(0) }; ALLOC_BUCKET_COUNT];
 
 struct CountingAllocator;
 
@@ -40,6 +68,7 @@ unsafe impl GlobalAlloc for CountingAllocator {
         if !ptr.is_null() {
             ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
             BYTES_ALLOCATED.fetch_add(layout.size() as u64, Ordering::Relaxed);
+            record_bucket_allocation(layout.size());
         }
         ptr
     }
@@ -59,9 +88,23 @@ unsafe impl GlobalAlloc for CountingAllocator {
             BYTES_DEALLOCATED.fetch_add(old_layout.size() as u64, Ordering::Relaxed);
             ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
             BYTES_ALLOCATED.fetch_add(new_size as u64, Ordering::Relaxed);
+            record_bucket_allocation(new_size);
         }
         new_ptr
     }
+}
+
+fn record_bucket_allocation(size: usize) {
+    let bucket = allocation_bucket(size);
+    BUCKET_ALLOCATIONS[bucket].fetch_add(1, Ordering::Relaxed);
+    BUCKET_BYTES_ALLOCATED[bucket].fetch_add(size as u64, Ordering::Relaxed);
+}
+
+fn allocation_bucket(size: usize) -> usize {
+    ALLOC_BUCKET_LIMITS
+        .iter()
+        .position(|limit| size <= *limit)
+        .expect("last allocation bucket must be usize::MAX")
 }
 
 #[derive(Clone, Copy, Default)]
@@ -70,6 +113,8 @@ struct AllocSnapshot {
     deallocations: u64,
     bytes_allocated: u64,
     bytes_deallocated: u64,
+    bucket_allocations: [u64; ALLOC_BUCKET_COUNT],
+    bucket_bytes_allocated: [u64; ALLOC_BUCKET_COUNT],
 }
 
 impl AllocSnapshot {
@@ -78,14 +123,27 @@ impl AllocSnapshot {
         DEALLOCATIONS.store(0, Ordering::Relaxed);
         BYTES_ALLOCATED.store(0, Ordering::Relaxed);
         BYTES_DEALLOCATED.store(0, Ordering::Relaxed);
+        for bucket in 0..ALLOC_BUCKET_COUNT {
+            BUCKET_ALLOCATIONS[bucket].store(0, Ordering::Relaxed);
+            BUCKET_BYTES_ALLOCATED[bucket].store(0, Ordering::Relaxed);
+        }
     }
 
     fn current() -> Self {
+        let mut bucket_allocations = [0; ALLOC_BUCKET_COUNT];
+        let mut bucket_bytes_allocated = [0; ALLOC_BUCKET_COUNT];
+        for bucket in 0..ALLOC_BUCKET_COUNT {
+            bucket_allocations[bucket] = BUCKET_ALLOCATIONS[bucket].load(Ordering::Relaxed);
+            bucket_bytes_allocated[bucket] = BUCKET_BYTES_ALLOCATED[bucket].load(Ordering::Relaxed);
+        }
+
         Self {
             allocations: ALLOCATIONS.load(Ordering::Relaxed),
             deallocations: DEALLOCATIONS.load(Ordering::Relaxed),
             bytes_allocated: BYTES_ALLOCATED.load(Ordering::Relaxed),
             bytes_deallocated: BYTES_DEALLOCATED.load(Ordering::Relaxed),
+            bucket_allocations,
+            bucket_bytes_allocated,
         }
     }
 }
@@ -97,6 +155,8 @@ struct AllocTotals {
     deallocations: u64,
     bytes_allocated: u64,
     bytes_deallocated: u64,
+    bucket_allocations: [u64; ALLOC_BUCKET_COUNT],
+    bucket_bytes_allocated: [u64; ALLOC_BUCKET_COUNT],
 }
 
 impl AllocTotals {
@@ -106,6 +166,10 @@ impl AllocTotals {
         self.deallocations += snapshot.deallocations;
         self.bytes_allocated += snapshot.bytes_allocated;
         self.bytes_deallocated += snapshot.bytes_deallocated;
+        for bucket in 0..ALLOC_BUCKET_COUNT {
+            self.bucket_allocations[bucket] += snapshot.bucket_allocations[bucket];
+            self.bucket_bytes_allocated[bucket] += snapshot.bucket_bytes_allocated[bucket];
+        }
     }
 
     fn print(&self, phase: &str) {
@@ -123,6 +187,47 @@ impl AllocTotals {
             format_bytes(net_bytes),
         );
     }
+
+    fn print_buckets(&self) {
+        let samples = self.samples as f64;
+        let mut buckets = (0..ALLOC_BUCKET_COUNT)
+            .map(|bucket| {
+                (
+                    bucket,
+                    self.bucket_allocations[bucket] as f64 / samples,
+                    self.bucket_bytes_allocated[bucket] as f64 / samples,
+                )
+            })
+            .filter(|(_, allocations, _)| *allocations > 0.0)
+            .collect::<Vec<_>>();
+
+        buckets.sort_by(|left, right| right.2.partial_cmp(&left.2).unwrap_or(std::cmp::Ordering::Equal));
+
+        for (bucket, allocations, bytes_allocated) in buckets.into_iter().take(6) {
+            println!(
+                "    {:<14} allocs/op={allocations:>7.1} allocated/op={}",
+                bucket_label(bucket),
+                format_bytes(bytes_allocated),
+            );
+        }
+    }
+}
+
+fn bucket_label(bucket: usize) -> String {
+    let upper = ALLOC_BUCKET_LIMITS[bucket];
+    if bucket == 0 {
+        return format!("<= {}", format_bytes(upper as f64));
+    }
+
+    if upper == usize::MAX {
+        return format!("> {}", format_bytes(ALLOC_BUCKET_LIMITS[bucket - 1] as f64));
+    }
+
+    format!(
+        "{}..{}",
+        format_bytes((ALLOC_BUCKET_LIMITS[bucket - 1] + 1) as f64),
+        format_bytes(upper as f64),
+    )
 }
 
 struct ProfileContext {
@@ -230,6 +335,13 @@ fn measure_phase(iterations: usize, mut phase: impl FnMut() -> AllocSnapshot) ->
     totals
 }
 
+fn print_phase(totals: AllocTotals, phase: &str, print_buckets: bool) {
+    totals.print(phase);
+    if print_buckets {
+        totals.print_buckets();
+    }
+}
+
 fn measure_parse(ctx: &ProfileContext, query_json: &str) -> AllocSnapshot {
     AllocSnapshot::reset();
     let query = ctx.parse_query(query_json);
@@ -308,6 +420,8 @@ fn main() {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(10);
+    let print_buckets =
+        std::env::var("ALLOC_PROFILE_BUCKETS").is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"));
     let data_dir = get_test_data_dir();
     let ctx = ProfileContext::new();
 
@@ -315,6 +429,7 @@ fn main() {
     println!("Iterations: {iterations}");
     println!("Warmup: {warmup}");
     println!("Queries: {}", query_names().join(", "));
+    println!("Buckets: {}", if print_buckets { "on" } else { "off" });
     println!();
 
     for name in query_names() {
@@ -325,13 +440,41 @@ fn main() {
         }
 
         println!("--- {name} ---");
-        measure_phase(iterations, || measure_parse(&ctx, &query)).print("parse_json");
-        measure_phase(iterations, || measure_into_doc(&ctx, &query)).print("into_doc");
-        measure_phase(iterations, || measure_graph_build(&ctx, &query)).print("graph_build");
-        measure_phase(iterations, || measure_translate(&ctx, &query)).print("translate_ir");
-        measure_phase(iterations, || measure_compile(&ctx, &query)).print("compile_ir");
-        measure_phase(iterations, || measure_full(&ctx, &query)).print("full_compile");
-        measure_phase(iterations, || measure_serialize(&ctx, &query)).print("serialize_json");
+        print_phase(
+            measure_phase(iterations, || measure_parse(&ctx, &query)),
+            "parse_json",
+            print_buckets,
+        );
+        print_phase(
+            measure_phase(iterations, || measure_into_doc(&ctx, &query)),
+            "into_doc",
+            print_buckets,
+        );
+        print_phase(
+            measure_phase(iterations, || measure_graph_build(&ctx, &query)),
+            "graph_build",
+            print_buckets,
+        );
+        print_phase(
+            measure_phase(iterations, || measure_translate(&ctx, &query)),
+            "translate_ir",
+            print_buckets,
+        );
+        print_phase(
+            measure_phase(iterations, || measure_compile(&ctx, &query)),
+            "compile_ir",
+            print_buckets,
+        );
+        print_phase(
+            measure_phase(iterations, || measure_full(&ctx, &query)),
+            "full_compile",
+            print_buckets,
+        );
+        print_phase(
+            measure_phase(iterations, || measure_serialize(&ctx, &query)),
+            "serialize_json",
+            print_buckets,
+        );
         println!();
     }
 }

--- a/query-compiler/query-compiler/src/binding.rs
+++ b/query-compiler/query-compiler/src/binding.rs
@@ -16,7 +16,7 @@ pub fn node_result(node: NodeRef) -> Cow<'static, str> {
 }
 
 pub fn projected_dependency(source: NodeRef, field: &SelectedField) -> Cow<'static, str> {
-    format!("{}{FIELD_SEPARATOR}{}", source.id(), field.prisma_name()).into()
+    format!("{}{FIELD_SEPARATOR}{}", source.index(), field.prisma_name()).into()
 }
 
 pub fn join_parent() -> Cow<'static, str> {

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -11,8 +11,7 @@ use query_core::{
     UpdateRecord, WriteQuery,
 };
 use query_structure::{
-    AggregationSelection, FieldArity, FieldSelection, FieldTypeInformation, ScalarField, SelectedField, Type,
-    TypeIdentifier,
+    AggregationSelection, FieldArity, FieldTypeInformation, ScalarField, SelectedField, Type, TypeIdentifier,
 };
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 use std::{borrow::Cow, fmt};
@@ -55,7 +54,7 @@ fn map_read_query(
 ) -> Option<ResultNode> {
     match query {
         ReadQuery::RecordQuery(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .nested_queries(&q.nested)
             .builder(builder)
@@ -63,7 +62,7 @@ fn map_read_query(
             .uses_relation_joins(q.relation_load_strategy.is_join())
             .call(),
         ReadQuery::ManyRecordsQuery(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .nested_queries(&q.nested)
             .builder(builder)
@@ -71,7 +70,7 @@ fn map_read_query(
             .uses_relation_joins(q.relation_load_strategy.is_join())
             .call(),
         ReadQuery::RelatedRecordsQuery(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .nested_queries(&q.nested)
             .builder(builder)
@@ -86,7 +85,7 @@ fn map_read_query(
 fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
     match query {
         WriteQuery::CreateRecord(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .builder(builder)
             .call(),
@@ -94,7 +93,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         WriteQuery::UpdateRecord(u) => {
             match u {
                 UpdateRecord::WithSelection(w) => get_result_node()
-                    .field_selection(&w.selected_fields)
+                    .field_selection(w.selected_fields.as_slice())
                     .selection_order(&w.selection_order)
                     .builder(builder)
                     .call(),
@@ -109,7 +108,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         WriteQuery::ExecuteRaw(_) => None,        // No data mapping
         WriteQuery::QueryRaw(_) => None,          // No data mapping
         WriteQuery::Upsert(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .builder(builder)
             .call(),
@@ -118,7 +117,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
 
 #[builder]
 fn get_result_node(
-    field_selection: &FieldSelection,
+    field_selection: &[SelectedField],
     selection_order: &[String],
     #[builder(default = &[])] nested_queries: &[ReadQuery],
     /// Indicates whether the query uses `relationJoins`. When true, the data mapper uses prisma names
@@ -147,14 +146,13 @@ fn get_result_node(
             }
             Some(SelectedField::Composite(_)) => todo!("MongoDB specific"),
             Some(SelectedField::Relation(f)) => {
-                let nested_selection = FieldSelection::new(f.selections.to_vec());
                 let original_name = if uses_relation_joins {
                     f.field.name().to_owned().into()
                 } else {
                     binding::nested_relation_field(&f.field)
                 };
                 let nested_node = get_result_node()
-                    .field_selection(&nested_selection)
+                    .field_selection(&f.selections)
                     .selection_order(&f.result_fields)
                     .builder(builder)
                     .original_name(original_name)
@@ -168,7 +166,8 @@ fn get_result_node(
             }
             Some(SelectedField::Virtual(f)) => {
                 for vs in field_selection
-                    .virtuals()
+                    .iter()
+                    .filter_map(SelectedField::as_virtual)
                     .filter(|vs| vs.serialized_group_name() == f.serialized_group_name())
                 {
                     let (group_name, field_name) = vs.serialized_name();
@@ -204,9 +203,9 @@ fn get_result_node(
     Some(node.build())
 }
 
-fn find_selection<'a>(field_selection: &'a FieldSelection, prisma_name: &str) -> Option<&'a SelectedField> {
+fn find_selection<'a>(field_selection: &'a [SelectedField], prisma_name: &str) -> Option<&'a SelectedField> {
     field_selection
-        .selections()
+        .iter()
         .find(|field| field.prisma_name_grouping_virtuals() == prisma_name)
 }
 
@@ -312,10 +311,12 @@ fn get_result_node_for_create_many(
     selected_fields: Option<&CreateManyRecordsFields>,
     builder: &mut ResultNodeBuilder,
 ) -> Option<ResultNode> {
+    let selected_fields = selected_fields?;
+
     get_result_node()
-        .field_selection(&selected_fields?.fields)
-        .selection_order(&selected_fields?.order)
-        .nested_queries(&selected_fields?.nested)
+        .field_selection(selected_fields.fields.as_slice())
+        .selection_order(&selected_fields.order)
+        .nested_queries(&selected_fields.nested)
         .builder(builder)
         .call()
 }
@@ -324,9 +325,11 @@ fn get_result_node_for_delete(
     selected_fields: Option<&DeleteRecordFields>,
     builder: &mut ResultNodeBuilder,
 ) -> Option<ResultNode> {
+    let selected_fields = selected_fields?;
+
     get_result_node()
-        .field_selection(&selected_fields?.fields)
-        .selection_order(&selected_fields?.order)
+        .field_selection(selected_fields.fields.as_slice())
+        .selection_order(&selected_fields.order)
         .builder(builder)
         .call()
 }
@@ -335,10 +338,12 @@ fn get_result_node_for_update_many(
     selected_fields: Option<&UpdateManyRecordsFields>,
     builder: &mut ResultNodeBuilder,
 ) -> Option<ResultNode> {
+    let selected_fields = selected_fields?;
+
     get_result_node()
-        .field_selection(&selected_fields?.fields)
-        .selection_order(&selected_fields?.order)
-        .nested_queries(&selected_fields?.nested)
+        .field_selection(selected_fields.fields.as_slice())
+        .selection_order(&selected_fields.order)
+        .nested_queries(&selected_fields.nested)
         .builder(builder)
         .call()
 }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -478,12 +478,12 @@ impl FieldScalarType {
         S: SerializeStruct,
     {
         match self {
-            Self::String => state.serialize_field("type", "string"),
-            Self::Int => state.serialize_field("type", "int"),
-            Self::BigInt => state.serialize_field("type", "bigint"),
-            Self::Float => state.serialize_field("type", "float"),
-            Self::Decimal => state.serialize_field("type", "decimal"),
-            Self::Boolean => state.serialize_field("type", "boolean"),
+            Self::String => state.serialize_field("type", "s"),
+            Self::Int => state.serialize_field("type", "i"),
+            Self::BigInt => state.serialize_field("type", "I"),
+            Self::Float => state.serialize_field("type", "f"),
+            Self::Decimal => state.serialize_field("type", "d"),
+            Self::Boolean => state.serialize_field("type", "b"),
             Self::Enum { name } => {
                 state.serialize_field("type", "enum")?;
                 state.serialize_field("name", name)
@@ -492,14 +492,14 @@ impl FieldScalarType {
                 state.serialize_field("type", "extension")?;
                 state.serialize_field("name", name)
             }
-            Self::Json => state.serialize_field("type", "json"),
-            Self::Object => state.serialize_field("type", "object"),
-            Self::DateTime => state.serialize_field("type", "datetime"),
+            Self::Json => state.serialize_field("type", "j"),
+            Self::Object => state.serialize_field("type", "o"),
+            Self::DateTime => state.serialize_field("type", "D"),
             Self::Bytes { encoding } => {
                 state.serialize_field("type", "bytes")?;
                 state.serialize_field("encoding", encoding)
             }
-            Self::Unsupported => state.serialize_field("type", "unsupported"),
+            Self::Unsupported => state.serialize_field("type", "x"),
         }
     }
 }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -383,6 +383,14 @@ impl FieldType {
             r#type: r#type.into(),
         }
     }
+
+    pub fn compact_name(&self) -> Option<&'static str> {
+        if self.arity.is_not_list() {
+            self.r#type.compact_name()
+        } else {
+            None
+        }
+    }
 }
 
 impl fmt::Display for FieldType {

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -353,6 +353,7 @@ fn get_result_node_for_update_many(
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldType {
+    #[serde(skip_serializing_if = "Arity::is_not_list")]
     arity: Arity,
     #[serde(flatten)]
     r#type: FieldScalarType,
@@ -479,6 +480,12 @@ pub enum Arity {
     Required,
     Optional,
     List,
+}
+
+impl Arity {
+    fn is_not_list(&self) -> bool {
+        !matches!(self, Self::List)
+    }
 }
 
 impl From<FieldArity> for Arity {

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -3,15 +3,14 @@ use crate::{
     result_node::{ResultNode, ResultNodeBuilder},
 };
 use bon::builder;
-use indexmap::IndexSet;
-use itertools::Itertools;
 use psl::datamodel_connector::Flavour;
 use query_core::{
     CreateManyRecordsFields, DeleteRecordFields, Node, Query, QueryGraph, ReadQuery, UpdateManyRecordsFields,
     UpdateRecord, WriteQuery,
 };
 use query_structure::{
-    AggregationSelection, FieldArity, FieldTypeInformation, ScalarField, SelectedField, Type, TypeIdentifier,
+    AggregationSelection, FieldArity, FieldTypeInformation, ScalarField, SelectedField, SelectionIdentifier, Type,
+    TypeIdentifier,
 };
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 use std::{borrow::Cow, fmt};
@@ -270,41 +269,41 @@ fn get_result_node_for_aggregation(
     builder: &mut ResultNodeBuilder,
     object_name: Option<Cow<'static, str>>,
 ) -> Option<ResultNode> {
-    let mut ordered_set = IndexSet::new();
+    let mut node = ResultNodeBuilder::new_object_with_capacity(object_name, selection_order.len());
 
-    for (key, nested) in selection_order {
+    for ((key, nested), selector) in selection_order.iter().zip(selectors) {
         if let Some(nested) = nested {
             for nested_key in nested {
-                ordered_set.insert((Some(key.as_str()), nested_key.as_str()));
+                if let Some(ident) = selector.identifiers().find(|ident| ident.field.name() == nested_key) {
+                    add_aggregation_result_field(&mut node, builder, ident);
+                }
             }
         } else {
-            ordered_set.insert((None, key.as_str()));
-        }
-    }
-
-    let mut node = ResultNodeBuilder::new_object_with_capacity(object_name, ordered_set.len());
-
-    for (name, prefix, db_alias, typ) in selectors
-        .iter()
-        .flat_map(|sel| {
-            sel.identifiers().map(move |ident| {
-                let db_alias = ident.db_alias();
-                let type_info = FieldTypeInformation::new(ident.typ, ident.arity, None);
-                (ident.field.name(), sel.aggregation_name(), db_alias, type_info)
-            })
-        })
-        .sorted_by_key(|(name, prefix, _, _)| ordered_set.get_index_of(&(*prefix, *name)))
-    {
-        let value = builder.new_value(db_alias.into_owned(), typ);
-        if let Some(prefix) = prefix {
-            node.entry_or_insert(prefix, None::<&str>)
-                .add_field(name.to_owned(), value);
-        } else {
-            node.add_field(name.to_owned(), value);
+            for ident in selector.identifiers().filter(|ident| ident.field.name() == key) {
+                add_aggregation_result_field(&mut node, builder, ident);
+            }
         }
     }
 
     Some(node.build())
+}
+
+fn add_aggregation_result_field(
+    node: &mut crate::result_node::ObjectBuilder,
+    builder: &mut ResultNodeBuilder,
+    ident: SelectionIdentifier<'_>,
+) {
+    let name = ident.field.name().to_owned();
+    let prefix = ident.aggregation_name;
+    let db_alias = ident.db_alias().into_owned();
+    let type_info = FieldTypeInformation::new(ident.typ, ident.arity, None);
+    let value = builder.new_value(db_alias, type_info);
+
+    if let Some(prefix) = prefix {
+        node.entry_or_insert(prefix, None::<&str>).add_field(name, value);
+    } else {
+        node.add_field(name, value);
+    }
 }
 
 fn get_result_node_for_create_many(

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -15,7 +15,7 @@ use query_structure::{
     TypeIdentifier,
 };
 use serde::{Serialize, Serializer, ser::SerializeStruct};
-use std::{borrow::Cow, collections::HashMap, fmt};
+use std::{borrow::Cow, fmt};
 
 pub fn map_result_structure(graph: &QueryGraph, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
     graph
@@ -134,23 +134,11 @@ fn get_result_node(
     builder: &mut ResultNodeBuilder<'_>,
     original_name: Option<Cow<'static, str>>,
 ) -> Option<ResultNode> {
-    let field_map = field_selection
-        .selections()
-        .map(|fs| (fs.prisma_name_grouping_virtuals(), fs))
-        .collect::<HashMap<_, _>>();
-    let grouped_virtuals = field_selection
-        .virtuals()
-        .into_group_map_by(|vs| vs.serialized_group_name());
-    let nested_map = nested_queries
-        .iter()
-        .map(|q| (q.get_alias_or_name(), q))
-        .collect::<HashMap<_, _>>();
-
     let mut node = ResultNodeBuilder::new_object(original_name);
     node.set_skip_nulls(skip_nulls);
 
     for prisma_name in selection_order {
-        match field_map.get(prisma_name.as_str()) {
+        match find_selection(field_selection, prisma_name) {
             Some(SelectedField::Scalar(field)) => {
                 node.add_field(
                     field.name().to_owned(),
@@ -179,10 +167,9 @@ fn get_result_node(
                 }
             }
             Some(SelectedField::Virtual(f)) => {
-                for vs in grouped_virtuals
-                    .get(f.serialized_group_name())
-                    .map(Vec::as_slice)
-                    .unwrap_or_default()
+                for vs in field_selection
+                    .virtuals()
+                    .filter(|vs| vs.serialized_group_name() == f.serialized_group_name())
                 {
                     let (group_name, field_name) = vs.serialized_name();
                     let db_name = if uses_relation_joins {
@@ -196,7 +183,7 @@ fn get_result_node(
                 }
             }
             None => {
-                if let Some(q) = nested_map.get(prisma_name.as_str()) {
+                if let Some(q) = nested_queries.iter().find(|q| q.get_alias_or_name() == prisma_name) {
                     let nested_node = map_read_query(
                         q,
                         builder,
@@ -215,6 +202,12 @@ fn get_result_node(
     }
 
     Some(node.build())
+}
+
+fn find_selection<'a>(field_selection: &'a FieldSelection, prisma_name: &str) -> Option<&'a SelectedField> {
+    field_selection
+        .selections()
+        .find(|field| field.prisma_name_grouping_virtuals() == prisma_name)
 }
 
 fn get_scalar_field_result_node(

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -14,7 +14,7 @@ use query_structure::{
     AggregationSelection, FieldArity, FieldSelection, FieldTypeInformation, ScalarField, SelectedField, Type,
     TypeIdentifier,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeStruct};
 use std::{borrow::Cow, collections::HashMap, fmt};
 
 pub fn map_result_structure(graph: &QueryGraph, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
@@ -350,13 +350,30 @@ fn get_result_node_for_update_many(
         .call()
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct FieldType {
-    #[serde(skip_serializing_if = "Arity::is_not_list")]
     arity: Arity,
-    #[serde(flatten)]
     r#type: FieldScalarType,
+}
+
+impl Serialize for FieldType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.arity.is_not_list() {
+            if let Some(name) = self.r#type.compact_name() {
+                return serializer.serialize_str(name);
+            }
+        }
+
+        let mut state = serializer.serialize_struct("FieldType", 3)?;
+        if !self.arity.is_not_list() {
+            state.serialize_field("arity", &self.arity)?;
+        }
+        self.r#type.serialize_fields(&mut state)?;
+        state.end()
+    }
 }
 
 impl FieldType {
@@ -429,6 +446,54 @@ impl fmt::Display for FieldScalarType {
             Self::DateTime => write!(f, "DateTime"),
             Self::Bytes { .. } => write!(f, "Bytes"),
             Self::Unsupported => write!(f, "Unsupported"),
+        }
+    }
+}
+
+impl FieldScalarType {
+    fn compact_name(&self) -> Option<&'static str> {
+        match self {
+            Self::String => Some("string"),
+            Self::Int => Some("int"),
+            Self::BigInt => Some("bigint"),
+            Self::Float => Some("float"),
+            Self::Decimal => Some("decimal"),
+            Self::Boolean => Some("boolean"),
+            Self::Json => Some("json"),
+            Self::Object => Some("object"),
+            Self::DateTime => Some("datetime"),
+            Self::Unsupported => Some("unsupported"),
+            Self::Enum { .. } | Self::Extension { .. } | Self::Bytes { .. } => None,
+        }
+    }
+
+    fn serialize_fields<S>(&self, state: &mut S) -> Result<(), S::Error>
+    where
+        S: SerializeStruct,
+    {
+        match self {
+            Self::String => state.serialize_field("type", "string"),
+            Self::Int => state.serialize_field("type", "int"),
+            Self::BigInt => state.serialize_field("type", "bigint"),
+            Self::Float => state.serialize_field("type", "float"),
+            Self::Decimal => state.serialize_field("type", "decimal"),
+            Self::Boolean => state.serialize_field("type", "boolean"),
+            Self::Enum { name } => {
+                state.serialize_field("type", "enum")?;
+                state.serialize_field("name", name)
+            }
+            Self::Extension { name } => {
+                state.serialize_field("type", "extension")?;
+                state.serialize_field("name", name)
+            }
+            Self::Json => state.serialize_field("type", "json"),
+            Self::Object => state.serialize_field("type", "object"),
+            Self::DateTime => state.serialize_field("type", "datetime"),
+            Self::Bytes { encoding } => {
+                state.serialize_field("type", "bytes")?;
+                state.serialize_field("encoding", encoding)
+            }
+            Self::Unsupported => state.serialize_field("type", "unsupported"),
         }
     }
 }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -104,6 +104,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         WriteQuery::DeleteManyRecords(_) => None, // No result data
         WriteQuery::ConnectRecords(_) => None,    // No result data
         WriteQuery::DisconnectRecords(_) => None, // No result data
+        WriteQuery::DisconnectAllRecords(_) => None, // No result data
         WriteQuery::ExecuteRaw(_) => None,        // No data mapping
         WriteQuery::QueryRaw(_) => None,          // No data mapping
         WriteQuery::Upsert(q) => get_result_node()

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -461,16 +461,16 @@ impl fmt::Display for FieldScalarType {
 impl FieldScalarType {
     fn compact_name(&self) -> Option<&'static str> {
         match self {
-            Self::String => Some("string"),
-            Self::Int => Some("int"),
-            Self::BigInt => Some("bigint"),
-            Self::Float => Some("float"),
-            Self::Decimal => Some("decimal"),
-            Self::Boolean => Some("boolean"),
-            Self::Json => Some("json"),
-            Self::Object => Some("object"),
-            Self::DateTime => Some("datetime"),
-            Self::Unsupported => Some("unsupported"),
+            Self::String => Some("s"),
+            Self::Int => Some("i"),
+            Self::BigInt => Some("I"),
+            Self::Float => Some("f"),
+            Self::Decimal => Some("d"),
+            Self::Boolean => Some("b"),
+            Self::Json => Some("j"),
+            Self::Object => Some("o"),
+            Self::DateTime => Some("D"),
+            Self::Unsupported => Some("x"),
             Self::Enum { .. } | Self::Extension { .. } | Self::Bytes { .. } => None,
         }
     }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -133,7 +133,7 @@ fn get_result_node(
     builder: &mut ResultNodeBuilder<'_>,
     original_name: Option<Cow<'static, str>>,
 ) -> Option<ResultNode> {
-    let mut node = ResultNodeBuilder::new_object(original_name);
+    let mut node = ResultNodeBuilder::new_object_with_capacity(original_name, selection_order.len());
     node.set_skip_nulls(skip_nulls);
 
     for prisma_name in selection_order {
@@ -282,7 +282,7 @@ fn get_result_node_for_aggregation(
         }
     }
 
-    let mut node = ResultNodeBuilder::new_object(object_name);
+    let mut node = ResultNodeBuilder::new_object_with_capacity(object_name, ordered_set.len());
 
     for (name, prefix, db_alias, typ) in selectors
         .iter()

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -368,11 +368,7 @@ impl Serialize for Expression {
                 }
                 tuple.end()
             }
-            Self::Validate {
-                expr,
-                rules,
-                error,
-            } => {
+            Self::Validate { expr, rules, error } => {
                 let mut tuple = serializer.serialize_tuple(5)?;
                 tuple.serialize_element("V")?;
                 tuple.serialize_element(expr)?;
@@ -627,6 +623,21 @@ impl Pagination {
     pub fn skip(&self) -> Option<i64> {
         self.skip
     }
+
+    pub fn remap_cursor_field_names<F>(mut self, map_field_name: &mut F) -> Option<Self>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        if let Some(cursor) = self.cursor.take() {
+            let mut mapped_cursor = HashMap::with_capacity(cursor.len());
+            for (field, value) in cursor {
+                mapped_cursor.insert(map_field_name(&field)?, value);
+            }
+            self.cursor = Some(mapped_cursor);
+        }
+
+        Some(self)
+    }
 }
 
 #[derive(Debug, Default, Builder)]
@@ -688,6 +699,25 @@ impl InMemoryOps {
                 operations: self,
             }
         }
+    }
+
+    pub fn remap_operation_field_names<F>(mut self, mut map_field_name: F) -> Option<Self>
+    where
+        F: FnMut(&str) -> Option<String>,
+    {
+        if let Some(distinct) = self.distinct.take() {
+            let mut mapped_distinct = Vec::with_capacity(distinct.len());
+            for field in distinct {
+                mapped_distinct.push(map_field_name(&field)?);
+            }
+            self.distinct = Some(mapped_distinct);
+        }
+
+        if let Some(pagination) = self.pagination.take() {
+            self.pagination = Some(pagination.remap_cursor_field_names(&mut map_field_name)?);
+        }
+
+        Some(self)
     }
 }
 

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -9,6 +9,7 @@ use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
 use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeTuple};
+use serde_json::Value;
 use thiserror::Error;
 
 mod format;
@@ -234,8 +235,11 @@ impl Serialize for Expression {
                 tuple.serialize_element("V")?;
                 tuple.serialize_element(expr)?;
                 tuple.serialize_element(rules)?;
-                tuple.serialize_element(error_identifier)?;
-                tuple.serialize_element(context)?;
+                tuple.serialize_element(compact_validation_error_identifier(error_identifier))?;
+                tuple.serialize_element(&CompactValidationContext {
+                    error_identifier,
+                    context,
+                })?;
                 tuple.end()
             }
             Self::If {
@@ -299,6 +303,110 @@ where
     tuple.serialize_element(tag)?;
     tuple.serialize_element(value)?;
     tuple.end()
+}
+
+fn compact_validation_error_identifier(error_identifier: &'static str) -> &'static str {
+    match error_identifier {
+        "RELATION_VIOLATION" => "r",
+        "MISSING_RELATED_RECORD" => "m",
+        "MISSING_RECORD" => "M",
+        "INCOMPLETE_CONNECT_INPUT" => "i",
+        "INCOMPLETE_CONNECT_OUTPUT" => "o",
+        "RECORDS_NOT_CONNECTED" => "n",
+        _ => error_identifier,
+    }
+}
+
+struct CompactValidationContext<'a> {
+    error_identifier: &'static str,
+    context: &'a Value,
+}
+
+impl Serialize for CompactValidationContext<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let Value::Object(context) = self.context else {
+            return self.context.serialize(serializer);
+        };
+
+        match self.error_identifier {
+            "RELATION_VIOLATION" => {
+                if let (Some(relation), Some(model_a), Some(model_b)) =
+                    (context.get("relation"), context.get("modelA"), context.get("modelB"))
+                {
+                    let mut tuple = serializer.serialize_tuple(3)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(model_a)?;
+                    tuple.serialize_element(model_b)?;
+                    return tuple.end();
+                }
+            }
+            "MISSING_RELATED_RECORD" => {
+                if let (Some(model), Some(relation), Some(relation_type), Some(operation)) = (
+                    context.get("model"),
+                    context.get("relation"),
+                    context.get("relationType"),
+                    context.get("operation"),
+                ) {
+                    if let Some(needed_for) = context.get("neededFor") {
+                        let mut tuple = serializer.serialize_tuple(5)?;
+                        tuple.serialize_element(model)?;
+                        tuple.serialize_element(relation)?;
+                        tuple.serialize_element(relation_type)?;
+                        tuple.serialize_element(operation)?;
+                        tuple.serialize_element(needed_for)?;
+                        return tuple.end();
+                    }
+
+                    let mut tuple = serializer.serialize_tuple(4)?;
+                    tuple.serialize_element(model)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(relation_type)?;
+                    tuple.serialize_element(operation)?;
+                    return tuple.end();
+                }
+            }
+            "MISSING_RECORD" => {
+                if let Some(operation) = context.get("operation") {
+                    return operation.serialize(serializer);
+                }
+            }
+            "INCOMPLETE_CONNECT_INPUT" => {
+                if let Some(expected_rows) = context.get("expectedRows") {
+                    return expected_rows.serialize(serializer);
+                }
+            }
+            "INCOMPLETE_CONNECT_OUTPUT" => {
+                if let (Some(expected_rows), Some(relation), Some(relation_type)) = (
+                    context.get("expectedRows"),
+                    context.get("relation"),
+                    context.get("relationType"),
+                ) {
+                    let mut tuple = serializer.serialize_tuple(3)?;
+                    tuple.serialize_element(expected_rows)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(relation_type)?;
+                    return tuple.end();
+                }
+            }
+            "RECORDS_NOT_CONNECTED" => {
+                if let (Some(relation), Some(parent), Some(child)) =
+                    (context.get("relation"), context.get("parent"), context.get("child"))
+                {
+                    let mut tuple = serializer.serialize_tuple(3)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(parent)?;
+                    tuple.serialize_element(child)?;
+                    return tuple.end();
+                }
+            }
+            _ => {}
+        }
+
+        self.context.serialize(serializer)
+    }
 }
 
 impl Expression {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -8,7 +8,7 @@ use bon::{Builder, bon};
 use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeTuple};
 use thiserror::Error;
 
 mod format;
@@ -43,8 +43,7 @@ pub struct JoinExpression {
     pub is_relation_unique: bool,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", content = "args", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum Expression {
     /// Expression that evaluates to a plain value.
     Value(PrismaValue),
@@ -83,7 +82,6 @@ pub enum Expression {
     Required(Box<Expression>),
 
     /// Application-level join.
-    #[serde(rename_all = "camelCase")]
     Join {
         parent: Box<Expression>,
         children: Vec<JoinExpression>,
@@ -105,7 +103,6 @@ pub enum Expression {
     },
 
     /// Validates the expression according to the data rule and throws an error if it doesn't match.
-    #[serde(rename_all = "camelCase")]
     Validate {
         expr: Box<Expression>,
         rules: Vec<DataRule>,
@@ -149,6 +146,134 @@ pub enum Expression {
         expr: Box<Expression>,
         operations: InMemoryOps,
     },
+}
+
+impl Serialize for Expression {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Value(value) => serialize_unary("v", value, serializer),
+            Self::Seq(expressions) => serialize_unary("s", expressions, serializer),
+            Self::Get { name } => serialize_unary("g", name, serializer),
+            Self::Let { bindings, expr } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("l")?;
+                tuple.serialize_element(bindings)?;
+                tuple.serialize_element(expr)?;
+                tuple.end()
+            }
+            Self::GetFirstNonEmpty { names } => serialize_unary("e", names, serializer),
+            Self::Query(query) => serialize_unary("q", query, serializer),
+            Self::Execute(query) => serialize_unary("x", query, serializer),
+            Self::Sum(expressions) => serialize_unary("+", expressions, serializer),
+            Self::Concat(expressions) => serialize_unary("c", expressions, serializer),
+            Self::Unique(expr) => serialize_unary("u", expr, serializer),
+            Self::Required(expr) => serialize_unary("r", expr, serializer),
+            Self::Join {
+                parent,
+                children,
+                can_assume_strict_equality,
+            } => {
+                let mut tuple = serializer.serialize_tuple(4)?;
+                tuple.serialize_element("j")?;
+                tuple.serialize_element(parent)?;
+                tuple.serialize_element(children)?;
+                tuple.serialize_element(can_assume_strict_equality)?;
+                tuple.end()
+            }
+            Self::MapField { field, records } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("m")?;
+                tuple.serialize_element(field)?;
+                tuple.serialize_element(records)?;
+                tuple.end()
+            }
+            Self::Transaction(expr) => serialize_unary("t", expr, serializer),
+            Self::DataMap { expr, structure, enums } => {
+                let mut tuple = serializer.serialize_tuple(4)?;
+                tuple.serialize_element("d")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(structure)?;
+                tuple.serialize_element(enums)?;
+                tuple.end()
+            }
+            Self::Validate {
+                expr,
+                rules,
+                error_identifier,
+                context,
+            } => {
+                let mut tuple = serializer.serialize_tuple(5)?;
+                tuple.serialize_element("V")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(rules)?;
+                tuple.serialize_element(error_identifier)?;
+                tuple.serialize_element(context)?;
+                tuple.end()
+            }
+            Self::If {
+                value,
+                rule,
+                then,
+                r#else,
+            } => {
+                let mut tuple = serializer.serialize_tuple(5)?;
+                tuple.serialize_element("?")?;
+                tuple.serialize_element(value)?;
+                tuple.serialize_element(rule)?;
+                tuple.serialize_element(then)?;
+                tuple.serialize_element(r#else)?;
+                tuple.end()
+            }
+            Self::Unit => {
+                let mut tuple = serializer.serialize_tuple(1)?;
+                tuple.serialize_element("0")?;
+                tuple.end()
+            }
+            Self::Diff { from, to, fields } => {
+                let mut tuple = serializer.serialize_tuple(4)?;
+                tuple.serialize_element("-")?;
+                tuple.serialize_element(from)?;
+                tuple.serialize_element(to)?;
+                tuple.serialize_element(fields)?;
+                tuple.end()
+            }
+            Self::InitializeRecord { expr, fields } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("i")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(fields)?;
+                tuple.end()
+            }
+            Self::MapRecord { expr, fields } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("M")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(fields)?;
+                tuple.end()
+            }
+            Self::Process { expr, operations } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("p")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(operations)?;
+                tuple.end()
+            }
+        }
+    }
+}
+
+fn serialize_unary<S, T>(tag: &'static str, value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    let mut tuple = serializer.serialize_tuple(2)?;
+    tuple.serialize_element(tag)?;
+    tuple.serialize_element(value)?;
+    tuple.end()
 }
 
 impl Expression {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -218,11 +218,13 @@ impl Serialize for Expression {
             }
             Self::Transaction(expr) => serialize_unary("t", expr, serializer),
             Self::DataMap { expr, structure, enums } => {
-                let mut tuple = serializer.serialize_tuple(4)?;
+                let mut tuple = serializer.serialize_tuple(if enums.is_empty() { 3 } else { 4 })?;
                 tuple.serialize_element("d")?;
                 tuple.serialize_element(expr)?;
                 tuple.serialize_element(structure)?;
-                tuple.serialize_element(enums)?;
+                if !enums.is_empty() {
+                    tuple.serialize_element(enums)?;
+                }
                 tuple.end()
             }
             Self::Validate {
@@ -654,6 +656,10 @@ pub struct EnumsMap(BTreeMap<String, BTreeMap<String, String>>);
 impl EnumsMap {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     pub fn add(&mut self, r#enum: InternalEnum) {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -6,10 +6,10 @@ use std::{
 use crate::{data_mapper::FieldType, result_node::ResultNode};
 use bon::{Builder, bon};
 use query_builder::DbQuery;
-use query_core::{DataExpectation, DataRule};
+use query_core::{DataDependencyError, DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
 use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeTuple};
-use serde_json::Value;
+use smallvec::SmallVec;
 use thiserror::Error;
 
 mod format;
@@ -263,9 +263,8 @@ pub enum Expression {
     /// Validates the expression according to the data rule and throws an error if it doesn't match.
     Validate {
         expr: Box<Expression>,
-        rules: Vec<DataRule>,
-        error_identifier: &'static str,
-        context: serde_json::Value,
+        rules: SmallVec<[DataRule; 1]>,
+        error: DataDependencyError,
     },
 
     /// Checks if `value` satisifies the `rule`, and executes `then` if it does, or `r#else` if it doesn't.
@@ -372,18 +371,14 @@ impl Serialize for Expression {
             Self::Validate {
                 expr,
                 rules,
-                error_identifier,
-                context,
+                error,
             } => {
                 let mut tuple = serializer.serialize_tuple(5)?;
                 tuple.serialize_element("V")?;
                 tuple.serialize_element(expr)?;
-                tuple.serialize_element(rules)?;
-                tuple.serialize_element(compact_validation_error_identifier(error_identifier))?;
-                tuple.serialize_element(&CompactValidationContext {
-                    error_identifier,
-                    context,
-                })?;
+                tuple.serialize_element(rules.as_slice())?;
+                tuple.serialize_element(error.compact_id())?;
+                tuple.serialize_element(&CompactValidationContext { error })?;
                 tuple.end()
             }
             Self::If {
@@ -449,21 +444,8 @@ where
     tuple.end()
 }
 
-fn compact_validation_error_identifier(error_identifier: &'static str) -> &'static str {
-    match error_identifier {
-        "RELATION_VIOLATION" => "r",
-        "MISSING_RELATED_RECORD" => "m",
-        "MISSING_RECORD" => "M",
-        "INCOMPLETE_CONNECT_INPUT" => "i",
-        "INCOMPLETE_CONNECT_OUTPUT" => "o",
-        "RECORDS_NOT_CONNECTED" => "n",
-        _ => error_identifier,
-    }
-}
-
 struct CompactValidationContext<'a> {
-    error_identifier: &'static str,
-    context: &'a Value,
+    error: &'a DataDependencyError,
 }
 
 impl Serialize for CompactValidationContext<'_> {
@@ -471,85 +453,7 @@ impl Serialize for CompactValidationContext<'_> {
     where
         S: Serializer,
     {
-        let Value::Object(context) = self.context else {
-            return self.context.serialize(serializer);
-        };
-
-        match self.error_identifier {
-            "RELATION_VIOLATION" => {
-                if let (Some(relation), Some(model_a), Some(model_b)) =
-                    (context.get("relation"), context.get("modelA"), context.get("modelB"))
-                {
-                    let mut tuple = serializer.serialize_tuple(3)?;
-                    tuple.serialize_element(relation)?;
-                    tuple.serialize_element(model_a)?;
-                    tuple.serialize_element(model_b)?;
-                    return tuple.end();
-                }
-            }
-            "MISSING_RELATED_RECORD" => {
-                if let (Some(model), Some(relation), Some(relation_type), Some(operation)) = (
-                    context.get("model"),
-                    context.get("relation"),
-                    context.get("relationType"),
-                    context.get("operation"),
-                ) {
-                    if let Some(needed_for) = context.get("neededFor") {
-                        let mut tuple = serializer.serialize_tuple(5)?;
-                        tuple.serialize_element(model)?;
-                        tuple.serialize_element(relation)?;
-                        tuple.serialize_element(relation_type)?;
-                        tuple.serialize_element(operation)?;
-                        tuple.serialize_element(needed_for)?;
-                        return tuple.end();
-                    }
-
-                    let mut tuple = serializer.serialize_tuple(4)?;
-                    tuple.serialize_element(model)?;
-                    tuple.serialize_element(relation)?;
-                    tuple.serialize_element(relation_type)?;
-                    tuple.serialize_element(operation)?;
-                    return tuple.end();
-                }
-            }
-            "MISSING_RECORD" => {
-                if let Some(operation) = context.get("operation") {
-                    return operation.serialize(serializer);
-                }
-            }
-            "INCOMPLETE_CONNECT_INPUT" => {
-                if let Some(expected_rows) = context.get("expectedRows") {
-                    return expected_rows.serialize(serializer);
-                }
-            }
-            "INCOMPLETE_CONNECT_OUTPUT" => {
-                if let (Some(expected_rows), Some(relation), Some(relation_type)) = (
-                    context.get("expectedRows"),
-                    context.get("relation"),
-                    context.get("relationType"),
-                ) {
-                    let mut tuple = serializer.serialize_tuple(3)?;
-                    tuple.serialize_element(expected_rows)?;
-                    tuple.serialize_element(relation)?;
-                    tuple.serialize_element(relation_type)?;
-                    return tuple.end();
-                }
-            }
-            "RECORDS_NOT_CONNECTED" => {
-                if let (Some(relation), Some(parent), Some(child)) =
-                    (context.get("relation"), context.get("parent"), context.get("child"))
-                {
-                    let mut tuple = serializer.serialize_tuple(3)?;
-                    tuple.serialize_element(relation)?;
-                    tuple.serialize_element(parent)?;
-                    tuple.serialize_element(child)?;
-                    return tuple.end();
-                }
-            }
-            _ => {}
-        }
-
-        self.context.serialize(serializer)
+        self.error.serialize_compact_context(serializer)
     }
 }
 
@@ -916,9 +820,8 @@ impl Expression {
     pub fn validate_expectation(expectation: &DataExpectation, expr: Expression) -> Expression {
         Expression::Validate {
             expr: expr.into(),
-            rules: expectation.rules().to_vec(),
-            error_identifier: expectation.error().id(),
-            context: expectation.error().context(),
+            rules: expectation.rules().iter().cloned().collect(),
+            error: expectation.error().clone(),
         }
     }
 }

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -8,7 +8,7 @@ use bon::{Builder, bon};
 use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
-use serde::{Serialize, Serializer, ser::SerializeTuple};
+use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeTuple};
 use thiserror::Error;
 
 mod format;
@@ -399,12 +399,32 @@ impl TryFrom<ScalarWriteOperation> for FieldOperation {
 #[error("unsupported scalar write operation: {0:?}")]
 pub struct UnsupportedScalarWriteOperation(ScalarWriteOperation);
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct Pagination {
     cursor: Option<HashMap<String, PrismaValue>>,
     take: Option<i64>,
     skip: Option<i64>,
+}
+
+impl Serialize for Pagination {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len =
+            usize::from(self.cursor.is_some()) + usize::from(self.take.is_some()) + usize::from(self.skip.is_some());
+        let mut map = serializer.serialize_map(Some(len))?;
+        if let Some(cursor) = &self.cursor {
+            map.serialize_entry("cursor", cursor)?;
+        }
+        if let Some(take) = self.take {
+            map.serialize_entry("take", &take)?;
+        }
+        if let Some(skip) = self.skip {
+            map.serialize_entry("skip", &skip)?;
+        }
+        map.end()
+    }
 }
 
 #[bon]
@@ -427,8 +447,7 @@ impl Pagination {
     }
 }
 
-#[derive(Debug, Default, Serialize, Builder)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Builder)]
 pub struct InMemoryOps {
     pub(crate) pagination: Option<Pagination>,
     pub(crate) distinct: Option<Vec<String>>,
@@ -437,6 +456,36 @@ pub struct InMemoryOps {
     #[builder(default)]
     pub(crate) nested: BTreeMap<String, InMemoryOps>,
     pub(crate) linking_fields: Option<Vec<String>>,
+}
+
+impl Serialize for InMemoryOps {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = usize::from(self.pagination.is_some())
+            + usize::from(self.distinct.is_some())
+            + usize::from(self.reverse)
+            + usize::from(!self.nested.is_empty())
+            + usize::from(self.linking_fields.is_some());
+        let mut map = serializer.serialize_map(Some(len))?;
+        if let Some(pagination) = &self.pagination {
+            map.serialize_entry("pagination", pagination)?;
+        }
+        if let Some(distinct) = &self.distinct {
+            map.serialize_entry("distinct", distinct)?;
+        }
+        if self.reverse {
+            map.serialize_entry("reverse", &self.reverse)?;
+        }
+        if !self.nested.is_empty() {
+            map.serialize_entry("nested", &self.nested)?;
+        }
+        if let Some(linking_fields) = &self.linking_fields {
+            map.serialize_entry("linkingFields", linking_fields)?;
+        }
+        map.end()
+    }
 }
 
 impl InMemoryOps {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -132,6 +132,7 @@ pub struct RawNestedReadQuery {
     pub query: DbQuery,
     pub fields: Vec<RawResultColumnMapping>,
     pub relations: Vec<RawNestedReadRelation>,
+    pub schedule: Option<RawNestedFinalOwnerSchedule>,
 }
 
 impl Serialize for RawNestedReadQuery {
@@ -139,12 +140,62 @@ impl Serialize for RawNestedReadQuery {
     where
         S: Serializer,
     {
-        let mut tuple = serializer.serialize_tuple(if self.relations.is_empty() { 2 } else { 3 })?;
+        let mut tuple = serializer.serialize_tuple(if self.schedule.is_some() {
+            4
+        } else if self.relations.is_empty() {
+            2
+        } else {
+            3
+        })?;
         tuple.serialize_element(&self.query)?;
         tuple.serialize_element(&self.fields)?;
-        if !self.relations.is_empty() {
+        if !self.relations.is_empty() || self.schedule.is_some() {
             tuple.serialize_element(&self.relations)?;
         }
+        if let Some(schedule) = &self.schedule {
+            tuple.serialize_element(schedule)?;
+        }
+        tuple.end()
+    }
+}
+
+#[derive(Debug)]
+pub struct RawNestedFinalOwnerSchedule {
+    pub root_key_column: RawResultColumnRef,
+    pub unique_relations: [usize; 2],
+    pub wrapper_list: RawNestedFinalOwnerNestedRelation,
+    pub child_list: RawNestedFinalOwnerNestedRelation,
+}
+
+impl Serialize for RawNestedFinalOwnerSchedule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(5)?;
+        tuple.serialize_element("f")?;
+        tuple.serialize_element(&self.root_key_column)?;
+        tuple.serialize_element(&self.unique_relations)?;
+        tuple.serialize_element(&self.wrapper_list)?;
+        tuple.serialize_element(&self.child_list)?;
+        tuple.end()
+    }
+}
+
+#[derive(Debug)]
+pub struct RawNestedFinalOwnerNestedRelation {
+    pub relation_index: usize,
+    pub child_relation_index: usize,
+}
+
+impl Serialize for RawNestedFinalOwnerNestedRelation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(&self.relation_index)?;
+        tuple.serialize_element(&self.child_relation_index)?;
         tuple.end()
     }
 }

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -13,10 +13,22 @@ use thiserror::Error;
 
 mod format;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct Binding {
     pub name: Cow<'static, str>,
     pub expr: Expression,
+}
+
+impl Serialize for Binding {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(&self.name)?;
+        tuple.serialize_element(&self.expr)?;
+        tuple.end()
+    }
 }
 
 impl Binding {
@@ -34,13 +46,26 @@ impl std::fmt::Display for Binding {
     }
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct JoinExpression {
     pub child: Expression,
     pub on: Vec<(String, String)>,
     pub parent_field: String,
     pub is_relation_unique: bool,
+}
+
+impl Serialize for JoinExpression {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(4)?;
+        tuple.serialize_element(&self.child)?;
+        tuple.serialize_element(&self.on)?;
+        tuple.serialize_element(&self.parent_field)?;
+        tuple.serialize_element(&self.is_relation_unique)?;
+        tuple.end()
+    }
 }
 
 #[derive(Debug)]

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, HashMap},
 };
 
-use crate::result_node::ResultNode;
+use crate::{data_mapper::FieldType, result_node::ResultNode};
 use bon::{Builder, bon};
 use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
@@ -70,6 +70,129 @@ impl Serialize for JoinExpression {
 }
 
 #[derive(Debug)]
+pub enum RawResultFieldName {
+    Field(String),
+    Path(Vec<String>),
+}
+
+impl Serialize for RawResultFieldName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Field(name) => name.serialize(serializer),
+            Self::Path(path) => path.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RawResultColumnMapping {
+    pub field_name: RawResultFieldName,
+    pub column: RawResultColumnRef,
+    pub field_type: Option<FieldType>,
+}
+
+impl Serialize for RawResultColumnMapping {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(if self.field_type.is_some() { 3 } else { 2 })?;
+        tuple.serialize_element(&self.field_name)?;
+        tuple.serialize_element(&self.column)?;
+        if let Some(field_type) = &self.field_type {
+            tuple.serialize_element(field_type)?;
+        }
+        tuple.end()
+    }
+}
+
+#[derive(Debug)]
+pub enum RawResultColumnRef {
+    Index(usize),
+    Name(String),
+}
+
+impl Serialize for RawResultColumnRef {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Index(index) => index.serialize(serializer),
+            Self::Name(name) => name.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RawNestedReadQuery {
+    pub query: DbQuery,
+    pub fields: Vec<RawResultColumnMapping>,
+    pub relations: Vec<RawNestedReadRelation>,
+}
+
+impl Serialize for RawNestedReadQuery {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(if self.relations.is_empty() { 2 } else { 3 })?;
+        tuple.serialize_element(&self.query)?;
+        tuple.serialize_element(&self.fields)?;
+        if !self.relations.is_empty() {
+            tuple.serialize_element(&self.relations)?;
+        }
+        tuple.end()
+    }
+}
+
+#[derive(Debug)]
+pub enum RawNestedReadRelation {
+    Direct(RawNestedReadDirectRelation),
+}
+
+impl Serialize for RawNestedReadRelation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Direct(relation) => relation.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct RawNestedReadDirectRelation {
+    pub field_name: String,
+    pub child: RawNestedReadQuery,
+    pub parent_column: RawResultColumnRef,
+    pub child_column: RawResultColumnRef,
+    pub scope_name: Cow<'static, str>,
+    pub is_relation_unique: bool,
+}
+
+impl Serialize for RawNestedReadDirectRelation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(7)?;
+        tuple.serialize_element("r")?;
+        tuple.serialize_element(&self.field_name)?;
+        tuple.serialize_element(&self.child)?;
+        tuple.serialize_element(&self.parent_column)?;
+        tuple.serialize_element(&self.child_column)?;
+        tuple.serialize_element(&self.scope_name)?;
+        tuple.serialize_element(&self.is_relation_unique)?;
+        tuple.end()
+    }
+}
+
+#[derive(Debug)]
 pub enum Expression {
     /// Expression that evaluates to a plain value.
     Value(PrismaValue),
@@ -125,6 +248,13 @@ pub enum Expression {
     DataMap {
         expr: Box<Expression>,
         structure: ResultNode,
+        enums: EnumsMap,
+    },
+
+    /// Raw result-set nested read specialized for query-mode relation loading.
+    RawNestedRead {
+        query: RawNestedReadQuery,
+        unique: bool,
         enums: EnumsMap,
     },
 
@@ -222,6 +352,16 @@ impl Serialize for Expression {
                 tuple.serialize_element("d")?;
                 tuple.serialize_element(expr)?;
                 tuple.serialize_element(structure)?;
+                if !enums.is_empty() {
+                    tuple.serialize_element(enums)?;
+                }
+                tuple.end()
+            }
+            Self::RawNestedRead { query, unique, enums } => {
+                let mut tuple = serializer.serialize_tuple(if enums.is_empty() { 3 } else { 4 })?;
+                tuple.serialize_element("n")?;
+                tuple.serialize_element(query)?;
+                tuple.serialize_element(unique)?;
                 if !enums.is_empty() {
                     tuple.serialize_element(enums)?;
                 }
@@ -470,6 +610,7 @@ impl Expression {
             Expression::DataMap { expr, .. } => {
                 expr.simplify();
             }
+            Expression::RawNestedRead { .. } => {}
             Expression::Validate { expr, .. } => {
                 expr.simplify();
             }
@@ -746,6 +887,13 @@ impl Expression {
             Expression::MapField { records, .. } => records.r#type(),
             Expression::Transaction(expression) => expression.r#type(),
             Expression::DataMap { expr, .. } => expr.r#type(),
+            Expression::RawNestedRead { unique, .. } => {
+                if *unique {
+                    ExpressionType::Record
+                } else {
+                    ExpressionType::List(Box::new(ExpressionType::Record))
+                }
+            }
             Expression::Validate { expr, .. } => expr.r#type(),
             Expression::If { then, r#else, .. } => {
                 let then_type = then.r#type();

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -173,6 +173,7 @@ pub struct RawNestedReadDirectRelation {
     pub child_column: RawResultColumnRef,
     pub scope_name: Cow<'static, str>,
     pub is_relation_unique: bool,
+    pub operations: InMemoryOps,
 }
 
 impl Serialize for RawNestedReadDirectRelation {
@@ -180,7 +181,7 @@ impl Serialize for RawNestedReadDirectRelation {
     where
         S: Serializer,
     {
-        let mut tuple = serializer.serialize_tuple(7)?;
+        let mut tuple = serializer.serialize_tuple(8)?;
         tuple.serialize_element("r")?;
         tuple.serialize_element(&self.field_name)?;
         tuple.serialize_element(&self.child)?;
@@ -188,6 +189,7 @@ impl Serialize for RawNestedReadDirectRelation {
         tuple.serialize_element(&self.child_column)?;
         tuple.serialize_element(&self.scope_name)?;
         tuple.serialize_element(&self.is_relation_unique)?;
+        tuple.serialize_element(&self.operations)?;
         tuple.end()
     }
 }

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -1,6 +1,6 @@
 use super::{
-    Binding, DbQuery, EnumsMap, Expression, FieldOperation, JoinExpression, Pagination, RawNestedReadQuery,
-    RawNestedReadRelation, RawResultColumnRef, RawResultFieldName,
+    Binding, DbQuery, EnumsMap, Expression, FieldOperation, JoinExpression, Pagination, RawNestedFinalOwnerSchedule,
+    RawNestedReadQuery, RawNestedReadRelation, RawResultColumnRef, RawResultFieldName,
 };
 use crate::{
     expression::{FieldInitializer, InMemoryOps},
@@ -67,12 +67,7 @@ where
             Expression::Transaction(expression) => self.transaction(expression),
             Expression::DataMap { expr, structure, enums } => self.data_map(expr, structure, enums),
             Expression::RawNestedRead { query, unique, enums } => self.raw_nested_read(query, *unique, enums),
-            Expression::Validate {
-                expr,
-                rules,
-                error,
-                ..
-            } => self.validate(expr, rules, error.id()),
+            Expression::Validate { expr, rules, error, .. } => self.validate(expr, rules, error.id()),
             Expression::If {
                 value,
                 rule,
@@ -346,7 +341,45 @@ where
                 .append(self.raw_nested_relations(&query.relations));
         }
 
+        if let Some(schedule) = &query.schedule {
+            doc = doc
+                .append(self.line())
+                .append(self.keyword("schedule"))
+                .append(self.space())
+                .append(self.raw_nested_final_owner_schedule(schedule));
+        }
+
         doc.align().parens()
+    }
+
+    fn raw_nested_final_owner_schedule(&'a self, schedule: &'a RawNestedFinalOwnerSchedule) -> PrettyDoc<'a, D> {
+        self.keyword("finalOwner").append(self.space()).append(self.object([
+            (
+                self.field_name("rootKey"),
+                self.raw_result_column_ref(&schedule.root_key_column),
+            ),
+            (
+                self.field_name("unique"),
+                self.text(format!(
+                    "[{}, {}]",
+                    schedule.unique_relations[0], schedule.unique_relations[1]
+                )),
+            ),
+            (
+                self.field_name("wrapperList"),
+                self.text(format!(
+                    "[{}, {}]",
+                    schedule.wrapper_list.relation_index, schedule.wrapper_list.child_relation_index
+                )),
+            ),
+            (
+                self.field_name("childList"),
+                self.text(format!(
+                    "[{}, {}]",
+                    schedule.child_list.relation_index, schedule.child_list.child_relation_index
+                )),
+            ),
+        ]))
     }
 
     fn raw_nested_relations(&'a self, relations: &'a [RawNestedReadRelation]) -> PrettyDoc<'a, D> {

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -391,7 +391,7 @@ where
     fn data_map_node(&'a self, node: &'a ResultNode) -> PrettyDoc<'a, D> {
         match node {
             ResultNode::AffectedRows => self.keyword("affectedRows"),
-            ResultNode::Object(object) => self.object(object.fields().iter().map(|(name, field)| {
+            ResultNode::Object(object) => self.object(object.fields().map(|(name, field)| {
                 let mut key = self.field_name(name);
                 if let ResultNode::Object(nested_object) = field {
                     let source = match nested_object.serialized_name() {

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -1,4 +1,7 @@
-use super::{Binding, DbQuery, EnumsMap, Expression, FieldOperation, JoinExpression, Pagination};
+use super::{
+    Binding, DbQuery, EnumsMap, Expression, FieldOperation, JoinExpression, Pagination, RawNestedReadQuery,
+    RawNestedReadRelation, RawResultColumnRef, RawResultFieldName,
+};
 use crate::{
     expression::{FieldInitializer, InMemoryOps},
     result_node::ResultNode,
@@ -63,6 +66,7 @@ where
             Expression::MapField { field, records } => self.map_field(field, records),
             Expression::Transaction(expression) => self.transaction(expression),
             Expression::DataMap { expr, structure, enums } => self.data_map(expr, structure, enums),
+            Expression::RawNestedRead { query, unique, enums } => self.raw_nested_read(query, *unique, enums),
             Expression::Validate {
                 expr,
                 rules,
@@ -299,6 +303,91 @@ where
         doc.append(self.expression(expr))
     }
 
+    fn raw_nested_read(&'a self, query: &'a RawNestedReadQuery, unique: bool, enums: &'a EnumsMap) -> PrettyDoc<'a, D> {
+        let mut doc = self
+            .keyword(if unique { "rawNestedReadUnique" } else { "rawNestedRead" })
+            .append(self.space())
+            .append(self.raw_nested_read_query(query));
+
+        if !enums.0.is_empty() {
+            doc = doc
+                .append(self.line())
+                .append(self.keyword("enums"))
+                .append(self.space())
+                .append(self.enum_map(enums));
+        }
+
+        doc
+    }
+
+    fn raw_nested_read_query(&'a self, query: &'a RawNestedReadQuery) -> PrettyDoc<'a, D> {
+        let fields = self.object(query.fields.iter().map(|field| {
+            let name = match &field.field_name {
+                RawResultFieldName::Field(name) => self.field_name(name),
+                RawResultFieldName::Path(path) => self
+                    .intersperse(path.iter().map(|segment| self.field_name(segment)), self.text("."))
+                    .align(),
+            };
+            (name, self.raw_result_column_ref(&field.column))
+        }));
+
+        let mut doc = self
+            .query("query", &query.query)
+            .append(self.line())
+            .append(self.keyword("fields"))
+            .append(self.space())
+            .append(fields);
+
+        if !query.relations.is_empty() {
+            doc = doc
+                .append(self.line())
+                .append(self.keyword("relations"))
+                .append(self.space())
+                .append(self.raw_nested_relations(&query.relations));
+        }
+
+        doc.align().parens()
+    }
+
+    fn raw_nested_relations(&'a self, relations: &'a [RawNestedReadRelation]) -> PrettyDoc<'a, D> {
+        self.intersperse(
+            relations.iter().map(|relation| match relation {
+                RawNestedReadRelation::Direct(relation) => self
+                    .field_name(&relation.field_name)
+                    .append(self.space())
+                    .append(self.keyword("on"))
+                    .append(self.space())
+                    .append(self.keyword("left"))
+                    .append(".")
+                    .append(self.raw_result_column_ref(&relation.parent_column))
+                    .append(self.space())
+                    .append("=")
+                    .append(self.space())
+                    .append(self.keyword("right"))
+                    .append(".")
+                    .append(self.raw_result_column_ref(&relation.child_column))
+                    .append(self.space())
+                    .append(if relation.is_relation_unique {
+                        self.keyword("unique")
+                    } else {
+                        self.keyword("many")
+                    })
+                    .append(self.space())
+                    .append(self.raw_nested_read_query(&relation.child)),
+            }),
+            self.text(",").append(self.line()),
+        )
+        .align()
+        .brackets()
+    }
+
+    fn raw_result_column_ref(&'a self, column: &'a RawResultColumnRef) -> PrettyDoc<'a, D> {
+        match column {
+            RawResultColumnRef::Index(index) => self.text(index.to_string()),
+            RawResultColumnRef::Name(name) => self.field_name(name),
+        }
+    }
+
     fn data_map_node(&'a self, node: &'a ResultNode) -> PrettyDoc<'a, D> {
         match node {
             ResultNode::AffectedRows => self.keyword("affectedRows"),
@@ -337,6 +426,11 @@ where
     }
 
     fn object(&'a self, pairs: impl IntoIterator<Item = (PrettyDoc<'a, D>, PrettyDoc<'a, D>)>) -> PrettyDoc<'a, D> {
+        let pairs = pairs.into_iter().collect::<Vec<_>>();
+        if pairs.is_empty() {
+            return self.text("{}");
+        }
+
         self.indented_braces(
             self.intersperse(
                 pairs

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -70,9 +70,9 @@ where
             Expression::Validate {
                 expr,
                 rules,
-                error_identifier,
+                error,
                 ..
-            } => self.validate(expr, rules, error_identifier),
+            } => self.validate(expr, rules, error.id()),
             Expression::If {
                 value,
                 rule,

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use indexmap::IndexMap;
 use query_structure::{FieldTypeInformation, TypeIdentifier};
 use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeStruct, ser::SerializeTuple};
 
@@ -42,8 +41,14 @@ impl Serialize for ResultNode {
 #[derive(Debug)]
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
-    fields: IndexMap<Cow<'static, str>, ResultNode>,
+    fields: Vec<ObjectField>,
     skip_nulls: bool,
+}
+
+#[derive(Debug)]
+pub struct ObjectField {
+    name: Cow<'static, str>,
+    node: ResultNode,
 }
 
 impl Serialize for Object {
@@ -66,7 +71,7 @@ impl Serialize for Object {
     }
 }
 
-struct SerializedObjectFields<'a>(&'a IndexMap<Cow<'static, str>, ResultNode>);
+struct SerializedObjectFields<'a>(&'a [ObjectField]);
 
 impl Serialize for SerializedObjectFields<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -77,12 +82,14 @@ impl Serialize for SerializedObjectFields<'_> {
     }
 }
 
-fn serialize_fields<S>(fields: &IndexMap<Cow<'static, str>, ResultNode>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_fields<S>(fields: &[ObjectField], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     let mut map = serializer.serialize_map(Some(fields.len()))?;
-    for (name, node) in fields {
+    for field in fields {
+        let name = &field.name;
+        let node = &field.node;
         match node {
             ResultNode::Field { db_name, field_type } if db_name == name => {
                 if let Some(compact_name) = field_type.compact_name() {
@@ -122,9 +129,13 @@ struct FieldNodeInObject<'a> {
 
 impl Object {
     fn new(serialized_name: Option<impl Into<Cow<'static, str>>>) -> Self {
+        Self::with_capacity(serialized_name, 0)
+    }
+
+    fn with_capacity(serialized_name: Option<impl Into<Cow<'static, str>>>, capacity: usize) -> Self {
         Self {
             serialized_name: serialized_name.map(Into::into),
-            fields: IndexMap::new(),
+            fields: Vec::with_capacity(capacity),
             skip_nulls: false,
         }
     }
@@ -138,8 +149,8 @@ impl Object {
         self.serialized_name.as_deref()
     }
 
-    pub fn fields(&self) -> &IndexMap<Cow<'static, str>, ResultNode> {
-        &self.fields
+    pub fn fields(&self) -> impl ExactSizeIterator<Item = (&Cow<'static, str>, &ResultNode)> {
+        self.fields.iter().map(|field| (&field.name, &field.node))
     }
 }
 
@@ -154,6 +165,13 @@ impl<'a> ResultNodeBuilder<'a> {
 
     pub fn new_object(serialized_name: Option<impl Into<Cow<'static, str>>>) -> ObjectBuilder {
         ObjectBuilder::new(serialized_name)
+    }
+
+    pub fn new_object_with_capacity(
+        serialized_name: Option<impl Into<Cow<'static, str>>>,
+        capacity: usize,
+    ) -> ObjectBuilder {
+        ObjectBuilder::with_capacity(serialized_name, capacity)
     }
 
     #[inline]
@@ -180,8 +198,12 @@ pub struct ObjectBuilder {
 
 impl ObjectBuilder {
     fn new(serialized_name: Option<impl Into<Cow<'static, str>>>) -> Self {
+        Self::with_capacity(serialized_name, 0)
+    }
+
+    fn with_capacity(serialized_name: Option<impl Into<Cow<'static, str>>>, capacity: usize) -> Self {
         Self {
-            object: Object::new(serialized_name),
+            object: Object::with_capacity(serialized_name, capacity),
         }
     }
 
@@ -212,13 +234,18 @@ impl ObjectBuilder {
         key: Cow<'static, str>,
         original_key: Option<Cow<'static, str>>,
     ) -> ObjectMutBuilder<'_> {
-        let node = self
-            .object
-            .fields
-            .entry(key)
-            .or_insert(ResultNode::Object(Object::new(original_key)));
+        let field_index = match self.object.fields.iter().position(|field| field.name == key) {
+            Some(index) => index,
+            None => {
+                self.object.fields.push(ObjectField {
+                    name: key,
+                    node: ResultNode::Object(Object::new(original_key)),
+                });
+                self.object.fields.len() - 1
+            }
+        };
 
-        let ResultNode::Object(object) = node else {
+        let ResultNode::Object(object) = &mut self.object.fields[field_index].node else {
             panic!("ObjectBuilder::entry_or_insert can only be called with key which is vacant or points at an object")
         };
 
@@ -240,6 +267,12 @@ impl<'a> ObjectMutBuilder<'a> {
     }
 
     pub fn add_field(&mut self, key: impl Into<Cow<'static, str>>, node: ResultNode) {
-        self.object.fields.insert(key.into(), node);
+        let key = key.into();
+        if let Some(field) = self.object.fields.iter_mut().find(|field| field.name == key) {
+            field.node = node;
+            return;
+        }
+
+        self.object.fields.push(ObjectField { name: key, node });
     }
 }

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -34,13 +34,28 @@ where
     let mut map = serializer.serialize_map(Some(fields.len()))?;
     for (name, node) in fields {
         match node {
-            ResultNode::Field { db_name, field_type } => map.serialize_entry(
-                name,
-                &FieldNodeInObject {
-                    db_name: (db_name != name).then_some(db_name),
-                    field_type,
-                },
-            )?,
+            ResultNode::Field { db_name, field_type } if db_name == name => {
+                if let Some(compact_name) = field_type.compact_name() {
+                    map.serialize_entry(name, compact_name)?;
+                } else {
+                    map.serialize_entry(
+                        name,
+                        &FieldNodeInObject {
+                            db_name: None,
+                            field_type,
+                        },
+                    )?;
+                }
+            }
+            ResultNode::Field { db_name, field_type } => {
+                map.serialize_entry(
+                    name,
+                    &FieldNodeInObject {
+                        db_name: Some(db_name),
+                        field_type,
+                    },
+                )?;
+            }
             node => map.serialize_entry(name, node)?,
         }
     }

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use indexmap::IndexMap;
 use query_structure::{FieldTypeInformation, TypeIdentifier};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeMap};
 
 use crate::{data_mapper::FieldType, expression::EnumsMap};
 
@@ -22,8 +22,43 @@ pub enum ResultNode {
 #[serde(rename_all = "camelCase")]
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
+    #[serde(serialize_with = "serialize_fields")]
     fields: IndexMap<Cow<'static, str>, ResultNode>,
     skip_nulls: bool,
+}
+
+fn serialize_fields<S>(fields: &IndexMap<Cow<'static, str>, ResultNode>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut map = serializer.serialize_map(Some(fields.len()))?;
+    for (name, node) in fields {
+        match node {
+            ResultNode::Field { db_name, field_type } if db_name == name => map.serialize_entry(
+                name,
+                &FieldNodeWithDefaultDbName {
+                    node_type: FieldNodeType::Field,
+                    field_type,
+                },
+            )?,
+            node => map.serialize_entry(name, node)?,
+        }
+    }
+    map.end()
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FieldNodeWithDefaultDbName<'a> {
+    #[serde(rename = "type")]
+    node_type: FieldNodeType,
+    field_type: &'a FieldType,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum FieldNodeType {
+    Field,
 }
 
 impl Object {

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -2,29 +2,79 @@ use std::borrow::Cow;
 
 use indexmap::IndexMap;
 use query_structure::{FieldTypeInformation, TypeIdentifier};
-use serde::{Serialize, Serializer, ser::SerializeMap};
+use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeStruct, ser::SerializeTuple};
 
 use crate::{data_mapper::FieldType, expression::EnumsMap};
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum ResultNode {
     AffectedRows,
     Object(Object),
-    #[serde(rename_all = "camelCase")]
     Field {
         db_name: Cow<'static, str>,
         field_type: FieldType,
     },
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+impl Serialize for ResultNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::AffectedRows => {
+                let mut state = serializer.serialize_struct("ResultNode", 1)?;
+                state.serialize_field("type", "affectedRows")?;
+                state.end()
+            }
+            Self::Object(object) => object.serialize(serializer),
+            Self::Field { db_name, field_type } => {
+                let mut state = serializer.serialize_struct("ResultNode", 3)?;
+                state.serialize_field("type", "field")?;
+                state.serialize_field("dbName", db_name)?;
+                state.serialize_field("fieldType", field_type)?;
+                state.end()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
-    #[serde(serialize_with = "serialize_fields")]
     fields: IndexMap<Cow<'static, str>, ResultNode>,
     skip_nulls: bool,
+}
+
+impl Serialize for Object {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if !self.skip_nulls {
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(&self.serialized_name)?;
+            tuple.serialize_element(&SerializedObjectFields(&self.fields))?;
+            return tuple.end();
+        }
+
+        let mut tuple = serializer.serialize_tuple(3)?;
+        tuple.serialize_element(&self.serialized_name)?;
+        tuple.serialize_element(&SerializedObjectFields(&self.fields))?;
+        tuple.serialize_element(&self.skip_nulls)?;
+        tuple.end()
+    }
+}
+
+struct SerializedObjectFields<'a>(&'a IndexMap<Cow<'static, str>, ResultNode>);
+
+impl Serialize for SerializedObjectFields<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_fields(self.0, serializer)
+    }
 }
 
 fn serialize_fields<S>(fields: &IndexMap<Cow<'static, str>, ResultNode>, serializer: S) -> Result<S::Ok, S::Error>

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -34,10 +34,10 @@ where
     let mut map = serializer.serialize_map(Some(fields.len()))?;
     for (name, node) in fields {
         match node {
-            ResultNode::Field { db_name, field_type } if db_name == name => map.serialize_entry(
+            ResultNode::Field { db_name, field_type } => map.serialize_entry(
                 name,
-                &FieldNodeWithDefaultDbName {
-                    node_type: FieldNodeType::Field,
+                &FieldNodeInObject {
+                    db_name: (db_name != name).then_some(db_name),
                     field_type,
                 },
             )?,
@@ -49,16 +49,10 @@ where
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct FieldNodeWithDefaultDbName<'a> {
-    #[serde(rename = "type")]
-    node_type: FieldNodeType,
+struct FieldNodeInObject<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    db_name: Option<&'a Cow<'static, str>>,
     field_type: &'a FieldType,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-enum FieldNodeType {
-    Field,
 }
 
 impl Object {

--- a/query-compiler/query-compiler/src/selection.rs
+++ b/query-compiler/query-compiler/src/selection.rs
@@ -1,44 +1,10 @@
-use itertools::Itertools;
 use query_core::{QueryGraphBuilderError, QueryGraphError};
-use query_structure::{Placeholder, PrismaValue, SelectionResult};
+use query_structure::Placeholder;
 
 use crate::{TranslateError, translate::TranslateResult};
 
-pub trait SelectionResultExt: Sized {
-    fn into_placeholder(self) -> TranslateResult<Placeholder>;
-}
-
-impl SelectionResultExt for SelectionResult {
-    fn into_placeholder(self) -> TranslateResult<Placeholder> {
-        let (_, pv) = self
-            .pairs
-            .into_iter()
-            .next()
-            .ok_or_else(|| query_graph_error("SelectionResult is expected to have at least one column"))?;
-
-        match pv {
-            PrismaValue::Placeholder(placeholder) => Ok(placeholder),
-            _ => Err(query_graph_error(format!(
-                "SelectionResult value must be a placeholder, got {pv}"
-            ))),
-        }
-    }
-}
-
-pub struct SelectionResults(Vec<SelectionResult>);
-
-impl SelectionResults {
-    pub fn new(results: Vec<SelectionResult>) -> Self {
-        SelectionResults(results)
-    }
-
-    pub fn into_placeholder(self) -> TranslateResult<Placeholder> {
-        self.0
-            .into_iter()
-            .exactly_one()
-            .map_err(|e| query_graph_error(format!("expected only one SelectionResult, got {}", e.count())))?
-            .into_placeholder()
-    }
+pub fn projected_placeholder(placeholder: Option<Placeholder>, label: &str) -> TranslateResult<Placeholder> {
+    placeholder.ok_or_else(|| query_graph_error(format!("{label} node is missing projected placeholder input")))
 }
 
 fn query_graph_error(message: impl Into<String>) -> TranslateError {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -558,6 +558,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                         *field.node_input_field(&mut node) =
                             Some(self.process_edge_placeholder(edge, &node, projected_selection)?);
                     }
+                    RowSink::ProjectedFieldPlaceholder(field) => {
+                        *field.node_input_field(&mut node) =
+                            Some(self.process_edge_source_placeholder(edge, projected_selection)?);
+                    }
                     RowSink::AllFilter(field) | RowSink::ExactlyOneFilter(field) => {
                         let fields = self.process_edge_selections(edge, &node, projected_selection);
                         *field.node_input_field(&mut node) = SelectionResult::new(fields).filter();
@@ -836,6 +840,38 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 binding::projected_dependency(self.graph.edge_source(edge), field)
             } else {
                 binding::node_result(self.graph.edge_source(edge))
+            },
+            r#type,
+        })
+    }
+
+    fn process_edge_source_placeholder(
+        &mut self,
+        edge: &EdgeRef,
+        selection: FieldSelection,
+    ) -> TranslateResult<Placeholder> {
+        let source = self.graph.edge_source(edge);
+        let source_node = self
+            .graph
+            .node_content(&source)
+            .ok_or_else(|| TranslateError::NodeContentEmpty(source.to_string()))?;
+        let bindings_refer_to_fields = matches!(source_node, Node::Query(_));
+        let binding_is_unique = matches!(source_node, Node::Query(q) if q.is_unique());
+        let field = selection.selections().last().ok_or_else(|| {
+            TranslateError::GraphBuildError(QueryGraphBuilderError::QueryGraphError(
+                QueryGraphError::InvariantViolation(
+                    "Projected field placeholder sink requires at least one field".into(),
+                ),
+            ))
+        })?;
+
+        let r#type = selected_field_placeholder_type(field, !binding_is_unique);
+
+        Ok(Placeholder {
+            name: if bindings_refer_to_fields {
+                binding::projected_dependency(source, field)
+            } else {
+                binding::node_result(source)
             },
             r#type,
         })

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -380,20 +380,18 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             })
             .collect::<TranslateResult<Vec<_>>>()?;
 
-        let result_nodes: Vec<NodeRef> = self.graph.result_nodes().collect();
-        let result_binding_names = bindings.iter().map(|b| b.name.clone()).collect::<Vec<_>>();
+        let has_single_result_node = self.graph.result_nodes().take(2).count() == 1;
 
-        if result_nodes.len() == 1 {
+        if has_single_result_node {
+            let result_binding_name = bindings.last().expect("no binding for result node").name.clone();
             Ok(Expression::Let {
                 bindings,
                 expr: Box::new(Expression::Get {
-                    name: result_binding_names
-                        .into_iter()
-                        .next_back()
-                        .expect("no binding for result node"),
+                    name: result_binding_name,
                 }),
             })
         } else {
+            let result_binding_names = bindings.iter().map(|b| b.name.clone()).collect::<Vec<_>>();
             Ok(Expression::Let {
                 bindings,
                 expr: Box::new(Expression::GetFirstNonEmpty {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -510,8 +510,15 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         // translate plucks the edges coming into node, we need to avoid accessing it afterwards
         let expr = NodeTranslator::new(self.graph, node, &incoming_edges, self.query_builder).translate()?;
 
-        if bindings.is_empty() && validations.is_empty() {
-            return Ok(expr);
+        if validations.is_empty() {
+            return Ok(if bindings.is_empty() {
+                expr
+            } else {
+                Expression::Let {
+                    bindings,
+                    expr: Box::new(expr),
+                }
+            });
         }
 
         let mut children = validations;

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -528,36 +528,37 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .iter()
             .flat_map(|edge| {
                 let edge_content = self.graph.edge_content(edge);
-                let Some(QueryGraphDependency::ProjectedDataDependency(selection, _, expectation)) = edge_content
+                let Some(QueryGraphDependency::ProjectedDataDependency(selection, sink, expectation)) = edge_content
                 else {
                     return Either::Left(std::iter::empty());
                 };
 
-                let requires_unique = matches!(
-                    edge_content,
-                    Some(QueryGraphDependency::ProjectedDataDependency(_, sink, _))
-                        if sink.is_unique()
-                );
+                let requires_unique = sink.is_unique();
 
                 let source = self.graph.edge_source(edge);
 
-                let expr = Expression::Get {
-                    name: binding::node_result(source),
-                };
-                let expr = match expectation {
-                    Some(expectation) => Expression::validate_expectation(expectation, expr),
-                    None => expr,
-                };
-                let expr = if requires_unique {
-                    Expression::Unique(expr.into())
-                } else {
-                    expr
-                };
+                let needs_parent_binding = expectation.is_some() || requires_unique;
+                let parent_binding = needs_parent_binding.then(|| {
+                    let expr = Expression::Get {
+                        name: binding::node_result(source),
+                    };
+                    let expr = match expectation {
+                        Some(expectation) => Expression::validate_expectation(expectation, expr),
+                        None => expr,
+                    };
+                    let expr = if requires_unique {
+                        Expression::Unique(expr.into())
+                    } else {
+                        expr
+                    };
 
-                let parent_binding = std::iter::once(Binding::new(source.id(), expr));
+                    Binding::new(source.id(), expr)
+                });
+
+                let parent_bindings = parent_binding.into_iter();
 
                 if create_field_bindings {
-                    Either::Right(Either::Left(parent_binding.chain(selection.selections().map(
+                    Either::Right(Either::Left(parent_bindings.chain(selection.selections().map(
                         move |field| {
                             Binding::new(
                                 binding::projected_dependency(source, field),
@@ -572,12 +573,8 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                         },
                     ))))
                 } else {
-                    Either::Right(Either::Right(parent_binding))
+                    Either::Right(Either::Right(parent_bindings))
                 }
-            })
-            .filter(|binding| match &binding.expr {
-                Expression::Get { name, .. } => name != &binding.name,
-                _ => true,
             })
             .collect::<Vec<_>>();
 

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -206,7 +206,8 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 })
             }
             Node::Flow(Flow::If { .. }) => self.translate_if(),
-            Node::Flow(Flow::Return(_)) => self.translate_return(),
+            Node::Flow(Flow::Return(_)) => self.translate_return(false),
+            Node::Flow(Flow::ReturnPreservingResult(_)) => self.translate_return(true),
             Node::Computation(Computation::DiffLeftToRight(_)) => self.translate_diff_left_to_right(),
             Node::Computation(Computation::DiffRightToLeft(_)) => self.translate_diff_right_to_left(),
             Node::Computation(Computation::RequiredOneToManySet(_)) => self.translate_required_one_to_many_set(),
@@ -234,6 +235,22 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             } else {
                 Expression::Seq(children).into()
             },
+        }
+    }
+
+    fn wrap_children_preserving_expr(&self, expr: Expression, mut children: Vec<Expression>) -> Expression {
+        if children.is_empty() {
+            return expr;
+        }
+
+        let result_name = binding::node_result(self.node);
+        children.push(Expression::Get {
+            name: result_name.clone(),
+        });
+
+        Expression::Let {
+            bindings: vec![Binding::new(result_name, expr)],
+            expr: Expression::Seq(children).into(),
         }
     }
 
@@ -328,20 +345,24 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         Ok(self.wrap_children_with_expr(expr, children))
     }
 
-    fn translate_return(&mut self) -> TranslateResult<Expression> {
+    fn translate_return(&mut self, preserve_result_after_children: bool) -> TranslateResult<Expression> {
         let children = self.translate_children()?;
 
         let node = self.graph.pluck_node(&self.node);
         let node = self.transform_node(node)?;
 
-        let Node::Flow(Flow::Return(data)) = node else {
+        let Node::Flow(Flow::Return(data) | Flow::ReturnPreservingResult(data)) = node else {
             panic!("current node must be Flow::Return");
         };
         let placeholder = projected_placeholder(data, "Return")?;
 
         let expr = Expression::Get { name: placeholder.name };
 
-        Ok(self.wrap_children_with_expr(expr, children))
+        if preserve_result_after_children {
+            Ok(self.wrap_children_preserving_expr(expr, children))
+        } else {
+            Ok(self.wrap_children_with_expr(expr, children))
+        }
     }
 
     fn translate_diff_left_to_right(&mut self) -> TranslateResult<Expression> {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -11,11 +11,11 @@ use query::{query_guarantees_raw_nested_read_root, translate_query};
 use query_builder::QueryBuilder;
 use query_core::{
     Computation, EdgeRef, Flow, Node, NodeRef, Query, QueryGraph, QueryGraphBuilderError, QueryGraphDependency,
-    QueryGraphError, RowCountSink, RowSink,
+    QueryGraphError, RowCountSink, RowSink, UpdateManyRecords, WriteQuery,
 };
 use query_structure::{
-    FieldSelection, FieldTypeInformation, IntoFilter, Placeholder, PrismaValue, PrismaValueType, SelectedField,
-    SelectionResult,
+    FieldSelection, FieldTypeInformation, IntoFilter, Placeholder, PrismaValue, PrismaValueType, RecordFilter,
+    SelectedField, SelectionResult, WriteArgs,
 };
 use thiserror::Error;
 
@@ -209,6 +209,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             Node::Flow(Flow::Return(_)) => self.translate_return(),
             Node::Computation(Computation::DiffLeftToRight(_)) => self.translate_diff_left_to_right(),
             Node::Computation(Computation::DiffRightToLeft(_)) => self.translate_diff_right_to_left(),
+            Node::Computation(Computation::RequiredOneToManySet(_)) => self.translate_required_one_to_many_set(),
         }
     }
 
@@ -371,6 +372,139 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             from: Expression::Get { name: from.name }.into(),
             to: Expression::Get { name: to.name }.into(),
             fields: diff.fields.db_names().collect(),
+        };
+
+        Ok(self.wrap_children_with_expr(expr, children))
+    }
+
+    fn translate_required_one_to_many_set(&mut self) -> TranslateResult<Expression> {
+        let children = self.translate_children()?;
+
+        let node = self.graph.pluck_node(&self.node);
+        let node = self.transform_node(node)?;
+
+        let Node::Computation(Computation::RequiredOneToManySet(set)) = node else {
+            panic!("current node must be Computation::RequiredOneToManySet");
+        };
+
+        let old_children = projected_placeholder(set.old_children, "RequiredOneToManySet.old_children")?;
+        let new_children = projected_placeholder(set.new_children, "RequiredOneToManySet.new_children")?;
+        let left_diff_name = binding::node_result(self.node);
+
+        let selector = SelectionResult::new(
+            set.fields
+                .selections()
+                .map(|field| {
+                    (
+                        field.clone(),
+                        PrismaValue::Placeholder(Placeholder::new(
+                            binding::projected_dependency(self.node, field),
+                            selected_field_placeholder_type(field, true),
+                        )),
+                    )
+                })
+                .collect(),
+        );
+
+        let mut update_args = WriteArgs::from_result(
+            SelectionResult::new(
+                set.parent_link
+                    .selections()
+                    .zip(set.child_link.selections())
+                    .map(|(parent_field, child_field)| {
+                        (
+                            child_field.clone(),
+                            PrismaValue::Placeholder(Placeholder::new(
+                                binding::projected_dependency(set.parent_node, parent_field),
+                                selected_field_placeholder_type(parent_field, false),
+                            )),
+                        )
+                    })
+                    .collect(),
+            ),
+            set.request_now,
+        );
+        update_args.update_datetimes(&set.child_model);
+
+        let update = UpdateManyRecords {
+            name: String::new(),
+            model: set.child_model,
+            record_filter: RecordFilter::from(vec![selector]),
+            args: update_args,
+            selected_fields: None,
+            limit: None,
+        };
+
+        let update_expr = translate_query(Query::Write(WriteQuery::UpdateManyRecords(update)), self.query_builder)?;
+        let parent_validation = Expression::validate_expectation(
+            &set.parent_expectation,
+            Expression::Get {
+                name: binding::node_result(set.parent_node),
+            },
+        );
+
+        let relation_validation = Expression::validate_expectation(
+            &set.relation_expectation,
+            Expression::Diff {
+                from: Expression::Get {
+                    name: old_children.name.clone(),
+                }
+                .into(),
+                to: Expression::Get {
+                    name: new_children.name.clone(),
+                }
+                .into(),
+                fields: set.fields.db_names().collect(),
+            },
+        );
+
+        let expr = Expression::Let {
+            bindings: vec![Binding::new(
+                left_diff_name.clone(),
+                Expression::Diff {
+                    from: Expression::Get {
+                        name: new_children.name.clone(),
+                    }
+                    .into(),
+                    to: Expression::Get {
+                        name: old_children.name.clone(),
+                    }
+                    .into(),
+                    fields: set.fields.db_names().collect(),
+                },
+            )],
+            expr: Expression::Seq(vec![
+                Expression::If {
+                    value: Expression::Get {
+                        name: left_diff_name.clone(),
+                    }
+                    .into(),
+                    rule: query_core::DataRule::RowCountNeq(0),
+                    then: Expression::Let {
+                        bindings: set
+                            .fields
+                            .selections()
+                            .map(|field| {
+                                Binding::new(
+                                    binding::projected_dependency(self.node, field),
+                                    Expression::MapField {
+                                        field: field.db_name().into(),
+                                        records: Expression::Get {
+                                            name: left_diff_name.clone(),
+                                        }
+                                        .into(),
+                                    },
+                                )
+                            })
+                            .collect(),
+                        expr: Expression::Seq(vec![parent_validation, update_expr]).into(),
+                    }
+                    .into(),
+                    r#else: Expression::Unit.into(),
+                },
+                relation_validation,
+            ])
+            .into(),
         };
 
         Ok(self.wrap_children_with_expr(expr, children))
@@ -663,16 +797,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             ))
         })?;
 
-        let r#type = field
-            .type_info()
-            .as_ref()
-            .map(FieldTypeInformation::to_prisma_type)
-            .unwrap_or(PrismaValueType::Any);
-        let r#type = if binding_is_unique {
-            r#type
-        } else {
-            PrismaValueType::List(r#type.into())
-        };
+        let r#type = selected_field_placeholder_type(field, !binding_is_unique);
 
         Ok(Placeholder {
             name: if bindings_refer_to_fields {
@@ -682,5 +807,19 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             },
             r#type,
         })
+    }
+}
+
+fn selected_field_placeholder_type(field: &SelectedField, list: bool) -> PrismaValueType {
+    let r#type = field
+        .type_info()
+        .as_ref()
+        .map(FieldTypeInformation::to_prisma_type)
+        .unwrap_or(PrismaValueType::Any);
+
+    if list {
+        PrismaValueType::List(r#type.into())
+    } else {
+        r#type
     }
 }

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -65,6 +65,7 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
         map_result_structure(&graph, &mut result_node_builder)
     };
     let result_reachability = ResultReachability::new(&graph);
+    graph.reserve_visited_capacity();
 
     let root = match root_nodes {
         RootNodes::None => Expression::Seq(Vec::new()),

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -5,7 +5,7 @@ use crate::binding;
 use crate::data_mapper::map_result_structure;
 use crate::expression::EnumsMap;
 use crate::result_node::ResultNodeBuilder;
-use crate::{Expression::Transaction, selection::SelectionResults};
+use crate::{Expression::Transaction, selection::projected_placeholder};
 use itertools::{Either, Itertools};
 use query::{query_guarantees_raw_nested_read_root, translate_query};
 use query_builder::QueryBuilder;
@@ -304,12 +304,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         let Node::Flow(Flow::If { rule, data }) = node else {
             panic!("current node must be Flow::If");
         };
+        let placeholder = projected_placeholder(data, "If")?;
 
         let expr = Expression::If {
-            value: Expression::Get {
-                name: SelectionResults::new(data).into_placeholder()?.name,
-            }
-            .into(),
+            value: Expression::Get { name: placeholder.name }.into(),
             rule,
             then: then_expr.into(),
             r#else: else_expr.into(),
@@ -327,10 +325,9 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         let Node::Flow(Flow::Return(data)) = node else {
             panic!("current node must be Flow::Return");
         };
+        let placeholder = projected_placeholder(data, "Return")?;
 
-        let expr = Expression::Get {
-            name: SelectionResults::new(data).into_placeholder()?.name,
-        };
+        let expr = Expression::Get { name: placeholder.name };
 
         Ok(self.wrap_children_with_expr(expr, children))
     }
@@ -345,15 +342,12 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             panic!("current node must be Computation::DiffLeftToRight");
         };
 
+        let from = projected_placeholder(diff.left, "DiffLeftToRight.left")?;
+        let to = projected_placeholder(diff.right, "DiffLeftToRight.right")?;
+
         let expr = Expression::Diff {
-            from: Expression::Get {
-                name: SelectionResults::new(diff.left).into_placeholder()?.name,
-            }
-            .into(),
-            to: Expression::Get {
-                name: SelectionResults::new(diff.right).into_placeholder()?.name,
-            }
-            .into(),
+            from: Expression::Get { name: from.name }.into(),
+            to: Expression::Get { name: to.name }.into(),
             fields: diff.fields.db_names().collect(),
         };
 
@@ -370,15 +364,12 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             panic!("current node must be Computation::DiffRightToLeft");
         };
 
+        let from = projected_placeholder(diff.right, "DiffRightToLeft.right")?;
+        let to = projected_placeholder(diff.left, "DiffRightToLeft.left")?;
+
         let expr = Expression::Diff {
-            from: Expression::Get {
-                name: SelectionResults::new(diff.right).into_placeholder()?.name,
-            }
-            .into(),
-            to: Expression::Get {
-                name: SelectionResults::new(diff.left).into_placeholder()?.name,
-            }
-            .into(),
+            from: Expression::Get { name: from.name }.into(),
+            to: Expression::Get { name: to.name }.into(),
             fields: diff.fields.db_names().collect(),
         };
 
@@ -388,35 +379,39 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
     fn transform_node(&mut self, mut node: Node) -> TranslateResult<Node> {
         for edge in self.parent_edges {
             match self.graph.take_edge(edge) {
-                Some(QueryGraphDependency::ProjectedDataDependency(selection, sink, _)) => {
-                    let fields = self.process_edge_selections(edge, &node, selection);
-
-                    match sink {
-                        RowSink::All(field) | RowSink::ExactlyOne(field) | RowSink::AtMostOne(field) => {
-                            *field.node_input_field(&mut node) = vec![SelectionResult::new(fields)];
-                        }
-                        RowSink::Single(field) => {
-                            *field.node_input_field(&mut node) = Some(SelectionResult::new(fields));
-                        }
-                        RowSink::AllFilter(field) | RowSink::ExactlyOneFilter(field) => {
-                            *field.node_input_field(&mut node) = SelectionResult::new(fields).filter();
-                        }
-                        RowSink::ExactlyOneWriteArgs(selection, field) => {
-                            let result = SelectionResult::new(fields);
-                            let model = node.as_query().map(Query::model);
-                            let args = field.node_input_field(&mut node);
-                            for arg in args {
-                                arg.inject(selection.assimilate(result.clone()).map_err(|err| {
-                                    TranslateError::GraphBuildError(QueryGraphBuilderError::DomainError(err))
-                                })?);
-                                if let Some(model) = &model {
-                                    arg.update_datetimes(model);
-                                }
+                Some(QueryGraphDependency::ProjectedDataDependency(projected_selection, sink, _)) => match sink {
+                    RowSink::All(field) | RowSink::ExactlyOne(field) | RowSink::AtMostOne(field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        *field.node_input_field(&mut node) = vec![SelectionResult::new(fields)];
+                    }
+                    RowSink::Single(field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        *field.node_input_field(&mut node) = Some(SelectionResult::new(fields));
+                    }
+                    RowSink::ProjectedPlaceholder(field) => {
+                        *field.node_input_field(&mut node) =
+                            Some(self.process_edge_placeholder(edge, &node, projected_selection)?);
+                    }
+                    RowSink::AllFilter(field) | RowSink::ExactlyOneFilter(field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        *field.node_input_field(&mut node) = SelectionResult::new(fields).filter();
+                    }
+                    RowSink::ExactlyOneWriteArgs(write_arg_selection, field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        let result = SelectionResult::new(fields);
+                        let model = node.as_query().map(Query::model);
+                        let args = field.node_input_field(&mut node);
+                        for arg in args {
+                            arg.inject(write_arg_selection.assimilate(result.clone()).map_err(|err| {
+                                TranslateError::GraphBuildError(QueryGraphBuilderError::DomainError(err))
+                            })?);
+                            if let Some(model) = &model {
+                                arg.update_datetimes(model);
                             }
                         }
-                        RowSink::Discard => {}
                     }
-                }
+                    RowSink::Discard => {}
+                },
 
                 Some(QueryGraphDependency::DataDependency(_, _)) => todo!(),
 
@@ -655,5 +650,40 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 )
             })
             .collect_vec()
+    }
+
+    fn process_edge_placeholder(
+        &mut self,
+        edge: &EdgeRef,
+        node: &Node,
+        selection: FieldSelection,
+    ) -> TranslateResult<Placeholder> {
+        let bindings_refer_to_fields = matches!(node, Node::Query(_));
+        let binding_is_unique = matches!(node, Node::Query(q) if q.is_unique());
+        let field = selection.selections().next().ok_or_else(|| {
+            TranslateError::GraphBuildError(QueryGraphBuilderError::QueryGraphError(
+                QueryGraphError::InvariantViolation("Projected placeholder sink requires at least one field".into()),
+            ))
+        })?;
+
+        let r#type = field
+            .type_info()
+            .as_ref()
+            .map(FieldTypeInformation::to_prisma_type)
+            .unwrap_or(PrismaValueType::Any);
+        let r#type = if binding_is_unique {
+            r#type
+        } else {
+            PrismaValueType::List(r#type.into())
+        };
+
+        Ok(Placeholder {
+            name: if bindings_refer_to_fields {
+                binding::projected_dependency(self.graph.edge_source(edge), field)
+            } else {
+                binding::node_result(self.graph.edge_source(edge))
+            },
+            r#type,
+        })
     }
 }

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -71,10 +71,14 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
     };
 
     let mut root = if let Some(structure) = structure {
-        Expression::DataMap {
-            expr: Box::new(root),
-            structure,
-            enums,
+        if matches!(root, Expression::RawNestedRead { .. }) {
+            root
+        } else {
+            Expression::DataMap {
+                expr: Box::new(root),
+                structure,
+                enums,
+            }
         }
     } else {
         root

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -43,6 +43,7 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
     let mut enums = EnumsMap::new();
     let mut result_node_builder = ResultNodeBuilder::new(&mut enums);
     let structure = map_result_structure(&graph, &mut result_node_builder);
+    let result_reachability = ResultReachability::new(&graph);
 
     // Must collect the root nodes first, because the following iteration is mutating the graph
     let root_nodes = {
@@ -62,10 +63,12 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
 
     let root = match root_nodes {
         RootNodes::None => Expression::Seq(Vec::new()),
-        RootNodes::One(node) => NodeTranslator::new(&mut graph, node, &[], builder).translate()?,
+        RootNodes::One(node) => {
+            NodeTranslator::new(&mut graph, node, &[], builder, &result_reachability).translate()?
+        }
         RootNodes::Many(nodes) => nodes
             .into_iter()
-            .map(|node| NodeTranslator::new(&mut graph, node, &[], builder).translate())
+            .map(|node| NodeTranslator::new(&mut graph, node, &[], builder, &result_reachability).translate())
             .collect::<TranslateResult<Vec<_>>>()
             .map(Expression::Seq)?,
     };
@@ -91,11 +94,55 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
     Ok(root)
 }
 
+struct ResultReachability {
+    can_reach_result: Vec<bool>,
+}
+
+impl ResultReachability {
+    fn new(graph: &QueryGraph) -> Self {
+        let mut can_reach_result = Vec::new();
+        let mut pending = graph.result_nodes().collect::<Vec<_>>();
+
+        for node in &pending {
+            Self::mark_reachable(&mut can_reach_result, *node);
+        }
+
+        while let Some(node) = pending.pop() {
+            for parent in graph.parent_nodes(&node) {
+                if Self::mark_reachable(&mut can_reach_result, parent) {
+                    pending.push(parent);
+                }
+            }
+        }
+
+        Self { can_reach_result }
+    }
+
+    fn contains(&self, node: &NodeRef) -> bool {
+        self.can_reach_result.get(node.index()).copied().unwrap_or(false)
+    }
+
+    fn mark_reachable(can_reach_result: &mut Vec<bool>, node: NodeRef) -> bool {
+        let index = node.index();
+        if index >= can_reach_result.len() {
+            can_reach_result.resize(index + 1, false);
+        }
+
+        if can_reach_result[index] {
+            false
+        } else {
+            can_reach_result[index] = true;
+            true
+        }
+    }
+}
+
 struct NodeTranslator<'a, 'b> {
     graph: &'a mut QueryGraph,
     node: NodeRef,
     parent_edges: &'b [EdgeRef],
     query_builder: &'b dyn QueryBuilder,
+    result_reachability: &'b ResultReachability,
 }
 
 impl<'a, 'b> NodeTranslator<'a, 'b> {
@@ -104,12 +151,14 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         node: NodeRef,
         parent_edges: &'b [EdgeRef],
         query_builder: &'b dyn QueryBuilder,
+        result_reachability: &'b ResultReachability,
     ) -> Self {
         Self {
             graph,
             node,
             parent_edges,
             query_builder,
+            result_reachability,
         }
     }
 
@@ -363,7 +412,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .iter()
             .enumerate()
             .filter_map(|(idx, (_, child_node))| {
-                if self.graph.subgraph_contains_result(child_node) {
+                if self.result_reachability.contains(child_node) {
                     Some(idx)
                 } else {
                     None
@@ -512,7 +561,14 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .collect::<Vec<_>>();
 
         // translate plucks the edges coming into node, we need to avoid accessing it afterwards
-        let expr = NodeTranslator::new(self.graph, node, &incoming_edges, self.query_builder).translate()?;
+        let expr = NodeTranslator::new(
+            self.graph,
+            node,
+            &incoming_edges,
+            self.query_builder,
+            self.result_reachability,
+        )
+        .translate()?;
 
         if validations.is_empty() {
             return Ok(if bindings.is_empty() {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -393,6 +393,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
     }
 
     fn fold_result_scopes(&mut self, result_subgraphs: Vec<(EdgeRef, NodeRef)>) -> TranslateResult<Expression> {
+        if let [(_, node)] = &result_subgraphs[..] {
+            return self.process_child_with_dependencies(*node);
+        }
+
         // if the subgraphs all point to the same result node, we fold them in sequence
         // if not, we can separate them with a getfirstnonempty
         let bindings = result_subgraphs

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -34,18 +34,41 @@ pub enum TranslateError {
 pub type TranslateResult<T> = Result<T, TranslateError>;
 
 pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> TranslateResult<Expression> {
+    enum RootNodes {
+        None,
+        One(NodeRef),
+        Many(Vec<NodeRef>),
+    }
+
     let mut enums = EnumsMap::new();
     let mut result_node_builder = ResultNodeBuilder::new(&mut enums);
     let structure = map_result_structure(&graph, &mut result_node_builder);
 
     // Must collect the root nodes first, because the following iteration is mutating the graph
-    let root_nodes: Vec<NodeRef> = graph.root_nodes().collect();
+    let root_nodes = {
+        let mut nodes = graph.root_nodes();
+        match (nodes.next(), nodes.next()) {
+            (None, _) => RootNodes::None,
+            (Some(node), None) => RootNodes::One(node),
+            (Some(first), Some(second)) => {
+                let mut roots = Vec::with_capacity(2 + nodes.size_hint().0);
+                roots.push(first);
+                roots.push(second);
+                roots.extend(nodes);
+                RootNodes::Many(roots)
+            }
+        }
+    };
 
-    let root = root_nodes
-        .into_iter()
-        .map(|node| NodeTranslator::new(&mut graph, node, &[], builder).translate())
-        .collect::<TranslateResult<Vec<_>>>()
-        .map(Expression::Seq)?;
+    let root = match root_nodes {
+        RootNodes::None => Expression::Seq(Vec::new()),
+        RootNodes::One(node) => NodeTranslator::new(&mut graph, node, &[], builder).translate()?,
+        RootNodes::Many(nodes) => nodes
+            .into_iter()
+            .map(|node| NodeTranslator::new(&mut graph, node, &[], builder).translate())
+            .collect::<TranslateResult<Vec<_>>>()
+            .map(Expression::Seq)?,
+    };
 
     let mut root = if let Some(structure) = structure {
         Expression::DataMap {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -7,7 +7,7 @@ use crate::expression::EnumsMap;
 use crate::result_node::ResultNodeBuilder;
 use crate::{Expression::Transaction, selection::SelectionResults};
 use itertools::{Either, Itertools};
-use query::translate_query;
+use query::{query_guarantees_raw_nested_read_root, translate_query};
 use query_builder::QueryBuilder;
 use query_core::{
     Computation, EdgeRef, Flow, Node, NodeRef, Query, QueryGraph, QueryGraphBuilderError, QueryGraphDependency,
@@ -33,18 +33,13 @@ pub enum TranslateError {
 
 pub type TranslateResult<T> = Result<T, TranslateError>;
 
+enum RootNodes {
+    None,
+    One(NodeRef),
+    Many(Vec<NodeRef>),
+}
+
 pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> TranslateResult<Expression> {
-    enum RootNodes {
-        None,
-        One(NodeRef),
-        Many(Vec<NodeRef>),
-    }
-
-    let mut enums = EnumsMap::new();
-    let mut result_node_builder = ResultNodeBuilder::new(&mut enums);
-    let structure = map_result_structure(&graph, &mut result_node_builder);
-    let result_reachability = ResultReachability::new(&graph);
-
     // Must collect the root nodes first, because the following iteration is mutating the graph
     let root_nodes = {
         let mut nodes = graph.root_nodes();
@@ -61,6 +56,16 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
         }
     };
 
+    let skip_result_mapping = root_guarantees_raw_nested_read(&graph, &root_nodes);
+    let mut enums = EnumsMap::new();
+    let mut result_node_builder = ResultNodeBuilder::new(&mut enums);
+    let structure = if skip_result_mapping {
+        None
+    } else {
+        map_result_structure(&graph, &mut result_node_builder)
+    };
+    let result_reachability = ResultReachability::new(&graph);
+
     let root = match root_nodes {
         RootNodes::None => Expression::Seq(Vec::new()),
         RootNodes::One(node) => {
@@ -72,6 +77,14 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
             .collect::<TranslateResult<Vec<_>>>()
             .map(Expression::Seq)?,
     };
+
+    if skip_result_mapping && !matches!(root, Expression::RawNestedRead { .. }) {
+        return Err(TranslateError::GraphBuildError(
+            QueryGraphBuilderError::QueryGraphError(QueryGraphError::InvariantViolation(
+                "raw nested read preflight did not produce a raw nested read".into(),
+            )),
+        ));
+    }
 
     let mut root = if let Some(structure) = structure {
         if matches!(root, Expression::RawNestedRead { .. }) {
@@ -92,6 +105,18 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
         return Ok(Transaction(Box::new(root)));
     }
     Ok(root)
+}
+
+fn root_guarantees_raw_nested_read(graph: &QueryGraph, root_nodes: &RootNodes) -> bool {
+    let RootNodes::One(node) = root_nodes else {
+        return false;
+    };
+
+    let Some(Node::Query(query)) = graph.node_content(node) else {
+        return false;
+    };
+
+    query_guarantees_raw_nested_read_root(query)
 }
 
 struct ResultReachability {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -403,19 +403,18 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
 
     fn process_child_with_dependencies(&mut self, node: NodeRef) -> TranslateResult<Expression> {
         let create_field_bindings = matches!(self.graph.node_content(&node), Some(Node::Query(_)));
+        let incoming_edges = self.graph.incoming_edges(&node);
 
-        let validations = self
-            .graph
-            .incoming_edges(&node)
-            .into_iter()
+        let validations = incoming_edges
+            .iter()
             .filter_map(|edge| {
                 let Some(QueryGraphDependency::DataDependency(RowCountSink::Discard, expectation)) =
-                    self.graph.edge_content(&edge)
+                    self.graph.edge_content(edge)
                 else {
                     return None;
                 };
                 let mut expr = Expression::Get {
-                    name: binding::node_result(self.graph.edge_source(&edge)),
+                    name: binding::node_result(self.graph.edge_source(edge)),
                 };
                 if let Some(expectation) = expectation {
                     expr = Expression::validate_expectation(expectation, expr);
@@ -424,12 +423,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             })
             .collect_vec();
 
-        let bindings = self
-            .graph
-            .incoming_edges(&node)
-            .into_iter()
+        let bindings = incoming_edges
+            .iter()
             .flat_map(|edge| {
-                let edge_content = self.graph.edge_content(&edge);
+                let edge_content = self.graph.edge_content(edge);
                 let Some(QueryGraphDependency::ProjectedDataDependency(selection, _, expectation)) = edge_content
                 else {
                     return Either::Left(std::iter::empty());
@@ -441,7 +438,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                         if sink.is_unique()
                 );
 
-                let source = self.graph.edge_source(&edge);
+                let source = self.graph.edge_source(edge);
 
                 let expr = Expression::Get {
                     name: binding::node_result(source),
@@ -484,8 +481,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .collect::<Vec<_>>();
 
         // translate plucks the edges coming into node, we need to avoid accessing it afterwards
-        let edges = self.graph.incoming_edges(&node);
-        let expr = NodeTranslator::new(self.graph, node, &edges, self.query_builder).translate()?;
+        let expr = NodeTranslator::new(self.graph, node, &incoming_edges, self.query_builder).translate()?;
 
         if bindings.is_empty() && validations.is_empty() {
             return Ok(expr);

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -281,8 +281,16 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             }
         }
 
+        let then_returns_condition = match self.graph.node_content(&self.node) {
+            Some(Node::Flow(Flow::If {
+                then_returns_condition, ..
+            })) => *then_returns_condition,
+            _ => false,
+        };
+
         let then_expr = match then_node {
-            Some(node) => self.process_child_with_dependencies(node)?,
+            Some(node) => Some(self.process_child_with_dependencies(node)?),
+            None if then_returns_condition => None,
             None => {
                 return Err(TranslateError::GraphBuildError(
                     QueryGraphBuilderError::QueryGraphError(QueryGraphError::InvariantViolation(
@@ -302,10 +310,13 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         let node = self.graph.pluck_node(&self.node);
         let node = self.transform_node(node)?;
 
-        let Node::Flow(Flow::If { rule, data }) = node else {
+        let Node::Flow(Flow::If { rule, data, .. }) = node else {
             panic!("current node must be Flow::If");
         };
         let placeholder = projected_placeholder(data, "If")?;
+        let then_expr = then_expr.unwrap_or_else(|| Expression::Get {
+            name: placeholder.name.clone(),
+        });
 
         let expr = Expression::If {
             value: Expression::Get { name: placeholder.name }.into(),

--- a/query-compiler/query-compiler/src/translate/query.rs
+++ b/query-compiler/query-compiler/src/translate/query.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use query_builder::QueryBuilder;
 use query_core::Query;
 use query_structure::{PrismaValue, ScalarWriteOperation, WriteOperation};
-use read::translate_read_query;
+use read::{guarantees_raw_nested_read_root, translate_read_query};
 use write::translate_write_query;
 
 use crate::{
@@ -50,5 +50,12 @@ pub(crate) fn translate_query(query: Query, builder: &dyn QueryBuilder) -> Trans
                 translate_write_query(wq, builder)
             }
         }
+    }
+}
+
+pub(super) fn query_guarantees_raw_nested_read_root(query: &Query) -> bool {
+    match query {
+        Query::Read(read_query) => guarantees_raw_nested_read_root(read_query),
+        Query::Write(_) => false,
     }
 }

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -17,7 +17,7 @@ use query_structure::{
     ConditionValue, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, QueryMode, RelationField,
     RelationLoadStrategy, ScalarCondition, ScalarField, ScalarFilter, ScalarProjection, SelectedField, Take,
 };
-use std::{collections::HashMap, slice};
+use std::{borrow::Cow, slice};
 
 mod in_memory_processing;
 
@@ -251,7 +251,18 @@ pub(super) fn add_inmemory_join(
 
 struct BuiltRawNestedReadQuery {
     query: RawNestedReadQuery,
-    column_indexes: HashMap<String, usize>,
+}
+
+struct RawColumnIndexes<'a> {
+    indexes: Vec<(Cow<'a, str>, usize)>,
+}
+
+impl RawColumnIndexes<'_> {
+    fn get(&self, name: &str) -> Option<usize> {
+        self.indexes
+            .iter()
+            .find_map(|(column, index)| (column.as_ref() == name).then_some(*index))
+    }
 }
 
 fn build_raw_nested_read_root(
@@ -314,7 +325,6 @@ fn build_raw_nested_read_query(
             fields,
             relations,
         },
-        column_indexes,
     }))
 }
 
@@ -331,18 +341,20 @@ fn build_get_records_query(
     }
 }
 
-fn raw_column_indexes(selected_fields: &FieldSelection) -> HashMap<String, usize> {
-    selected_fields
-        .selections()
-        .enumerate()
-        .map(|(index, field)| (field.db_name().into_owned(), index))
-        .collect()
+fn raw_column_indexes(selected_fields: &FieldSelection) -> RawColumnIndexes<'_> {
+    RawColumnIndexes {
+        indexes: selected_fields
+            .selections()
+            .enumerate()
+            .map(|(index, field)| (field.db_name(), index))
+            .collect(),
+    }
 }
 
 fn raw_result_column_mappings(
     selected_fields: &FieldSelection,
     selection_order: &[String],
-    column_indexes: &HashMap<String, usize>,
+    column_indexes: &RawColumnIndexes<'_>,
     enums: &mut EnumsMap,
 ) -> Option<Vec<RawResultColumnMapping>> {
     let mut mappings = Vec::new();
@@ -357,7 +369,7 @@ fn raw_result_column_mappings(
 
         match selection {
             SelectedField::Scalar(field) => {
-                let column_index = column_indexes.get::<str>(field.db_name().as_ref()).copied()?;
+                let column_index = column_indexes.get(field.db_name().as_ref())?;
                 mappings.push(RawResultColumnMapping {
                     field_name: RawResultFieldName::Field(field.name().to_owned()),
                     column: RawResultColumnRef::Index(column_index),
@@ -369,7 +381,7 @@ fn raw_result_column_mappings(
                     .virtuals()
                     .filter(|field| field.serialized_group_name() == virtual_selection.serialized_group_name())
                 {
-                    let column_index = column_indexes.get(&virtual_selection.db_alias()).copied()?;
+                    let column_index = column_indexes.get(&virtual_selection.db_alias())?;
                     let (group_name, field_name) = virtual_selection.serialized_name();
                     mappings.push(RawResultColumnMapping {
                         field_name: RawResultFieldName::Path(vec![group_name.to_owned(), field_name.to_owned()]),
@@ -399,7 +411,7 @@ fn raw_field_type(selection: &SelectedField, enums: &mut EnumsMap) -> Option<Fie
 
 fn build_raw_nested_read_relations(
     nested: &[ReadQuery],
-    parent_column_indexes: &HashMap<String, usize>,
+    parent_column_indexes: &RawColumnIndexes<'_>,
     has_unique_parent: bool,
     builder: &dyn QueryBuilder,
     enums: &mut EnumsMap,
@@ -428,20 +440,13 @@ fn build_raw_nested_read_relations(
         };
         let links = vec![ConditionalLink::new(child_scalar, vec![condition])];
 
-        let Some((child, join)) = build_raw_read_related_records(rrq, links, has_unique_parent, builder, enums)? else {
-            return Ok(None);
-        };
-        let [child_field] = &join.fields[..] else {
-            return Ok(None);
-        };
-
-        let Some(parent_column_index) = parent_column_indexes
-            .get::<str>(parent_scalar.db_name().as_ref())
-            .copied()
+        let Some((child, join, child_column_index)) =
+            build_raw_read_related_records(rrq, links, has_unique_parent, builder, enums)?
         else {
             return Ok(None);
         };
-        let Some(child_column_index) = child.column_indexes.get(child_field).copied() else {
+
+        let Some(parent_column_index) = parent_column_indexes.get(parent_scalar.db_name().as_ref()) else {
             return Ok(None);
         };
 
@@ -464,7 +469,7 @@ fn build_raw_read_related_records(
     has_unique_parent: bool,
     builder: &dyn QueryBuilder,
     enums: &mut EnumsMap,
-) -> TranslateResult<Option<(BuiltRawNestedReadQuery, JoinMetadata)>> {
+) -> TranslateResult<Option<(BuiltRawNestedReadQuery, JoinMetadata, usize)>> {
     if rrq.args.take == Take::Some(0) {
         return Ok(None);
     }
@@ -525,6 +530,12 @@ fn build_raw_read_related_records(
     else {
         return Ok(None);
     };
+    let [child_field] = &join.fields[..] else {
+        return Ok(None);
+    };
+    let Some(child_column_index) = column_indexes.get(child_field) else {
+        return Ok(None);
+    };
     let child_has_unique_parent = has_unique_parent && join.is_relation_unique;
     let Some(relations) =
         build_raw_nested_read_relations(&rrq.nested, &column_indexes, child_has_unique_parent, builder, enums)?
@@ -539,34 +550,38 @@ fn build_raw_read_related_records(
                 fields,
                 relations,
             },
-            column_indexes,
         },
         join,
+        child_column_index,
     )))
 }
 
 fn raw_many_to_many_child_column_indexes(
     selected_fields: &FieldSelection,
     linking_field_alias: String,
-) -> HashMap<String, usize> {
-    let mut column_indexes = HashMap::with_capacity(selected_fields.selections().len() + 1);
+) -> RawColumnIndexes<'_> {
+    let mut column_indexes = RawColumnIndexes {
+        indexes: Vec::with_capacity(selected_fields.selections().len() + 1),
+    };
     let mut next_index = 0;
 
     for field in selected_fields.selections() {
         if matches!(field, SelectedField::Scalar(_)) {
-            column_indexes.insert(field.db_name().into_owned(), next_index);
+            column_indexes.indexes.push((field.db_name(), next_index));
             next_index += 1;
         }
     }
 
     // `build_get_related_records()` selects scalar model columns, then the hidden m2m linking alias,
     // then any additional virtual selections.
-    column_indexes.insert(linking_field_alias, next_index);
+    column_indexes
+        .indexes
+        .push((Cow::Owned(linking_field_alias), next_index));
     next_index += 1;
 
     for field in selected_fields.selections() {
         if matches!(field, SelectedField::Virtual(_)) {
-            column_indexes.insert(field.db_name().into_owned(), next_index);
+            column_indexes.indexes.push((field.db_name(), next_index));
             next_index += 1;
         }
     }

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -122,18 +122,20 @@ pub(super) fn add_inmemory_join(
     nested: Vec<ReadQuery>,
     builder: &dyn QueryBuilder,
 ) -> TranslateResult<Expression> {
-    let all_linking_fields = nested
+    let mut all_linking_fields = nested
         .iter()
         .flat_map(|nested| match nested {
             ReadQuery::RelatedRecordsQuery(rrq) => rrq.parent_field.left_scalars(),
             _ => unreachable!(),
         })
-        .unique()
-        .sorted_by(|a, b| a.name().cmp(b.name()));
+        .collect::<Vec<_>>();
+    all_linking_fields.sort_by(|a, b| a.name().cmp(b.name()));
+    all_linking_fields.dedup_by(|a, b| a.name() == b.name());
 
     let linking_fields_bindings = all_linking_fields
+        .iter()
         .map(|sf| Binding {
-            name: binding::join_parent_field(&sf),
+            name: binding::join_parent_field(sf),
             expr: Expression::MapField {
                 field: sf.db_name().into(),
                 records: Box::new(Expression::Get {

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -433,9 +433,7 @@ fn build_raw_nested_read_relations(
             })
             .collect();
 
-        let Some((child, join)) =
-            build_raw_read_related_records(rrq.clone(), links, has_unique_parent, builder, enums)?
-        else {
+        let Some((child, join)) = build_raw_read_related_records(rrq, links, has_unique_parent, builder, enums)? else {
             return Ok(None);
         };
         let [child_field] = &join.fields[..] else {
@@ -466,7 +464,7 @@ fn build_raw_nested_read_relations(
 }
 
 fn build_raw_read_related_records(
-    mut rrq: RelatedRecordsQuery,
+    rrq: &RelatedRecordsQuery,
     links: Vec<ConditionalLink>,
     has_unique_parent: bool,
     builder: &dyn QueryBuilder,
@@ -479,7 +477,7 @@ fn build_raw_read_related_records(
     let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
     let mut linkage = RelationLinkage::new(rrq.parent_field.clone(), links);
 
-    if let Some(results) = rrq.parent_results.take() {
+    if let Some(results) = rrq.parent_results.clone() {
         let parent_link_id = rrq.parent_field.linking_fields();
         let selection = results
             .into_iter()
@@ -506,15 +504,16 @@ fn build_raw_read_related_records(
         .clone()
         .into_without_relations()
         .into_virtuals_last();
-    let in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut rrq.args, has_unique_parent);
+    let mut args = rrq.args.clone();
+    let in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut args, has_unique_parent);
     if !in_memory_ops.is_empty() {
         return Ok(None);
     }
 
     let (child_query, join) = if is_many_to_many {
-        build_read_m2m_query(linkage, rrq.args, &selected_fields, builder)?
+        build_read_m2m_query(linkage, args, &selected_fields, builder)?
     } else {
-        build_read_one2m_query(linkage, rrq.args, &selected_fields, builder)?
+        build_read_one2m_query(linkage, args, &selected_fields, builder)?
     };
     let Expression::Query(db_query) = child_query else {
         return Ok(None);

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -2,8 +2,9 @@ use crate::{
     TranslateError, binding,
     data_mapper::FieldType,
     expression::{
-        Binding, EnumsMap, Expression, InMemoryOps, JoinExpression, RawNestedReadDirectRelation, RawNestedReadQuery,
-        RawNestedReadRelation, RawResultColumnMapping, RawResultColumnRef, RawResultFieldName,
+        Binding, EnumsMap, Expression, InMemoryOps, JoinExpression, RawNestedFinalOwnerNestedRelation,
+        RawNestedFinalOwnerSchedule, RawNestedReadDirectRelation, RawNestedReadQuery, RawNestedReadRelation,
+        RawResultColumnMapping, RawResultColumnRef, RawResultFieldName,
     },
     translate::TranslateResult,
 };
@@ -506,7 +507,7 @@ fn build_raw_nested_read_root(
     unique: bool,
 ) -> TranslateResult<Option<Expression>> {
     let mut enums = EnumsMap::new();
-    let Some(query) = build_raw_nested_read_query(
+    let Some(mut query) = build_raw_nested_read_query(
         builder,
         model,
         args,
@@ -519,6 +520,7 @@ fn build_raw_nested_read_root(
     else {
         return Ok(None);
     };
+    query.query.schedule = try_build_raw_nested_final_owner_schedule(&query.query, unique, &enums);
 
     Ok(Some(Expression::RawNestedRead {
         query: query.query,
@@ -555,8 +557,153 @@ fn build_raw_nested_read_query(
             query: db_query,
             fields,
             relations,
+            schedule: None,
         },
     }))
+}
+
+fn try_build_raw_nested_final_owner_schedule(
+    query: &RawNestedReadQuery,
+    _unique: bool,
+    enums: &EnumsMap,
+) -> Option<RawNestedFinalOwnerSchedule> {
+    if !enums.is_empty() || query.relations.len() != 4 {
+        return None;
+    }
+
+    let mut unique_relations = Vec::with_capacity(2);
+    let mut wrapper_list = None;
+    let mut child_list = None;
+
+    for (relation_index, relation) in query.relations.iter().enumerate() {
+        let RawNestedReadRelation::Direct(relation) = relation;
+
+        if relation.is_relation_unique {
+            if !raw_nested_final_owner_ops_are_empty(&relation.operations) || !relation.child.relations.is_empty() {
+                return None;
+            }
+            unique_relations.push(relation_index);
+            continue;
+        }
+
+        if let Some(child_relation_index) = raw_nested_final_owner_wrapper_relation_child_index(relation) {
+            if wrapper_list.is_some() {
+                return None;
+            }
+            wrapper_list = Some(RawNestedFinalOwnerNestedRelation {
+                relation_index,
+                child_relation_index,
+            });
+            continue;
+        }
+
+        if let Some(child_relation_index) = raw_nested_final_owner_child_list_relation_child_index(relation) {
+            if child_list.is_some() {
+                return None;
+            }
+            child_list = Some(RawNestedFinalOwnerNestedRelation {
+                relation_index,
+                child_relation_index,
+            });
+            continue;
+        }
+
+        return None;
+    }
+
+    let wrapper_list = wrapper_list?;
+    let child_list = child_list?;
+    let [unique0, unique1] = unique_relations.try_into().ok()?;
+    let root_key_column =
+        raw_nested_direct_relation(&query.relations[wrapper_list.relation_index])?.parent_column_index()?;
+    if root_key_column
+        != raw_nested_direct_relation(&query.relations[child_list.relation_index])?.parent_column_index()?
+    {
+        return None;
+    }
+
+    Some(RawNestedFinalOwnerSchedule {
+        root_key_column: RawResultColumnRef::Index(root_key_column),
+        unique_relations: [unique0, unique1],
+        wrapper_list,
+        child_list,
+    })
+}
+
+fn raw_nested_final_owner_wrapper_relation_child_index(relation: &RawNestedReadDirectRelation) -> Option<usize> {
+    if !raw_nested_final_owner_ops_are_empty(&relation.operations) || !relation.child.fields.is_empty() {
+        return None;
+    }
+
+    let child_relation_index = raw_nested_final_owner_single_child_relation_index(&relation.child)?;
+    let child_relation = raw_nested_direct_relation(&relation.child.relations[child_relation_index])?;
+    if child_relation.is_relation_unique
+        && raw_nested_final_owner_ops_are_empty(&child_relation.operations)
+        && child_relation.child.relations.is_empty()
+    {
+        Some(child_relation_index)
+    } else {
+        None
+    }
+}
+
+fn raw_nested_final_owner_child_list_relation_child_index(relation: &RawNestedReadDirectRelation) -> Option<usize> {
+    if !raw_nested_final_owner_row_ops_supported(&relation.operations) || relation.child.fields.is_empty() {
+        return None;
+    }
+
+    let child_relation_index = raw_nested_final_owner_single_child_relation_index(&relation.child)?;
+    let child_relation = raw_nested_direct_relation(&relation.child.relations[child_relation_index])?;
+    if child_relation.is_relation_unique
+        && raw_nested_final_owner_ops_are_empty(&child_relation.operations)
+        && child_relation.child.relations.is_empty()
+    {
+        Some(child_relation_index)
+    } else {
+        None
+    }
+}
+
+fn raw_nested_final_owner_single_child_relation_index(query: &RawNestedReadQuery) -> Option<usize> {
+    (query.relations.len() == 1).then_some(0)
+}
+
+fn raw_nested_direct_relation(relation: &RawNestedReadRelation) -> Option<&RawNestedReadDirectRelation> {
+    match relation {
+        RawNestedReadRelation::Direct(relation) => Some(relation),
+    }
+}
+
+trait RawNestedFinalOwnerColumnIndex {
+    fn parent_column_index(&self) -> Option<usize>;
+}
+
+impl RawNestedFinalOwnerColumnIndex for RawNestedReadDirectRelation {
+    fn parent_column_index(&self) -> Option<usize> {
+        match self.parent_column {
+            RawResultColumnRef::Index(index) => Some(index),
+            RawResultColumnRef::Name(_) => None,
+        }
+    }
+}
+
+fn raw_nested_final_owner_ops_are_empty(ops: &InMemoryOps) -> bool {
+    ops.pagination.is_none()
+        && ops.distinct.is_none()
+        && !ops.reverse
+        && ops.nested.is_empty()
+        && ops.linking_fields.is_none()
+}
+
+fn raw_nested_final_owner_row_ops_supported(ops: &InMemoryOps) -> bool {
+    ops.distinct.is_none()
+        && ops.linking_fields.is_none()
+        && !ops.reverse
+        && ops.nested.is_empty()
+        && ops
+            .pagination
+            .as_ref()
+            .is_none_or(|pagination| pagination.cursor().is_none())
 }
 
 fn build_get_records_query(
@@ -807,6 +954,7 @@ fn build_raw_read_related_records(
                 query: db_query,
                 fields,
                 relations,
+                schedule: None,
             },
         },
         join,

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -410,9 +410,6 @@ fn build_raw_nested_read_relations(
         let ReadQuery::RelatedRecordsQuery(rrq) = nested else {
             return Ok(None);
         };
-        if rrq.parent_field.relation().is_many_to_many() {
-            return Ok(None);
-        }
 
         let left_scalars = rrq.parent_field.left_scalars();
         let [parent_scalar] = &left_scalars[..] else {
@@ -475,10 +472,11 @@ fn build_raw_read_related_records(
     builder: &dyn QueryBuilder,
     enums: &mut EnumsMap,
 ) -> TranslateResult<Option<(BuiltRawNestedReadQuery, JoinMetadata)>> {
-    if rrq.args.take == Take::Some(0) || rrq.parent_field.relation().is_many_to_many() {
+    if rrq.args.take == Take::Some(0) {
         return Ok(None);
     }
 
+    let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
     let mut linkage = RelationLinkage::new(rrq.parent_field.clone(), links);
 
     if let Some(results) = rrq.parent_results.take() {
@@ -513,11 +511,22 @@ fn build_raw_read_related_records(
         return Ok(None);
     }
 
-    let (child_query, join) = build_read_one2m_query(linkage, rrq.args, &selected_fields, builder)?;
+    let (child_query, join) = if is_many_to_many {
+        build_read_m2m_query(linkage, rrq.args, &selected_fields, builder)?
+    } else {
+        build_read_one2m_query(linkage, rrq.args, &selected_fields, builder)?
+    };
     let Expression::Query(db_query) = child_query else {
         return Ok(None);
     };
-    let column_indexes = raw_column_indexes(&selected_fields);
+    let column_indexes = if is_many_to_many {
+        let [linking_field_alias] = &join.fields[..] else {
+            return Ok(None);
+        };
+        raw_many_to_many_child_column_indexes(&selected_fields, linking_field_alias.clone())
+    } else {
+        raw_column_indexes(&selected_fields)
+    };
     let Some(fields) = raw_result_column_mappings(&selected_fields, &rrq.selection_order, &column_indexes, enums)
     else {
         return Ok(None);
@@ -540,6 +549,35 @@ fn build_raw_read_related_records(
         },
         join,
     )))
+}
+
+fn raw_many_to_many_child_column_indexes(
+    selected_fields: &FieldSelection,
+    linking_field_alias: String,
+) -> HashMap<String, usize> {
+    let mut column_indexes = HashMap::with_capacity(selected_fields.selections().len() + 1);
+    let mut next_index = 0;
+
+    for field in selected_fields.selections() {
+        if matches!(field, SelectedField::Scalar(_)) {
+            column_indexes.insert(field.db_name().into_owned(), next_index);
+            next_index += 1;
+        }
+    }
+
+    // `build_get_related_records()` selects scalar model columns, then the hidden m2m linking alias,
+    // then any additional virtual selections.
+    column_indexes.insert(linking_field_alias, next_index);
+    next_index += 1;
+
+    for field in selected_fields.selections() {
+        if matches!(field, SelectedField::Virtual(_)) {
+            column_indexes.insert(field.db_name().into_owned(), next_index);
+            next_index += 1;
+        }
+    }
+
+    column_indexes
 }
 
 fn build_read_related_records(

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -411,27 +411,22 @@ fn build_raw_nested_read_relations(
             return Ok(None);
         };
 
-        let left_scalars = rrq.parent_field.left_scalars();
-        let [parent_scalar] = &left_scalars[..] else {
+        let Some(parent_scalar) = rrq.parent_field.single_left_scalar() else {
             return Ok(None);
         };
-
-        let links = left_scalars
-            .iter()
-            .zip(get_relation_scalars_for_filters(&rrq.parent_field))
-            .map(|(parent_scalar, child_scalar)| {
-                let placeholder = Placeholder {
-                    name: binding::join_parent_field(parent_scalar),
-                    r#type: parent_scalar.type_info().to_prisma_type(),
-                };
-                let condition = if has_unique_parent {
-                    ScalarCondition::Equals(ConditionValue::value(PrismaValue::from(placeholder)))
-                } else {
-                    ScalarCondition::In(placeholder.into())
-                };
-                ConditionalLink::new(child_scalar.clone(), vec![condition])
-            })
-            .collect();
+        let Some(child_scalar) = get_single_relation_scalar_for_filters(&rrq.parent_field) else {
+            return Ok(None);
+        };
+        let placeholder = Placeholder {
+            name: binding::join_parent_field(&parent_scalar),
+            r#type: parent_scalar.type_info().to_prisma_type(),
+        };
+        let condition = if has_unique_parent {
+            ScalarCondition::Equals(ConditionValue::value(PrismaValue::from(placeholder)))
+        } else {
+            ScalarCondition::In(placeholder.into())
+        };
+        let links = vec![ConditionalLink::new(child_scalar, vec![condition])];
 
         let Some((child, join)) = build_raw_read_related_records(rrq, links, has_unique_parent, builder, enums)? else {
             return Ok(None);
@@ -455,7 +450,7 @@ fn build_raw_nested_read_relations(
             child: child.query,
             parent_column: RawResultColumnRef::Index(parent_column_index),
             child_column: RawResultColumnRef::Index(child_column_index),
-            scope_name: binding::join_parent_field(parent_scalar),
+            scope_name: binding::join_parent_field(&parent_scalar),
             is_relation_unique: join.is_relation_unique,
         }));
     }
@@ -651,6 +646,14 @@ fn get_relation_scalars_for_filters(rf: &RelationField) -> Vec<ScalarField> {
         rf.left_scalars()
     } else {
         rf.related_field().left_scalars()
+    }
+}
+
+fn get_single_relation_scalar_for_filters(rf: &RelationField) -> Option<ScalarField> {
+    if rf.relation().is_many_to_many() {
+        rf.single_left_scalar()
+    } else {
+        rf.related_field().single_left_scalar()
     }
 }
 

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -2,7 +2,7 @@ use crate::{
     TranslateError, binding,
     data_mapper::FieldType,
     expression::{
-        Binding, EnumsMap, Expression, JoinExpression, RawNestedReadDirectRelation, RawNestedReadQuery,
+        Binding, EnumsMap, Expression, InMemoryOps, JoinExpression, RawNestedReadDirectRelation, RawNestedReadQuery,
         RawNestedReadRelation, RawResultColumnMapping, RawResultColumnRef, RawResultFieldName,
     },
     translate::TranslateResult,
@@ -440,7 +440,7 @@ fn build_raw_nested_read_relations(
         };
         let links = vec![ConditionalLink::new(child_scalar, vec![condition])];
 
-        let Some((child, join, child_column_index)) =
+        let Some((child, join, child_column_index, operations)) =
             build_raw_read_related_records(rrq, links, has_unique_parent, builder, enums)?
         else {
             return Ok(None);
@@ -457,6 +457,7 @@ fn build_raw_nested_read_relations(
             child_column: RawResultColumnRef::Index(child_column_index),
             scope_name: binding::join_parent_field(&parent_scalar),
             is_relation_unique: join.is_relation_unique,
+            operations,
         }));
     }
 
@@ -469,7 +470,7 @@ fn build_raw_read_related_records(
     has_unique_parent: bool,
     builder: &dyn QueryBuilder,
     enums: &mut EnumsMap,
-) -> TranslateResult<Option<(BuiltRawNestedReadQuery, JoinMetadata, usize)>> {
+) -> TranslateResult<Option<(BuiltRawNestedReadQuery, JoinMetadata, usize, InMemoryOps)>> {
     if rrq.args.take == Take::Some(0) {
         return Ok(None);
     }
@@ -506,7 +507,7 @@ fn build_raw_read_related_records(
         .into_virtuals_last();
     let mut args = rrq.args.clone();
     let in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut args, has_unique_parent);
-    if !in_memory_ops.is_empty() {
+    if !raw_nested_relation_operations_supported(&in_memory_ops) {
         return Ok(None);
     }
 
@@ -553,7 +554,19 @@ fn build_raw_read_related_records(
         },
         join,
         child_column_index,
+        in_memory_ops,
     )))
+}
+
+fn raw_nested_relation_operations_supported(ops: &InMemoryOps) -> bool {
+    ops.distinct.is_none()
+        && !ops.reverse
+        && ops.nested.is_empty()
+        && ops.linking_fields.is_none()
+        && ops
+            .pagination
+            .as_ref()
+            .is_none_or(|pagination| pagination.cursor().is_none())
 }
 
 fn raw_many_to_many_child_column_indexes(

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -8,7 +8,7 @@ use crate::{
     translate::TranslateResult,
 };
 use itertools::Itertools;
-use query_builder::{ConditionalLink, DbQuery, QueryBuilder, RelationLinkage};
+use query_builder::{ConditionalLink, DbQuery, QueryArgumentsExt, QueryBuilder, RelationLinkage};
 use query_core::{
     AggregateRecordsQuery, DataExpectation, DataOperation, MissingRecord, QueryGraphBuilderError, QueryOption,
     QueryOptions, ReadQuery, RelatedRecordsQuery,
@@ -156,6 +156,141 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
             }
         }
     })
+}
+
+pub(crate) fn guarantees_raw_nested_read_root(query: &ReadQuery) -> bool {
+    match query {
+        ReadQuery::RecordQuery(rq) => {
+            rq.relation_load_strategy == RelationLoadStrategy::Query
+                && !rq.nested.is_empty()
+                && !rq.options.contains(QueryOption::ThrowOnEmpty)
+                && rq.filter.as_ref().is_some_and(filter_cannot_chunk)
+                && raw_result_mapping_supported(&rq.selected_fields, &rq.selection_order)
+                && raw_nested_relations_supported(&rq.nested, &rq.selected_fields, true)
+        }
+        ReadQuery::ManyRecordsQuery(mrq) => {
+            if mrq.args.take == Take::Some(0) {
+                return false;
+            }
+
+            mrq.relation_load_strategy == RelationLoadStrategy::Query
+                && !mrq.nested.is_empty()
+                && root_in_memory_ops_empty(&mrq.args)
+                && !mrq.options.contains(QueryOption::ThrowOnEmpty)
+                && args_cannot_chunk(&mrq.args)
+                && raw_result_mapping_supported(&mrq.selected_fields, &mrq.selection_order)
+                && raw_nested_relations_supported(
+                    &mrq.nested,
+                    &mrq.selected_fields,
+                    matches!(mrq.args.take, Take::One | Take::NegativeOne),
+                )
+        }
+        ReadQuery::RelatedRecordsQuery(_) | ReadQuery::AggregateRecordsQuery(_) => false,
+    }
+}
+
+fn root_in_memory_ops_empty(args: &QueryArguments) -> bool {
+    !args.needs_reversed_order()
+        && !args.requires_inmemory_pagination(RelationLoadStrategy::Query)
+        && !args.requires_inmemory_distinct(RelationLoadStrategy::Query)
+}
+
+fn raw_nested_relations_supported(
+    nested: &[ReadQuery],
+    parent_selected_fields: &FieldSelection,
+    has_unique_parent: bool,
+) -> bool {
+    nested.iter().all(|nested| {
+        let ReadQuery::RelatedRecordsQuery(rrq) = nested else {
+            return false;
+        };
+
+        let Some(parent_scalar) = rrq.parent_field.single_left_scalar() else {
+            return false;
+        };
+
+        selected_fields_contain_db_name(parent_selected_fields, parent_scalar.db_name())
+            && get_single_relation_scalar_for_filters(&rrq.parent_field).is_some()
+            && raw_related_records_supported(rrq, has_unique_parent)
+    })
+}
+
+fn raw_related_records_supported(rrq: &RelatedRecordsQuery, has_unique_parent: bool) -> bool {
+    if rrq.args.take == Take::Some(0)
+        || rrq.parent_results.is_some()
+        || !args_cannot_chunk(&rrq.args)
+        || !raw_nested_relation_operations_may_be_supported(&rrq.args, has_unique_parent)
+        || !raw_result_mapping_supported(&rrq.selected_fields, &rrq.selection_order)
+    {
+        return false;
+    }
+
+    let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
+    let Some(child_scalar) = get_single_relation_scalar_for_filters(&rrq.parent_field) else {
+        return false;
+    };
+
+    if !is_many_to_many && !selected_fields_contain_db_name(&rrq.selected_fields, child_scalar.db_name()) {
+        return false;
+    }
+
+    let child_has_unique_parent = has_unique_parent && !is_many_to_many && !rrq.parent_field.arity().is_list();
+    raw_nested_relations_supported(&rrq.nested, &rrq.selected_fields, child_has_unique_parent)
+}
+
+fn raw_nested_relation_operations_may_be_supported(args: &QueryArguments, has_unique_parent: bool) -> bool {
+    if args.needs_reversed_order() {
+        return false;
+    }
+
+    let needs_pagination = args.take.is_some() || args.skip.is_some() || args.cursor.is_some();
+    let must_paginate_in_memory =
+        needs_pagination && (!has_unique_parent || args.requires_inmemory_processing(RelationLoadStrategy::Query));
+    if must_paginate_in_memory && args.cursor.is_some() {
+        return false;
+    }
+
+    let needs_distinct = args.distinct.is_some();
+    let must_distinct_in_memory =
+        needs_distinct && (!has_unique_parent || args.requires_inmemory_distinct(RelationLoadStrategy::Query));
+
+    !must_distinct_in_memory
+}
+
+fn args_cannot_chunk(args: &QueryArguments) -> bool {
+    args.filter.as_ref().is_none_or(filter_cannot_chunk)
+}
+
+fn filter_cannot_chunk(filter: &Filter) -> bool {
+    !filter.should_batch(1)
+}
+
+fn raw_result_mapping_supported(selected_fields: &FieldSelection, selection_order: &[String]) -> bool {
+    if selected_fields
+        .selections()
+        .any(|field| matches!(field, SelectedField::Composite(_)))
+    {
+        return false;
+    }
+
+    selection_order.iter().all(|prisma_name| {
+        let Some(selection) = selected_fields
+            .selections()
+            .filter(|field| !matches!(field, SelectedField::Relation(_)))
+            .find(|field| field.prisma_name_grouping_virtuals() == prisma_name.as_str())
+        else {
+            return true;
+        };
+
+        selection.type_info().is_some()
+    })
+}
+
+fn selected_fields_contain_db_name(selected_fields: &FieldSelection, db_name: &str) -> bool {
+    selected_fields
+        .selections()
+        .filter(|field| !matches!(field, SelectedField::Relation(_)))
+        .any(|field| field.db_name().as_ref() == db_name)
 }
 
 pub(super) fn add_inmemory_join(

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -310,7 +310,7 @@ fn build_read_one2m_query(
 ) -> TranslateResult<(Expression, JoinMetadata)> {
     let (field, conditions_per_field) = linkage.into_parent_field_and_conditions();
 
-    let filters = args
+    let mut filters = args
         .filter
         .take()
         .into_iter()
@@ -322,10 +322,21 @@ fn build_read_one2m_query(
                     mode: QueryMode::Default,
                 })
             })
-        }))
-        .collect_vec();
+        }));
 
-    args.filter = Some(Filter::And(filters));
+    let filter = match (filters.next(), filters.next()) {
+        (None, _) => Filter::And(Vec::new()),
+        (Some(filter), None) => filter,
+        (Some(first), Some(second)) => {
+            let mut all_filters = Vec::with_capacity(2 + filters.size_hint().0);
+            all_filters.push(first);
+            all_filters.push(second);
+            all_filters.extend(filters);
+            Filter::And(all_filters)
+        }
+    };
+
+    args.filter = Some(filter);
 
     let expr = build_get_records(
         builder,

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -22,7 +22,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
         ReadQuery::RecordQuery(mut rq) => {
             let selected_fields = match rq.relation_load_strategy {
                 RelationLoadStrategy::Join => rq.selected_fields.into_virtuals_last(),
-                RelationLoadStrategy::Query => rq.selected_fields.without_relations().into_virtuals_last(),
+                RelationLoadStrategy::Query => rq.selected_fields.into_without_relations().into_virtuals_last(),
             };
 
             let mut args = QueryArguments::from((
@@ -53,7 +53,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
 
             let selected_fields = match mrq.relation_load_strategy {
                 RelationLoadStrategy::Join => mrq.selected_fields.into_virtuals_last(),
-                RelationLoadStrategy::Query => mrq.selected_fields.without_relations().into_virtuals_last(),
+                RelationLoadStrategy::Query => mrq.selected_fields.into_without_relations().into_virtuals_last(),
             };
 
             let take = mrq.args.take;
@@ -243,7 +243,7 @@ fn build_read_related_records(
         }
     }
 
-    let selected_fields = rrq.selected_fields.without_relations().into_virtuals_last();
+    let selected_fields = rrq.selected_fields.into_without_relations().into_virtuals_last();
 
     let mut in_memory_ops =
         in_memory_processing::extract_in_memory_ops_for_nested_query(&mut rrq.args, has_unique_parent);

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -357,10 +357,10 @@ fn raw_result_column_mappings(
 
         match selection {
             SelectedField::Scalar(field) => {
-                column_indexes.get::<str>(field.db_name().as_ref())?;
+                let column_index = column_indexes.get::<str>(field.db_name().as_ref()).copied()?;
                 mappings.push(RawResultColumnMapping {
                     field_name: RawResultFieldName::Field(field.name().to_owned()),
-                    column: RawResultColumnRef::Name(field.db_name().to_owned()),
+                    column: RawResultColumnRef::Index(column_index),
                     field_type: Some(raw_field_type(selection, enums)?),
                 });
             }
@@ -369,11 +369,11 @@ fn raw_result_column_mappings(
                     .virtuals()
                     .filter(|field| field.serialized_group_name() == virtual_selection.serialized_group_name())
                 {
-                    column_indexes.get(&virtual_selection.db_alias())?;
+                    let column_index = column_indexes.get(&virtual_selection.db_alias()).copied()?;
                     let (group_name, field_name) = virtual_selection.serialized_name();
                     mappings.push(RawResultColumnMapping {
                         field_name: RawResultFieldName::Path(vec![group_name.to_owned(), field_name.to_owned()]),
-                        column: RawResultColumnRef::Name(virtual_selection.db_alias()),
+                        column: RawResultColumnRef::Index(column_index),
                         field_type: Some(raw_field_type(
                             &SelectedField::Virtual(virtual_selection.clone()),
                             enums,
@@ -445,21 +445,21 @@ fn build_raw_nested_read_relations(
             return Ok(None);
         };
 
-        let Some(_) = parent_column_indexes
+        let Some(parent_column_index) = parent_column_indexes
             .get::<str>(parent_scalar.db_name().as_ref())
             .copied()
         else {
             return Ok(None);
         };
-        let Some(_) = child.column_indexes.get(child_field).copied() else {
+        let Some(child_column_index) = child.column_indexes.get(child_field).copied() else {
             return Ok(None);
         };
 
         relations.push(RawNestedReadRelation::Direct(RawNestedReadDirectRelation {
             field_name: rrq.alias.as_deref().unwrap_or(&rrq.name).to_owned(),
             child: child.query,
-            parent_column: RawResultColumnRef::Name(parent_scalar.db_name().to_owned()),
-            child_column: RawResultColumnRef::Name(child_field.clone()),
+            parent_column: RawResultColumnRef::Index(parent_column_index),
+            child_column: RawResultColumnRef::Index(child_column_index),
             scope_name: binding::join_parent_field(parent_scalar),
             is_relation_unique: join.is_relation_unique,
         }));

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -217,12 +217,13 @@ fn raw_nested_relations_supported(
 
 fn raw_related_records_supported(rrq: &RelatedRecordsQuery, has_unique_parent: bool) -> bool {
     let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
+    let supports_parent_grouped_ops = raw_nested_relation_supports_parent_grouped_ops(rrq, is_many_to_many);
 
     if rrq.args.take == Take::Some(0)
         || rrq.parent_results.is_some()
         || !args_cannot_chunk(&rrq.args)
-        || !raw_nested_relation_operations_may_be_supported(&rrq.args, has_unique_parent, is_many_to_many)
-        || (is_many_to_many
+        || !raw_nested_relation_operations_may_be_supported(&rrq.args, has_unique_parent, supports_parent_grouped_ops)
+        || (supports_parent_grouped_ops
             && !raw_nested_relation_operation_result_fields_supported(
                 &rrq.args,
                 &rrq.selected_fields,
@@ -244,6 +245,10 @@ fn raw_related_records_supported(rrq: &RelatedRecordsQuery, has_unique_parent: b
 
     let child_has_unique_parent = has_unique_parent && !is_many_to_many && !rrq.parent_field.arity().is_list();
     raw_nested_relations_supported(&rrq.nested, &rrq.selected_fields, child_has_unique_parent)
+}
+
+fn raw_nested_relation_supports_parent_grouped_ops(rrq: &RelatedRecordsQuery, is_many_to_many: bool) -> bool {
+    is_many_to_many || rrq.parent_field.arity().is_list()
 }
 
 fn raw_nested_relation_operations_may_be_supported(
@@ -702,6 +707,7 @@ fn build_raw_read_related_records(
     }
 
     let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
+    let supports_parent_grouped_ops = raw_nested_relation_supports_parent_grouped_ops(rrq, is_many_to_many);
     let mut linkage = RelationLinkage::new(rrq.parent_field.clone(), links);
 
     if let Some(results) = rrq.parent_results.clone() {
@@ -733,7 +739,7 @@ fn build_raw_read_related_records(
         .into_virtuals_last();
     let mut args = rrq.args.clone();
     let mut in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut args, has_unique_parent);
-    if !is_many_to_many && !raw_nested_relation_operations_supported(&in_memory_ops, false) {
+    if !raw_nested_relation_operations_supported(&in_memory_ops, supports_parent_grouped_ops) {
         return Ok(None);
     }
 
@@ -744,8 +750,10 @@ fn build_raw_read_related_records(
     };
     if is_many_to_many && !in_memory_ops.is_empty_toplevel() {
         in_memory_ops.linking_fields = Some(join.fields.clone());
+    } else if supports_parent_grouped_ops && raw_nested_relation_operations_need_record_fields(&in_memory_ops) {
+        in_memory_ops.linking_fields = Some(join.fields.clone());
     }
-    if !raw_nested_relation_operations_supported(&in_memory_ops, is_many_to_many) {
+    if !raw_nested_relation_operations_supported(&in_memory_ops, supports_parent_grouped_ops) {
         return Ok(None);
     }
 
@@ -764,7 +772,7 @@ fn build_raw_read_related_records(
     else {
         return Ok(None);
     };
-    if is_many_to_many && raw_nested_relation_operations_need_record_fields(&in_memory_ops) {
+    if supports_parent_grouped_ops && raw_nested_relation_operations_need_record_fields(&in_memory_ops) {
         let Some(field_name_mappings) =
             raw_nested_operation_field_name_mappings(&selected_fields, &rrq.selection_order)
         else {

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -216,16 +216,24 @@ fn raw_nested_relations_supported(
 }
 
 fn raw_related_records_supported(rrq: &RelatedRecordsQuery, has_unique_parent: bool) -> bool {
+    let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
+
     if rrq.args.take == Take::Some(0)
         || rrq.parent_results.is_some()
         || !args_cannot_chunk(&rrq.args)
-        || !raw_nested_relation_operations_may_be_supported(&rrq.args, has_unique_parent)
+        || !raw_nested_relation_operations_may_be_supported(&rrq.args, has_unique_parent, is_many_to_many)
+        || (is_many_to_many
+            && !raw_nested_relation_operation_result_fields_supported(
+                &rrq.args,
+                &rrq.selected_fields,
+                &rrq.selection_order,
+                has_unique_parent,
+            ))
         || !raw_result_mapping_supported(&rrq.selected_fields, &rrq.selection_order)
     {
         return false;
     }
 
-    let is_many_to_many = rrq.parent_field.relation().is_many_to_many();
     let Some(child_scalar) = get_single_relation_scalar_for_filters(&rrq.parent_field) else {
         return false;
     };
@@ -238,7 +246,11 @@ fn raw_related_records_supported(rrq: &RelatedRecordsQuery, has_unique_parent: b
     raw_nested_relations_supported(&rrq.nested, &rrq.selected_fields, child_has_unique_parent)
 }
 
-fn raw_nested_relation_operations_may_be_supported(args: &QueryArguments, has_unique_parent: bool) -> bool {
+fn raw_nested_relation_operations_may_be_supported(
+    args: &QueryArguments,
+    has_unique_parent: bool,
+    supports_parent_grouped_ops: bool,
+) -> bool {
     if args.needs_reversed_order() {
         return false;
     }
@@ -246,15 +258,90 @@ fn raw_nested_relation_operations_may_be_supported(args: &QueryArguments, has_un
     let needs_pagination = args.take.is_some() || args.skip.is_some() || args.cursor.is_some();
     let must_paginate_in_memory =
         needs_pagination && (!has_unique_parent || args.requires_inmemory_processing(RelationLoadStrategy::Query));
-    if must_paginate_in_memory && args.cursor.is_some() {
+    if must_paginate_in_memory && args.cursor.is_some() && !supports_parent_grouped_ops {
         return false;
     }
-
     let needs_distinct = args.distinct.is_some();
     let must_distinct_in_memory =
         needs_distinct && (!has_unique_parent || args.requires_inmemory_distinct(RelationLoadStrategy::Query));
 
-    !must_distinct_in_memory
+    if must_distinct_in_memory && !supports_parent_grouped_ops {
+        return false;
+    }
+
+    true
+}
+
+fn raw_nested_relation_operation_result_fields_supported(
+    args: &QueryArguments,
+    selected_fields: &FieldSelection,
+    selection_order: &[String],
+    has_unique_parent: bool,
+) -> bool {
+    let needs_pagination = args.take.is_some() || args.skip.is_some() || args.cursor.is_some();
+    let must_paginate_in_memory =
+        needs_pagination && (!has_unique_parent || args.requires_inmemory_processing(RelationLoadStrategy::Query));
+    let must_match_cursor_fields = must_paginate_in_memory && args.cursor.is_some();
+    let needs_distinct = args.distinct.is_some();
+    let must_distinct_in_memory =
+        needs_distinct && (!has_unique_parent || args.requires_inmemory_distinct(RelationLoadStrategy::Query));
+
+    if !must_match_cursor_fields && !must_distinct_in_memory {
+        return true;
+    }
+
+    let Some(result_fields) = raw_nested_result_field_names(selected_fields, selection_order) else {
+        return false;
+    };
+
+    if must_match_cursor_fields
+        && !args
+            .cursor
+            .as_ref()
+            .is_none_or(|cursor| cursor.db_names().all(|field| result_fields.iter().any(|result| result == field.as_ref())))
+    {
+        return false;
+    }
+
+    if must_distinct_in_memory
+        && !args
+            .distinct
+            .as_ref()
+            .is_none_or(|distinct| distinct.db_names().all(|field| result_fields.iter().any(|result| result == &field)))
+    {
+        return false;
+    }
+
+    true
+}
+
+fn raw_nested_result_field_names(selected_fields: &FieldSelection, selection_order: &[String]) -> Option<Vec<String>> {
+    let mut result_fields = Vec::new();
+
+    for prisma_name in selection_order {
+        let Some(selection) = selected_fields
+            .selections()
+            .find(|field| field.prisma_name_grouping_virtuals() == prisma_name.as_str())
+        else {
+            continue;
+        };
+
+        match selection {
+            SelectedField::Scalar(field) => result_fields.push(field.name().to_owned()),
+            SelectedField::Virtual(virtual_selection) => {
+                result_fields.extend(
+                    selected_fields
+                        .virtuals()
+                        .filter(|field| field.serialized_group_name() == virtual_selection.serialized_group_name())
+                        .map(|field| field.serialized_field_name().to_owned()),
+                );
+            }
+            SelectedField::Relation(_) => {}
+            SelectedField::Composite(_) => return None,
+        }
+    }
+
+    Some(result_fields)
 }
 
 fn args_cannot_chunk(args: &QueryArguments) -> bool {
@@ -641,8 +728,8 @@ fn build_raw_read_related_records(
         .into_without_relations()
         .into_virtuals_last();
     let mut args = rrq.args.clone();
-    let in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut args, has_unique_parent);
-    if !raw_nested_relation_operations_supported(&in_memory_ops) {
+    let mut in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut args, has_unique_parent);
+    if !is_many_to_many && !raw_nested_relation_operations_supported(&in_memory_ops, false) {
         return Ok(None);
     }
 
@@ -651,6 +738,13 @@ fn build_raw_read_related_records(
     } else {
         build_read_one2m_query(linkage, args, &selected_fields, builder)?
     };
+    if is_many_to_many && !in_memory_ops.is_empty_toplevel() {
+        in_memory_ops.linking_fields = Some(join.fields.clone());
+    }
+    if !raw_nested_relation_operations_supported(&in_memory_ops, is_many_to_many) {
+        return Ok(None);
+    }
+
     let Expression::Query(db_query) = child_query else {
         return Ok(None);
     };
@@ -666,6 +760,9 @@ fn build_raw_read_related_records(
     else {
         return Ok(None);
     };
+    if !raw_nested_relation_operation_mappings_supported(&in_memory_ops, &fields) {
+        return Ok(None);
+    }
     let [child_field] = &join.fields[..] else {
         return Ok(None);
     };
@@ -693,15 +790,52 @@ fn build_raw_read_related_records(
     )))
 }
 
-fn raw_nested_relation_operations_supported(ops: &InMemoryOps) -> bool {
+fn raw_nested_relation_operations_supported(ops: &InMemoryOps, supports_parent_grouped_ops: bool) -> bool {
+    if ops.reverse || !ops.nested.is_empty() {
+        return false;
+    }
+
+    if supports_parent_grouped_ops {
+        return true;
+    }
+
     ops.distinct.is_none()
-        && !ops.reverse
-        && ops.nested.is_empty()
         && ops.linking_fields.is_none()
         && ops
             .pagination
             .as_ref()
             .is_none_or(|pagination| pagination.cursor().is_none())
+}
+
+fn raw_nested_relation_operation_mappings_supported(ops: &InMemoryOps, mappings: &[RawResultColumnMapping]) -> bool {
+    let has_cursor = ops
+        .pagination
+        .as_ref()
+        .is_some_and(|pagination| pagination.cursor().is_some());
+    if ops.distinct.is_none() && !has_cursor {
+        return true;
+    }
+
+    let has_record_field = |name: &str| {
+        mappings
+            .iter()
+            .any(|mapping| matches!(&mapping.field_name, RawResultFieldName::Field(field) if field == name))
+    };
+
+    if let Some(pagination) = &ops.pagination
+        && let Some(cursor) = pagination.cursor()
+        && !cursor.keys().all(|field| has_record_field(field))
+    {
+        return false;
+    }
+
+    if let Some(distinct) = &ops.distinct
+        && !distinct.iter().all(|field| has_record_field(field))
+    {
+        return false;
+    }
+
+    true
 }
 
 fn raw_many_to_many_child_column_indexes(

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -1,19 +1,23 @@
 use crate::{
     TranslateError, binding,
-    expression::{Binding, Expression, JoinExpression},
+    data_mapper::FieldType,
+    expression::{
+        Binding, EnumsMap, Expression, JoinExpression, RawNestedReadDirectRelation, RawNestedReadQuery,
+        RawNestedReadRelation, RawResultColumnMapping, RawResultColumnRef, RawResultFieldName,
+    },
     translate::TranslateResult,
 };
 use itertools::Itertools;
-use query_builder::{ConditionalLink, QueryBuilder, RelationLinkage};
+use query_builder::{ConditionalLink, DbQuery, QueryBuilder, RelationLinkage};
 use query_core::{
     AggregateRecordsQuery, DataExpectation, DataOperation, MissingRecord, QueryGraphBuilderError, QueryOption,
     QueryOptions, ReadQuery, RelatedRecordsQuery,
 };
 use query_structure::{
     ConditionValue, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, QueryMode, RelationField,
-    RelationLoadStrategy, ScalarCondition, ScalarField, ScalarFilter, ScalarProjection, Take,
+    RelationLoadStrategy, ScalarCondition, ScalarField, ScalarFilter, ScalarProjection, SelectedField, Take,
 };
-use std::slice;
+use std::{collections::HashMap, slice};
 
 mod in_memory_processing;
 
@@ -33,6 +37,24 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
 
             let in_memory_ops =
                 in_memory_processing::extract_in_memory_ops(&mut args, rq.relation_load_strategy, &mut rq.nested);
+
+            if rq.relation_load_strategy == RelationLoadStrategy::Query
+                && !rq.nested.is_empty()
+                && in_memory_ops.is_empty()
+                && !rq.options.contains(QueryOption::ThrowOnEmpty)
+            {
+                if let Some(expr) = build_raw_nested_read_root(
+                    builder,
+                    &rq.model,
+                    args.clone(),
+                    &selected_fields,
+                    &rq.selection_order,
+                    &rq.nested,
+                    true,
+                )? {
+                    return Ok(expr);
+                }
+            }
 
             let expr = build_get_records(builder, &rq.model, args, &selected_fields, rq.relation_load_strategy)?;
             let expr = in_memory_ops.into_expression(expr);
@@ -60,6 +82,25 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
 
             let in_memory_ops =
                 in_memory_processing::extract_in_memory_ops(&mut mrq.args, mrq.relation_load_strategy, &mut mrq.nested);
+
+            if mrq.relation_load_strategy == RelationLoadStrategy::Query
+                && !mrq.nested.is_empty()
+                && in_memory_ops.is_empty()
+                && !mrq.options.contains(QueryOption::ThrowOnEmpty)
+            {
+                let unique = matches!(take, Take::One | Take::NegativeOne);
+                if let Some(expr) = build_raw_nested_read_root(
+                    builder,
+                    &mrq.model,
+                    mrq.args.clone(),
+                    &selected_fields,
+                    &mrq.selection_order,
+                    &mrq.nested,
+                    unique,
+                )? {
+                    return Ok(expr);
+                }
+            }
 
             let expr = build_get_records(
                 builder,
@@ -206,6 +247,299 @@ pub(super) fn add_inmemory_join(
             }),
         }),
     })
+}
+
+struct BuiltRawNestedReadQuery {
+    query: RawNestedReadQuery,
+    column_indexes: HashMap<String, usize>,
+}
+
+fn build_raw_nested_read_root(
+    builder: &dyn QueryBuilder,
+    model: &Model,
+    args: QueryArguments,
+    selected_fields: &FieldSelection,
+    selection_order: &[String],
+    nested: &[ReadQuery],
+    unique: bool,
+) -> TranslateResult<Option<Expression>> {
+    let mut enums = EnumsMap::new();
+    let Some(query) = build_raw_nested_read_query(
+        builder,
+        model,
+        args,
+        selected_fields,
+        selection_order,
+        nested,
+        unique,
+        &mut enums,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(Expression::RawNestedRead {
+        query: query.query,
+        unique,
+        enums,
+    }))
+}
+
+fn build_raw_nested_read_query(
+    builder: &dyn QueryBuilder,
+    model: &Model,
+    args: QueryArguments,
+    selected_fields: &FieldSelection,
+    selection_order: &[String],
+    nested: &[ReadQuery],
+    has_unique_parent: bool,
+    enums: &mut EnumsMap,
+) -> TranslateResult<Option<BuiltRawNestedReadQuery>> {
+    let Some(db_query) = build_get_records_query(builder, model, args, selected_fields, RelationLoadStrategy::Query)?
+    else {
+        return Ok(None);
+    };
+    let column_indexes = raw_column_indexes(selected_fields);
+    let Some(fields) = raw_result_column_mappings(selected_fields, selection_order, &column_indexes, enums) else {
+        return Ok(None);
+    };
+    let Some(relations) = build_raw_nested_read_relations(nested, &column_indexes, has_unique_parent, builder, enums)?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(BuiltRawNestedReadQuery {
+        query: RawNestedReadQuery {
+            query: db_query,
+            fields,
+            relations,
+        },
+        column_indexes,
+    }))
+}
+
+fn build_get_records_query(
+    builder: &dyn QueryBuilder,
+    model: &Model,
+    args: QueryArguments,
+    selected_fields: &FieldSelection,
+    relation_load_strategy: RelationLoadStrategy,
+) -> TranslateResult<Option<DbQuery>> {
+    match build_get_records(builder, model, args, selected_fields, relation_load_strategy)? {
+        Expression::Query(query) => Ok(Some(query)),
+        _ => Ok(None),
+    }
+}
+
+fn raw_column_indexes(selected_fields: &FieldSelection) -> HashMap<String, usize> {
+    selected_fields
+        .selections()
+        .enumerate()
+        .map(|(index, field)| (field.db_name().into_owned(), index))
+        .collect()
+}
+
+fn raw_result_column_mappings(
+    selected_fields: &FieldSelection,
+    selection_order: &[String],
+    column_indexes: &HashMap<String, usize>,
+    enums: &mut EnumsMap,
+) -> Option<Vec<RawResultColumnMapping>> {
+    let mut mappings = Vec::new();
+
+    for prisma_name in selection_order {
+        let Some(selection) = selected_fields
+            .selections()
+            .find(|field| field.prisma_name_grouping_virtuals() == prisma_name.as_str())
+        else {
+            continue;
+        };
+
+        match selection {
+            SelectedField::Scalar(field) => {
+                column_indexes.get::<str>(field.db_name().as_ref())?;
+                mappings.push(RawResultColumnMapping {
+                    field_name: RawResultFieldName::Field(field.name().to_owned()),
+                    column: RawResultColumnRef::Name(field.db_name().to_owned()),
+                    field_type: Some(raw_field_type(selection, enums)?),
+                });
+            }
+            SelectedField::Virtual(virtual_selection) => {
+                for virtual_selection in selected_fields
+                    .virtuals()
+                    .filter(|field| field.serialized_group_name() == virtual_selection.serialized_group_name())
+                {
+                    column_indexes.get(&virtual_selection.db_alias())?;
+                    let (group_name, field_name) = virtual_selection.serialized_name();
+                    mappings.push(RawResultColumnMapping {
+                        field_name: RawResultFieldName::Path(vec![group_name.to_owned(), field_name.to_owned()]),
+                        column: RawResultColumnRef::Name(virtual_selection.db_alias()),
+                        field_type: Some(raw_field_type(
+                            &SelectedField::Virtual(virtual_selection.clone()),
+                            enums,
+                        )?),
+                    });
+                }
+            }
+            SelectedField::Relation(_) => {}
+            SelectedField::Composite(_) => return None,
+        }
+    }
+
+    Some(mappings)
+}
+
+fn raw_field_type(selection: &SelectedField, enums: &mut EnumsMap) -> Option<FieldType> {
+    let type_info = selection.type_info()?;
+    if let query_structure::TypeIdentifier::Enum(id) = type_info.typ.id {
+        enums.add(type_info.typ.dm.clone().zip(id));
+    }
+    Some(FieldType::from(&type_info))
+}
+
+fn build_raw_nested_read_relations(
+    nested: &[ReadQuery],
+    parent_column_indexes: &HashMap<String, usize>,
+    has_unique_parent: bool,
+    builder: &dyn QueryBuilder,
+    enums: &mut EnumsMap,
+) -> TranslateResult<Option<Vec<RawNestedReadRelation>>> {
+    let mut relations = Vec::with_capacity(nested.len());
+
+    for nested in nested {
+        let ReadQuery::RelatedRecordsQuery(rrq) = nested else {
+            return Ok(None);
+        };
+        if rrq.parent_field.relation().is_many_to_many() {
+            return Ok(None);
+        }
+
+        let left_scalars = rrq.parent_field.left_scalars();
+        let [parent_scalar] = &left_scalars[..] else {
+            return Ok(None);
+        };
+
+        let links = left_scalars
+            .iter()
+            .zip(get_relation_scalars_for_filters(&rrq.parent_field))
+            .map(|(parent_scalar, child_scalar)| {
+                let placeholder = Placeholder {
+                    name: binding::join_parent_field(parent_scalar),
+                    r#type: parent_scalar.type_info().to_prisma_type(),
+                };
+                let condition = if has_unique_parent {
+                    ScalarCondition::Equals(ConditionValue::value(PrismaValue::from(placeholder)))
+                } else {
+                    ScalarCondition::In(placeholder.into())
+                };
+                ConditionalLink::new(child_scalar.clone(), vec![condition])
+            })
+            .collect();
+
+        let Some((child, join)) =
+            build_raw_read_related_records(rrq.clone(), links, has_unique_parent, builder, enums)?
+        else {
+            return Ok(None);
+        };
+        let [child_field] = &join.fields[..] else {
+            return Ok(None);
+        };
+
+        let Some(_) = parent_column_indexes
+            .get::<str>(parent_scalar.db_name().as_ref())
+            .copied()
+        else {
+            return Ok(None);
+        };
+        let Some(_) = child.column_indexes.get(child_field).copied() else {
+            return Ok(None);
+        };
+
+        relations.push(RawNestedReadRelation::Direct(RawNestedReadDirectRelation {
+            field_name: rrq.alias.as_deref().unwrap_or(&rrq.name).to_owned(),
+            child: child.query,
+            parent_column: RawResultColumnRef::Name(parent_scalar.db_name().to_owned()),
+            child_column: RawResultColumnRef::Name(child_field.clone()),
+            scope_name: binding::join_parent_field(parent_scalar),
+            is_relation_unique: join.is_relation_unique,
+        }));
+    }
+
+    Ok(Some(relations))
+}
+
+fn build_raw_read_related_records(
+    mut rrq: RelatedRecordsQuery,
+    links: Vec<ConditionalLink>,
+    has_unique_parent: bool,
+    builder: &dyn QueryBuilder,
+    enums: &mut EnumsMap,
+) -> TranslateResult<Option<(BuiltRawNestedReadQuery, JoinMetadata)>> {
+    if rrq.args.take == Take::Some(0) || rrq.parent_field.relation().is_many_to_many() {
+        return Ok(None);
+    }
+
+    let mut linkage = RelationLinkage::new(rrq.parent_field.clone(), links);
+
+    if let Some(results) = rrq.parent_results.take() {
+        let parent_link_id = rrq.parent_field.linking_fields();
+        let selection = results
+            .into_iter()
+            .exactly_one()
+            .expect("parent results should be exactly one in the query compiler")
+            .split_into(slice::from_ref(&parent_link_id))
+            .pop()
+            .unwrap();
+
+        for (field, val) in FieldSelection::from(get_relation_scalars_for_filters(&rrq.parent_field))
+            .assimilate(selection)
+            .map_err(QueryGraphBuilderError::from)?
+            .pairs
+            .into_iter()
+        {
+            let Some(sf) = field.as_scalar() else { continue };
+            let p = val.into_placeholder().expect("expected placeholder in parent results");
+            linkage.add_condition(sf.clone(), ScalarCondition::In(p.into()));
+        }
+    }
+
+    let selected_fields = rrq
+        .selected_fields
+        .clone()
+        .into_without_relations()
+        .into_virtuals_last();
+    let in_memory_ops = in_memory_processing::extract_in_memory_ops_for_nested_query(&mut rrq.args, has_unique_parent);
+    if !in_memory_ops.is_empty() {
+        return Ok(None);
+    }
+
+    let (child_query, join) = build_read_one2m_query(linkage, rrq.args, &selected_fields, builder)?;
+    let Expression::Query(db_query) = child_query else {
+        return Ok(None);
+    };
+    let column_indexes = raw_column_indexes(&selected_fields);
+    let Some(fields) = raw_result_column_mappings(&selected_fields, &rrq.selection_order, &column_indexes, enums)
+    else {
+        return Ok(None);
+    };
+    let child_has_unique_parent = has_unique_parent && join.is_relation_unique;
+    let Some(relations) =
+        build_raw_nested_read_relations(&rrq.nested, &column_indexes, child_has_unique_parent, builder, enums)?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some((
+        BuiltRawNestedReadQuery {
+            query: RawNestedReadQuery {
+                query: db_query,
+                fields,
+                relations,
+            },
+            column_indexes,
+        },
+        join,
+    )))
 }
 
 fn build_read_related_records(

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -290,24 +290,26 @@ fn raw_nested_relation_operation_result_fields_supported(
         return true;
     }
 
-    let Some(result_fields) = raw_nested_result_field_names(selected_fields, selection_order) else {
+    let Some(result_fields) = raw_nested_operation_field_name_mappings(selected_fields, selection_order) else {
         return false;
     };
 
     if must_match_cursor_fields
-        && !args
-            .cursor
-            .as_ref()
-            .is_none_or(|cursor| cursor.db_names().all(|field| result_fields.iter().any(|result| result == field.as_ref())))
+        && !args.cursor.as_ref().is_none_or(|cursor| {
+            cursor
+                .db_names()
+                .all(|field| raw_nested_operation_field_name(&result_fields, field.as_ref()).is_some())
+        })
     {
         return false;
     }
 
     if must_distinct_in_memory
-        && !args
-            .distinct
-            .as_ref()
-            .is_none_or(|distinct| distinct.db_names().all(|field| result_fields.iter().any(|result| result == &field)))
+        && !args.distinct.as_ref().is_none_or(|distinct| {
+            distinct
+                .db_names()
+                .all(|field| raw_nested_operation_field_name(&result_fields, &field).is_some())
+        })
     {
         return false;
     }
@@ -315,7 +317,10 @@ fn raw_nested_relation_operation_result_fields_supported(
     true
 }
 
-fn raw_nested_result_field_names(selected_fields: &FieldSelection, selection_order: &[String]) -> Option<Vec<String>> {
+fn raw_nested_operation_field_name_mappings(
+    selected_fields: &FieldSelection,
+    selection_order: &[String],
+) -> Option<Vec<(String, String)>> {
     let mut result_fields = Vec::new();
 
     for prisma_name in selection_order {
@@ -327,21 +332,20 @@ fn raw_nested_result_field_names(selected_fields: &FieldSelection, selection_ord
         };
 
         match selection {
-            SelectedField::Scalar(field) => result_fields.push(field.name().to_owned()),
-            SelectedField::Virtual(virtual_selection) => {
-                result_fields.extend(
-                    selected_fields
-                        .virtuals()
-                        .filter(|field| field.serialized_group_name() == virtual_selection.serialized_group_name())
-                        .map(|field| field.serialized_field_name().to_owned()),
-                );
-            }
+            SelectedField::Scalar(field) => result_fields.push((field.db_name().to_owned(), field.name().to_owned())),
+            SelectedField::Virtual(_) => {}
             SelectedField::Relation(_) => {}
             SelectedField::Composite(_) => return None,
         }
     }
 
     Some(result_fields)
+}
+
+fn raw_nested_operation_field_name<'a>(mappings: &'a [(String, String)], field_name: &str) -> Option<&'a str> {
+    mappings
+        .iter()
+        .find_map(|(db_name, result_name)| (db_name == field_name).then_some(result_name.as_str()))
 }
 
 fn args_cannot_chunk(args: &QueryArguments) -> bool {
@@ -760,6 +764,19 @@ fn build_raw_read_related_records(
     else {
         return Ok(None);
     };
+    if is_many_to_many && raw_nested_relation_operations_need_record_fields(&in_memory_ops) {
+        let Some(field_name_mappings) =
+            raw_nested_operation_field_name_mappings(&selected_fields, &rrq.selection_order)
+        else {
+            return Ok(None);
+        };
+        let Some(mapped_ops) = in_memory_ops.remap_operation_field_names(|field| {
+            raw_nested_operation_field_name(&field_name_mappings, field).map(ToOwned::to_owned)
+        }) else {
+            return Ok(None);
+        };
+        in_memory_ops = mapped_ops;
+    }
     if !raw_nested_relation_operation_mappings_supported(&in_memory_ops, &fields) {
         return Ok(None);
     }
@@ -808,11 +825,7 @@ fn raw_nested_relation_operations_supported(ops: &InMemoryOps, supports_parent_g
 }
 
 fn raw_nested_relation_operation_mappings_supported(ops: &InMemoryOps, mappings: &[RawResultColumnMapping]) -> bool {
-    let has_cursor = ops
-        .pagination
-        .as_ref()
-        .is_some_and(|pagination| pagination.cursor().is_some());
-    if ops.distinct.is_none() && !has_cursor {
+    if !raw_nested_relation_operations_need_record_fields(ops) {
         return true;
     }
 
@@ -836,6 +849,14 @@ fn raw_nested_relation_operation_mappings_supported(ops: &InMemoryOps, mappings:
     }
 
     true
+}
+
+fn raw_nested_relation_operations_need_record_fields(ops: &InMemoryOps) -> bool {
+    ops.distinct.is_some()
+        || ops
+            .pagination
+            .as_ref()
+            .is_some_and(|pagination| pagination.cursor().is_some())
 }
 
 fn raw_many_to_many_child_column_indexes(

--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -1,8 +1,8 @@
 use itertools::{Either, Itertools};
 use query_builder::{CreateRecord, CreateRecordDefaultsQuery, QueryBuilder};
 use query_core::{
-    ConnectRecords, DeleteManyRecords, DeleteRecord, DisconnectRecords, RawQuery, UpdateManyRecords, UpdateRecord,
-    UpdateRecordWithSelection, UpdateRecordWithoutSelection, WriteQuery,
+    ConnectRecords, DeleteManyRecords, DeleteRecord, DisconnectAllRecords, DisconnectRecords, RawQuery,
+    UpdateManyRecords, UpdateRecord, UpdateRecordWithSelection, UpdateRecordWithoutSelection, WriteQuery,
 };
 use query_structure::{
     FieldSelection, Filter, IntoFilter, Model, PrismaValue, PrismaValueType, QueryArguments, RecordFilter,
@@ -362,6 +362,17 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
             let parent_id = parent_id.as_ref().expect("should have parent ID for disconnect");
             let query = builder
                 .build_m2m_disconnect(relation_field, parent_id, &child_ids)
+                .map_err(TranslateError::QueryBuildFailure)?;
+            Expression::Execute(query)
+        }
+
+        WriteQuery::DisconnectAllRecords(DisconnectAllRecords {
+            parent_id,
+            relation_field,
+        }) => {
+            let parent_id = parent_id.as_ref().expect("should have parent ID for disconnect-all");
+            let query = builder
+                .build_m2m_disconnect_all(relation_field, parent_id)
                 .map_err(TranslateError::QueryBuildFailure)?;
             Expression::Execute(query)
         }

--- a/query-compiler/query-compiler/tests/data/nested-upsert-nested-only.json
+++ b/query-compiler/query-compiler/tests/data/nested-upsert-nested-only.json
@@ -1,0 +1,43 @@
+{
+  "modelName": "User",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1737556028164@prisma.io" },
+      "data": {
+        "posts": {
+          "upsert": {
+            "where": { "id": 11 },
+            "update": {
+              "categories": {
+                "connect": { "id": 10 }
+              }
+            },
+            "create": {
+              "title": "Nested upsert created post",
+              "categories": {
+                "connect": { "id": 10 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "posts": {
+        "arguments": {},
+        "selection": {
+          "$composites": true,
+          "$scalars": true,
+          "categories": {
+            "arguments": {},
+            "selection": { "$composites": true, "$scalars": true }
+          }
+        }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/query-compound-id.json
+++ b/query-compiler/query-compiler/tests/data/query-compound-id.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "ParentModelWithCompositeId",
+  "action": "findUnique",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": {
+        "a_b": {
+          "a": 1,
+          "b": 1
+        }
+      }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/query-m2m-pagination-mapped-distinct.json
+++ b/query-compiler/query-compiler/tests/data/query-m2m-pagination-mapped-distinct.json
@@ -1,0 +1,23 @@
+{
+  "modelName": "MappedPost",
+  "action": "findMany",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query"
+    },
+    "selection": {
+      "$scalars": true,
+      "categories": {
+        "arguments": {
+          "cursor": {
+            "id": 1
+          },
+          "skip": 1,
+          "take": 1,
+          "distinct": ["id"]
+        },
+        "selection": { "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/schema.prisma
+++ b/query-compiler/query-compiler/tests/data/schema.prisma
@@ -49,6 +49,17 @@ model Category {
   posts Post[]
 }
 
+model MappedPost {
+  id         Int              @id @default(autoincrement()) @map("post_id")
+  categories MappedCategory[]
+}
+
+model MappedCategory {
+  id    Int          @id @default(autoincrement()) @map("cat_id")
+  name  String
+  posts MappedPost[]
+}
+
 model ParentModelWithCompositeId {
   a        Int
   b        Int

--- a/query-compiler/query-compiler/tests/data/update-m2m-connect.json
+++ b/query-compiler/query-compiler/tests/data/update-m2m-connect.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "Post",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "id": 1 },
+      "data": { "categories": { "connect": [{ "id": 1 }, { "id": 2 }] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "categories": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
+++ b/query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "Post",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "id": 1 },
+      "data": { "categories": { "set": [] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "categories": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/update-m2m-set.json
+++ b/query-compiler/query-compiler/tests/data/update-m2m-set.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "Post",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "id": 1 },
+      "data": { "categories": { "set": [{ "id": 1 }, { "id": 2 }] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "categories": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/update-set-nested-empty.json
+++ b/query-compiler/query-compiler/tests/data/update-set-nested-empty.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "User",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1737556028164@prisma.io" },
+      "data": { "posts": { "set": [] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "posts": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/upsert-empty-update.json
+++ b/query-compiler/query-compiler/tests/data/upsert-empty-update.json
@@ -1,0 +1,15 @@
+{
+  "modelName": "User",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1@prisma.io" },
+      "update": {},
+      "create": { "email": "user.1@prisma.io" }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/upsert-nested-only-update.json
+++ b/query-compiler/query-compiler/tests/data/upsert-nested-only-update.json
@@ -1,0 +1,23 @@
+{
+  "modelName": "User",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1@prisma.io" },
+      "update": {
+        "posts": {
+          "create": { "title": "Nested upsert update post" }
+        }
+      },
+      "create": { "email": "user.1@prisma.io" }
+    },
+    "selection": {
+      "$scalars": true,
+      "posts": {
+        "arguments": {},
+        "selection": { "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-nested-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-nested-m2m.json.snap
@@ -1,35 +1,61 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/aggregate-nested-m2m.json
+snapshot_kind: text
 ---
-dataMap {
-    posts (from @nested$posts): {
-        _count (inlined): {
-            categories: Int (_aggr_count_categories)
-        }
-    }
-}
-unique (let @parent = query «SELECT "public"."User"."id" FROM "public"."User"
-                             WHERE "public"."User"."email"::text LIKE $1 LIMIT
-                             $2 OFFSET $3»
-                      params [const(String("%prisma.io%")), const(BigInt(1)),
-                              const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."Post"."id", "public"."Post"."userId",
-                   COALESCE("aggr_selection_0_Category"."_aggr_count_categories",
-                   0) AS "_aggr_count_categories" FROM "public"."Post" LEFT JOIN
-                   (SELECT "public"."_CategoryToPost"."B",
-                   COUNT("public"."_CategoryToPost"."B") AS
-                   "_aggr_count_categories" FROM "public"."Category" LEFT JOIN
-                   "public"."_CategoryToPost" ON ("public"."Category"."id" =
-                   "public"."_CategoryToPost"."A") WHERE
-                   "public"."Category"."name"::text LIKE $1 GROUP BY
-                   "public"."_CategoryToPost"."B") AS
-                   "aggr_selection_0_Category" ON ("public"."Post"."id" =
-                   "aggr_selection_0_Category"."B") WHERE
-                   "public"."Post"."userId" IN [$2,*] ORDER BY
-                   "public"."Post"."id" ASC OFFSET $3»
-            params [const(String("%tech%")), var(@parent$id as Int),
-                    const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts)
+rawNestedReadUnique (query «SELECT "public"."User"."id" FROM "public"."User"
+                            WHERE "public"."User"."email"::text LIKE $1 LIMIT $2
+                            OFFSET $3»
+                     params [const(String("%prisma.io%")), const(BigInt(1)),
+                             const(BigInt(0))]
+                     fields {}
+                     relations [posts on left.id = right.userId many (query
+                                                                      «SELECT
+                                                                       "public"."Post"."id",
+                                                                       "public"."Post"."userId",
+                                                                       COALESCE("aggr_selection_0_Category"."_aggr_count_categories",
+                                                                       0) AS
+                                                                       "_aggr_count_categories"
+                                                                       FROM
+                                                                       "public"."Post"
+                                                                       LEFT JOIN
+                                                                       (SELECT
+                                                                       "public"."_CategoryToPost"."B",
+                                                                       COUNT("public"."_CategoryToPost"."B")
+                                                                       AS
+                                                                       "_aggr_count_categories"
+                                                                       FROM
+                                                                       "public"."Category"
+                                                                       LEFT JOIN
+                                                                       "public"."_CategoryToPost"
+                                                                       ON
+                                                                       ("public"."Category"."id"
+                                                                       =
+                                                                       "public"."_CategoryToPost"."A")
+                                                                       WHERE
+                                                                       "public"."Category"."name"::text
+                                                                       LIKE $1
+                                                                       GROUP BY
+                                                                       "public"."_CategoryToPost"."B")
+                                                                       AS
+                                                                       "aggr_selection_0_Category"
+                                                                       ON
+                                                                       ("public"."Post"."id"
+                                                                       =
+                                                                       "aggr_selection_0_Category"."B")
+                                                                       WHERE
+                                                                       "public"."Post"."userId"
+                                                                       = $2
+                                                                       ORDER BY
+                                                                       "public"."Post"."id"
+                                                                       ASC
+                                                                       OFFSET
+                                                                       $3»
+                                                                      params [const(String("%tech%")),
+                                                                              var(@parent$id as Int),
+                                                                              const(BigInt(0))]
+                                                                      fields {
+                                                                          _count.categories: _aggr_count_categories
+                                                                      })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-nested-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@aggregate-nested-m2m.json.snap
@@ -11,8 +11,7 @@ rawNestedReadUnique (query «SELECT "public"."User"."id" FROM "public"."User"
                      params [const(String("%prisma.io%")), const(BigInt(1)),
                              const(BigInt(0))]
                      fields {}
-                     relations [posts on left.id = right.userId many (query
-                                                                      «SELECT
+                     relations [posts on left.0 = right.1 many (query «SELECT
                                                                        "public"."Post"."id",
                                                                        "public"."Post"."userId",
                                                                        COALESCE("aggr_selection_0_Category"."_aggr_count_categories",
@@ -53,9 +52,9 @@ rawNestedReadUnique (query «SELECT "public"."User"."id" FROM "public"."User"
                                                                        ASC
                                                                        OFFSET
                                                                        $3»
-                                                                      params [const(String("%tech%")),
-                                                                              var(@parent$id as Int),
-                                                                              const(BigInt(0))]
-                                                                      fields {
-                                                                          _count.categories: _aggr_count_categories
-                                                                      })])
+                                                                params [const(String("%tech%")),
+                                                                        var(@parent$id as Int),
+                                                                        const(BigInt(0))]
+                                                                fields {
+                                                                    _count.categories: 2
+                                                                })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
@@ -62,30 +62,29 @@ transaction
                               params [var(0$id as Int), const(BigInt(1)),
                                       const(BigInt(0))]
                               fields {
-                                  id: id
-                                  email: email
-                                  role: role
+                                  id: 0
+                                  email: 1
+                                  role: 2
                               }
-                              relations [posts on left.id = right.userId many (query
-                                                                               «SELECT
-                                                                                "public"."Post"."id",
-                                                                                "public"."Post"."title",
-                                                                                "public"."Post"."userId"
-                                                                                FROM
-                                                                                "public"."Post"
-                                                                                WHERE
-                                                                                "public"."Post"."userId"
-                                                                                =
-                                                                                $1
-                                                                                OFFSET
-                                                                                $2»
-                                                                               params [var(@parent$id as Int),
-                                                                                       const(BigInt(0))]
-                                                                               fields {
-                                                                                   id: id
-                                                                                   title: title
-                                                                                   userId: userId
-                                                                               })])
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
          enums {
              Role: {
                  admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-m2m.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-m2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -52,18 +54,41 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in let @parent = unique (query «SELECT "public"."User"."id",
-                                      "public"."User"."email",
-                                      "public"."User"."role"::text FROM
-                                      "public"."User" WHERE "public"."User"."id"
-                                      = $1 LIMIT $2 OFFSET $3»
-                               params [var(0$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
-         in let @parent$id = mapField id (get @parent)
-            in join (get @parent)
-               with (query «SELECT "public"."Post"."id",
-                            "public"."Post"."title", "public"."Post"."userId"
-                            FROM "public"."Post" WHERE "public"."Post"."userId"
-                            = $1 OFFSET $2»
-                     params [var(@parent$id as Int),
-                             const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: id
+                                  email: email
+                                  role: role
+                              }
+                              relations [posts on left.id = right.userId many (query
+                                                                               «SELECT
+                                                                                "public"."Post"."id",
+                                                                                "public"."Post"."title",
+                                                                                "public"."Post"."userId"
+                                                                                FROM
+                                                                                "public"."Post"
+                                                                                WHERE
+                                                                                "public"."Post"."userId"
+                                                                                =
+                                                                                $1
+                                                                                OFFSET
+                                                                                $2»
+                                                                               params [var(@parent$id as Int),
+                                                                                       const(BigInt(0))]
+                                                                               fields {
+                                                                                   id: id
+                                                                                   title: title
+                                                                                   userId: userId
+                                                                               })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -30,9 +30,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           0$id = mapField id (get 0)
       in let 1 = execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                          (("public"."Post"."id" = $2 AND 1=1) OR
-                          ("public"."Post"."id" = $3 AND 1=1) OR
-                          ("public"."Post"."id" = $4 AND 1=1))»
+                          ("public"."Post"."id" = $2 OR "public"."Post"."id" =
+                          $3 OR "public"."Post"."id" = $4)»
                  params [var(0$id as Int), const(BigInt(8)), const(BigInt(9)),
                          const(BigInt(10))]
          in validate (get 1)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -52,30 +52,29 @@ transaction
                               params [var(0$id as Int), const(BigInt(1)),
                                       const(BigInt(0))]
                               fields {
-                                  id: id
-                                  email: email
-                                  role: role
+                                  id: 0
+                                  email: 1
+                                  role: 2
                               }
-                              relations [posts on left.id = right.userId many (query
-                                                                               «SELECT
-                                                                                "public"."Post"."id",
-                                                                                "public"."Post"."title",
-                                                                                "public"."Post"."userId"
-                                                                                FROM
-                                                                                "public"."Post"
-                                                                                WHERE
-                                                                                "public"."Post"."userId"
-                                                                                =
-                                                                                $1
-                                                                                OFFSET
-                                                                                $2»
-                                                                               params [var(@parent$id as Int),
-                                                                                       const(BigInt(0))]
-                                                                               fields {
-                                                                                   id: id
-                                                                                   title: title
-                                                                                   userId: userId
-                                                                               })])
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
          enums {
              Role: {
                  admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-connect.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -42,18 +44,41 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in let @parent = unique (query «SELECT "public"."User"."id",
-                                      "public"."User"."email",
-                                      "public"."User"."role"::text FROM
-                                      "public"."User" WHERE "public"."User"."id"
-                                      = $1 LIMIT $2 OFFSET $3»
-                               params [var(0$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
-         in let @parent$id = mapField id (get @parent)
-            in join (get @parent)
-               with (query «SELECT "public"."Post"."id",
-                            "public"."Post"."title", "public"."Post"."userId"
-                            FROM "public"."Post" WHERE "public"."Post"."userId"
-                            = $1 OFFSET $2»
-                     params [var(@parent$id as Int),
-                             const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: id
+                                  email: email
+                                  role: role
+                              }
+                              relations [posts on left.id = right.userId many (query
+                                                                               «SELECT
+                                                                                "public"."Post"."id",
+                                                                                "public"."Post"."title",
+                                                                                "public"."Post"."userId"
+                                                                                FROM
+                                                                                "public"."Post"
+                                                                                WHERE
+                                                                                "public"."Post"."userId"
+                                                                                =
+                                                                                $1
+                                                                                OFFSET
+                                                                                $2»
+                                                                               params [var(@parent$id as Int),
+                                                                                       const(BigInt(0))]
+                                                                               fields {
+                                                                                   id: id
+                                                                                   title: title
+                                                                                   userId: userId
+                                                                               })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
@@ -21,8 +21,7 @@ transaction
        }
    }
    let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("john@example.com")), const(BigInt(1)),
                            const(BigInt(0))])
    in let 2 = if (rowCountNeq 0 (get 1))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
@@ -54,30 +54,30 @@ transaction
                                                const(BigInt(1)),
                                                const(BigInt(0))]
                                        fields {
-                                           id: id
-                                           title: title
-                                           userId: userId
+                                           id: 0
+                                           title: 1
+                                           userId: 2
                                        }
-                                       relations [user on left.userId = right.id unique (query
-                                                                                         «SELECT
-                                                                                          "public"."User"."id",
-                                                                                          "public"."User"."email",
-                                                                                          "public"."User"."role"::text
-                                                                                          FROM
-                                                                                          "public"."User"
-                                                                                          WHERE
-                                                                                          "public"."User"."id"
-                                                                                          =
-                                                                                          $1
-                                                                                          OFFSET
-                                                                                          $2»
-                                                                                         params [var(@parent$userId as Int),
-                                                                                                 const(BigInt(0))]
-                                                                                         fields {
-                                                                                             id: id
-                                                                                             email: email
-                                                                                             role: role
-                                                                                         })])
+                                       relations [user on left.2 = right.0 unique (query
+                                                                                   «SELECT
+                                                                                    "public"."User"."id",
+                                                                                    "public"."User"."email",
+                                                                                    "public"."User"."role"::text
+                                                                                    FROM
+                                                                                    "public"."User"
+                                                                                    WHERE
+                                                                                    "public"."User"."id"
+                                                                                    =
+                                                                                    $1
+                                                                                    OFFSET
+                                                                                    $2»
+                                                                                   params [var(@parent$userId as Int),
+                                                                                           const(BigInt(0))]
+                                                                                   fields {
+                                                                                       id: 0
+                                                                                       email: 1
+                                                                                       role: 2
+                                                                                   })])
                   enums {
                       Role: {
                           admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-connectOrCreate-m2one.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -42,21 +44,43 @@ transaction
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");
                    0$id = mapField id (get 0)
-               in let @parent = unique (query «SELECT "public"."Post"."id",
-                                               "public"."Post"."title",
-                                               "public"."Post"."userId" FROM
-                                               "public"."Post" WHERE
-                                               "public"."Post"."id" = $1 LIMIT
-                                               $2 OFFSET $3»
-                                        params [var(0$id as Int),
-                                                const(BigInt(1)),
-                                                const(BigInt(0))])
-                  in let @parent$userId = mapField userId (get @parent)
-                     in join (get @parent)
-                        with (query «SELECT "public"."User"."id",
-                                     "public"."User"."email",
-                                     "public"."User"."role"::text FROM
-                                     "public"."User" WHERE "public"."User"."id"
-                                     = $1 OFFSET $2»
-                              params [var(@parent$userId as Int),
-                                      const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user
+               in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                              "public"."Post"."title",
+                                              "public"."Post"."userId" FROM
+                                              "public"."Post" WHERE
+                                              "public"."Post"."id" = $1 LIMIT $2
+                                              OFFSET $3»
+                                       params [var(0$id as Int),
+                                               const(BigInt(1)),
+                                               const(BigInt(0))]
+                                       fields {
+                                           id: id
+                                           title: title
+                                           userId: userId
+                                       }
+                                       relations [user on left.userId = right.id unique (query
+                                                                                         «SELECT
+                                                                                          "public"."User"."id",
+                                                                                          "public"."User"."email",
+                                                                                          "public"."User"."role"::text
+                                                                                          FROM
+                                                                                          "public"."User"
+                                                                                          WHERE
+                                                                                          "public"."User"."id"
+                                                                                          =
+                                                                                          $1
+                                                                                          OFFSET
+                                                                                          $2»
+                                                                                         params [var(@parent$userId as Int),
+                                                                                                 const(BigInt(0))]
+                                                                                         fields {
+                                                                                             id: id
+                                                                                             email: email
+                                                                                             role: role
+                                                                                         })])
+                  enums {
+                      Role: {
+                          admin: ADMIN
+                          user: USER
+                      }
+                  }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -44,14 +44,14 @@ transaction
                                    "public"."Post"."id"»
                             params [const(String("Quantum Topological Embeddings of Mycorrhizal Networks: A Fractal Analysis of Phyllotaxic Algorithms in Non-Euclidean Plant Informatic")),
                                     var(2$id as Int)])
-            in let 6 = unique (query «SELECT "public"."Category"."id" FROM
+            in let 5 = unique (query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
                                       "public"."Category"."id" = $1 LIMIT $2
                                       OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
-               in let 8 = if (rowCountNeq 0 (get 6))
-                      then get 6
+               in let 7 = if (rowCountNeq 0 (get 5))
+                      then get 5
                       else unique (query «INSERT INTO "public"."Category"
                                           ("id","name") VALUES ($1,$2) RETURNING
                                           "public"."Category"."id"»
@@ -61,15 +61,15 @@ transaction
                          [ rowCountNeq 0
                          ] orRaise "MISSING_RELATED_RECORD");
                          0$id = mapField id (get 0);
-                         8 = validate (get 8)
+                         7 = validate (get 7)
                          [ rowCountEq 1
                          ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                         8$id = mapField id (get 8)
+                         7$id = mapField id (get 7)
                      in execute «INSERT INTO "public"."_CategoryToPost"
                                  ("B","A") VALUES [($1),*],* ON CONFLICT DO
                                  NOTHING»
                         params [product(var(0$id as Int[]),
-                                        var(8$id as Int[]))];
+                                        var(7$id as Int[]))];
                let 0 = unique (validate (get 0)
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -25,8 +25,7 @@ transaction
        }
    }
    let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("john@example.com")), const(BigInt(1)),
                            const(BigInt(0))])
    in let 2 = if (rowCountNeq 0 (get 1))
@@ -45,8 +44,8 @@ transaction
                                     var(2$id as Int)])
             in let 6 = unique (query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
-                                      ("public"."Category"."id" = $1 AND 1=1)
-                                      LIMIT $2 OFFSET $3»
+                                      "public"."Category"."id" = $1 LIMIT $2
+                                      OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
                in if (rowCountNeq 0 (get 6))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-connectOrCreate-mixed.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -85,31 +87,75 @@ transaction
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");
                    0$id = mapField id (get 0)
-               in let @parent = unique (query «SELECT "public"."Post"."id",
-                                               "public"."Post"."title",
-                                               "public"."Post"."userId" FROM
-                                               "public"."Post" WHERE
-                                               "public"."Post"."id" = $1 LIMIT
-                                               $2 OFFSET $3»
-                                        params [var(0$id as Int),
-                                                const(BigInt(1)),
-                                                const(BigInt(0))])
-                  in let @parent$id = mapField id (get @parent);
-                         @parent$userId = mapField userId (get @parent)
-                     in join (get @parent)
-                        with (query «SELECT "public"."User"."id",
-                                     "public"."User"."email",
-                                     "public"."User"."role"::text FROM
-                                     "public"."User" WHERE "public"."User"."id"
-                                     = $1 OFFSET $2»
-                              params [var(@parent$userId as Int),
-                                      const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user,
-                             (query «SELECT "public"."Category"."id",
-                                     "public"."Category"."name", "t0"."B" AS
-                                     "CategoryToPost@Post" FROM
-                                     "public"."Category" INNER JOIN
-                                     "public"."_CategoryToPost" AS "t0" ON
-                                     "t0"."A" = "public"."Category"."id" WHERE
-                                     (1=1 AND "t0"."B" = $1) OFFSET $2»
-                              params [var(@parent$id as Int),
-                                      const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+               in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                              "public"."Post"."title",
+                                              "public"."Post"."userId" FROM
+                                              "public"."Post" WHERE
+                                              "public"."Post"."id" = $1 LIMIT $2
+                                              OFFSET $3»
+                                       params [var(0$id as Int),
+                                               const(BigInt(1)),
+                                               const(BigInt(0))]
+                                       fields {
+                                           id: 0
+                                           title: 1
+                                           userId: 2
+                                       }
+                                       relations [user on left.2 = right.0 unique (query
+                                                                                   «SELECT
+                                                                                    "public"."User"."id",
+                                                                                    "public"."User"."email",
+                                                                                    "public"."User"."role"::text
+                                                                                    FROM
+                                                                                    "public"."User"
+                                                                                    WHERE
+                                                                                    "public"."User"."id"
+                                                                                    =
+                                                                                    $1
+                                                                                    OFFSET
+                                                                                    $2»
+                                                                                   params [var(@parent$userId as Int),
+                                                                                           const(BigInt(0))]
+                                                                                   fields {
+                                                                                       id: 0
+                                                                                       email: 1
+                                                                                       role: 2
+                                                                                   }),
+                                                  categories on left.0 = right.2 many (query
+                                                                                       «SELECT
+                                                                                        "public"."Category"."id",
+                                                                                        "public"."Category"."name",
+                                                                                        "t0"."B"
+                                                                                        AS
+                                                                                        "CategoryToPost@Post"
+                                                                                        FROM
+                                                                                        "public"."Category"
+                                                                                        INNER
+                                                                                        JOIN
+                                                                                        "public"."_CategoryToPost"
+                                                                                        AS
+                                                                                        "t0"
+                                                                                        ON
+                                                                                        "t0"."A"
+                                                                                        =
+                                                                                        "public"."Category"."id"
+                                                                                        WHERE
+                                                                                        (1=1
+                                                                                        AND
+                                                                                        "t0"."B"
+                                                                                        =
+                                                                                        $1)
+                                                                                        OFFSET
+                                                                                        $2»
+                                                                                       params [var(@parent$id as Int),
+                                                                                               const(BigInt(0))]
+                                                                                       fields {
+                                                                                           id: 0
+                                                                                           name: 1
+                                                                                       })])
+                  enums {
+                      Role: {
+                          admin: ADMIN
+                          user: USER
+                      }
+                  }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -50,39 +50,26 @@ transaction
                                       OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
-               in if (rowCountNeq 0 (get 6))
-                  then let 0 = unique (validate (get 0)
-                           [ rowCountNeq 0
-                           ] orRaise "MISSING_RELATED_RECORD");
-                           0$id = mapField id (get 0);
-                           6 = validate (get 6)
-                           [ rowCountEq 1
-                           ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                           6$id = mapField id (get 6)
-                       in execute «INSERT INTO "public"."_CategoryToPost"
-                                   ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                   NOTHING»
-                          params [product(var(0$id as Int[]),
-                                          var(6$id as Int[]))]
-                  else let 7 = unique (query «INSERT INTO "public"."Category"
-                                              ("id","name") VALUES ($1,$2)
-                                              RETURNING
-                                              "public"."Category"."id"»
-                                       params [const(BigInt(10)),
-                                               const(String("Mushrooms"))])
-                       in let 0 = unique (validate (get 0)
-                              [ rowCountNeq 0
-                              ] orRaise "MISSING_RELATED_RECORD");
-                              0$id = mapField id (get 0);
-                              7 = validate (get 7)
-                              [ rowCountEq 1
-                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                              7$id = mapField id (get 7)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                      NOTHING»
-                             params [product(var(0$id as Int[]),
-                                             var(7$id as Int[]))];
+               in let 8 = if (rowCountNeq 0 (get 6))
+                      then get 6
+                      else unique (query «INSERT INTO "public"."Category"
+                                          ("id","name") VALUES ($1,$2) RETURNING
+                                          "public"."Category"."id"»
+                                   params [const(BigInt(10)),
+                                           const(String("Mushrooms"))])
+                  in let 0 = unique (validate (get 0)
+                         [ rowCountNeq 0
+                         ] orRaise "MISSING_RELATED_RECORD");
+                         0$id = mapField id (get 0);
+                         8 = validate (get 8)
+                         [ rowCountEq 1
+                         ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                         8$id = mapField id (get 8)
+                     in execute «INSERT INTO "public"."_CategoryToPost"
+                                 ("B","A") VALUES [($1),*],* ON CONFLICT DO
+                                 NOTHING»
+                        params [product(var(0$id as Int[]),
+                                        var(8$id as Int[]))];
                let 0 = unique (validate (get 0)
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -44,14 +44,14 @@ transaction
                                    "public"."Post"."id"»
                             params [const(String("Quantum Topological Embeddings of Mycorrhizal Networks: A Fractal Analysis of Phyllotaxic Algorithms in Non-Euclidean Plant Informatic")),
                                     var(2$id as Int)])
-            in let 5 = unique (query «SELECT "public"."Category"."id" FROM
+            in let 4 = unique (query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
                                       "public"."Category"."id" = $1 LIMIT $2
                                       OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
-               in let 7 = if (rowCountNeq 0 (get 5))
-                      then get 5
+               in let 6 = if (rowCountNeq 0 (get 4))
+                      then get 4
                       else unique (query «INSERT INTO "public"."Category"
                                           ("id","name") VALUES ($1,$2) RETURNING
                                           "public"."Category"."id"»
@@ -61,15 +61,15 @@ transaction
                          [ rowCountNeq 0
                          ] orRaise "MISSING_RELATED_RECORD");
                          0$id = mapField id (get 0);
-                         7 = validate (get 7)
+                         6 = validate (get 6)
                          [ rowCountEq 1
                          ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                         7$id = mapField id (get 7)
+                         6$id = mapField id (get 6)
                      in execute «INSERT INTO "public"."_CategoryToPost"
                                  ("B","A") VALUES [($1),*],* ON CONFLICT DO
                                  NOTHING»
                         params [product(var(0$id as Int[]),
-                                        var(7$id as Int[]))];
+                                        var(6$id as Int[]))];
                let 0 = unique (validate (get 0)
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -25,8 +25,7 @@ transaction
        }
    }
    let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                          ("public"."User"."id" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 1 = unique (validate (get 1)
@@ -39,8 +38,8 @@ transaction
                                  var(1$id as Int)])
          in let 2 = unique (query «SELECT "public"."Category"."id" FROM
                                    "public"."Category" WHERE
-                                   ("public"."Category"."id" = $1 AND 1=1) LIMIT
-                                   $2 OFFSET $3»
+                                   "public"."Category"."id" = $1 LIMIT $2 OFFSET
+                                   $3»
                             params [const(BigInt(10)), const(BigInt(1)),
                                     const(BigInt(0))])
             in if (rowCountNeq 0 (get 2))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -44,36 +44,24 @@ transaction
                                    $3»
                             params [const(BigInt(10)), const(BigInt(1)),
                                     const(BigInt(0))])
-            in if (rowCountNeq 0 (get 2))
-               then let 0 = unique (validate (get 0)
-                        [ rowCountNeq 0
-                        ] orRaise "MISSING_RELATED_RECORD");
-                        0$id = mapField id (get 0);
-                        2 = validate (get 2)
-                        [ rowCountEq 1
-                        ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                        2$id = mapField id (get 2)
-                    in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
-                                VALUES [($1),*],* ON CONFLICT DO NOTHING»
-                       params [product(var(0$id as Int[]), var(2$id as Int[]))]
-               else let 3 = unique (query «INSERT INTO "public"."Category"
-                                           ("id","name") VALUES ($1,$2)
-                                           RETURNING "public"."Category"."id"»
-                                    params [const(BigInt(10)),
-                                            const(String("JavaScript"))])
-                    in let 0 = unique (validate (get 0)
-                           [ rowCountNeq 0
-                           ] orRaise "MISSING_RELATED_RECORD");
-                           0$id = mapField id (get 0);
-                           3 = validate (get 3)
-                           [ rowCountEq 1
-                           ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                           3$id = mapField id (get 3)
-                       in execute «INSERT INTO "public"."_CategoryToPost"
-                                   ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                   NOTHING»
-                          params [product(var(0$id as Int[]),
-                                          var(3$id as Int[]))];
+            in let 4 = if (rowCountNeq 0 (get 2))
+                   then get 2
+                   else unique (query «INSERT INTO "public"."Category"
+                                       ("id","name") VALUES ($1,$2) RETURNING
+                                       "public"."Category"."id"»
+                                params [const(BigInt(10)),
+                                        const(String("JavaScript"))])
+               in let 0 = unique (validate (get 0)
+                      [ rowCountNeq 0
+                      ] orRaise "MISSING_RELATED_RECORD");
+                      0$id = mapField id (get 0);
+                      4 = validate (get 4)
+                      [ rowCountEq 1
+                      ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                      4$id = mapField id (get 4)
+                  in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                              VALUES [($1),*],* ON CONFLICT DO NOTHING»
+                     params [product(var(0$id as Int[]), var(4$id as Int[]))];
             let 0 = unique (validate (get 0)
                 [ rowCountNeq 0
                 ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-connectOrCreate-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -76,29 +78,74 @@ transaction
                 [ rowCountNeq 0
                 ] orRaise "MISSING_RECORD");
                 0$id = mapField id (get 0)
-            in let @parent = unique (query «SELECT "public"."Post"."id",
-                                            "public"."Post"."title",
-                                            "public"."Post"."userId" FROM
-                                            "public"."Post" WHERE
-                                            "public"."Post"."id" = $1 LIMIT $2
-                                            OFFSET $3»
-                                     params [var(0$id as Int), const(BigInt(1)),
-                                             const(BigInt(0))])
-               in let @parent$id = mapField id (get @parent);
-                      @parent$userId = mapField userId (get @parent)
-                  in join (get @parent)
-                     with (query «SELECT "public"."User"."id",
-                                  "public"."User"."email",
-                                  "public"."User"."role"::text FROM
-                                  "public"."User" WHERE "public"."User"."id" =
-                                  $1 OFFSET $2»
-                           params [var(@parent$userId as Int),
-                                   const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user,
-                          (query «SELECT "public"."Category"."id",
-                                  "public"."Category"."name", "t0"."B" AS
-                                  "CategoryToPost@Post" FROM "public"."Category"
-                                  INNER JOIN "public"."_CategoryToPost" AS "t0"
-                                  ON "t0"."A" = "public"."Category"."id" WHERE
-                                  (1=1 AND "t0"."B" = $1) OFFSET $2»
-                           params [var(@parent$id as Int),
-                                   const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+            in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                           "public"."Post"."title",
+                                           "public"."Post"."userId" FROM
+                                           "public"."Post" WHERE
+                                           "public"."Post"."id" = $1 LIMIT $2
+                                           OFFSET $3»
+                                    params [var(0$id as Int), const(BigInt(1)),
+                                            const(BigInt(0))]
+                                    fields {
+                                        id: 0
+                                        title: 1
+                                        userId: 2
+                                    }
+                                    relations [user on left.2 = right.0 unique (query
+                                                                                «SELECT
+                                                                                 "public"."User"."id",
+                                                                                 "public"."User"."email",
+                                                                                 "public"."User"."role"::text
+                                                                                 FROM
+                                                                                 "public"."User"
+                                                                                 WHERE
+                                                                                 "public"."User"."id"
+                                                                                 =
+                                                                                 $1
+                                                                                 OFFSET
+                                                                                 $2»
+                                                                                params [var(@parent$userId as Int),
+                                                                                        const(BigInt(0))]
+                                                                                fields {
+                                                                                    id: 0
+                                                                                    email: 1
+                                                                                    role: 2
+                                                                                }),
+                                               categories on left.0 = right.2 many (query
+                                                                                    «SELECT
+                                                                                     "public"."Category"."id",
+                                                                                     "public"."Category"."name",
+                                                                                     "t0"."B"
+                                                                                     AS
+                                                                                     "CategoryToPost@Post"
+                                                                                     FROM
+                                                                                     "public"."Category"
+                                                                                     INNER
+                                                                                     JOIN
+                                                                                     "public"."_CategoryToPost"
+                                                                                     AS
+                                                                                     "t0"
+                                                                                     ON
+                                                                                     "t0"."A"
+                                                                                     =
+                                                                                     "public"."Category"."id"
+                                                                                     WHERE
+                                                                                     (1=1
+                                                                                     AND
+                                                                                     "t0"."B"
+                                                                                     =
+                                                                                     $1)
+                                                                                     OFFSET
+                                                                                     $2»
+                                                                                    params [var(@parent$id as Int),
+                                                                                            const(BigInt(0))]
+                                                                                    fields {
+                                                                                        id: 0
+                                                                                        name: 1
+                                                                                    })])
+               enums {
+                   Role: {
+                       admin: ADMIN
+                       user: USER
+                   }
+               }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
@@ -47,30 +47,29 @@ transaction
                               params [var(0$id as Int), const(BigInt(1)),
                                       const(BigInt(0))]
                               fields {
-                                  id: id
-                                  email: email
-                                  role: role
+                                  id: 0
+                                  email: 1
+                                  role: 2
                               }
-                              relations [posts on left.id = right.userId many (query
-                                                                               «SELECT
-                                                                                "public"."Post"."id",
-                                                                                "public"."Post"."title",
-                                                                                "public"."Post"."userId"
-                                                                                FROM
-                                                                                "public"."Post"
-                                                                                WHERE
-                                                                                "public"."Post"."userId"
-                                                                                =
-                                                                                $1
-                                                                                OFFSET
-                                                                                $2»
-                                                                               params [var(@parent$id as Int),
-                                                                                       const(BigInt(0))]
-                                                                               fields {
-                                                                                   id: id
-                                                                                   title: title
-                                                                                   userId: userId
-                                                                               })])
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
          enums {
              Role: {
                  admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-create.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/create-nested-create.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -37,18 +39,41 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in let @parent = unique (query «SELECT "public"."User"."id",
-                                      "public"."User"."email",
-                                      "public"."User"."role"::text FROM
-                                      "public"."User" WHERE "public"."User"."id"
-                                      = $1 LIMIT $2 OFFSET $3»
-                               params [var(0$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
-         in let @parent$id = mapField id (get @parent)
-            in join (get @parent)
-               with (query «SELECT "public"."Post"."id",
-                            "public"."Post"."title", "public"."Post"."userId"
-                            FROM "public"."Post" WHERE "public"."Post"."userId"
-                            = $1 OFFSET $2»
-                     params [var(@parent$id as Int),
-                             const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: id
+                                  email: email
+                                  role: role
+                              }
+                              relations [posts on left.id = right.userId many (query
+                                                                               «SELECT
+                                                                                "public"."Post"."id",
+                                                                                "public"."Post"."title",
+                                                                                "public"."Post"."userId"
+                                                                                FROM
+                                                                                "public"."Post"
+                                                                                WHERE
+                                                                                "public"."Post"."userId"
+                                                                                =
+                                                                                $1
+                                                                                OFFSET
+                                                                                $2»
+                                                                               params [var(@parent$id as Int),
+                                                                                       const(BigInt(0))]
+                                                                               fields {
+                                                                                   id: id
+                                                                                   title: title
+                                                                                   userId: userId
+                                                                               })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@delete-one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@delete-one.json.snap
@@ -8,8 +8,8 @@ dataMap {
     title: String (title)
     userId: Int (userId)
 }
-let 0 = unique (query «DELETE FROM "public"."Post" WHERE ("public"."Post"."id" =
-                       $1 AND 1=1) RETURNING "public"."Post"."id",
+let 0 = unique (query «DELETE FROM "public"."Post" WHERE "public"."Post"."id" =
+                       $1 RETURNING "public"."Post"."id",
                        "public"."Post"."title", "public"."Post"."userId"»
                 params [const(BigInt(1))])
 in let 0 = validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-distinct-pagination-query.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-distinct-pagination-query.json.snap
@@ -2,31 +2,29 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/nested-distinct-pagination-query.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    posts (from @nested$posts): {
-        id: Int (id)
-        title: String (title)
-    }
-}
-let @parent = query «SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1
-                     OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (process {
-               .: {
-                   linkingFields: (userId)
-                   distinct: (title)
-                   pagination: {
-                       skip: 20
-                       take: 10
-                   }
+rawNestedRead (query «SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1
+                      OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: 0
                }
-           } (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                     "public"."Post"."userId" FROM "public"."Post" WHERE
-                     "public"."Post"."userId" IN [$1,*] ORDER BY
-                     "public"."Post"."id" ASC OFFSET $2»
-              params [var(@parent$id as Int),
-                      const(BigInt(0))])) on left.(id) = right.(userId) as @nested$posts
+               relations [posts on left.0 = right.2 many (query «SELECT
+                                                                 "public"."Post"."id",
+                                                                 "public"."Post"."title",
+                                                                 "public"."Post"."userId"
+                                                                 FROM
+                                                                 "public"."Post"
+                                                                 WHERE
+                                                                 "public"."Post"."userId"
+                                                                 IN [$1,*] ORDER
+                                                                 BY
+                                                                 "public"."Post"."id"
+                                                                 ASC OFFSET $2»
+                                                          params [var(@parent$id as Int),
+                                                                  const(BigInt(0))]
+                                                          fields {
+                                                              id: 0
+                                                              title: 1
+                                                          })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-pagination-query.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-pagination-query.json.snap
@@ -2,30 +2,29 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/nested-pagination-query.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    posts (from @nested$posts): {
-        id: Int (id)
-        title: String (title)
-    }
-}
-let @parent = query «SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1
-                     OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (process {
-               .: {
-                   linkingFields: (userId)
-                   pagination: {
-                       skip: 20
-                       take: 10
-                   }
+rawNestedRead (query «SELECT "public"."User"."id" FROM "public"."User" WHERE 1=1
+                      OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: 0
                }
-           } (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                     "public"."Post"."userId" FROM "public"."Post" WHERE
-                     "public"."Post"."userId" IN [$1,*] ORDER BY
-                     "public"."Post"."id" ASC OFFSET $2»
-              params [var(@parent$id as Int),
-                      const(BigInt(0))])) on left.(id) = right.(userId) as @nested$posts
+               relations [posts on left.0 = right.2 many (query «SELECT
+                                                                 "public"."Post"."id",
+                                                                 "public"."Post"."title",
+                                                                 "public"."Post"."userId"
+                                                                 FROM
+                                                                 "public"."Post"
+                                                                 WHERE
+                                                                 "public"."Post"."userId"
+                                                                 IN [$1,*] ORDER
+                                                                 BY
+                                                                 "public"."Post"."id"
+                                                                 ASC OFFSET $2»
+                                                          params [var(@parent$id as Int),
+                                                                  const(BigInt(0))]
+                                                          fields {
+                                                              id: 0
+                                                              title: 1
+                                                          })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -1,0 +1,158 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/nested-upsert-nested-only.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+       posts (from @nested$posts): {
+           id: Int (id)
+           title: String (title)
+           userId: Int (userId)
+           categories (from @nested$categories): {
+               id: Int (id)
+               name: String (name)
+           }
+       }
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
+                          "public"."User"."role"::text FROM "public"."User"
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+                   params [const(String("user.1737556028164@prisma.io")),
+                           const(BigInt(1)), const(BigInt(0))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = query «SELECT "public"."Post"."id", "public"."Post"."userId"
+                        FROM "public"."Post" WHERE ("public"."Post"."id" = $1
+                        AND "public"."Post"."userId" IN [$2,*]) OFFSET $3»
+                 params [const(BigInt(11)), var(0$id as Int), const(BigInt(0))]
+         in if (rowCountNeq 0 (get 1))
+            then let 1 = validate (get 1)
+                     [ rowCountNeq 0
+                     ] orRaise "MISSING_RELATED_RECORD"
+                 in let 6 = get 1
+                    in let 7 = query «SELECT "public"."Category"."id" FROM
+                                      "public"."Category" WHERE
+                                      "public"."Category"."id" = $1 OFFSET $2»
+                               params [const(BigInt(10)), const(BigInt(0))]
+                       in let 6 = unique (validate (get 6)
+                              [ rowCountNeq 0
+                              ] orRaise "MISSING_RELATED_RECORD");
+                              6$id = mapField id (get 6);
+                              7 = validate (get 7)
+                              [ rowCountEq 1
+                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                              7$id = mapField id (get 7)
+                          in execute «INSERT INTO "public"."_CategoryToPost"
+                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
+                                      NOTHING»
+                             params [product(var(6$id as Int[]),
+                                             var(7$id as Int[]))]
+            else let 0 = unique (validate (get 0)
+                     [ rowCountNeq 0
+                     ] orRaise "MISSING_RELATED_RECORD");
+                     0$id = mapField id (get 0)
+                 in let 3 = unique (query «INSERT INTO "public"."Post"
+                                           ("title","userId") VALUES ($1,$2)
+                                           RETURNING "public"."Post"."id"»
+                                    params [const(String("Nested upsert created post")),
+                                            var(0$id as Int)])
+                    in let 4 = query «SELECT "public"."Category"."id" FROM
+                                      "public"."Category" WHERE
+                                      "public"."Category"."id" = $1 OFFSET $2»
+                               params [const(BigInt(10)), const(BigInt(0))]
+                       in let 3 = unique (validate (get 3)
+                              [ rowCountNeq 0
+                              ] orRaise "MISSING_RELATED_RECORD");
+                              3$id = mapField id (get 3);
+                              4 = validate (get 4)
+                              [ rowCountEq 1
+                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                              4$id = mapField id (get 4)
+                          in execute «INSERT INTO "public"."_CategoryToPost"
+                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
+                                      NOTHING»
+                             params [product(var(3$id as Int[]),
+                                             var(4$id as Int[]))];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  email: 1
+                                  role: 2
+                              }
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         }
+                                                                         relations [categories on left.0 = right.2 many (query
+                                                                                                                         «SELECT
+                                                                                                                          "public"."Category"."id",
+                                                                                                                          "public"."Category"."name",
+                                                                                                                          "t0"."B"
+                                                                                                                          AS
+                                                                                                                          "CategoryToPost@Post"
+                                                                                                                          FROM
+                                                                                                                          "public"."Category"
+                                                                                                                          INNER
+                                                                                                                          JOIN
+                                                                                                                          "public"."_CategoryToPost"
+                                                                                                                          AS
+                                                                                                                          "t0"
+                                                                                                                          ON
+                                                                                                                          "t0"."A"
+                                                                                                                          =
+                                                                                                                          "public"."Category"."id"
+                                                                                                                          WHERE
+                                                                                                                          (1=1
+                                                                                                                          AND
+                                                                                                                          "t0"."B"
+                                                                                                                          IN
+                                                                                                                          [$1,*])
+                                                                                                                          OFFSET
+                                                                                                                          $2»
+                                                                                                                         params [var(@parent$id as Int),
+                                                                                                                                 const(BigInt(0))]
+                                                                                                                         fields {
+                                                                                                                             id: 0
+                                                                                                                             name: 1
+                                                                                                                         })])])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -34,10 +34,8 @@ transaction
                         FROM "public"."Post" WHERE ("public"."Post"."id" = $1
                         AND "public"."Post"."userId" IN [$2,*]) OFFSET $3»
                  params [const(BigInt(11)), var(0$id as Int), const(BigInt(0))]
-         in let 2 = if (rowCountNeq 0 (get 1))
-                then validate (get 1)
-                     [ rowCountNeq 0
-                     ] orRaise "MISSING_RELATED_RECORD"
+         in let 3 = if (rowCountNeq 0 (get 1))
+                then get 1
                 else let 0 = unique (validate (get 0)
                          [ rowCountNeq 0
                          ] orRaise "MISSING_RELATED_RECORD");
@@ -47,21 +45,21 @@ transaction
                                        RETURNING "public"."Post"."id"»
                                 params [const(String("Nested upsert created post")),
                                         var(0$id as Int)])
-            in let 5 = query «SELECT "public"."Category"."id" FROM
+            in let 4 = query «SELECT "public"."Category"."id" FROM
                               "public"."Category" WHERE "public"."Category"."id"
                               = $1 OFFSET $2»
                        params [const(BigInt(10)), const(BigInt(0))]
-               in let 2 = unique (validate (get 2)
+               in let 3 = unique (validate (get 3)
                       [ rowCountNeq 0
                       ] orRaise "MISSING_RELATED_RECORD");
-                      2$id = mapField id (get 2);
-                      5 = validate (get 5)
+                      3$id = mapField id (get 3);
+                      4 = validate (get 4)
                       [ rowCountEq 1
                       ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                      5$id = mapField id (get 5)
+                      4$id = mapField id (get 4)
                   in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
                               VALUES [($1),*],* ON CONFLICT DO NOTHING»
-                     params [product(var(2$id as Int[]), var(5$id as Int[]))];
+                     params [product(var(3$id as Int[]), var(4$id as Int[]))];
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -25,9 +25,8 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -35,54 +35,34 @@ transaction
                         FROM "public"."Post" WHERE ("public"."Post"."id" = $1
                         AND "public"."Post"."userId" IN [$2,*]) OFFSET $3»
                  params [const(BigInt(11)), var(0$id as Int), const(BigInt(0))]
-         in if (rowCountNeq 0 (get 1))
-            then let 1 = validate (get 1)
+         in let 2 = if (rowCountNeq 0 (get 1))
+                then validate (get 1)
                      [ rowCountNeq 0
                      ] orRaise "MISSING_RELATED_RECORD"
-                 in let 6 = get 1
-                    in let 7 = query «SELECT "public"."Category"."id" FROM
-                                      "public"."Category" WHERE
-                                      "public"."Category"."id" = $1 OFFSET $2»
-                               params [const(BigInt(10)), const(BigInt(0))]
-                       in let 6 = unique (validate (get 6)
-                              [ rowCountNeq 0
-                              ] orRaise "MISSING_RELATED_RECORD");
-                              6$id = mapField id (get 6);
-                              7 = validate (get 7)
-                              [ rowCountEq 1
-                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                              7$id = mapField id (get 7)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                      NOTHING»
-                             params [product(var(6$id as Int[]),
-                                             var(7$id as Int[]))]
-            else let 0 = unique (validate (get 0)
-                     [ rowCountNeq 0
-                     ] orRaise "MISSING_RELATED_RECORD");
-                     0$id = mapField id (get 0)
-                 in let 3 = unique (query «INSERT INTO "public"."Post"
-                                           ("title","userId") VALUES ($1,$2)
-                                           RETURNING "public"."Post"."id"»
-                                    params [const(String("Nested upsert created post")),
-                                            var(0$id as Int)])
-                    in let 4 = query «SELECT "public"."Category"."id" FROM
-                                      "public"."Category" WHERE
-                                      "public"."Category"."id" = $1 OFFSET $2»
-                               params [const(BigInt(10)), const(BigInt(0))]
-                       in let 3 = unique (validate (get 3)
-                              [ rowCountNeq 0
-                              ] orRaise "MISSING_RELATED_RECORD");
-                              3$id = mapField id (get 3);
-                              4 = validate (get 4)
-                              [ rowCountEq 1
-                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                              4$id = mapField id (get 4)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                      NOTHING»
-                             params [product(var(3$id as Int[]),
-                                             var(4$id as Int[]))];
+                else let 0 = unique (validate (get 0)
+                         [ rowCountNeq 0
+                         ] orRaise "MISSING_RELATED_RECORD");
+                         0$id = mapField id (get 0)
+                     in unique (query «INSERT INTO "public"."Post"
+                                       ("title","userId") VALUES ($1,$2)
+                                       RETURNING "public"."Post"."id"»
+                                params [const(String("Nested upsert created post")),
+                                        var(0$id as Int)])
+            in let 5 = query «SELECT "public"."Category"."id" FROM
+                              "public"."Category" WHERE "public"."Category"."id"
+                              = $1 OFFSET $2»
+                       params [const(BigInt(10)), const(BigInt(0))]
+               in let 2 = unique (validate (get 2)
+                      [ rowCountNeq 0
+                      ] orRaise "MISSING_RELATED_RECORD");
+                      2$id = mapField id (get 2);
+                      5 = validate (get 5)
+                      [ rowCountEq 1
+                      ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                      5$id = mapField id (get 5)
+                  in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                              VALUES [($1),*],* ON CONFLICT DO NOTHING»
+                     params [product(var(2$id as Int[]), var(5$id as Int[]))];
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-compound-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-compound-id.json.snap
@@ -1,0 +1,18 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/query-compound-id.json
+snapshot_kind: text
+---
+dataMap {
+    a: Int (a)
+    b: Int (b)
+}
+unique (query «SELECT "public"."ParentModelWithCompositeId"."a",
+               "public"."ParentModelWithCompositeId"."b" FROM
+               "public"."ParentModelWithCompositeId" WHERE
+               ("public"."ParentModelWithCompositeId"."a" = $1 AND
+               "public"."ParentModelWithCompositeId"."b" = $2) LIMIT $3 OFFSET
+               $4»
+        params [const(BigInt(1)), const(BigInt(1)), const(BigInt(1)),
+                const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m-pagination-mapped-distinct.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m-pagination-mapped-distinct.json.snap
@@ -1,0 +1,44 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/query-m2m-pagination-mapped-distinct.json
+snapshot_kind: text
+---
+dataMap {
+    id: Int (post_id)
+    categories (from @nested$categories): {
+        id: Int (cat_id)
+        name: String (name)
+    }
+}
+let @parent = query «SELECT "public"."MappedPost"."post_id" FROM
+                     "public"."MappedPost" WHERE 1=1 OFFSET $1»
+              params [const(BigInt(0))]
+in let @parent$id = mapField post_id (get @parent)
+   in join (get @parent)
+      with (process {
+               .: {
+                   linkingFields: (MappedCategoryToMappedPost@MappedPost)
+                   distinct: (cat_id)
+                   pagination: {
+                       skip: 1
+                       take: 1
+                       cursor: {
+                           cat_id: const(Int(1))
+                       }
+                   }
+               }
+           } (query «SELECT "public"."MappedCategory"."cat_id",
+                     "public"."MappedCategory"."name", "t1"."B" AS
+                     "MappedCategoryToMappedPost@MappedPost" FROM
+                     "public"."MappedCategory" INNER JOIN
+                     "public"."_MappedCategoryToMappedPost" AS "t1" ON "t1"."A"
+                     = "public"."MappedCategory"."cat_id" WHERE
+                     ("public"."MappedCategory"."cat_id" >= (SELECT
+                     "public"."MappedCategory"."cat_id" FROM
+                     "public"."MappedCategory" WHERE
+                     ("public"."MappedCategory"."cat_id") = ($1)) AND "t1"."B"
+                     IN [$2,*]) ORDER BY "public"."MappedCategory"."cat_id" ASC
+                     OFFSET $3»
+              params [const(BigInt(1)), var(@parent$id as Int),
+                      const(BigInt(0))])) on left.(post_id) = right.(MappedCategoryToMappedPost@MappedPost) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m-pagination-mapped-distinct.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m-pagination-mapped-distinct.json.snap
@@ -4,41 +4,45 @@ expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-m2m-pagination-mapped-distinct.json
 snapshot_kind: text
 ---
-dataMap {
-    id: Int (post_id)
-    categories (from @nested$categories): {
-        id: Int (cat_id)
-        name: String (name)
-    }
-}
-let @parent = query «SELECT "public"."MappedPost"."post_id" FROM
-                     "public"."MappedPost" WHERE 1=1 OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$id = mapField post_id (get @parent)
-   in join (get @parent)
-      with (process {
-               .: {
-                   linkingFields: (MappedCategoryToMappedPost@MappedPost)
-                   distinct: (cat_id)
-                   pagination: {
-                       skip: 1
-                       take: 1
-                       cursor: {
-                           cat_id: const(Int(1))
-                       }
-                   }
+rawNestedRead (query «SELECT "public"."MappedPost"."post_id" FROM
+                      "public"."MappedPost" WHERE 1=1 OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: 0
                }
-           } (query «SELECT "public"."MappedCategory"."cat_id",
-                     "public"."MappedCategory"."name", "t1"."B" AS
-                     "MappedCategoryToMappedPost@MappedPost" FROM
-                     "public"."MappedCategory" INNER JOIN
-                     "public"."_MappedCategoryToMappedPost" AS "t1" ON "t1"."A"
-                     = "public"."MappedCategory"."cat_id" WHERE
-                     ("public"."MappedCategory"."cat_id" >= (SELECT
-                     "public"."MappedCategory"."cat_id" FROM
-                     "public"."MappedCategory" WHERE
-                     ("public"."MappedCategory"."cat_id") = ($1)) AND "t1"."B"
-                     IN [$2,*]) ORDER BY "public"."MappedCategory"."cat_id" ASC
-                     OFFSET $3»
-              params [const(BigInt(1)), var(@parent$id as Int),
-                      const(BigInt(0))])) on left.(post_id) = right.(MappedCategoryToMappedPost@MappedPost) as @nested$categories
+               relations [categories on left.0 = right.2 many (query «SELECT
+                                                                      "public"."MappedCategory"."cat_id",
+                                                                      "public"."MappedCategory"."name",
+                                                                      "t0"."B"
+                                                                      AS
+                                                                      "MappedCategoryToMappedPost@MappedPost"
+                                                                      FROM
+                                                                      "public"."MappedCategory"
+                                                                      INNER JOIN
+                                                                      "public"."_MappedCategoryToMappedPost"
+                                                                      AS "t0" ON
+                                                                      "t0"."A" =
+                                                                      "public"."MappedCategory"."cat_id"
+                                                                      WHERE
+                                                                      ("public"."MappedCategory"."cat_id"
+                                                                      >= (SELECT
+                                                                      "public"."MappedCategory"."cat_id"
+                                                                      FROM
+                                                                      "public"."MappedCategory"
+                                                                      WHERE
+                                                                      ("public"."MappedCategory"."cat_id")
+                                                                      = ($1))
+                                                                      AND
+                                                                      "t0"."B"
+                                                                      IN [$2,*])
+                                                                      ORDER BY
+                                                                      "public"."MappedCategory"."cat_id"
+                                                                      ASC OFFSET
+                                                                      $3»
+                                                               params [const(BigInt(1)),
+                                                                       var(@parent$id as Int),
+                                                                       const(BigInt(0))]
+                                                               fields {
+                                                                   id: 0
+                                                                   name: 1
+                                                               })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
@@ -14,8 +14,8 @@ dataMap {
 }
 let @parent = unique (query «SELECT "public"."Post"."id",
                              "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE ("public"."Post"."id" =
-                             $1 AND 1=1) LIMIT $2 OFFSET $3»
+                             FROM "public"."Post" WHERE "public"."Post"."id" =
+                             $1 LIMIT $2 OFFSET $3»
                       params [const(BigInt(1)), const(BigInt(1)),
                               const(BigInt(0))])
 in let @parent$id = mapField id (get @parent)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
@@ -1,29 +1,43 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-m2m.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    title: String (title)
-    userId: Int (userId)
-    categories (from @nested$categories): {
-        id: Int (id)
-        name: String (name)
-    }
-}
-let @parent = unique (query «SELECT "public"."Post"."id",
-                             "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE "public"."Post"."id" =
-                             $1 LIMIT $2 OFFSET $3»
-                      params [const(BigInt(1)), const(BigInt(1)),
-                              const(BigInt(0))])
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."Category"."id", "public"."Category"."name",
-                   "t0"."B" AS "CategoryToPost@Post" FROM "public"."Category"
-                   INNER JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
-                   "public"."Category"."id" WHERE (1=1 AND "t0"."B" = $1) OFFSET
-                   $2»
-            params [var(@parent$id as Int),
-                    const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                            "public"."Post"."title", "public"."Post"."userId"
+                            FROM "public"."Post" WHERE "public"."Post"."id" = $1
+                            LIMIT $2 OFFSET $3»
+                     params [const(BigInt(1)), const(BigInt(1)),
+                             const(BigInt(0))]
+                     fields {
+                         id: 0
+                         title: 1
+                         userId: 2
+                     }
+                     relations [categories on left.0 = right.2 many (query
+                                                                     «SELECT
+                                                                      "public"."Category"."id",
+                                                                      "public"."Category"."name",
+                                                                      "t0"."B"
+                                                                      AS
+                                                                      "CategoryToPost@Post"
+                                                                      FROM
+                                                                      "public"."Category"
+                                                                      INNER JOIN
+                                                                      "public"."_CategoryToPost"
+                                                                      AS "t0" ON
+                                                                      "t0"."A" =
+                                                                      "public"."Category"."id"
+                                                                      WHERE (1=1
+                                                                      AND
+                                                                      "t0"."B" =
+                                                                      $1) OFFSET
+                                                                      $2»
+                                                                     params [var(@parent$id as Int),
+                                                                             const(BigInt(0))]
+                                                                     fields {
+                                                                         id: 0
+                                                                         name: 1
+                                                                     })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o.json.snap
@@ -13,24 +13,22 @@ rawNestedRead (query «SELECT "public"."Activation"."id",
                       WHERE 1=1 OFFSET $1»
                params [const(BigInt(0))]
                fields {
-                   issued: issued
-                   secret: secret
-                   done: done
+                   issued: 1
+                   secret: 2
+                   done: 3
                }
-               relations [user on left.userId = right.id unique (query «SELECT
-                                                                        "public"."User"."id",
-                                                                        "public"."User"."email"
-                                                                        FROM
-                                                                        "public"."User"
-                                                                        WHERE
-                                                                        "public"."User"."id"
-                                                                        IN
-                                                                        [$1,*]
-                                                                        OFFSET
-                                                                        $2»
-                                                                 params [var(@parent$userId as Int),
-                                                                         const(BigInt(0))]
-                                                                 fields {
-                                                                     id: id
-                                                                     email: email
-                                                                 })])
+               relations [user on left.4 = right.0 unique (query «SELECT
+                                                                  "public"."User"."id",
+                                                                  "public"."User"."email"
+                                                                  FROM
+                                                                  "public"."User"
+                                                                  WHERE
+                                                                  "public"."User"."id"
+                                                                  IN [$1,*]
+                                                                  OFFSET $2»
+                                                           params [var(@parent$userId as Int),
+                                                                   const(BigInt(0))]
+                                                           fields {
+                                                               id: 0
+                                                               email: 1
+                                                           })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2o.json.snap
@@ -1,28 +1,36 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-m2o.json
+snapshot_kind: text
 ---
-dataMap {
-    issued: DateTime (issued)
-    secret: String (secret)
-    done: Boolean (done)
-    user (from @nested$user): {
-        id: Int (id)
-        email: String (email)
-    }
-}
-let @parent = query «SELECT "public"."Activation"."id",
-                     "public"."Activation"."issued",
-                     "public"."Activation"."secret",
-                     "public"."Activation"."done",
-                     "public"."Activation"."userId" FROM "public"."Activation"
-                     WHERE 1=1 OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$userId = mapField userId (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."User"."id", "public"."User"."email" FROM
-                   "public"."User" WHERE "public"."User"."id" IN [$1,*] OFFSET
-                   $2»
-            params [var(@parent$userId as Int),
-                    const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user
+rawNestedRead (query «SELECT "public"."Activation"."id",
+                      "public"."Activation"."issued",
+                      "public"."Activation"."secret",
+                      "public"."Activation"."done",
+                      "public"."Activation"."userId" FROM "public"."Activation"
+                      WHERE 1=1 OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   issued: issued
+                   secret: secret
+                   done: done
+               }
+               relations [user on left.userId = right.id unique (query «SELECT
+                                                                        "public"."User"."id",
+                                                                        "public"."User"."email"
+                                                                        FROM
+                                                                        "public"."User"
+                                                                        WHERE
+                                                                        "public"."User"."id"
+                                                                        IN
+                                                                        [$1,*]
+                                                                        OFFSET
+                                                                        $2»
+                                                                 params [var(@parent$userId as Int),
+                                                                         const(BigInt(0))]
+                                                                 fields {
+                                                                     id: id
+                                                                     email: email
+                                                                 })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-m2m.json.snap
@@ -1,27 +1,40 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-many-m2m.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    title: String (title)
-    userId: Int (userId)
-    categories (from @nested$categories): {
-        id: Int (id)
-        name: String (name)
-    }
-}
-let @parent = query «SELECT "public"."Post"."id", "public"."Post"."title",
-                     "public"."Post"."userId" FROM "public"."Post" WHERE 1=1
-                     OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."Category"."id", "public"."Category"."name",
-                   "t0"."B" AS "CategoryToPost@Post" FROM "public"."Category"
-                   INNER JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
-                   "public"."Category"."id" WHERE (1=1 AND "t0"."B" IN [$1,*])
-                   OFFSET $2»
-            params [var(@parent$id as Int),
-                    const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+rawNestedRead (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                      "public"."Post"."userId" FROM "public"."Post" WHERE 1=1
+                      OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: 0
+                   title: 1
+                   userId: 2
+               }
+               relations [categories on left.0 = right.2 many (query «SELECT
+                                                                      "public"."Category"."id",
+                                                                      "public"."Category"."name",
+                                                                      "t0"."B"
+                                                                      AS
+                                                                      "CategoryToPost@Post"
+                                                                      FROM
+                                                                      "public"."Category"
+                                                                      INNER JOIN
+                                                                      "public"."_CategoryToPost"
+                                                                      AS "t0" ON
+                                                                      "t0"."A" =
+                                                                      "public"."Category"."id"
+                                                                      WHERE (1=1
+                                                                      AND
+                                                                      "t0"."B"
+                                                                      IN [$1,*])
+                                                                      OFFSET $2»
+                                                               params [var(@parent$id as Int),
+                                                                       const(BigInt(0))]
+                                                               fields {
+                                                                   id: 0
+                                                                   name: 1
+                                                               })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-one2m.json.snap
@@ -10,29 +10,27 @@ rawNestedRead (query «SELECT "public"."Post"."id", "public"."Post"."title",
                       OFFSET $1»
                params [const(BigInt(0))]
                fields {
-                   id: id
-                   title: title
-                   userId: userId
+                   id: 0
+                   title: 1
+                   userId: 2
                }
-               relations [user on left.userId = right.id unique (query «SELECT
-                                                                        "public"."User"."id",
-                                                                        "public"."User"."email",
-                                                                        "public"."User"."role"::text
-                                                                        FROM
-                                                                        "public"."User"
-                                                                        WHERE
-                                                                        "public"."User"."id"
-                                                                        IN
-                                                                        [$1,*]
-                                                                        OFFSET
-                                                                        $2»
-                                                                 params [var(@parent$userId as Int),
-                                                                         const(BigInt(0))]
-                                                                 fields {
-                                                                     id: id
-                                                                     email: email
-                                                                     role: role
-                                                                 })])
+               relations [user on left.2 = right.0 unique (query «SELECT
+                                                                  "public"."User"."id",
+                                                                  "public"."User"."email",
+                                                                  "public"."User"."role"::text
+                                                                  FROM
+                                                                  "public"."User"
+                                                                  WHERE
+                                                                  "public"."User"."id"
+                                                                  IN [$1,*]
+                                                                  OFFSET $2»
+                                                           params [var(@parent$userId as Int),
+                                                                   const(BigInt(0))]
+                                                           fields {
+                                                               id: 0
+                                                               email: 1
+                                                               role: 2
+                                                           })])
 enums {
     Role: {
         admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-many-one2m.json.snap
@@ -1,32 +1,41 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-many-one2m.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    title: String (title)
-    userId: Int (userId)
-    user (from @nested$user): {
-        id: Int (id)
-        email: String (email)
-        role: Enum<Role> (role)
-    }
-}
+rawNestedRead (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                      "public"."Post"."userId" FROM "public"."Post" WHERE 1=1
+                      OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: id
+                   title: title
+                   userId: userId
+               }
+               relations [user on left.userId = right.id unique (query «SELECT
+                                                                        "public"."User"."id",
+                                                                        "public"."User"."email",
+                                                                        "public"."User"."role"::text
+                                                                        FROM
+                                                                        "public"."User"
+                                                                        WHERE
+                                                                        "public"."User"."id"
+                                                                        IN
+                                                                        [$1,*]
+                                                                        OFFSET
+                                                                        $2»
+                                                                 params [var(@parent$userId as Int),
+                                                                         const(BigInt(0))]
+                                                                 fields {
+                                                                     id: id
+                                                                     email: email
+                                                                     role: role
+                                                                 })])
 enums {
     Role: {
         admin: ADMIN
         user: USER
     }
 }
-let @parent = query «SELECT "public"."Post"."id", "public"."Post"."title",
-                     "public"."Post"."userId" FROM "public"."Post" WHERE 1=1
-                     OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$userId = mapField userId (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."User"."id", "public"."User"."email",
-                   "public"."User"."role"::text FROM "public"."User" WHERE
-                   "public"."User"."id" IN [$1,*] OFFSET $2»
-            params [var(@parent$userId as Int),
-                    const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-non-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-non-unique-one2m-pagination.json.snap
@@ -2,37 +2,36 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-non-unique-one2m-pagination.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    email: String (email)
-    role: Enum<Role> (role)
-    posts (from @nested$posts): {
-        id: Int (id)
-    }
-}
+rawNestedRead (query «SELECT "public"."User"."id", "public"."User"."email",
+                      "public"."User"."role"::text FROM "public"."User" WHERE
+                      "public"."User"."id" = $1 OFFSET $2»
+               params [const(BigInt(1)), const(BigInt(0))]
+               fields {
+                   id: 0
+                   email: 1
+                   role: 2
+               }
+               relations [posts on left.0 = right.1 many (query «SELECT
+                                                                 "public"."Post"."id",
+                                                                 "public"."Post"."userId"
+                                                                 FROM
+                                                                 "public"."Post"
+                                                                 WHERE
+                                                                 "public"."Post"."userId"
+                                                                 IN [$1,*] ORDER
+                                                                 BY
+                                                                 "public"."Post"."id"
+                                                                 ASC OFFSET $2»
+                                                          params [var(@parent$id as Int),
+                                                                  const(BigInt(0))]
+                                                          fields {
+                                                              id: 0
+                                                          })])
 enums {
     Role: {
         admin: ADMIN
         user: USER
     }
 }
-let @parent = query «SELECT "public"."User"."id", "public"."User"."email",
-                     "public"."User"."role"::text FROM "public"."User" WHERE
-                     "public"."User"."id" = $1 OFFSET $2»
-              params [const(BigInt(1)), const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (process {
-               .: {
-                   linkingFields: (userId)
-                   pagination: {
-                       skip: 10
-                       take: 10
-                   }
-               }
-           } (query «SELECT "public"."Post"."id", "public"."Post"."userId" FROM
-                     "public"."Post" WHERE "public"."Post"."userId" IN [$1,*]
-                     ORDER BY "public"."Post"."id" ASC OFFSET $2»
-              params [var(@parent$id as Int),
-                      const(BigInt(0))])) on left.(id) = right.(userId) as @nested$posts

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m.json.snap
@@ -1,26 +1,35 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-o2m.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    email: String (email)
-    activations (from @nested$activations): {
-        issued: DateTime (issued)
-        secret: String (secret)
-        done: Boolean (done)
-    }
-}
-let @parent = query «SELECT "public"."User"."id", "public"."User"."email" FROM
-                     "public"."User" WHERE 1=1 OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."Activation"."id",
-                   "public"."Activation"."issued",
-                   "public"."Activation"."secret", "public"."Activation"."done",
-                   "public"."Activation"."userId" FROM "public"."Activation"
-                   WHERE "public"."Activation"."userId" IN [$1,*] OFFSET $2»
-            params [var(@parent$id as Int),
-                    const(BigInt(0))]) on left.(id) = right.(userId) as @nested$activations
+rawNestedRead (query «SELECT "public"."User"."id", "public"."User"."email" FROM
+                      "public"."User" WHERE 1=1 OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: id
+                   email: email
+               }
+               relations [activations on left.id = right.userId many (query
+                                                                      «SELECT
+                                                                       "public"."Activation"."id",
+                                                                       "public"."Activation"."issued",
+                                                                       "public"."Activation"."secret",
+                                                                       "public"."Activation"."done",
+                                                                       "public"."Activation"."userId"
+                                                                       FROM
+                                                                       "public"."Activation"
+                                                                       WHERE
+                                                                       "public"."Activation"."userId"
+                                                                       IN [$1,*]
+                                                                       OFFSET
+                                                                       $2»
+                                                                      params [var(@parent$id as Int),
+                                                                              const(BigInt(0))]
+                                                                      fields {
+                                                                          issued: issued
+                                                                          secret: secret
+                                                                          done: done
+                                                                      })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-o2m.json.snap
@@ -9,11 +9,10 @@ rawNestedRead (query «SELECT "public"."User"."id", "public"."User"."email" FROM
                       "public"."User" WHERE 1=1 OFFSET $1»
                params [const(BigInt(0))]
                fields {
-                   id: id
-                   email: email
+                   id: 0
+                   email: 1
                }
-               relations [activations on left.id = right.userId many (query
-                                                                      «SELECT
+               relations [activations on left.0 = right.4 many (query «SELECT
                                                                        "public"."Activation"."id",
                                                                        "public"."Activation"."issued",
                                                                        "public"."Activation"."secret",
@@ -26,10 +25,10 @@ rawNestedRead (query «SELECT "public"."User"."id", "public"."User"."email" FROM
                                                                        IN [$1,*]
                                                                        OFFSET
                                                                        $2»
-                                                                      params [var(@parent$id as Int),
-                                                                              const(BigInt(0))]
-                                                                      fields {
-                                                                          issued: issued
-                                                                          secret: secret
-                                                                          done: done
-                                                                      })])
+                                                                params [var(@parent$id as Int),
+                                                                        const(BigInt(0))]
+                                                                fields {
+                                                                    issued: 1
+                                                                    secret: 2
+                                                                    done: 3
+                                                                })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m-pagination.json.snap
@@ -2,41 +2,50 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-one2m-pagination.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    title: String (title)
-    userId: Int (userId)
-    categories (from @nested$categories): {
-        id: Int (id)
-        name: String (name)
-    }
-}
-let @parent = query «SELECT "public"."Post"."id", "public"."Post"."title",
-                     "public"."Post"."userId" FROM "public"."Post" WHERE 1=1
-                     OFFSET $1»
-              params [const(BigInt(0))]
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (process {
-               .: {
-                   linkingFields: (CategoryToPost@Post)
-                   distinct: (id)
-                   pagination: {
-                       skip: 1
-                       take: 1
-                       cursor: {
-                           id: const(Int(1))
-                       }
-                   }
+rawNestedRead (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                      "public"."Post"."userId" FROM "public"."Post" WHERE 1=1
+                      OFFSET $1»
+               params [const(BigInt(0))]
+               fields {
+                   id: 0
+                   title: 1
+                   userId: 2
                }
-           } (query «SELECT "public"."Category"."id",
-                     "public"."Category"."name", "t0"."B" AS
-                     "CategoryToPost@Post" FROM "public"."Category" INNER JOIN
-                     "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
-                     "public"."Category"."id" WHERE ("public"."Category"."id" >=
-                     (SELECT "public"."Category"."id" FROM "public"."Category"
-                     WHERE ("public"."Category"."id") = ($1)) AND "t0"."B" IN
-                     [$2,*]) ORDER BY "public"."Category"."id" ASC OFFSET $3»
-              params [const(BigInt(1)), var(@parent$id as Int),
-                      const(BigInt(0))])) on left.(id) = right.(CategoryToPost@Post) as @nested$categories
+               relations [categories on left.0 = right.2 many (query «SELECT
+                                                                      "public"."Category"."id",
+                                                                      "public"."Category"."name",
+                                                                      "t0"."B"
+                                                                      AS
+                                                                      "CategoryToPost@Post"
+                                                                      FROM
+                                                                      "public"."Category"
+                                                                      INNER JOIN
+                                                                      "public"."_CategoryToPost"
+                                                                      AS "t0" ON
+                                                                      "t0"."A" =
+                                                                      "public"."Category"."id"
+                                                                      WHERE
+                                                                      ("public"."Category"."id"
+                                                                      >= (SELECT
+                                                                      "public"."Category"."id"
+                                                                      FROM
+                                                                      "public"."Category"
+                                                                      WHERE
+                                                                      ("public"."Category"."id")
+                                                                      = ($1))
+                                                                      AND
+                                                                      "t0"."B"
+                                                                      IN [$2,*])
+                                                                      ORDER BY
+                                                                      "public"."Category"."id"
+                                                                      ASC OFFSET
+                                                                      $3»
+                                                               params [const(BigInt(1)),
+                                                                       var(@parent$id as Int),
+                                                                       const(BigInt(0))]
+                                                               fields {
+                                                                   id: 0
+                                                                   name: 1
+                                                               })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
@@ -12,12 +12,11 @@ rawNestedReadUnique (query «SELECT "public"."Post"."id",
                      params [const(BigInt(1)), const(BigInt(1)),
                              const(BigInt(0))]
                      fields {
-                         id: id
-                         title: title
-                         userId: userId
+                         id: 0
+                         title: 1
+                         userId: 2
                      }
-                     relations [user on left.userId = right.id unique (query
-                                                                       «SELECT
+                     relations [user on left.2 = right.0 unique (query «SELECT
                                                                         "public"."User"."id",
                                                                         "public"."User"."email",
                                                                         "public"."User"."role"::text
@@ -28,13 +27,13 @@ rawNestedReadUnique (query «SELECT "public"."Post"."id",
                                                                         = $1
                                                                         OFFSET
                                                                         $2»
-                                                                       params [var(@parent$userId as Int),
-                                                                               const(BigInt(0))]
-                                                                       fields {
-                                                                           id: id
-                                                                           email: email
-                                                                           role: role
-                                                                       })])
+                                                                 params [var(@parent$userId as Int),
+                                                                         const(BigInt(0))]
+                                                                 fields {
+                                                                     id: 0
+                                                                     email: 1
+                                                                     role: 2
+                                                                 })])
 enums {
     Role: {
         admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
@@ -21,8 +21,8 @@ enums {
 }
 let @parent = unique (query «SELECT "public"."Post"."id",
                              "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE ("public"."Post"."id" =
-                             $1 AND 1=1) LIMIT $2 OFFSET $3»
+                             FROM "public"."Post" WHERE "public"."Post"."id" =
+                             $1 LIMIT $2 OFFSET $3»
                       params [const(BigInt(1)), const(BigInt(1)),
                               const(BigInt(0))])
 in let @parent$userId = mapField userId (get @parent)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
@@ -1,34 +1,43 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-one2m.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    title: String (title)
-    userId: Int (userId)
-    user (from @nested$user): {
-        id: Int (id)
-        email: String (email)
-        role: Enum<Role> (role)
-    }
-}
+rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                            "public"."Post"."title", "public"."Post"."userId"
+                            FROM "public"."Post" WHERE "public"."Post"."id" = $1
+                            LIMIT $2 OFFSET $3»
+                     params [const(BigInt(1)), const(BigInt(1)),
+                             const(BigInt(0))]
+                     fields {
+                         id: id
+                         title: title
+                         userId: userId
+                     }
+                     relations [user on left.userId = right.id unique (query
+                                                                       «SELECT
+                                                                        "public"."User"."id",
+                                                                        "public"."User"."email",
+                                                                        "public"."User"."role"::text
+                                                                        FROM
+                                                                        "public"."User"
+                                                                        WHERE
+                                                                        "public"."User"."id"
+                                                                        = $1
+                                                                        OFFSET
+                                                                        $2»
+                                                                       params [var(@parent$userId as Int),
+                                                                               const(BigInt(0))]
+                                                                       fields {
+                                                                           id: id
+                                                                           email: email
+                                                                           role: role
+                                                                       })])
 enums {
     Role: {
         admin: ADMIN
         user: USER
     }
 }
-let @parent = unique (query «SELECT "public"."Post"."id",
-                             "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE "public"."Post"."id" =
-                             $1 LIMIT $2 OFFSET $3»
-                      params [const(BigInt(1)), const(BigInt(1)),
-                              const(BigInt(0))])
-in let @parent$userId = mapField userId (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."User"."id", "public"."User"."email",
-                   "public"."User"."role"::text FROM "public"."User" WHERE
-                   "public"."User"."id" = $1 OFFSET $2»
-            params [var(@parent$userId as Int),
-                    const(BigInt(0))]) on unique left.(userId) = right.(id) as @nested$user

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
@@ -1,32 +1,44 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/query-unique-one2m-pagination.json
+snapshot_kind: text
 ---
-dataMap {
-    id: Int (id)
-    email: String (email)
-    role: Enum<Role> (role)
-    posts (from @nested$posts): {
-        id: Int (id)
-    }
-}
+rawNestedReadUnique (query «SELECT "public"."User"."id",
+                            "public"."User"."email",
+                            "public"."User"."role"::text FROM "public"."User"
+                            WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
+                     params [const(BigInt(1)), const(BigInt(1)),
+                             const(BigInt(0))]
+                     fields {
+                         id: id
+                         email: email
+                         role: role
+                     }
+                     relations [posts on left.id = right.userId many (query
+                                                                      «SELECT
+                                                                       "public"."Post"."id",
+                                                                       "public"."Post"."userId"
+                                                                       FROM
+                                                                       "public"."Post"
+                                                                       WHERE
+                                                                       "public"."Post"."userId"
+                                                                       = $1
+                                                                       ORDER BY
+                                                                       "public"."Post"."id"
+                                                                       ASC LIMIT
+                                                                       $2 OFFSET
+                                                                       $3»
+                                                                      params [var(@parent$id as Int),
+                                                                              const(BigInt(10)),
+                                                                              const(BigInt(10))]
+                                                                      fields {
+                                                                          id: id
+                                                                      })])
 enums {
     Role: {
         admin: ADMIN
         user: USER
     }
 }
-let @parent = unique (query «SELECT "public"."User"."id",
-                             "public"."User"."email",
-                             "public"."User"."role"::text FROM "public"."User"
-                             WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
-                      params [const(BigInt(1)), const(BigInt(1)),
-                              const(BigInt(0))])
-in let @parent$id = mapField id (get @parent)
-   in join (get @parent)
-      with (query «SELECT "public"."Post"."id", "public"."Post"."userId" FROM
-                   "public"."Post" WHERE "public"."Post"."userId" = $1 ORDER BY
-                   "public"."Post"."id" ASC LIMIT $2 OFFSET $3»
-            params [var(@parent$id as Int), const(BigInt(10)),
-                    const(BigInt(10))]) on left.(id) = right.(userId) as @nested$posts

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
@@ -12,12 +12,11 @@ rawNestedReadUnique (query «SELECT "public"."User"."id",
                      params [const(BigInt(1)), const(BigInt(1)),
                              const(BigInt(0))]
                      fields {
-                         id: id
-                         email: email
-                         role: role
+                         id: 0
+                         email: 1
+                         role: 2
                      }
-                     relations [posts on left.id = right.userId many (query
-                                                                      «SELECT
+                     relations [posts on left.0 = right.1 many (query «SELECT
                                                                        "public"."Post"."id",
                                                                        "public"."Post"."userId"
                                                                        FROM
@@ -30,12 +29,12 @@ rawNestedReadUnique (query «SELECT "public"."User"."id",
                                                                        ASC LIMIT
                                                                        $2 OFFSET
                                                                        $3»
-                                                                      params [var(@parent$id as Int),
-                                                                              const(BigInt(10)),
-                                                                              const(BigInt(10))]
-                                                                      fields {
-                                                                          id: id
-                                                                      })])
+                                                                params [var(@parent$id as Int),
+                                                                        const(BigInt(10)),
+                                                                        const(BigInt(10))]
+                                                                fields {
+                                                                    id: 0
+                                                                })])
 enums {
     Role: {
         admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
@@ -20,8 +20,7 @@ enums {
 let @parent = unique (query «SELECT "public"."User"."id",
                              "public"."User"."email",
                              "public"."User"."role"::text FROM "public"."User"
-                             WHERE ("public"."User"."id" = $1 AND 1=1) LIMIT $2
-                             OFFSET $3»
+                             WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
                       params [const(BigInt(1)), const(BigInt(1)),
                               const(BigInt(0))])
 in let @parent$id = mapField id (get @parent)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
@@ -10,8 +10,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Employee"."id",
                           "public"."Employee"."managerId" FROM
-                          "public"."Employee" WHERE ("public"."Employee"."id" =
-                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                          "public"."Employee" WHERE "public"."Employee"."id" =
+                          $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0 = unique (validate (get 0)
@@ -19,8 +19,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           0$id = mapField id (get 0)
       in let 1 = execute «UPDATE "public"."Employee" SET "managerId" = $1 WHERE
-                          (("public"."Employee"."id" = $2 AND 1=1) OR
-                          ("public"."Employee"."id" = $3 AND 1=1))»
+                          ("public"."Employee"."id" = $2 OR
+                          "public"."Employee"."id" = $3)»
                  params [var(0$id as Int), const(BigInt(2)), const(BigInt(3))]
          in validate (get 1)
             [ affectedRowCountEq 2

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
@@ -2,14 +2,14 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect-child-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
        id: Int (id)
        managerId: Int? (managerId)
    }
-   let 0 = unique (query «SELECT "public"."Employee"."id",
-                          "public"."Employee"."managerId" FROM
+   let 0 = unique (query «SELECT "public"."Employee"."id" FROM
                           "public"."Employee" WHERE "public"."Employee"."id" =
                           $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect-parent-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -19,8 +20,7 @@ transaction
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
                                 WHERE "public"."Employee"."id" = $2 RETURNING
-                                "public"."Employee"."id",
-                                "public"."Employee"."managerId"»
+                                "public"."Employee"."id"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)
                 [ rowCountNeq 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
@@ -9,8 +9,8 @@ transaction
        managerId: Int? (managerId)
    }
    let 1 = unique (query «SELECT "public"."Employee"."id" FROM
-                          "public"."Employee" WHERE ("public"."Employee"."id" =
-                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                          "public"."Employee" WHERE "public"."Employee"."id" =
+                          $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(2)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 1 = unique (validate (get 1)
@@ -18,8 +18,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
-                                WHERE ("public"."Employee"."id" = $2 AND 1=1)
-                                RETURNING "public"."Employee"."id",
+                                WHERE "public"."Employee"."id" = $2 RETURNING
+                                "public"."Employee"."id",
                                 "public"."Employee"."managerId"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -22,8 +22,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
                           "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0 = unique (validate (get 0)
@@ -31,7 +30,7 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           0$id = mapField id (get 0)
       in let 1 = execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                          ("public"."Post"."id" = $2 AND 1=1)»
+                          "public"."Post"."id" = $2»
                  params [var(0$id as Int), const(BigInt(11))]
          in validate (get 1)
             [ affectedRowCountEq 1

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -40,18 +42,41 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in let @parent = unique (query «SELECT "public"."User"."id",
-                                      "public"."User"."email",
-                                      "public"."User"."role"::text FROM
-                                      "public"."User" WHERE "public"."User"."id"
-                                      = $1 LIMIT $2 OFFSET $3»
-                               params [var(0$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
-         in let @parent$id = mapField id (get @parent)
-            in join (get @parent)
-               with (query «SELECT "public"."Post"."id",
-                            "public"."Post"."title", "public"."Post"."userId"
-                            FROM "public"."Post" WHERE "public"."Post"."userId"
-                            = $1 OFFSET $2»
-                     params [var(@parent$id as Int),
-                             const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: id
+                                  email: email
+                                  role: role
+                              }
+                              relations [posts on left.id = right.userId many (query
+                                                                               «SELECT
+                                                                                "public"."Post"."id",
+                                                                                "public"."Post"."title",
+                                                                                "public"."Post"."userId"
+                                                                                FROM
+                                                                                "public"."Post"
+                                                                                WHERE
+                                                                                "public"."Post"."userId"
+                                                                                =
+                                                                                $1
+                                                                                OFFSET
+                                                                                $2»
+                                                                               params [var(@parent$id as Int),
+                                                                                       const(BigInt(0))]
+                                                                               fields {
+                                                                                   id: id
+                                                                                   title: title
+                                                                                   userId: userId
+                                                                               })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -1,6 +1,5 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
-assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect.json
 snapshot_kind: text
@@ -22,9 +21,8 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -50,30 +50,29 @@ transaction
                               params [var(0$id as Int), const(BigInt(1)),
                                       const(BigInt(0))]
                               fields {
-                                  id: id
-                                  email: email
-                                  role: role
+                                  id: 0
+                                  email: 1
+                                  role: 2
                               }
-                              relations [posts on left.id = right.userId many (query
-                                                                               «SELECT
-                                                                                "public"."Post"."id",
-                                                                                "public"."Post"."title",
-                                                                                "public"."Post"."userId"
-                                                                                FROM
-                                                                                "public"."Post"
-                                                                                WHERE
-                                                                                "public"."Post"."userId"
-                                                                                =
-                                                                                $1
-                                                                                OFFSET
-                                                                                $2»
-                                                                               params [var(@parent$id as Int),
-                                                                                       const(BigInt(0))]
-                                                                               fields {
-                                                                                   id: id
-                                                                                   title: title
-                                                                                   userId: userId
-                                                                               })])
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
          enums {
              Role: {
                  admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
@@ -2,14 +2,14 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-create-child-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
        id: Int (id)
        managerId: Int? (managerId)
    }
-   let 0 = unique (query «SELECT "public"."Employee"."id",
-                          "public"."Employee"."managerId" FROM
+   let 0 = unique (query «SELECT "public"."Employee"."id" FROM
                           "public"."Employee" WHERE "public"."Employee"."id" =
                           $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
@@ -10,8 +10,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Employee"."id",
                           "public"."Employee"."managerId" FROM
-                          "public"."Employee" WHERE ("public"."Employee"."id" =
-                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                          "public"."Employee" WHERE "public"."Employee"."id" =
+                          $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
@@ -16,8 +16,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
-                                WHERE ("public"."Employee"."id" = $2 AND 1=1)
-                                RETURNING "public"."Employee"."id",
+                                WHERE "public"."Employee"."id" = $2 RETURNING
+                                "public"."Employee"."id",
                                 "public"."Employee"."managerId"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-create-parent-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -17,8 +18,7 @@ transaction
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
                                 WHERE "public"."Employee"."id" = $2 RETURNING
-                                "public"."Employee"."id",
-                                "public"."Employee"."managerId"»
+                                "public"."Employee"."id"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)
                 [ rowCountNeq 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-connect.json.snap
@@ -1,0 +1,83 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-m2m-connect.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       title: String (title)
+       userId: Int (userId)
+       categories (from @nested$categories): {
+           id: Int (id)
+           name: String (name)
+       }
+   }
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 1 = query «SELECT "public"."Category"."id" FROM "public"."Category"
+                     WHERE ("public"."Category"."id" = $1 OR
+                     "public"."Category"."id" = $2) OFFSET $3»
+              params [const(BigInt(1)), const(BigInt(2)), const(BigInt(0))]
+      in let 0 = unique (validate (get 0)
+             [ rowCountNeq 0
+             ] orRaise "MISSING_RELATED_RECORD");
+             0$id = mapField id (get 0);
+             1 = validate (get 1)
+             [ rowCountEq 2
+             ] orRaise "INCOMPLETE_CONNECT_INPUT";
+             1$id = mapField id (get 1)
+         in execute «INSERT INTO "public"."_CategoryToPost" ("B","A") VALUES
+                     [($1),*],* ON CONFLICT DO NOTHING»
+            params [product(var(0$id as Int[]), var(1$id as Int[]))];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                     "public"."Post"."title",
+                                     "public"."Post"."userId" FROM
+                                     "public"."Post" WHERE "public"."Post"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  title: 1
+                                  userId: 2
+                              }
+                              relations [categories on left.0 = right.2 many (query
+                                                                              «SELECT
+                                                                               "public"."Category"."id",
+                                                                               "public"."Category"."name",
+                                                                               "t0"."B"
+                                                                               AS
+                                                                               "CategoryToPost@Post"
+                                                                               FROM
+                                                                               "public"."Category"
+                                                                               INNER
+                                                                               JOIN
+                                                                               "public"."_CategoryToPost"
+                                                                               AS
+                                                                               "t0"
+                                                                               ON
+                                                                               "t0"."A"
+                                                                               =
+                                                                               "public"."Category"."id"
+                                                                               WHERE
+                                                                               (1=1
+                                                                               AND
+                                                                               "t0"."B"
+                                                                               =
+                                                                               $1)
+                                                                               OFFSET
+                                                                               $2»
+                                                                              params [var(@parent$id as Int),
+                                                                                      const(BigInt(0))]
+                                                                              fields {
+                                                                                  id: 0
+                                                                                  name: 1
+                                                                              })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -14,22 +14,14 @@ transaction
                           "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
-   in let 0$id = mapField id (get 0)
-      in let 1 = query «SELECT "public"."Category"."id", "t0"."B" AS
-                        "CategoryToPost@Post" FROM "public"."Category" INNER
-                        JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
-                        "public"."Category"."id" WHERE ("public"."Category"."id"
-                        = $1 AND "t0"."B" IN [$2,*]) OFFSET $3»
-                 params [const(BigInt(1)), var(0$id as Int), const(BigInt(0))]
-         in let 0 = unique (validate (get 0)
-                [ rowCountNeq 0
-                ] orRaise "MISSING_RELATED_RECORD");
-                0$id = mapField id (get 0);
-                1$id = mapField id (get 1)
-            in execute «DELETE FROM "public"."_CategoryToPost" WHERE
-                        ("public"."_CategoryToPost"."B" = ($1) AND
-                        "public"."_CategoryToPost"."A" IN [$2,*])»
-               params [var(0$id as Int), var(1$id as Int)];
+   in let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RELATED_RECORD");
+          0$id = mapField id (get 0)
+      in execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                  ("public"."_CategoryToPost"."B" = ($1) AND
+                  "public"."_CategoryToPost"."A" IN ($2))»
+         params [var(0$id as Int), const(BigInt(1))];
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-disconnect.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -9,8 +10,7 @@ transaction
        title: String (title)
        userId: Int (userId)
    }
-   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                          "public"."Post"."userId" FROM "public"."Post" WHERE
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
                           "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -11,8 +11,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
                           "public"."Post"."userId" FROM "public"."Post" WHERE
-                          ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0$id = mapField id (get 0)
@@ -20,7 +19,7 @@ transaction
                         "CategoryToPost@Post" FROM "public"."Category" INNER
                         JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
                         "public"."Category"."id" WHERE ("public"."Category"."id"
-                        = $1 AND 1=1 AND "t0"."B" IN [$2,*]) OFFSET $3»
+                        = $1 AND "t0"."B" IN [$2,*]) OFFSET $3»
                  params [const(BigInt(1)), var(0$id as Int), const(BigInt(0))]
          in let 0 = unique (validate (get 0)
                 [ rowCountNeq 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
@@ -14,8 +14,7 @@ transaction
            name: String (name)
        }
    }
-   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                          "public"."Post"."userId" FROM "public"."Post" WHERE
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
                           "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
@@ -1,0 +1,76 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       title: String (title)
+       userId: Int (userId)
+       categories (from @nested$categories): {
+           id: Int (id)
+           name: String (name)
+       }
+   }
+   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                          "public"."Post"."userId" FROM "public"."Post" WHERE
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RELATED_RECORD");
+          0$id = mapField id (get 0)
+      in execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                  "public"."_CategoryToPost"."B" = ($1)»
+         params [var(0$id as Int)];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                     "public"."Post"."title",
+                                     "public"."Post"."userId" FROM
+                                     "public"."Post" WHERE "public"."Post"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  title: 1
+                                  userId: 2
+                              }
+                              relations [categories on left.0 = right.2 many (query
+                                                                              «SELECT
+                                                                               "public"."Category"."id",
+                                                                               "public"."Category"."name",
+                                                                               "t0"."B"
+                                                                               AS
+                                                                               "CategoryToPost@Post"
+                                                                               FROM
+                                                                               "public"."Category"
+                                                                               INNER
+                                                                               JOIN
+                                                                               "public"."_CategoryToPost"
+                                                                               AS
+                                                                               "t0"
+                                                                               ON
+                                                                               "t0"."A"
+                                                                               =
+                                                                               "public"."Category"."id"
+                                                                               WHERE
+                                                                               (1=1
+                                                                               AND
+                                                                               "t0"."B"
+                                                                               =
+                                                                               $1)
+                                                                               OFFSET
+                                                                               $2»
+                                                                              params [var(@parent$id as Int),
+                                                                                      const(BigInt(0))]
+                                                                              fields {
+                                                                                  id: 0
+                                                                                  name: 1
+                                                                              })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
@@ -1,0 +1,92 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-m2m-set.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       title: String (title)
+       userId: Int (userId)
+       categories (from @nested$categories): {
+           id: Int (id)
+           name: String (name)
+       }
+   }
+   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                          "public"."Post"."userId" FROM "public"."Post" WHERE
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RELATED_RECORD");
+          0$id = mapField id (get 0)
+      in let 1 = execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                          "public"."_CategoryToPost"."B" = ($1)»
+                 params [var(0$id as Int)]
+         in let 2 = query «SELECT "public"."Category"."id" FROM
+                           "public"."Category" WHERE ("public"."Category"."id" =
+                           $1 OR "public"."Category"."id" = $2) OFFSET $3»
+                    params [const(BigInt(1)), const(BigInt(2)),
+                            const(BigInt(0))]
+            in let 0 = unique (validate (get 0)
+                   [ rowCountNeq 0
+                   ] orRaise "MISSING_RELATED_RECORD");
+                   0$id = mapField id (get 0);
+                   2 = validate (get 2)
+                   [ rowCountEq 2
+                   ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                   2$id = mapField id (get 2)
+               in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                           VALUES [($1),*],* ON CONFLICT DO NOTHING»
+                  params [product(var(0$id as Int[]), var(2$id as Int[]))];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                     "public"."Post"."title",
+                                     "public"."Post"."userId" FROM
+                                     "public"."Post" WHERE "public"."Post"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  title: 1
+                                  userId: 2
+                              }
+                              relations [categories on left.0 = right.2 many (query
+                                                                              «SELECT
+                                                                               "public"."Category"."id",
+                                                                               "public"."Category"."name",
+                                                                               "t0"."B"
+                                                                               AS
+                                                                               "CategoryToPost@Post"
+                                                                               FROM
+                                                                               "public"."Category"
+                                                                               INNER
+                                                                               JOIN
+                                                                               "public"."_CategoryToPost"
+                                                                               AS
+                                                                               "t0"
+                                                                               ON
+                                                                               "t0"."A"
+                                                                               =
+                                                                               "public"."Category"."id"
+                                                                               WHERE
+                                                                               (1=1
+                                                                               AND
+                                                                               "t0"."B"
+                                                                               =
+                                                                               $1)
+                                                                               OFFSET
+                                                                               $2»
+                                                                              params [var(@parent$id as Int),
+                                                                                      const(BigInt(0))]
+                                                                              fields {
+                                                                                  id: 0
+                                                                                  name: 1
+                                                                              })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
@@ -14,8 +14,7 @@ transaction
            name: String (name)
        }
    }
-   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                          "public"."Post"."userId" FROM "public"."Post" WHERE
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
                           "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-one-returning.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-one-returning.json.snap
@@ -7,7 +7,7 @@ dataMap {
     email: String (email)
 }
 let 0 = unique (query «UPDATE "public"."User" SET "email" = $1 WHERE
-                       ("public"."User"."email" = $2 AND 1=1) RETURNING
+                       "public"."User"."email" = $2 RETURNING
                        "public"."User"."id", "public"."User"."email"»
                 params [const(String("user.2737556028164@prisma.io")),
                         const(String("user.1737556028164@prisma.io"))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-push.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-push.json.snap
@@ -10,7 +10,7 @@ dataMap {
 }
 let 0 = unique (query «UPDATE "public"."DataTypes" SET "intArray" =
                        "public"."DataTypes"."intArray" || $1 WHERE
-                       ("public"."DataTypes"."id" = $2 AND 1=1) RETURNING
+                       "public"."DataTypes"."id" = $2 RETURNING
                        "public"."DataTypes"."id",
                        "public"."DataTypes"."optString",
                        "public"."DataTypes"."intArray"»

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
@@ -21,9 +21,8 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
@@ -1,0 +1,83 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-set-nested-empty.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+       posts (from @nested$posts): {
+           id: Int (id)
+           title: String (title)
+           userId: Int (userId)
+       }
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
+                          "public"."User"."role"::text FROM "public"."User"
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+                   params [const(String("user.1737556028164@prisma.io")),
+                           const(BigInt(1)), const(BigInt(0))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = query «SELECT "public"."Post"."id", "public"."Post"."userId"
+                        FROM "public"."Post" WHERE (1=1 AND
+                        "public"."Post"."userId" IN [$1,*]) OFFSET $2»
+                 params [var(0$id as Int), const(BigInt(0))]
+         in let 1 = validate (get 1)
+                [ rowCountEq 0
+                ] orRaise "RELATION_VIOLATION"
+            in if (rowCountNeq 0 (get 1))
+               then let 1$id = mapField id (get 1)
+                    in execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
+                                ("public"."Post"."id" IN [$2,*] AND 1=1)»
+                       params [const(Null), var(1$id as Int)]
+               else ();
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  email: 1
+                                  role: 2
+                              }
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
@@ -31,15 +31,10 @@ transaction
                         FROM "public"."Post" WHERE (1=1 AND
                         "public"."Post"."userId" IN [$1,*]) OFFSET $2»
                  params [var(0$id as Int), const(BigInt(0))]
-         in let 1 = validate (get 1)
-                [ rowCountEq 0
-                ] orRaise "RELATION_VIOLATION"
-            in if (rowCountNeq 0 (get 1))
-               then let 1$id = mapField id (get 1)
-                    in execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                                ("public"."Post"."id" IN [$2,*] AND 1=1)»
-                       params [const(Null), var(1$id as Int)]
-               else ();
+         in validate (get 1)
+            [ rowCountEq 0
+            ] orRaise "RELATION_VIOLATION";
+            ();
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
@@ -10,8 +10,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Patient"."id",
                           "public"."Patient"."userId" FROM "public"."Patient"
-                          WHERE ("public"."Patient"."id" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+                          WHERE "public"."Patient"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0$id = mapField id (get 0);

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: "query-compiler/query-compiler/tests/data/update-set-nested-prisma#27650.json"
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -13,38 +14,25 @@ transaction
                           WHERE "public"."Patient"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
-   in let 0$id = mapField id (get 0);
-          0$userId = mapField userId (get 0)
-      in let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User"
-                                WHERE (1=1 AND "public"."User"."id" IN [$1,*])
-                                OFFSET $2»
-                         params [var(0$userId as Int), const(BigInt(0))])
-         in let 1 = validate (get 1)
-                [ rowCountNeq 0
-                ] orRaise "MISSING_RELATED_RECORD"
-            in let 2 = get 1
-               in let 2$id = mapField id (get 2)
-                  in let 3 = unique (query «SELECT
-                                            "public"."NotificationSettings"."userId"
-                                            FROM "public"."NotificationSettings"
-                                            WHERE (1=1 AND
-                                            "public"."NotificationSettings"."userId"
-                                            IN [$1,*]) OFFSET $2»
-                                     params [var(2$id as Int),
-                                             const(BigInt(0))])
-                     in let 3 = unique (validate (get 3)
-                            [ rowCountNeq 0
-                            ] orRaise "MISSING_RELATED_RECORD");
-                            3$userId = mapField userId (get 3)
-                        in unique (query «UPDATE "public"."NotificationSettings"
-                                          SET "emailMarketing" = $1,
-                                          "smsMarketing" = $2 WHERE
-                                          ("public"."NotificationSettings"."userId"
-                                          IN [$3,*] AND 1=1) RETURNING
-                                          "public"."NotificationSettings"."userId"»
-                                   params [const(Boolean(true)),
-                                           const(Boolean(false)),
-                                           var(3$userId as Int)]);
+   in let 1 = get 0$userId
+      in let 1$id = mapField id (get 1)
+         in let 2 = unique (query «SELECT
+                                   "public"."NotificationSettings"."userId" FROM
+                                   "public"."NotificationSettings" WHERE (1=1
+                                   AND "public"."NotificationSettings"."userId"
+                                   IN [$1,*]) OFFSET $2»
+                            params [var(1$id as Int), const(BigInt(0))])
+            in let 2 = unique (validate (get 2)
+                   [ rowCountNeq 0
+                   ] orRaise "MISSING_RELATED_RECORD");
+                   2$userId = mapField userId (get 2)
+               in unique (query «UPDATE "public"."NotificationSettings" SET
+                                 "emailMarketing" = $1, "smsMarketing" = $2
+                                 WHERE ("public"."NotificationSettings"."userId"
+                                 IN [$3,*] AND 1=1) RETURNING
+                                 "public"."NotificationSettings"."userId"»
+                          params [const(Boolean(true)), const(Boolean(false)),
+                                  var(2$userId as Int)]);
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
@@ -19,16 +19,10 @@ transaction
                                 WHERE (1=1 AND "public"."User"."id" IN [$1,*])
                                 OFFSET $2»
                          params [var(0$userId as Int), const(BigInt(0))])
-         in let 1 = unique (validate (get 1)
+         in let 1 = validate (get 1)
                 [ rowCountNeq 0
-                ] orRaise "MISSING_RELATED_RECORD");
-                1$id = mapField id (get 1)
-            in let 2 = unique (query «SELECT "public"."User"."id" FROM
-                                      "public"."User" WHERE (1=1 AND
-                                      "public"."User"."id" IN [$1,*]) LIMIT $2
-                                      OFFSET $3»
-                               params [var(1$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
+                ] orRaise "MISSING_RELATED_RECORD"
+            in let 2 = get 1
                in let 2$id = mapField id (get 2)
                   in let 3 = unique (query «SELECT
                                             "public"."NotificationSettings"."userId"

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -1,7 +1,9 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-set-nested.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -62,18 +64,41 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in let @parent = unique (query «SELECT "public"."User"."id",
-                                      "public"."User"."email",
-                                      "public"."User"."role"::text FROM
-                                      "public"."User" WHERE "public"."User"."id"
-                                      = $1 LIMIT $2 OFFSET $3»
-                               params [var(0$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
-         in let @parent$id = mapField id (get @parent)
-            in join (get @parent)
-               with (query «SELECT "public"."Post"."id",
-                            "public"."Post"."title", "public"."Post"."userId"
-                            FROM "public"."Post" WHERE "public"."Post"."userId"
-                            = $1 OFFSET $2»
-                     params [var(@parent$id as Int),
-                             const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: id
+                                  email: email
+                                  role: role
+                              }
+                              relations [posts on left.id = right.userId many (query
+                                                                               «SELECT
+                                                                                "public"."Post"."id",
+                                                                                "public"."Post"."title",
+                                                                                "public"."Post"."userId"
+                                                                                FROM
+                                                                                "public"."Post"
+                                                                                WHERE
+                                                                                "public"."Post"."userId"
+                                                                                =
+                                                                                $1
+                                                                                OFFSET
+                                                                                $2»
+                                                                               params [var(@parent$id as Int),
+                                                                                       const(BigInt(0))]
+                                                                               fields {
+                                                                                   id: id
+                                                                                   title: title
+                                                                                   userId: userId
+                                                                               })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -72,30 +72,29 @@ transaction
                               params [var(0$id as Int), const(BigInt(1)),
                                       const(BigInt(0))]
                               fields {
-                                  id: id
-                                  email: email
-                                  role: role
+                                  id: 0
+                                  email: 1
+                                  role: 2
                               }
-                              relations [posts on left.id = right.userId many (query
-                                                                               «SELECT
-                                                                                "public"."Post"."id",
-                                                                                "public"."Post"."title",
-                                                                                "public"."Post"."userId"
-                                                                                FROM
-                                                                                "public"."Post"
-                                                                                WHERE
-                                                                                "public"."Post"."userId"
-                                                                                =
-                                                                                $1
-                                                                                OFFSET
-                                                                                $2»
-                                                                               params [var(@parent$id as Int),
-                                                                                       const(BigInt(0))]
-                                                                               fields {
-                                                                                   id: id
-                                                                                   title: title
-                                                                                   userId: userId
-                                                                               })])
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
          enums {
              Role: {
                  admin: ADMIN

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -1,6 +1,5 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
-assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-set-nested.json
 snapshot_kind: text
@@ -22,9 +21,8 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -39,21 +39,18 @@ transaction
                             const(BigInt(0))]
             in let 3 = diff (get 2) (get 1)
                in if (rowCountNeq 0 (get 3))
-                  then let 0 = unique (validate (get 0)
-                           [ rowCountNeq 0
-                           ] orRaise "MISSING_RELATED_RECORD");
-                           0$id = mapField id (get 0);
-                           3$id = mapField id (get 3)
-                       in execute «UPDATE "public"."Post" SET "userId" = $1
+                  then let 3$id = mapField id (get 3)
+                       in validate (get 0)
+                          [ rowCountNeq 0
+                          ] orRaise "MISSING_RELATED_RECORD";
+                          execute «UPDATE "public"."Post" SET "userId" = $1
                                    WHERE ("public"."Post"."id" IN [$2,*] AND
                                    1=1)»
                           params [var(0$id as Int), var(3$id as Int)]
                   else ();
-               let 4 = diff (get 1) (get 2)
-               in validate (get 4)
+                  validate (diff (get 1) (get 2))
                   [ rowCountEq 0
                   ] orRaise "RELATION_VIOLATION";
-                  ();
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -50,16 +50,10 @@ transaction
                           params [var(0$id as Int), var(3$id as Int)]
                   else ();
                let 4 = diff (get 1) (get 2)
-               in let 4 = validate (get 4)
-                      [ rowCountEq 0
-                      ] orRaise "RELATION_VIOLATION"
-                  in if (rowCountNeq 0 (get 4))
-                     then let 4$id = mapField id (get 4)
-                          in execute «UPDATE "public"."Post" SET "userId" = $1
-                                      WHERE ("public"."Post"."id" IN [$2,*] AND
-                                      1=1)»
-                             params [const(Null), var(4$id as Int)]
-                     else ();
+               in validate (get 4)
+                  [ rowCountEq 0
+                  ] orRaise "RELATION_VIOLATION";
+                  ();
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -22,8 +22,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
                           "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)
@@ -32,8 +31,8 @@ transaction
                         "public"."Post"."userId" IN [$1,*]) OFFSET $2»
                  params [var(0$id as Int), const(BigInt(0))]
          in let 2 = query «SELECT "public"."Post"."id" FROM "public"."Post"
-                           WHERE (("public"."Post"."id" = $1 AND 1=1) OR
-                           ("public"."Post"."id" = $2 AND 1=1)) OFFSET $3»
+                           WHERE ("public"."Post"."id" = $1 OR
+                           "public"."Post"."id" = $2) OFFSET $3»
                     params [const(BigInt(11)), const(BigInt(12)),
                             const(BigInt(0))]
             in let 3 = diff (get 2) (get 1)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
@@ -19,32 +19,19 @@ transaction
    let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
                   "public"."User"."email" = $1 OFFSET $2»
            params [const(String("user.1@prisma.io")), const(BigInt(0))]
-   in if (rowCountNeq 0 (get 0))
-      then let 2 = get 0
-           in let 2 = unique (validate (get 2)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  2$id = mapField id (get 2)
-              in unique (query «SELECT "public"."User"."id",
-                                "public"."User"."email",
-                                "public"."User"."role"::text FROM
-                                "public"."User" WHERE "public"."User"."id" = $1
-                                LIMIT $2 OFFSET $3»
-                         params [var(2$id as Int), const(BigInt(1)),
-                                 const(BigInt(0))])
-      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
-                                  VALUES ($1,CAST($2::text AS "public"."Role"))
-                                  RETURNING "public"."User"."id"»
-                           params [const(String("user.1@prisma.io")),
-                                   const(String("user"))])
-           in let 1 = unique (validate (get 1)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  1$id = mapField id (get 1)
-              in unique (query «SELECT "public"."User"."id",
-                                "public"."User"."email",
-                                "public"."User"."role"::text FROM
-                                "public"."User" WHERE "public"."User"."id" = $1
-                                LIMIT $2 OFFSET $3»
-                         params [var(1$id as Int), const(BigInt(1)),
-                                 const(BigInt(0))])
+   in let 4 = if (rowCountNeq 0 (get 0))
+          then get 0
+          else unique (query «INSERT INTO "public"."User" ("email","role")
+                              VALUES ($1,CAST($2::text AS "public"."Role"))
+                              RETURNING "public"."User"."id"»
+                       params [const(String("user.1@prisma.io")),
+                               const(String("user"))])
+      in let 4 = unique (validate (get 4)
+             [ rowCountNeq 0
+             ] orRaise "MISSING_RECORD");
+             4$id = mapField id (get 4)
+         in unique (query «SELECT "public"."User"."id", "public"."User"."email",
+                           "public"."User"."role"::text FROM "public"."User"
+                           WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
+                    params [var(4$id as Int), const(BigInt(1)),
+                            const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
@@ -1,0 +1,50 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-empty-update.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                  "public"."User"."email" = $1 OFFSET $2»
+           params [const(String("user.1@prisma.io")), const(BigInt(0))]
+   in if (rowCountNeq 0 (get 0))
+      then let 2 = get 0
+           in let 2 = unique (validate (get 2)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  2$id = mapField id (get 2)
+              in unique (query «SELECT "public"."User"."id",
+                                "public"."User"."email",
+                                "public"."User"."role"::text FROM
+                                "public"."User" WHERE "public"."User"."id" = $1
+                                LIMIT $2 OFFSET $3»
+                         params [var(2$id as Int), const(BigInt(1)),
+                                 const(BigInt(0))])
+      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
+                                  VALUES ($1,CAST($2::text AS "public"."Role"))
+                                  RETURNING "public"."User"."id"»
+                           params [const(String("user.1@prisma.io")),
+                                   const(String("user"))])
+           in let 1 = unique (validate (get 1)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  1$id = mapField id (get 1)
+              in unique (query «SELECT "public"."User"."id",
+                                "public"."User"."email",
+                                "public"."User"."role"::text FROM
+                                "public"."User" WHERE "public"."User"."id" = $1
+                                LIMIT $2 OFFSET $3»
+                         params [var(1$id as Int), const(BigInt(1)),
+                                 const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
@@ -24,106 +24,63 @@ transaction
    let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
                   "public"."User"."email" = $1 OFFSET $2»
            params [const(String("user.1@prisma.io")), const(BigInt(0))]
-   in if (rowCountNeq 0 (get 0))
-      then let 2 = get 0
-           in let 2 = unique (validate (get 2)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RELATED_RECORD");
-                  2$id = mapField id (get 2)
-              in unique (query «INSERT INTO "public"."Post" ("title","userId")
-                                VALUES ($1,$2) RETURNING "public"."Post"."id"»
-                         params [const(String("Nested upsert update post")),
-                                 var(2$id as Int)]);
-              let 2 = unique (validate (get 2)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  2$id = mapField id (get 2)
-              in rawNestedReadUnique (query «SELECT "public"."User"."id",
-                                             "public"."User"."email",
-                                             "public"."User"."role"::text FROM
-                                             "public"."User" WHERE
-                                             "public"."User"."id" = $1 LIMIT $2
-                                             OFFSET $3»
-                                      params [var(2$id as Int),
-                                              const(BigInt(1)),
-                                              const(BigInt(0))]
-                                      fields {
-                                          id: 0
-                                          email: 1
-                                          role: 2
-                                      }
-                                      relations [posts on left.0 = right.2 many (query
-                                                                                 «SELECT
-                                                                                  "public"."Post"."id",
-                                                                                  "public"."Post"."title",
-                                                                                  "public"."Post"."userId"
-                                                                                  FROM
-                                                                                  "public"."Post"
-                                                                                  WHERE
-                                                                                  "public"."Post"."userId"
-                                                                                  =
-                                                                                  $1
-                                                                                  OFFSET
-                                                                                  $2»
-                                                                                 params [var(@parent$id as Int),
-                                                                                         const(BigInt(0))]
-                                                                                 fields {
-                                                                                     id: 0
-                                                                                     title: 1
-                                                                                     userId: 2
-                                                                                 })])
-                 enums {
-                     Role: {
-                         admin: ADMIN
-                         user: USER
-                     }
-                 }
-      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
-                                  VALUES ($1,CAST($2::text AS "public"."Role"))
-                                  RETURNING "public"."User"."id"»
-                           params [const(String("user.1@prisma.io")),
-                                   const(String("user"))])
-           in let 1 = unique (validate (get 1)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  1$id = mapField id (get 1)
-              in rawNestedReadUnique (query «SELECT "public"."User"."id",
-                                             "public"."User"."email",
-                                             "public"."User"."role"::text FROM
-                                             "public"."User" WHERE
-                                             "public"."User"."id" = $1 LIMIT $2
-                                             OFFSET $3»
-                                      params [var(1$id as Int),
-                                              const(BigInt(1)),
-                                              const(BigInt(0))]
-                                      fields {
-                                          id: 0
-                                          email: 1
-                                          role: 2
-                                      }
-                                      relations [posts on left.0 = right.2 many (query
-                                                                                 «SELECT
-                                                                                  "public"."Post"."id",
-                                                                                  "public"."Post"."title",
-                                                                                  "public"."Post"."userId"
-                                                                                  FROM
-                                                                                  "public"."Post"
-                                                                                  WHERE
-                                                                                  "public"."Post"."userId"
-                                                                                  =
-                                                                                  $1
-                                                                                  OFFSET
-                                                                                  $2»
-                                                                                 params [var(@parent$id as Int),
-                                                                                         const(BigInt(0))]
-                                                                                 fields {
-                                                                                     id: 0
-                                                                                     title: 1
-                                                                                     userId: 2
-                                                                                 })])
-                 enums {
-                     Role: {
-                         admin: ADMIN
-                         user: USER
-                     }
-                 }
+   in let 5 = if (rowCountNeq 0 (get 0))
+          then let 2 = get 0
+               in let 2 = unique (validate (get 2)
+                      [ rowCountNeq 0
+                      ] orRaise "MISSING_RELATED_RECORD");
+                      2$id = mapField id (get 2)
+                  in unique (query «INSERT INTO "public"."Post"
+                                    ("title","userId") VALUES ($1,$2) RETURNING
+                                    "public"."Post"."id"»
+                             params [const(String("Nested upsert update post")),
+                                     var(2$id as Int)]);
+                  get 2
+          else unique (query «INSERT INTO "public"."User" ("email","role")
+                              VALUES ($1,CAST($2::text AS "public"."Role"))
+                              RETURNING "public"."User"."id"»
+                       params [const(String("user.1@prisma.io")),
+                               const(String("user"))])
+      in let 5 = unique (validate (get 5)
+             [ rowCountNeq 0
+             ] orRaise "MISSING_RECORD");
+             5$id = mapField id (get 5)
+         in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                        "public"."User"."email",
+                                        "public"."User"."role"::text FROM
+                                        "public"."User" WHERE
+                                        "public"."User"."id" = $1 LIMIT $2
+                                        OFFSET $3»
+                                 params [var(5$id as Int), const(BigInt(1)),
+                                         const(BigInt(0))]
+                                 fields {
+                                     id: 0
+                                     email: 1
+                                     role: 2
+                                 }
+                                 relations [posts on left.0 = right.2 many (query
+                                                                            «SELECT
+                                                                             "public"."Post"."id",
+                                                                             "public"."Post"."title",
+                                                                             "public"."Post"."userId"
+                                                                             FROM
+                                                                             "public"."Post"
+                                                                             WHERE
+                                                                             "public"."Post"."userId"
+                                                                             =
+                                                                             $1
+                                                                             OFFSET
+                                                                             $2»
+                                                                            params [var(@parent$id as Int),
+                                                                                    const(BigInt(0))]
+                                                                            fields {
+                                                                                id: 0
+                                                                                title: 1
+                                                                                userId: 2
+                                                                            })])
+            enums {
+                Role: {
+                    admin: ADMIN
+                    user: USER
+                }
+            }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
@@ -1,0 +1,129 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-nested-only-update.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+       posts (from @nested$posts): {
+           id: Int (id)
+           title: String (title)
+           userId: Int (userId)
+       }
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                  "public"."User"."email" = $1 OFFSET $2»
+           params [const(String("user.1@prisma.io")), const(BigInt(0))]
+   in if (rowCountNeq 0 (get 0))
+      then let 2 = get 0
+           in let 2 = unique (validate (get 2)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RELATED_RECORD");
+                  2$id = mapField id (get 2)
+              in unique (query «INSERT INTO "public"."Post" ("title","userId")
+                                VALUES ($1,$2) RETURNING "public"."Post"."id"»
+                         params [const(String("Nested upsert update post")),
+                                 var(2$id as Int)]);
+              let 2 = unique (validate (get 2)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  2$id = mapField id (get 2)
+              in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                             "public"."User"."email",
+                                             "public"."User"."role"::text FROM
+                                             "public"."User" WHERE
+                                             "public"."User"."id" = $1 LIMIT $2
+                                             OFFSET $3»
+                                      params [var(2$id as Int),
+                                              const(BigInt(1)),
+                                              const(BigInt(0))]
+                                      fields {
+                                          id: 0
+                                          email: 1
+                                          role: 2
+                                      }
+                                      relations [posts on left.0 = right.2 many (query
+                                                                                 «SELECT
+                                                                                  "public"."Post"."id",
+                                                                                  "public"."Post"."title",
+                                                                                  "public"."Post"."userId"
+                                                                                  FROM
+                                                                                  "public"."Post"
+                                                                                  WHERE
+                                                                                  "public"."Post"."userId"
+                                                                                  =
+                                                                                  $1
+                                                                                  OFFSET
+                                                                                  $2»
+                                                                                 params [var(@parent$id as Int),
+                                                                                         const(BigInt(0))]
+                                                                                 fields {
+                                                                                     id: 0
+                                                                                     title: 1
+                                                                                     userId: 2
+                                                                                 })])
+                 enums {
+                     Role: {
+                         admin: ADMIN
+                         user: USER
+                     }
+                 }
+      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
+                                  VALUES ($1,CAST($2::text AS "public"."Role"))
+                                  RETURNING "public"."User"."id"»
+                           params [const(String("user.1@prisma.io")),
+                                   const(String("user"))])
+           in let 1 = unique (validate (get 1)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  1$id = mapField id (get 1)
+              in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                             "public"."User"."email",
+                                             "public"."User"."role"::text FROM
+                                             "public"."User" WHERE
+                                             "public"."User"."id" = $1 LIMIT $2
+                                             OFFSET $3»
+                                      params [var(1$id as Int),
+                                              const(BigInt(1)),
+                                              const(BigInt(0))]
+                                      fields {
+                                          id: 0
+                                          email: 1
+                                          role: 2
+                                      }
+                                      relations [posts on left.0 = right.2 many (query
+                                                                                 «SELECT
+                                                                                  "public"."Post"."id",
+                                                                                  "public"."Post"."title",
+                                                                                  "public"."Post"."userId"
+                                                                                  FROM
+                                                                                  "public"."Post"
+                                                                                  WHERE
+                                                                                  "public"."Post"."userId"
+                                                                                  =
+                                                                                  $1
+                                                                                  OFFSET
+                                                                                  $2»
+                                                                                 params [var(@parent$id as Int),
+                                                                                         const(BigInt(0))]
+                                                                                 fields {
+                                                                                     id: 0
+                                                                                     title: 1
+                                                                                     userId: 2
+                                                                                 })])
+                 enums {
+                     Role: {
+                         admin: ADMIN
+                         user: USER
+                     }
+                 }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert.json.snap
@@ -16,8 +16,8 @@ enums {
 }
 unique (query «INSERT INTO "public"."User" ("email","role") VALUES
                ($1,CAST($2::text AS "public"."Role")) ON CONFLICT ("email") DO
-               UPDATE SET "email" = $3 WHERE ("public"."User"."email" = $4 AND
-               1=1) RETURNING "public"."User"."id", "public"."User"."email",
+               UPDATE SET "email" = $3 WHERE "public"."User"."email" = $4
+               RETURNING "public"."User"."id", "public"."User"."email",
                "public"."User"."role"::text»
         params [const(String("user.1@prisma.io")), const(String("user")),
                 const(String("user.2@prisma.io")),

--- a/query-compiler/query-structure/src/field/relation.rs
+++ b/query-compiler/query-structure/src/field/relation.rs
@@ -111,6 +111,40 @@ impl RelationField {
         self.linking_fields_impl()
     }
 
+    pub fn single_left_scalar(&self) -> Option<ScalarFieldRef> {
+        let walker = self.walker();
+        let relation = walker.relation();
+
+        match relation.refine() {
+            walkers::RefinedRelationWalker::Inline(rel) => {
+                let forward = rel.forward_relation_field().unwrap();
+                let field = if forward.id == self.id {
+                    let mut fields = forward.fields()?;
+                    let field = fields.next()?;
+
+                    if fields.next().is_some() {
+                        return None;
+                    }
+
+                    field
+                } else {
+                    let mut fields = forward.referenced_fields()?;
+                    let field = fields.next()?;
+
+                    if fields.next().is_some() {
+                        return None;
+                    }
+
+                    field
+                };
+
+                Some(self.dm.clone().zip(ScalarFieldId::InModel(field.id)))
+            }
+            walkers::RefinedRelationWalker::TwoWayEmbeddedManyToMany(_)
+            | walkers::RefinedRelationWalker::ImplicitManyToMany(_) => self.model().single_primary_identifier_scalar(),
+        }
+    }
+
     pub fn db_names(&self) -> impl Iterator<Item = String> {
         self.scalar_fields().into_iter().map(|f| f.db_name().to_owned())
     }

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -23,6 +23,10 @@ impl FieldSelection {
         self.selections
     }
 
+    pub fn as_slice(&self) -> &[SelectedField] {
+        &self.selections
+    }
+
     /// Returns `true` if self contains (at least) all fields specified in `other`. `false` otherwise.
     /// Recurses into composite selections and ensures that composite selections are supersets as well.
     pub fn is_superset_of(&self, other: &Self) -> bool {

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -68,7 +68,24 @@ impl FieldSelection {
         )
     }
 
+    pub fn into_without_relations(self) -> Self {
+        FieldSelection::new(
+            self.selections
+                .into_iter()
+                .filter(|field| !matches!(field, SelectedField::Relation(_)))
+                .collect(),
+        )
+    }
+
     pub fn into_virtuals_last(self) -> Self {
+        if !self
+            .selections
+            .iter()
+            .any(|field| matches!(field, SelectedField::Virtual(_)))
+        {
+            return self;
+        }
+
         let (virtuals, non_virtuals): (Vec<_>, Vec<_>) = self
             .into_iter()
             .partition(|field| matches!(field, SelectedField::Virtual(_)));

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -240,6 +240,22 @@ impl FieldSelection {
     /// occurrence of the first field in order from left (`self`) to right (`other`)
     /// is retained. Assumes that both selections reason over the same model.
     pub fn merge(self, other: FieldSelection) -> FieldSelection {
+        if other.selections.is_empty() {
+            return self;
+        }
+
+        if self.selections.is_empty() {
+            return other;
+        }
+
+        if other
+            .selections
+            .iter()
+            .all(|selection| self.selections.contains(selection))
+        {
+            return self;
+        }
+
         let selections = self.selections.into_iter().chain(other.selections).unique().collect();
 
         FieldSelection { selections }

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -192,10 +192,29 @@ impl FieldSelection {
     ///
     /// /!\ Important assumption: All selections are on the same model.
     pub fn union(selections: Vec<Self>) -> Self {
-        let chained = selections.into_iter().flatten();
+        Self::union_iter(selections)
+    }
+
+    /// Merges all given `FieldSelection` a set union of all.
+    ///
+    /// /!\ Important assumption: All selections are on the same model.
+    pub fn union_iter(selections: impl IntoIterator<Item = Self>) -> Self {
+        let mut selections = selections.into_iter();
+        let Some(first) = selections.next() else {
+            return Self::default();
+        };
+
+        let Some(second) = selections.next() else {
+            return first;
+        };
 
         FieldSelection {
-            selections: chained.unique().collect(),
+            selections: first
+                .into_iter()
+                .chain(second)
+                .chain(selections.flatten())
+                .unique()
+                .collect(),
         }
     }
 

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -78,19 +78,29 @@ impl FieldSelection {
     }
 
     pub fn into_virtuals_last(self) -> Self {
-        if !self
+        let virtual_count = self
             .selections
             .iter()
-            .any(|field| matches!(field, SelectedField::Virtual(_)))
-        {
+            .filter(|field| matches!(field, SelectedField::Virtual(_)))
+            .count();
+
+        if virtual_count == 0 {
             return self;
         }
 
-        let (virtuals, non_virtuals): (Vec<_>, Vec<_>) = self
-            .into_iter()
-            .partition(|field| matches!(field, SelectedField::Virtual(_)));
+        let mut non_virtuals = Vec::with_capacity(self.selections.len());
+        let mut virtuals = Vec::with_capacity(virtual_count);
 
-        FieldSelection::new(non_virtuals.into_iter().chain(virtuals).collect())
+        for field in self.selections {
+            if matches!(field, SelectedField::Virtual(_)) {
+                virtuals.push(field);
+            } else {
+                non_virtuals.push(field);
+            }
+        }
+
+        non_virtuals.extend(virtuals);
+        FieldSelection::new(non_virtuals)
     }
 
     pub fn to_virtuals_last(&self) -> Self {

--- a/query-compiler/query-structure/src/filter/into_filter.rs
+++ b/query-compiler/query-structure/src/filter/into_filter.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use prisma_value::PrismaValue;
 
 use super::*;
@@ -12,16 +11,22 @@ pub trait IntoFilter {
 
 impl IntoFilter for SelectionResult {
     fn filter(self) -> Filter {
-        let filters: Vec<Filter> = self
-            .pairs
-            .into_iter()
-            .map(|(selection, value)| match selection {
-                SelectedField::Scalar(sf) => sf.equals(value),
-                SelectedField::Composite(_) => unreachable!(), // [Composites] todo
-                SelectedField::Relation(_) => unreachable!(),
-                SelectedField::Virtual(_) => unreachable!(),
-            })
-            .collect();
+        let mut pairs = self.pairs.into_iter();
+
+        let Some((selection, value)) = pairs.next() else {
+            return Filter::and(Vec::new());
+        };
+
+        let first = into_scalar_filter(selection, value);
+
+        let Some((selection, value)) = pairs.next() else {
+            return first;
+        };
+
+        let mut filters = Vec::with_capacity(2 + pairs.size_hint().0);
+        filters.push(first);
+        filters.push(into_scalar_filter(selection, value));
+        filters.extend(pairs.map(|(selection, value)| into_scalar_filter(selection, value)));
 
         Filter::and(filters)
     }
@@ -29,24 +34,53 @@ impl IntoFilter for SelectionResult {
 
 impl IntoFilter for Vec<SelectionResult> {
     fn filter(self) -> Filter {
-        match self
-            .iter()
-            .exactly_one()
-            .ok()
-            .and_then(SelectionResult::as_placeholders)
-        {
-            Some(pairs) => Filter::and(
-                pairs
-                    .into_iter()
-                    .map(|(sf, val)| {
-                        let PrismaValue::Placeholder(p) = val else {
-                            unreachable!("as_placeholders guarantees all values are placeholders")
-                        };
-                        sf.is_in(p.clone())
-                    })
-                    .collect(),
-            ),
-            None => Filter::or(self.into_iter().map(|id| id.filter()).collect()),
+        if let [result] = &self[..] {
+            if let Some(filter) = placeholder_filter(result) {
+                return filter;
+            }
         }
+
+        Filter::or(self.into_iter().map(|id| id.filter()).collect())
     }
+}
+
+fn into_scalar_filter(selection: SelectedField, value: PrismaValue) -> Filter {
+    match selection {
+        SelectedField::Scalar(sf) => sf.equals(value),
+        SelectedField::Composite(_) => unreachable!(), // [Composites] todo
+        SelectedField::Relation(_) => unreachable!(),
+        SelectedField::Virtual(_) => unreachable!(),
+    }
+}
+
+fn placeholder_filter(result: &SelectionResult) -> Option<Filter> {
+    let mut pairs = result.pairs.iter();
+
+    let Some((selection, value)) = pairs.next() else {
+        return Some(Filter::and(Vec::new()));
+    };
+
+    let first = into_placeholder_filter(selection, value)?;
+
+    let Some((selection, value)) = pairs.next() else {
+        return Some(first);
+    };
+
+    let mut filters = Vec::with_capacity(2 + pairs.size_hint().0);
+    filters.push(first);
+    filters.push(into_placeholder_filter(selection, value)?);
+
+    for (selection, value) in pairs {
+        filters.push(into_placeholder_filter(selection, value)?);
+    }
+
+    Some(Filter::and(filters))
+}
+
+fn into_placeholder_filter(selection: &SelectedField, value: &PrismaValue) -> Option<Filter> {
+    let (SelectedField::Scalar(sf), PrismaValue::Placeholder(p)) = (selection, value) else {
+        return None;
+    };
+
+    Some(sf.is_in(p.clone()))
 }

--- a/query-compiler/query-structure/src/model.rs
+++ b/query-compiler/query-structure/src/model.rs
@@ -32,6 +32,17 @@ impl Model {
         }
     }
 
+    pub fn single_primary_identifier_scalar(&self) -> Option<ScalarFieldRef> {
+        let mut ids = self.primary_identifier_scalars();
+        let id = ids.next()?;
+
+        if ids.next().is_some() {
+            return None;
+        }
+
+        Some(self.dm.clone().zip(ScalarFieldId::InModel(id)))
+    }
+
     pub fn shard_aware_primary_identifier(&self) -> FieldSelection {
         let id = self.primary_identifier_scalars().collect_vec();
 

--- a/query-compiler/request-handlers/src/protocols/json/body.rs
+++ b/query-compiler/request-handlers/src/protocols/json/body.rs
@@ -127,11 +127,14 @@ impl SelectionSet {
         key == ALL_COMPOSITES
     }
 
-    pub fn get_excluded_keys(&self) -> Vec<String> {
-        self.0
-            .iter()
-            .filter_map(|(k, v)| (!v.is_selected()).then_some(k.to_owned()))
-            .collect()
+    pub fn get_excluded_keys(&self) -> Option<Vec<String>> {
+        let mut excluded_keys: Option<Vec<String>> = None;
+        for (key, value) in self.0.iter() {
+            if !value.is_selected() {
+                excluded_keys.get_or_insert_with(Vec::new).push(key.to_owned());
+            }
+        }
+        excluded_keys
     }
 
     pub(crate) fn into_selection(self) -> impl Iterator<Item = (String, SelectionSetValue)> {

--- a/query-compiler/request-handlers/src/protocols/json/body.rs
+++ b/query-compiler/request-handlers/src/protocols/json/body.rs
@@ -127,16 +127,6 @@ impl SelectionSet {
         key == ALL_COMPOSITES
     }
 
-    pub fn get_excluded_keys(&self) -> Option<Vec<String>> {
-        let mut excluded_keys: Option<Vec<String>> = None;
-        for (key, value) in self.0.iter() {
-            if !value.is_selected() {
-                excluded_keys.get_or_insert_with(Vec::new).push(key.to_owned());
-            }
-        }
-        excluded_keys
-    }
-
     pub(crate) fn into_selection(self) -> impl Iterator<Item = (String, SelectionSetValue)> {
         self.0.into_iter()
     }

--- a/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -61,9 +61,8 @@ impl<'a> JsonProtocolAdapter<'a> {
             None => vec![],
         };
 
-        let excluded_keys = query_selection.get_excluded_keys();
-
         let mut selection = Selection::new(field.name().clone(), None, arguments, Vec::new());
+        let mut excluded_keys: Option<Vec<String>> = None;
 
         for (selection_name, selected) in query_selection.into_selection() {
             match selected {
@@ -96,7 +95,8 @@ impl<'a> JsonProtocolAdapter<'a> {
                 }
                 // <field_name>: false
                 crate::SelectionSetValue::Shorthand(false) => {
-                    selection.push_nested_exclusion(selection_name);
+                    selection.push_nested_exclusion(selection_name.clone());
+                    excluded_keys.get_or_insert_with(Vec::new).push(selection_name);
                 }
                 // <field_name>: { selection: { ... }, arguments: { ... } }
                 crate::SelectionSetValue::Nested(nested_query) => {

--- a/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -134,7 +134,7 @@ impl<'a> JsonProtocolAdapter<'a> {
     }
 
     fn convert_arguments(args: IndexMap<String, JsonValue>) -> crate::Result<Vec<(String, ArgumentValue)>> {
-        let mut res = vec![];
+        let mut res = Vec::with_capacity(args.len());
 
         for (name, value) in args {
             let value = Self::convert_argument(value)?;
@@ -146,9 +146,6 @@ impl<'a> JsonProtocolAdapter<'a> {
     }
 
     fn convert_argument(value: JsonValue) -> crate::Result<ArgumentValue> {
-        let err_message = format!("Could not convert argument value {:?} to ArgumentValue.", &value);
-        let build_err = || HandlerError::query_conversion(err_message.clone());
-
         match value {
             serde_json::Value::String(s) => Ok(ArgumentValue::string(s)),
             serde_json::Value::Array(v) => {
@@ -173,8 +170,8 @@ impl<'a> JsonProtocolAdapter<'a> {
                     let value = obj
                         .get(custom_types::VALUE)
                         .and_then(|v| v.as_str())
-                        .ok_or_else(build_err)?;
-                    let date = parse_datetime(value).map_err(|_| build_err())?;
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
+                    let date = parse_datetime(value).map_err(|_| Self::argument_conversion_error_for_object(&obj))?;
 
                     Ok(ArgumentValue::datetime(date))
                 }
@@ -182,60 +179,64 @@ impl<'a> JsonProtocolAdapter<'a> {
                     let value = obj
                         .get(custom_types::VALUE)
                         .and_then(|v| v.as_str())
-                        .ok_or_else(build_err)?;
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
 
-                    i64::from_str(value).map(ArgumentValue::bigint).map_err(|_| build_err())
+                    i64::from_str(value)
+                        .map(ArgumentValue::bigint)
+                        .map_err(|_| Self::argument_conversion_error_for_object(&obj))
                 }
                 Some(custom_types::DECIMAL) => {
                     let value = obj
                         .get(custom_types::VALUE)
                         .and_then(|v| v.as_str())
-                        .ok_or_else(build_err)?;
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
 
                     BigDecimal::from_str(value)
                         .map(ArgumentValue::float)
-                        .map_err(|_| build_err())
+                        .map_err(|_| Self::argument_conversion_error_for_object(&obj))
                 }
 
                 Some(custom_types::RAW) => {
-                    let value = obj.get(custom_types::VALUE).ok_or_else(build_err)?;
+                    let value = obj
+                        .get(custom_types::VALUE)
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
                     Ok(ArgumentValue::raw(value.clone()))
                 }
                 Some(custom_types::BYTES) => {
                     let value = obj
                         .get(custom_types::VALUE)
                         .and_then(|v| v.as_str())
-                        .ok_or_else(build_err)?;
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
 
-                    decode_bytes(value).map(ArgumentValue::bytes).map_err(|_| build_err())
+                    decode_bytes(value)
+                        .map(ArgumentValue::bytes)
+                        .map_err(|_| Self::argument_conversion_error_for_object(&obj))
                 }
-                Some(custom_types::JSON) => {
-                    let value = obj
-                        .remove(custom_types::VALUE)
-                        .and_then(|v| match v {
-                            JsonValue::String(str) => Some(str),
-                            _ => None,
-                        })
-                        .ok_or_else(build_err)?;
-
-                    Ok(ArgumentValue::json(value))
-                }
+                Some(custom_types::JSON) => match obj.remove(custom_types::VALUE) {
+                    Some(JsonValue::String(value)) => Ok(ArgumentValue::json(value)),
+                    Some(value) => {
+                        obj.insert(custom_types::VALUE.to_string(), value);
+                        Err(Self::argument_conversion_error_for_object(&obj))
+                    }
+                    None => Err(Self::argument_conversion_error_for_object(&obj)),
+                },
                 Some(custom_types::ENUM) => {
                     let value = obj
                         .get(custom_types::VALUE)
                         .and_then(|v| v.as_str())
-                        .ok_or_else(build_err)?;
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
 
                     Ok(ArgumentValue::r#enum(value.to_string()))
                 }
                 Some(custom_types::FIELD_REF) => {
-                    let value = obj
-                        .remove(custom_types::VALUE)
-                        .and_then(|v| match v {
-                            JsonValue::Object(obj) => Some(obj),
-                            _ => None,
-                        })
-                        .ok_or_else(build_err)?;
+                    let value = match obj.remove(custom_types::VALUE) {
+                        Some(JsonValue::Object(value)) => value,
+                        Some(value) => {
+                            obj.insert(custom_types::VALUE.to_string(), value);
+                            return Err(Self::argument_conversion_error_for_object(&obj));
+                        }
+                        None => return Err(Self::argument_conversion_error_for_object(&obj)),
+                    };
                     let values = value
                         .into_iter()
                         .map(|(k, v)| Ok((k, Self::convert_argument(v)?)))
@@ -244,7 +245,9 @@ impl<'a> JsonProtocolAdapter<'a> {
                     Ok(ArgumentValue::FieldRef(values))
                 }
                 Some(custom_types::PARAM) => {
-                    let value = obj.remove(custom_types::VALUE).ok_or_else(build_err)?;
+                    let value = obj
+                        .remove(custom_types::VALUE)
+                        .ok_or_else(|| Self::argument_conversion_error_for_object(&obj))?;
                     let placeholder =
                         serde_json::from_value(value).map_err(|e| HandlerError::QueryConversion(e.to_string()))?;
 
@@ -260,6 +263,14 @@ impl<'a> JsonProtocolAdapter<'a> {
                 }
             },
         }
+    }
+
+    fn argument_conversion_error(value: &JsonValue) -> HandlerError {
+        HandlerError::query_conversion(format!("Could not convert argument value {value:?} to ArgumentValue."))
+    }
+
+    fn argument_conversion_error_for_object(obj: &serde_json::Map<String, JsonValue>) -> HandlerError {
+        Self::argument_conversion_error(&JsonValue::Object(obj.clone()))
     }
 
     fn create_shorthand_selection(

--- a/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -126,8 +126,10 @@ impl<'a> JsonProtocolAdapter<'a> {
         // Keys have to be removed after the nested selections have been created
         // because we can't guarantee that we will encounter `<field>: false` _after_ `$scalars|$composites: true`.
         // This is important because otherwise, the selection wouldn't be filled and `<field>: false` would have nothing to filter out.
-        for key in excluded_keys {
-            selection.remove_nested_selection(&key);
+        if let Some(excluded_keys) = excluded_keys {
+            for key in excluded_keys {
+                selection.remove_nested_selection(&key);
+            }
         }
 
         Ok(selection)


### PR DESCRIPTION
## Summary

Draft status PR for the engines side of the ongoing Prisma Client performance work. This branch contains query-compiler, query-plan serialization, raw-nested read, and compile-path allocation changes that the sibling Prisma branch consumes.

This is intentionally **not merge-ready as a final review unit**. The branch is currently large (`113` commits ahead, `1` commit behind fresh `main`) because it accumulated accepted experiments and measurement infrastructure during the performance investigation. I am opening it now so CI and reviewers can see the real state, then the next packaging step should be slicing it into smaller stacked PRs if this is too much to review at once.

Sibling Prisma PR: https://github.com/prisma/prisma/pull/29655

Extracted child PRs:

- https://github.com/prisma/prisma-engines/pull/5821
- https://github.com/prisma/prisma-engines/pull/5822

Current split plan: `wip/client-performance-pr-stack.md` in the sibling Prisma PR branch.

## Linked Prisma branch for CI

The engines workflow reads this command from the PR body and builds Prisma adapters/client code from the sibling branch:

/prisma-branch prisma-client-performance-2026-06-08

The reciprocal Prisma PR uses `/engine-branch prisma-client-performance-2026-06-08-engines` so Prisma CI builds this engines branch.

## Main Contents

- Compact and allocation-focused query-plan serialization work.
- Query-compiler graph/translation allocation reductions backed by allocation probes and Criterion checks.
- Raw-nested relation-op emission for pagination/distinct cases, including M:N mapped operation fields and one-to-many parent grouping.
- Raw-nested final-owner schedule marker emission for the Prisma runtime to consume.
- Quaint/Postgres `INSERT ... SELECT ... RETURNING` and insert-in-CTE prerequisites for a future M:N connect phase-owner, while the direct CTE phase-owner prototype itself stayed reverted.
- Focused benchmark fixtures and allocation-profile infrastructure used by the investigation.

## Current Performance Readout

See the sibling Prisma report for the cross-repo rollup: `wip/client-performance-intermediate-report.md` on `prisma-client-performance-2026-06-08`.

Important engine-side examples from the journal:

- FK-backed required to-one nested update child-read shortcut: `update-set-nested-prisma#27650` full-compile allocations `1621 -> 1453`, Criterion about `153.20 -> 135.75 us`.
- Raw-nested one-to-many relation-op path: `nested-distinct-pagination-query` full-compile allocations `726 -> 627`, Criterion about `75.20 -> 65.90 us`.
- M:N mapped relation-op path: `query-m2m-pagination-mapped-distinct` full-compile allocations `1519 -> 942`, Criterion about `134.37 -> 83.23 us`.
- M:N `set` parent-key delete work: `update-m2m-set-empty` `1547 -> 1208` and `update-m2m-set` `1922 -> 1586` full-compile allocations.
- Nested-only upsert shared read: `upsert-nested-only-update` full-compile allocations `1835 -> 1475`, with focused Criterion around `187.37 -> 149.31 us`.

## Validation Already Run Locally

Representative accepted slices were validated with combinations of:

- `cargo check -p query-compiler`
- `cargo test -p query-compiler --test queries`
- focused allocation-profile runs against the named query-compiler fixtures
- focused Criterion patched/control checks for target rows and sampled controls
- `make build-qc-wasm` for runtime-consuming query-compiler changes

The latest Prisma-side harness restart revalidated the generated prepared-helper slice against this branch context; see the sibling PR for exact `pnpm` commands.

## Proposed Review Split

If this draft PR is too large as expected, split into a stack roughly like:

0. Quaint insert-select / insert-CTE prerequisites for future M:N connect work. Extracted as https://github.com/prisma/prisma-engines/pull/5821.
1. Parser/request allocation reductions. Extracted as https://github.com/prisma/prisma-engines/pull/5822.
2. Compact internal plan serialization plus allocation/profile infrastructure.
3. Compiler-local graph/translation allocation reductions.
4. Raw-nested read plans.
5. Write graph pruning.
6. Raw-nested relation ops and final-owner schedule marker emission.

Internal formats in this stack are lockstep-only. There should not be old/new compatibility readers unless a real external persistence boundary is identified.
