### PR TITLE
perf(query-compiler): emit compact query plans

### DIFF
--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -9,7 +9,6 @@ use chrono::prelude::*;
 use serde::de::Unexpected;
 use serde::ser::{SerializeMap, SerializeTuple};
 use serde::{Deserialize, Deserializer, Serialize, ser::Serializer};
-use serde_json::json;
 use std::{borrow::Cow, convert::TryFrom, fmt, str::FromStr};
 use uuid::Uuid;
 
@@ -358,24 +357,31 @@ where
 fn serialize_generator_call<S>(
     name: &str,
     args: &[PrismaValue],
-    return_type: &PrismaValueType,
+    _return_type: &PrismaValueType,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    let mut map = serializer.serialize_map(Some(2))?;
+    struct CompactGeneratorCall<'a> {
+        name: &'a str,
+        args: &'a [PrismaValue],
+    }
 
-    map.serialize_entry("prisma__type", "generatorCall")?;
-    map.serialize_entry(
-        "prisma__value",
-        &json!({
-            "name": name,
-            "args": args,
-            "returnType": return_type,
-        }),
-    )?;
+    impl Serialize for CompactGeneratorCall<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(self.name)?;
+            tuple.serialize_element(self.args)?;
+            tuple.end()
+        }
+    }
 
+    let mut map = serializer.serialize_map(Some(1))?;
+    map.serialize_entry("$g", &CompactGeneratorCall { name, args })?;
     map.end()
 }
 

--- a/libs/prisma-value/src/lib.rs
+++ b/libs/prisma-value/src/lib.rs
@@ -7,7 +7,7 @@ use base64::prelude::*;
 use bigdecimal::{BigDecimal, FromPrimitive, ToPrimitive};
 use chrono::prelude::*;
 use serde::de::Unexpected;
-use serde::ser::SerializeMap;
+use serde::ser::{SerializeMap, SerializeTuple};
 use serde::{Deserialize, Deserializer, Serialize, ser::Serializer};
 use serde_json::json;
 use std::{borrow::Cow, convert::TryFrom, fmt, str::FromStr};
@@ -327,17 +327,31 @@ fn serialize_placeholder<S>(Placeholder { name, r#type }: &Placeholder, serializ
 where
     S: Serializer,
 {
-    let mut map = serializer.serialize_map(Some(2))?;
+    struct CompactPlaceholderValue<'a> {
+        name: &'a Cow<'static, str>,
+        r#type: String,
+    }
 
-    map.serialize_entry("prisma__type", "param")?;
+    impl Serialize for CompactPlaceholderValue<'_> {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(self.name)?;
+            tuple.serialize_element(&self.r#type)?;
+            tuple.end()
+        }
+    }
+
+    let mut map = serializer.serialize_map(Some(1))?;
     map.serialize_entry(
-        "prisma__value",
-        &json!({
-            "name": name,
-            "type": r#type.to_string(),
-        }),
+        "$p",
+        &CompactPlaceholderValue {
+            name,
+            r#type: r#type.to_string(),
+        },
     )?;
-
     map.end()
 }
 

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 pub use error::*;
 use psl::datamodel_connector::{ConnectorCapabilities, ConnectorCapability};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeTuple};
 use smallvec::{SmallVec, smallvec};
 use tracing::trace;
 
@@ -260,8 +260,7 @@ impl DataExpectation {
 }
 
 /// A rule a data dependency needs to fulfill to be considered valid.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "type", content = "args", rename_all = "camelCase")]
+#[derive(Debug, Clone)]
 pub enum DataRule {
     /// Expect the data dependency to contain an exact number of rows.
     RowCountEq(usize),
@@ -271,6 +270,30 @@ pub enum DataRule {
     AffectedRowCountEq(usize),
     /// Expect the edge to not be taken and never match any data.
     Never,
+}
+
+impl Serialize for DataRule {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::RowCountEq(count) => serialize_rule_tuple("=", count, serializer),
+            Self::RowCountNeq(count) => serialize_rule_tuple("!", count, serializer),
+            Self::AffectedRowCountEq(count) => serialize_rule_tuple("a", count, serializer),
+            Self::Never => serializer.serialize_str("n"),
+        }
+    }
+}
+
+fn serialize_rule_tuple<S>(tag: &'static str, count: &usize, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut tuple = serializer.serialize_tuple(2)?;
+    tuple.serialize_element(tag)?;
+    tuple.serialize_element(count)?;
+    tuple.end()
 }
 
 impl fmt::Display for DataRule {

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -311,6 +311,7 @@ pub enum DynamicArgType {
 pub struct ArgType {
     pub arity: Arity,
     pub scalar_type: ArgScalarType,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub db_type: Option<String>,
 }
 

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -413,13 +413,13 @@ impl Serialize for ArgType {
         S: Serializer,
     {
         if self.arity == Arity::Scalar && self.db_type.is_none() {
-            return serializer.serialize_str(self.scalar_type.as_str());
+            return serializer.serialize_str(self.scalar_type.compact_str());
         }
 
         if self.arity == Arity::Scalar {
             if let Some(db_type) = &self.db_type {
                 let mut tuple = serializer.serialize_tuple(2)?;
-                tuple.serialize_element(self.scalar_type.as_str())?;
+                tuple.serialize_element(self.scalar_type.compact_str())?;
                 tuple.serialize_element(db_type)?;
                 return tuple.end();
             }
@@ -486,6 +486,23 @@ impl ArgScalarType {
             Self::DateTime => "datetime",
             Self::Bytes => "bytes",
             Self::Unknown => "unknown",
+        }
+    }
+
+    fn compact_str(&self) -> &'static str {
+        match self {
+            Self::String => "s",
+            Self::Int => "i",
+            Self::BigInt => "I",
+            Self::Float => "f",
+            Self::Decimal => "d",
+            Self::Boolean => "b",
+            Self::Enum => "e",
+            Self::Uuid => "u",
+            Self::Json => "j",
+            Self::DateTime => "D",
+            Self::Bytes => "B",
+            Self::Unknown => "?",
         }
     }
 }

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -2,7 +2,7 @@ use query_structure::{
     AggregationSelection, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, RecordFilter,
     RelationField, RelationLoadStrategy, ScalarCondition, ScalarField, SelectedField, SelectionResult, WriteArgs,
 };
-use serde::{Serialize, Serializer, ser::SerializeSeq};
+use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct};
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::{collections::HashMap, fmt};
@@ -308,26 +308,53 @@ where
     seq.end()
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "arity", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum DynamicArgType {
-    Tuple {
-        elements: Vec<ArgType>,
-    },
-    #[serde(untagged)]
-    Single {
-        #[serde(flatten)]
-        r#type: ArgType,
-    },
+    Tuple { elements: Vec<ArgType> },
+    Single { r#type: ArgType },
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+impl Serialize for DynamicArgType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Tuple { elements } => {
+                let mut state = serializer.serialize_struct("DynamicArgType", 2)?;
+                state.serialize_field("arity", "tuple")?;
+                state.serialize_field("elements", elements)?;
+                state.end()
+            }
+            Self::Single { r#type } => r#type.serialize(serializer),
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct ArgType {
     pub arity: Arity,
     pub scalar_type: ArgScalarType,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub db_type: Option<String>,
+}
+
+impl Serialize for ArgType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.arity == Arity::Scalar && self.db_type.is_none() {
+            return serializer.serialize_str(self.scalar_type.as_str());
+        }
+
+        let mut state = serializer.serialize_struct("ArgType", 3)?;
+        state.serialize_field("arity", &self.arity)?;
+        state.serialize_field("scalarType", self.scalar_type.as_str())?;
+        if let Some(db_type) = &self.db_type {
+            state.serialize_field("dbType", db_type)?;
+        }
+        state.end()
+    }
 }
 
 impl ArgType {
@@ -364,6 +391,25 @@ pub enum ArgScalarType {
     DateTime,
     Bytes,
     Unknown,
+}
+
+impl ArgScalarType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::String => "string",
+            Self::Int => "int",
+            Self::BigInt => "bigint",
+            Self::Float => "float",
+            Self::Decimal => "decimal",
+            Self::Boolean => "boolean",
+            Self::Enum => "enum",
+            Self::Uuid => "uuid",
+            Self::Json => "json",
+            Self::DateTime => "datetime",
+            Self::Bytes => "bytes",
+            Self::Unknown => "unknown",
+        }
+    }
 }
 
 /// Indicates whether the parameters of this query can be chunked into smaller queries.

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -334,10 +334,22 @@ impl Serialize for SerializedFragments<'_> {
         for fragment in self.0 {
             match fragment {
                 Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
+                Fragment::Parameter => seq.serialize_element(&ParameterFragment)?,
                 fragment => seq.serialize_element(fragment)?,
             }
         }
         seq.end()
+    }
+}
+
+struct ParameterFragment;
+
+impl Serialize for ParameterFragment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_none()
     }
 }
 

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -2,7 +2,7 @@ use query_structure::{
     AggregationSelection, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, RecordFilter,
     RelationField, RelationLoadStrategy, ScalarCondition, ScalarField, SelectedField, SelectionResult, WriteArgs,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeSeq};
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::{collections::HashMap, fmt};
@@ -227,6 +227,7 @@ pub enum DbQuery {
     },
     #[serde(rename_all = "camelCase")]
     TemplateSql {
+        #[serde(serialize_with = "serialize_fragments")]
         fragments: Vec<Fragment>,
         args: Vec<PrismaValue>,
         arg_types: Vec<DynamicArgType>,
@@ -291,6 +292,20 @@ impl fmt::Display for DbQuery {
         }
         Ok(())
     }
+}
+
+fn serialize_fragments<S>(fragments: &Vec<Fragment>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut seq = serializer.serialize_seq(Some(fragments.len()))?;
+    for fragment in fragments {
+        match fragment {
+            Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
+            fragment => seq.serialize_element(fragment)?,
+        }
+    }
+    seq.end()
 }
 
 #[derive(Debug, Serialize)]

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -2,7 +2,7 @@ use query_structure::{
     AggregationSelection, FieldSelection, Filter, Model, Placeholder, PrismaValue, QueryArguments, RecordFilter,
     RelationField, RelationLoadStrategy, ScalarCondition, ScalarField, SelectedField, SelectionResult, WriteArgs,
 };
-use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct};
+use serde::{Serialize, Serializer, ser::SerializeSeq, ser::SerializeStruct, ser::SerializeTuple};
 use std::collections::BTreeMap;
 use std::fmt::Formatter;
 use std::{collections::HashMap, fmt};
@@ -216,24 +216,53 @@ impl fmt::Display for RelationLinkage {
     }
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum DbQuery {
-    #[serde(rename_all = "camelCase")]
     RawSql {
         sql: String,
         args: Vec<PrismaValue>,
         arg_types: Vec<ArgType>,
     },
-    #[serde(rename_all = "camelCase")]
     TemplateSql {
-        #[serde(serialize_with = "serialize_fragments")]
         fragments: Vec<Fragment>,
         args: Vec<PrismaValue>,
         arg_types: Vec<DynamicArgType>,
         placeholder_format: PlaceholderFormat,
         chunkable: Chunkable,
     },
+}
+
+impl Serialize for DbQuery {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::RawSql { sql, args, arg_types } => {
+                let mut state = serializer.serialize_struct("DbQuery", 4)?;
+                state.serialize_field("type", "rawSql")?;
+                state.serialize_field("sql", sql)?;
+                state.serialize_field("args", args)?;
+                state.serialize_field("argTypes", arg_types)?;
+                state.end()
+            }
+            Self::TemplateSql {
+                fragments,
+                args,
+                arg_types,
+                placeholder_format,
+                chunkable,
+            } => {
+                let mut tuple = serializer.serialize_tuple(5)?;
+                tuple.serialize_element(&SerializedFragments(fragments))?;
+                tuple.serialize_element(&SerializedPlaceholderFormat(placeholder_format))?;
+                tuple.serialize_element(args)?;
+                tuple.serialize_element(arg_types)?;
+                tuple.serialize_element(chunkable)?;
+                tuple.end()
+            }
+        }
+    }
 }
 
 impl DbQuery {
@@ -294,18 +323,36 @@ impl fmt::Display for DbQuery {
     }
 }
 
-fn serialize_fragments<S>(fragments: &Vec<Fragment>, serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    let mut seq = serializer.serialize_seq(Some(fragments.len()))?;
-    for fragment in fragments {
-        match fragment {
-            Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
-            fragment => seq.serialize_element(fragment)?,
+struct SerializedFragments<'a>(&'a Vec<Fragment>);
+
+impl Serialize for SerializedFragments<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        for fragment in self.0 {
+            match fragment {
+                Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
+                fragment => seq.serialize_element(fragment)?,
+            }
         }
+        seq.end()
     }
-    seq.end()
+}
+
+struct SerializedPlaceholderFormat<'a>(&'a PlaceholderFormat);
+
+impl Serialize for SerializedPlaceholderFormat<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(self.0.prefix)?;
+        tuple.serialize_element(&self.0.has_numbering)?;
+        tuple.end()
+    }
 }
 
 #[derive(Debug)]

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -335,7 +335,17 @@ impl Serialize for SerializedFragments<'_> {
             match fragment {
                 Fragment::StringChunk { chunk } => seq.serialize_element(chunk)?,
                 Fragment::Parameter => seq.serialize_element(&ParameterFragment)?,
-                fragment => seq.serialize_element(fragment)?,
+                Fragment::ParameterTuple {
+                    item_prefix,
+                    item_separator,
+                    item_suffix,
+                } => seq.serialize_element(&("T", item_prefix, item_separator, item_suffix))?,
+                Fragment::ParameterTupleList {
+                    item_prefix,
+                    item_separator,
+                    item_suffix,
+                    group_separator,
+                } => seq.serialize_element(&("L", item_prefix, item_separator, item_suffix, group_separator))?,
             }
         }
         seq.end()

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -416,6 +416,15 @@ impl Serialize for ArgType {
             return serializer.serialize_str(self.scalar_type.as_str());
         }
 
+        if self.arity == Arity::Scalar {
+            if let Some(db_type) = &self.db_type {
+                let mut tuple = serializer.serialize_tuple(2)?;
+                tuple.serialize_element(self.scalar_type.as_str())?;
+                tuple.serialize_element(db_type)?;
+                return tuple.end();
+            }
+        }
+
         let mut state = serializer.serialize_struct("ArgType", 3)?;
         state.serialize_field("arity", &self.arity)?;
         state.serialize_field("scalarType", self.scalar_type.as_str())?;

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -11,8 +11,7 @@ use query_core::{
     UpdateRecord, WriteQuery,
 };
 use query_structure::{
-    AggregationSelection, FieldArity, FieldSelection, FieldTypeInformation, ScalarField, SelectedField, Type,
-    TypeIdentifier,
+    AggregationSelection, FieldArity, FieldTypeInformation, ScalarField, SelectedField, Type, TypeIdentifier,
 };
 use serde::{Serialize, Serializer, ser::SerializeStruct};
 use std::{borrow::Cow, fmt};
@@ -55,7 +54,7 @@ fn map_read_query(
 ) -> Option<ResultNode> {
     match query {
         ReadQuery::RecordQuery(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .nested_queries(&q.nested)
             .builder(builder)
@@ -63,7 +62,7 @@ fn map_read_query(
             .uses_relation_joins(q.relation_load_strategy.is_join())
             .call(),
         ReadQuery::ManyRecordsQuery(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .nested_queries(&q.nested)
             .builder(builder)
@@ -71,7 +70,7 @@ fn map_read_query(
             .uses_relation_joins(q.relation_load_strategy.is_join())
             .call(),
         ReadQuery::RelatedRecordsQuery(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .nested_queries(&q.nested)
             .builder(builder)
@@ -86,7 +85,7 @@ fn map_read_query(
 fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
     match query {
         WriteQuery::CreateRecord(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .builder(builder)
             .call(),
@@ -94,7 +93,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         WriteQuery::UpdateRecord(u) => {
             match u {
                 UpdateRecord::WithSelection(w) => get_result_node()
-                    .field_selection(&w.selected_fields)
+                    .field_selection(w.selected_fields.as_slice())
                     .selection_order(&w.selection_order)
                     .builder(builder)
                     .call(),
@@ -109,7 +108,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         WriteQuery::ExecuteRaw(_) => None,        // No data mapping
         WriteQuery::QueryRaw(_) => None,          // No data mapping
         WriteQuery::Upsert(q) => get_result_node()
-            .field_selection(&q.selected_fields)
+            .field_selection(q.selected_fields.as_slice())
             .selection_order(&q.selection_order)
             .builder(builder)
             .call(),
@@ -118,7 +117,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
 
 #[builder]
 fn get_result_node(
-    field_selection: &FieldSelection,
+    field_selection: &[SelectedField],
     selection_order: &[String],
     #[builder(default = &[])] nested_queries: &[ReadQuery],
     /// Indicates whether the query uses `relationJoins`. When true, the data mapper uses prisma names
@@ -147,14 +146,13 @@ fn get_result_node(
             }
             Some(SelectedField::Composite(_)) => todo!("MongoDB specific"),
             Some(SelectedField::Relation(f)) => {
-                let nested_selection = FieldSelection::new(f.selections.to_vec());
                 let original_name = if uses_relation_joins {
                     f.field.name().to_owned().into()
                 } else {
                     binding::nested_relation_field(&f.field)
                 };
                 let nested_node = get_result_node()
-                    .field_selection(&nested_selection)
+                    .field_selection(&f.selections)
                     .selection_order(&f.result_fields)
                     .builder(builder)
                     .original_name(original_name)
@@ -168,7 +166,8 @@ fn get_result_node(
             }
             Some(SelectedField::Virtual(f)) => {
                 for vs in field_selection
-                    .virtuals()
+                    .iter()
+                    .filter_map(SelectedField::as_virtual)
                     .filter(|vs| vs.serialized_group_name() == f.serialized_group_name())
                 {
                     let (group_name, field_name) = vs.serialized_name();
@@ -204,9 +203,9 @@ fn get_result_node(
     Some(node.build())
 }
 
-fn find_selection<'a>(field_selection: &'a FieldSelection, prisma_name: &str) -> Option<&'a SelectedField> {
+fn find_selection<'a>(field_selection: &'a [SelectedField], prisma_name: &str) -> Option<&'a SelectedField> {
     field_selection
-        .selections()
+        .iter()
         .find(|field| field.prisma_name_grouping_virtuals() == prisma_name)
 }
 
@@ -312,10 +311,12 @@ fn get_result_node_for_create_many(
     selected_fields: Option<&CreateManyRecordsFields>,
     builder: &mut ResultNodeBuilder,
 ) -> Option<ResultNode> {
+    let selected_fields = selected_fields?;
+
     get_result_node()
-        .field_selection(&selected_fields?.fields)
-        .selection_order(&selected_fields?.order)
-        .nested_queries(&selected_fields?.nested)
+        .field_selection(selected_fields.fields.as_slice())
+        .selection_order(&selected_fields.order)
+        .nested_queries(&selected_fields.nested)
         .builder(builder)
         .call()
 }
@@ -324,9 +325,11 @@ fn get_result_node_for_delete(
     selected_fields: Option<&DeleteRecordFields>,
     builder: &mut ResultNodeBuilder,
 ) -> Option<ResultNode> {
+    let selected_fields = selected_fields?;
+
     get_result_node()
-        .field_selection(&selected_fields?.fields)
-        .selection_order(&selected_fields?.order)
+        .field_selection(selected_fields.fields.as_slice())
+        .selection_order(&selected_fields.order)
         .builder(builder)
         .call()
 }
@@ -335,10 +338,12 @@ fn get_result_node_for_update_many(
     selected_fields: Option<&UpdateManyRecordsFields>,
     builder: &mut ResultNodeBuilder,
 ) -> Option<ResultNode> {
+    let selected_fields = selected_fields?;
+
     get_result_node()
-        .field_selection(&selected_fields?.fields)
-        .selection_order(&selected_fields?.order)
-        .nested_queries(&selected_fields?.nested)
+        .field_selection(selected_fields.fields.as_slice())
+        .selection_order(&selected_fields.order)
+        .nested_queries(&selected_fields.nested)
         .builder(builder)
         .call()
 }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -480,12 +480,12 @@ impl FieldScalarType {
         S: SerializeStruct,
     {
         match self {
-            Self::String => state.serialize_field("type", "string"),
-            Self::Int => state.serialize_field("type", "int"),
-            Self::BigInt => state.serialize_field("type", "bigint"),
-            Self::Float => state.serialize_field("type", "float"),
-            Self::Decimal => state.serialize_field("type", "decimal"),
-            Self::Boolean => state.serialize_field("type", "boolean"),
+            Self::String => state.serialize_field("type", "s"),
+            Self::Int => state.serialize_field("type", "i"),
+            Self::BigInt => state.serialize_field("type", "I"),
+            Self::Float => state.serialize_field("type", "f"),
+            Self::Decimal => state.serialize_field("type", "d"),
+            Self::Boolean => state.serialize_field("type", "b"),
             Self::Enum { name } => {
                 state.serialize_field("type", "enum")?;
                 state.serialize_field("name", name)
@@ -494,14 +494,14 @@ impl FieldScalarType {
                 state.serialize_field("type", "extension")?;
                 state.serialize_field("name", name)
             }
-            Self::Json => state.serialize_field("type", "json"),
-            Self::Object => state.serialize_field("type", "object"),
-            Self::DateTime => state.serialize_field("type", "datetime"),
+            Self::Json => state.serialize_field("type", "j"),
+            Self::Object => state.serialize_field("type", "o"),
+            Self::DateTime => state.serialize_field("type", "D"),
             Self::Bytes { encoding } => {
                 state.serialize_field("type", "bytes")?;
                 state.serialize_field("encoding", encoding)
             }
-            Self::Unsupported => state.serialize_field("type", "unsupported"),
+            Self::Unsupported => state.serialize_field("type", "x"),
         }
     }
 }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -383,6 +383,14 @@ impl FieldType {
             r#type: r#type.into(),
         }
     }
+
+    pub fn compact_name(&self) -> Option<&'static str> {
+        if self.arity.is_not_list() {
+            self.r#type.compact_name()
+        } else {
+            None
+        }
+    }
 }
 
 impl fmt::Display for FieldType {

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -353,6 +353,7 @@ fn get_result_node_for_update_many(
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldType {
+    #[serde(skip_serializing_if = "Arity::is_not_list")]
     arity: Arity,
     #[serde(flatten)]
     r#type: FieldScalarType,
@@ -479,6 +480,12 @@ pub enum Arity {
     Required,
     Optional,
     List,
+}
+
+impl Arity {
+    fn is_not_list(&self) -> bool {
+        !matches!(self, Self::List)
+    }
 }
 
 impl From<FieldArity> for Arity {

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -15,7 +15,7 @@ use query_structure::{
     TypeIdentifier,
 };
 use serde::{Serialize, Serializer, ser::SerializeStruct};
-use std::{borrow::Cow, collections::HashMap, fmt};
+use std::{borrow::Cow, fmt};
 
 pub fn map_result_structure(graph: &QueryGraph, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
     graph
@@ -134,23 +134,11 @@ fn get_result_node(
     builder: &mut ResultNodeBuilder<'_>,
     original_name: Option<Cow<'static, str>>,
 ) -> Option<ResultNode> {
-    let field_map = field_selection
-        .selections()
-        .map(|fs| (fs.prisma_name_grouping_virtuals(), fs))
-        .collect::<HashMap<_, _>>();
-    let grouped_virtuals = field_selection
-        .virtuals()
-        .into_group_map_by(|vs| vs.serialized_group_name());
-    let nested_map = nested_queries
-        .iter()
-        .map(|q| (q.get_alias_or_name(), q))
-        .collect::<HashMap<_, _>>();
-
     let mut node = ResultNodeBuilder::new_object(original_name);
     node.set_skip_nulls(skip_nulls);
 
     for prisma_name in selection_order {
-        match field_map.get(prisma_name.as_str()) {
+        match find_selection(field_selection, prisma_name) {
             Some(SelectedField::Scalar(field)) => {
                 node.add_field(
                     field.name().to_owned(),
@@ -179,10 +167,9 @@ fn get_result_node(
                 }
             }
             Some(SelectedField::Virtual(f)) => {
-                for vs in grouped_virtuals
-                    .get(f.serialized_group_name())
-                    .map(Vec::as_slice)
-                    .unwrap_or_default()
+                for vs in field_selection
+                    .virtuals()
+                    .filter(|vs| vs.serialized_group_name() == f.serialized_group_name())
                 {
                     let (group_name, field_name) = vs.serialized_name();
                     let db_name = if uses_relation_joins {
@@ -196,7 +183,7 @@ fn get_result_node(
                 }
             }
             None => {
-                if let Some(q) = nested_map.get(prisma_name.as_str()) {
+                if let Some(q) = nested_queries.iter().find(|q| q.get_alias_or_name() == prisma_name) {
                     let nested_node = map_read_query(
                         q,
                         builder,
@@ -215,6 +202,12 @@ fn get_result_node(
     }
 
     Some(node.build())
+}
+
+fn find_selection<'a>(field_selection: &'a FieldSelection, prisma_name: &str) -> Option<&'a SelectedField> {
+    field_selection
+        .selections()
+        .find(|field| field.prisma_name_grouping_virtuals() == prisma_name)
 }
 
 fn get_scalar_field_result_node(

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -14,7 +14,7 @@ use query_structure::{
     AggregationSelection, FieldArity, FieldSelection, FieldTypeInformation, ScalarField, SelectedField, Type,
     TypeIdentifier,
 };
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeStruct};
 use std::{borrow::Cow, collections::HashMap, fmt};
 
 pub fn map_result_structure(graph: &QueryGraph, builder: &mut ResultNodeBuilder) -> Option<ResultNode> {
@@ -350,13 +350,30 @@ fn get_result_node_for_update_many(
         .call()
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct FieldType {
-    #[serde(skip_serializing_if = "Arity::is_not_list")]
     arity: Arity,
-    #[serde(flatten)]
     r#type: FieldScalarType,
+}
+
+impl Serialize for FieldType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.arity.is_not_list() {
+            if let Some(name) = self.r#type.compact_name() {
+                return serializer.serialize_str(name);
+            }
+        }
+
+        let mut state = serializer.serialize_struct("FieldType", 3)?;
+        if !self.arity.is_not_list() {
+            state.serialize_field("arity", &self.arity)?;
+        }
+        self.r#type.serialize_fields(&mut state)?;
+        state.end()
+    }
 }
 
 impl FieldType {
@@ -429,6 +446,54 @@ impl fmt::Display for FieldScalarType {
             Self::DateTime => write!(f, "DateTime"),
             Self::Bytes { .. } => write!(f, "Bytes"),
             Self::Unsupported => write!(f, "Unsupported"),
+        }
+    }
+}
+
+impl FieldScalarType {
+    fn compact_name(&self) -> Option<&'static str> {
+        match self {
+            Self::String => Some("string"),
+            Self::Int => Some("int"),
+            Self::BigInt => Some("bigint"),
+            Self::Float => Some("float"),
+            Self::Decimal => Some("decimal"),
+            Self::Boolean => Some("boolean"),
+            Self::Json => Some("json"),
+            Self::Object => Some("object"),
+            Self::DateTime => Some("datetime"),
+            Self::Unsupported => Some("unsupported"),
+            Self::Enum { .. } | Self::Extension { .. } | Self::Bytes { .. } => None,
+        }
+    }
+
+    fn serialize_fields<S>(&self, state: &mut S) -> Result<(), S::Error>
+    where
+        S: SerializeStruct,
+    {
+        match self {
+            Self::String => state.serialize_field("type", "string"),
+            Self::Int => state.serialize_field("type", "int"),
+            Self::BigInt => state.serialize_field("type", "bigint"),
+            Self::Float => state.serialize_field("type", "float"),
+            Self::Decimal => state.serialize_field("type", "decimal"),
+            Self::Boolean => state.serialize_field("type", "boolean"),
+            Self::Enum { name } => {
+                state.serialize_field("type", "enum")?;
+                state.serialize_field("name", name)
+            }
+            Self::Extension { name } => {
+                state.serialize_field("type", "extension")?;
+                state.serialize_field("name", name)
+            }
+            Self::Json => state.serialize_field("type", "json"),
+            Self::Object => state.serialize_field("type", "object"),
+            Self::DateTime => state.serialize_field("type", "datetime"),
+            Self::Bytes { encoding } => {
+                state.serialize_field("type", "bytes")?;
+                state.serialize_field("encoding", encoding)
+            }
+            Self::Unsupported => state.serialize_field("type", "unsupported"),
         }
     }
 }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -461,16 +461,16 @@ impl fmt::Display for FieldScalarType {
 impl FieldScalarType {
     fn compact_name(&self) -> Option<&'static str> {
         match self {
-            Self::String => Some("string"),
-            Self::Int => Some("int"),
-            Self::BigInt => Some("bigint"),
-            Self::Float => Some("float"),
-            Self::Decimal => Some("decimal"),
-            Self::Boolean => Some("boolean"),
-            Self::Json => Some("json"),
-            Self::Object => Some("object"),
-            Self::DateTime => Some("datetime"),
-            Self::Unsupported => Some("unsupported"),
+            Self::String => Some("s"),
+            Self::Int => Some("i"),
+            Self::BigInt => Some("I"),
+            Self::Float => Some("f"),
+            Self::Decimal => Some("d"),
+            Self::Boolean => Some("b"),
+            Self::Json => Some("j"),
+            Self::Object => Some("o"),
+            Self::DateTime => Some("D"),
+            Self::Unsupported => Some("x"),
             Self::Enum { .. } | Self::Extension { .. } | Self::Bytes { .. } => None,
         }
     }

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -133,7 +133,7 @@ fn get_result_node(
     builder: &mut ResultNodeBuilder<'_>,
     original_name: Option<Cow<'static, str>>,
 ) -> Option<ResultNode> {
-    let mut node = ResultNodeBuilder::new_object(original_name);
+    let mut node = ResultNodeBuilder::new_object_with_capacity(original_name, selection_order.len());
     node.set_skip_nulls(skip_nulls);
 
     for prisma_name in selection_order {
@@ -282,7 +282,7 @@ fn get_result_node_for_aggregation(
         }
     }
 
-    let mut node = ResultNodeBuilder::new_object(object_name);
+    let mut node = ResultNodeBuilder::new_object_with_capacity(object_name, ordered_set.len());
 
     for (name, prefix, db_alias, typ) in selectors
         .iter()

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -9,6 +9,7 @@ use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
 use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeTuple};
+use serde_json::Value;
 use thiserror::Error;
 
 mod format;
@@ -234,8 +235,11 @@ impl Serialize for Expression {
                 tuple.serialize_element("V")?;
                 tuple.serialize_element(expr)?;
                 tuple.serialize_element(rules)?;
-                tuple.serialize_element(error_identifier)?;
-                tuple.serialize_element(context)?;
+                tuple.serialize_element(compact_validation_error_identifier(error_identifier))?;
+                tuple.serialize_element(&CompactValidationContext {
+                    error_identifier,
+                    context,
+                })?;
                 tuple.end()
             }
             Self::If {
@@ -299,6 +303,110 @@ where
     tuple.serialize_element(tag)?;
     tuple.serialize_element(value)?;
     tuple.end()
+}
+
+fn compact_validation_error_identifier(error_identifier: &'static str) -> &'static str {
+    match error_identifier {
+        "RELATION_VIOLATION" => "r",
+        "MISSING_RELATED_RECORD" => "m",
+        "MISSING_RECORD" => "M",
+        "INCOMPLETE_CONNECT_INPUT" => "i",
+        "INCOMPLETE_CONNECT_OUTPUT" => "o",
+        "RECORDS_NOT_CONNECTED" => "n",
+        _ => error_identifier,
+    }
+}
+
+struct CompactValidationContext<'a> {
+    error_identifier: &'static str,
+    context: &'a Value,
+}
+
+impl Serialize for CompactValidationContext<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let Value::Object(context) = self.context else {
+            return self.context.serialize(serializer);
+        };
+
+        match self.error_identifier {
+            "RELATION_VIOLATION" => {
+                if let (Some(relation), Some(model_a), Some(model_b)) =
+                    (context.get("relation"), context.get("modelA"), context.get("modelB"))
+                {
+                    let mut tuple = serializer.serialize_tuple(3)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(model_a)?;
+                    tuple.serialize_element(model_b)?;
+                    return tuple.end();
+                }
+            }
+            "MISSING_RELATED_RECORD" => {
+                if let (Some(model), Some(relation), Some(relation_type), Some(operation)) = (
+                    context.get("model"),
+                    context.get("relation"),
+                    context.get("relationType"),
+                    context.get("operation"),
+                ) {
+                    if let Some(needed_for) = context.get("neededFor") {
+                        let mut tuple = serializer.serialize_tuple(5)?;
+                        tuple.serialize_element(model)?;
+                        tuple.serialize_element(relation)?;
+                        tuple.serialize_element(relation_type)?;
+                        tuple.serialize_element(operation)?;
+                        tuple.serialize_element(needed_for)?;
+                        return tuple.end();
+                    }
+
+                    let mut tuple = serializer.serialize_tuple(4)?;
+                    tuple.serialize_element(model)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(relation_type)?;
+                    tuple.serialize_element(operation)?;
+                    return tuple.end();
+                }
+            }
+            "MISSING_RECORD" => {
+                if let Some(operation) = context.get("operation") {
+                    return operation.serialize(serializer);
+                }
+            }
+            "INCOMPLETE_CONNECT_INPUT" => {
+                if let Some(expected_rows) = context.get("expectedRows") {
+                    return expected_rows.serialize(serializer);
+                }
+            }
+            "INCOMPLETE_CONNECT_OUTPUT" => {
+                if let (Some(expected_rows), Some(relation), Some(relation_type)) = (
+                    context.get("expectedRows"),
+                    context.get("relation"),
+                    context.get("relationType"),
+                ) {
+                    let mut tuple = serializer.serialize_tuple(3)?;
+                    tuple.serialize_element(expected_rows)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(relation_type)?;
+                    return tuple.end();
+                }
+            }
+            "RECORDS_NOT_CONNECTED" => {
+                if let (Some(relation), Some(parent), Some(child)) =
+                    (context.get("relation"), context.get("parent"), context.get("child"))
+                {
+                    let mut tuple = serializer.serialize_tuple(3)?;
+                    tuple.serialize_element(relation)?;
+                    tuple.serialize_element(parent)?;
+                    tuple.serialize_element(child)?;
+                    return tuple.end();
+                }
+            }
+            _ => {}
+        }
+
+        self.context.serialize(serializer)
+    }
 }
 
 impl Expression {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -8,7 +8,7 @@ use bon::{Builder, bon};
 use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeTuple};
 use thiserror::Error;
 
 mod format;
@@ -43,8 +43,7 @@ pub struct JoinExpression {
     pub is_relation_unique: bool,
 }
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", content = "args", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum Expression {
     /// Expression that evaluates to a plain value.
     Value(PrismaValue),
@@ -83,7 +82,6 @@ pub enum Expression {
     Required(Box<Expression>),
 
     /// Application-level join.
-    #[serde(rename_all = "camelCase")]
     Join {
         parent: Box<Expression>,
         children: Vec<JoinExpression>,
@@ -105,7 +103,6 @@ pub enum Expression {
     },
 
     /// Validates the expression according to the data rule and throws an error if it doesn't match.
-    #[serde(rename_all = "camelCase")]
     Validate {
         expr: Box<Expression>,
         rules: Vec<DataRule>,
@@ -149,6 +146,134 @@ pub enum Expression {
         expr: Box<Expression>,
         operations: InMemoryOps,
     },
+}
+
+impl Serialize for Expression {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Value(value) => serialize_unary("v", value, serializer),
+            Self::Seq(expressions) => serialize_unary("s", expressions, serializer),
+            Self::Get { name } => serialize_unary("g", name, serializer),
+            Self::Let { bindings, expr } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("l")?;
+                tuple.serialize_element(bindings)?;
+                tuple.serialize_element(expr)?;
+                tuple.end()
+            }
+            Self::GetFirstNonEmpty { names } => serialize_unary("e", names, serializer),
+            Self::Query(query) => serialize_unary("q", query, serializer),
+            Self::Execute(query) => serialize_unary("x", query, serializer),
+            Self::Sum(expressions) => serialize_unary("+", expressions, serializer),
+            Self::Concat(expressions) => serialize_unary("c", expressions, serializer),
+            Self::Unique(expr) => serialize_unary("u", expr, serializer),
+            Self::Required(expr) => serialize_unary("r", expr, serializer),
+            Self::Join {
+                parent,
+                children,
+                can_assume_strict_equality,
+            } => {
+                let mut tuple = serializer.serialize_tuple(4)?;
+                tuple.serialize_element("j")?;
+                tuple.serialize_element(parent)?;
+                tuple.serialize_element(children)?;
+                tuple.serialize_element(can_assume_strict_equality)?;
+                tuple.end()
+            }
+            Self::MapField { field, records } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("m")?;
+                tuple.serialize_element(field)?;
+                tuple.serialize_element(records)?;
+                tuple.end()
+            }
+            Self::Transaction(expr) => serialize_unary("t", expr, serializer),
+            Self::DataMap { expr, structure, enums } => {
+                let mut tuple = serializer.serialize_tuple(4)?;
+                tuple.serialize_element("d")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(structure)?;
+                tuple.serialize_element(enums)?;
+                tuple.end()
+            }
+            Self::Validate {
+                expr,
+                rules,
+                error_identifier,
+                context,
+            } => {
+                let mut tuple = serializer.serialize_tuple(5)?;
+                tuple.serialize_element("V")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(rules)?;
+                tuple.serialize_element(error_identifier)?;
+                tuple.serialize_element(context)?;
+                tuple.end()
+            }
+            Self::If {
+                value,
+                rule,
+                then,
+                r#else,
+            } => {
+                let mut tuple = serializer.serialize_tuple(5)?;
+                tuple.serialize_element("?")?;
+                tuple.serialize_element(value)?;
+                tuple.serialize_element(rule)?;
+                tuple.serialize_element(then)?;
+                tuple.serialize_element(r#else)?;
+                tuple.end()
+            }
+            Self::Unit => {
+                let mut tuple = serializer.serialize_tuple(1)?;
+                tuple.serialize_element("0")?;
+                tuple.end()
+            }
+            Self::Diff { from, to, fields } => {
+                let mut tuple = serializer.serialize_tuple(4)?;
+                tuple.serialize_element("-")?;
+                tuple.serialize_element(from)?;
+                tuple.serialize_element(to)?;
+                tuple.serialize_element(fields)?;
+                tuple.end()
+            }
+            Self::InitializeRecord { expr, fields } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("i")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(fields)?;
+                tuple.end()
+            }
+            Self::MapRecord { expr, fields } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("M")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(fields)?;
+                tuple.end()
+            }
+            Self::Process { expr, operations } => {
+                let mut tuple = serializer.serialize_tuple(3)?;
+                tuple.serialize_element("p")?;
+                tuple.serialize_element(expr)?;
+                tuple.serialize_element(operations)?;
+                tuple.end()
+            }
+        }
+    }
+}
+
+fn serialize_unary<S, T>(tag: &'static str, value: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    let mut tuple = serializer.serialize_tuple(2)?;
+    tuple.serialize_element(tag)?;
+    tuple.serialize_element(value)?;
+    tuple.end()
 }
 
 impl Expression {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -218,11 +218,13 @@ impl Serialize for Expression {
             }
             Self::Transaction(expr) => serialize_unary("t", expr, serializer),
             Self::DataMap { expr, structure, enums } => {
-                let mut tuple = serializer.serialize_tuple(4)?;
+                let mut tuple = serializer.serialize_tuple(if enums.is_empty() { 3 } else { 4 })?;
                 tuple.serialize_element("d")?;
                 tuple.serialize_element(expr)?;
                 tuple.serialize_element(structure)?;
-                tuple.serialize_element(enums)?;
+                if !enums.is_empty() {
+                    tuple.serialize_element(enums)?;
+                }
                 tuple.end()
             }
             Self::Validate {
@@ -654,6 +656,10 @@ pub struct EnumsMap(BTreeMap<String, BTreeMap<String, String>>);
 impl EnumsMap {
     pub fn new() -> Self {
         Default::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     pub fn add(&mut self, r#enum: InternalEnum) {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -8,7 +8,7 @@ use bon::{Builder, bon};
 use query_builder::DbQuery;
 use query_core::{DataExpectation, DataRule};
 use query_structure::{InternalEnum, PrismaValue, PrismaValueType, ScalarWriteOperation};
-use serde::{Serialize, Serializer, ser::SerializeTuple};
+use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeTuple};
 use thiserror::Error;
 
 mod format;
@@ -399,12 +399,32 @@ impl TryFrom<ScalarWriteOperation> for FieldOperation {
 #[error("unsupported scalar write operation: {0:?}")]
 pub struct UnsupportedScalarWriteOperation(ScalarWriteOperation);
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct Pagination {
     cursor: Option<HashMap<String, PrismaValue>>,
     take: Option<i64>,
     skip: Option<i64>,
+}
+
+impl Serialize for Pagination {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len =
+            usize::from(self.cursor.is_some()) + usize::from(self.take.is_some()) + usize::from(self.skip.is_some());
+        let mut map = serializer.serialize_map(Some(len))?;
+        if let Some(cursor) = &self.cursor {
+            map.serialize_entry("cursor", cursor)?;
+        }
+        if let Some(take) = self.take {
+            map.serialize_entry("take", &take)?;
+        }
+        if let Some(skip) = self.skip {
+            map.serialize_entry("skip", &skip)?;
+        }
+        map.end()
+    }
 }
 
 #[bon]
@@ -427,8 +447,7 @@ impl Pagination {
     }
 }
 
-#[derive(Debug, Default, Serialize, Builder)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug, Default, Builder)]
 pub struct InMemoryOps {
     pub(crate) pagination: Option<Pagination>,
     pub(crate) distinct: Option<Vec<String>>,
@@ -437,6 +456,36 @@ pub struct InMemoryOps {
     #[builder(default)]
     pub(crate) nested: BTreeMap<String, InMemoryOps>,
     pub(crate) linking_fields: Option<Vec<String>>,
+}
+
+impl Serialize for InMemoryOps {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let len = usize::from(self.pagination.is_some())
+            + usize::from(self.distinct.is_some())
+            + usize::from(self.reverse)
+            + usize::from(!self.nested.is_empty())
+            + usize::from(self.linking_fields.is_some());
+        let mut map = serializer.serialize_map(Some(len))?;
+        if let Some(pagination) = &self.pagination {
+            map.serialize_entry("pagination", pagination)?;
+        }
+        if let Some(distinct) = &self.distinct {
+            map.serialize_entry("distinct", distinct)?;
+        }
+        if self.reverse {
+            map.serialize_entry("reverse", &self.reverse)?;
+        }
+        if !self.nested.is_empty() {
+            map.serialize_entry("nested", &self.nested)?;
+        }
+        if let Some(linking_fields) = &self.linking_fields {
+            map.serialize_entry("linkingFields", linking_fields)?;
+        }
+        map.end()
+    }
 }
 
 impl InMemoryOps {

--- a/query-compiler/query-compiler/src/expression.rs
+++ b/query-compiler/query-compiler/src/expression.rs
@@ -13,10 +13,22 @@ use thiserror::Error;
 
 mod format;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct Binding {
     pub name: Cow<'static, str>,
     pub expr: Expression,
+}
+
+impl Serialize for Binding {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(2)?;
+        tuple.serialize_element(&self.name)?;
+        tuple.serialize_element(&self.expr)?;
+        tuple.end()
+    }
 }
 
 impl Binding {
@@ -34,13 +46,26 @@ impl std::fmt::Display for Binding {
     }
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Debug)]
 pub struct JoinExpression {
     pub child: Expression,
     pub on: Vec<(String, String)>,
     pub parent_field: String,
     pub is_relation_unique: bool,
+}
+
+impl Serialize for JoinExpression {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut tuple = serializer.serialize_tuple(4)?;
+        tuple.serialize_element(&self.child)?;
+        tuple.serialize_element(&self.on)?;
+        tuple.serialize_element(&self.parent_field)?;
+        tuple.serialize_element(&self.is_relation_unique)?;
+        tuple.end()
+    }
 }
 
 #[derive(Debug)]

--- a/query-compiler/query-compiler/src/expression/format.rs
+++ b/query-compiler/query-compiler/src/expression/format.rs
@@ -302,7 +302,7 @@ where
     fn data_map_node(&'a self, node: &'a ResultNode) -> PrettyDoc<'a, D> {
         match node {
             ResultNode::AffectedRows => self.keyword("affectedRows"),
-            ResultNode::Object(object) => self.object(object.fields().iter().map(|(name, field)| {
+            ResultNode::Object(object) => self.object(object.fields().map(|(name, field)| {
                 let mut key = self.field_name(name);
                 if let ResultNode::Object(nested_object) = field {
                     let source = match nested_object.serialized_name() {

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use indexmap::IndexMap;
 use query_structure::{FieldTypeInformation, TypeIdentifier};
 use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeStruct, ser::SerializeTuple};
 
@@ -42,8 +41,14 @@ impl Serialize for ResultNode {
 #[derive(Debug)]
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
-    fields: IndexMap<Cow<'static, str>, ResultNode>,
+    fields: Vec<ObjectField>,
     skip_nulls: bool,
+}
+
+#[derive(Debug)]
+pub struct ObjectField {
+    name: Cow<'static, str>,
+    node: ResultNode,
 }
 
 impl Serialize for Object {
@@ -66,7 +71,7 @@ impl Serialize for Object {
     }
 }
 
-struct SerializedObjectFields<'a>(&'a IndexMap<Cow<'static, str>, ResultNode>);
+struct SerializedObjectFields<'a>(&'a [ObjectField]);
 
 impl Serialize for SerializedObjectFields<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -77,12 +82,14 @@ impl Serialize for SerializedObjectFields<'_> {
     }
 }
 
-fn serialize_fields<S>(fields: &IndexMap<Cow<'static, str>, ResultNode>, serializer: S) -> Result<S::Ok, S::Error>
+fn serialize_fields<S>(fields: &[ObjectField], serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
     let mut map = serializer.serialize_map(Some(fields.len()))?;
-    for (name, node) in fields {
+    for field in fields {
+        let name = &field.name;
+        let node = &field.node;
         match node {
             ResultNode::Field { db_name, field_type } if db_name == name => {
                 if let Some(compact_name) = field_type.compact_name() {
@@ -122,9 +129,13 @@ struct FieldNodeInObject<'a> {
 
 impl Object {
     fn new(serialized_name: Option<impl Into<Cow<'static, str>>>) -> Self {
+        Self::with_capacity(serialized_name, 0)
+    }
+
+    fn with_capacity(serialized_name: Option<impl Into<Cow<'static, str>>>, capacity: usize) -> Self {
         Self {
             serialized_name: serialized_name.map(Into::into),
-            fields: IndexMap::new(),
+            fields: Vec::with_capacity(capacity),
             skip_nulls: false,
         }
     }
@@ -138,8 +149,8 @@ impl Object {
         self.serialized_name.as_deref()
     }
 
-    pub fn fields(&self) -> &IndexMap<Cow<'static, str>, ResultNode> {
-        &self.fields
+    pub fn fields(&self) -> impl ExactSizeIterator<Item = (&Cow<'static, str>, &ResultNode)> {
+        self.fields.iter().map(|field| (&field.name, &field.node))
     }
 }
 
@@ -154,6 +165,13 @@ impl<'a> ResultNodeBuilder<'a> {
 
     pub fn new_object(serialized_name: Option<impl Into<Cow<'static, str>>>) -> ObjectBuilder {
         ObjectBuilder::new(serialized_name)
+    }
+
+    pub fn new_object_with_capacity(
+        serialized_name: Option<impl Into<Cow<'static, str>>>,
+        capacity: usize,
+    ) -> ObjectBuilder {
+        ObjectBuilder::with_capacity(serialized_name, capacity)
     }
 
     #[inline]
@@ -180,8 +198,12 @@ pub struct ObjectBuilder {
 
 impl ObjectBuilder {
     fn new(serialized_name: Option<impl Into<Cow<'static, str>>>) -> Self {
+        Self::with_capacity(serialized_name, 0)
+    }
+
+    fn with_capacity(serialized_name: Option<impl Into<Cow<'static, str>>>, capacity: usize) -> Self {
         Self {
-            object: Object::new(serialized_name),
+            object: Object::with_capacity(serialized_name, capacity),
         }
     }
 
@@ -212,13 +234,18 @@ impl ObjectBuilder {
         key: Cow<'static, str>,
         original_key: Option<Cow<'static, str>>,
     ) -> ObjectMutBuilder<'_> {
-        let node = self
-            .object
-            .fields
-            .entry(key)
-            .or_insert(ResultNode::Object(Object::new(original_key)));
+        let field_index = match self.object.fields.iter().position(|field| field.name == key) {
+            Some(index) => index,
+            None => {
+                self.object.fields.push(ObjectField {
+                    name: key,
+                    node: ResultNode::Object(Object::new(original_key)),
+                });
+                self.object.fields.len() - 1
+            }
+        };
 
-        let ResultNode::Object(object) = node else {
+        let ResultNode::Object(object) = &mut self.object.fields[field_index].node else {
             panic!("ObjectBuilder::entry_or_insert can only be called with key which is vacant or points at an object")
         };
 
@@ -240,6 +267,12 @@ impl<'a> ObjectMutBuilder<'a> {
     }
 
     pub fn add_field(&mut self, key: impl Into<Cow<'static, str>>, node: ResultNode) {
-        self.object.fields.insert(key.into(), node);
+        let key = key.into();
+        if let Some(field) = self.object.fields.iter_mut().find(|field| field.name == key) {
+            field.node = node;
+            return;
+        }
+
+        self.object.fields.push(ObjectField { name: key, node });
     }
 }

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -34,13 +34,28 @@ where
     let mut map = serializer.serialize_map(Some(fields.len()))?;
     for (name, node) in fields {
         match node {
-            ResultNode::Field { db_name, field_type } => map.serialize_entry(
-                name,
-                &FieldNodeInObject {
-                    db_name: (db_name != name).then_some(db_name),
-                    field_type,
-                },
-            )?,
+            ResultNode::Field { db_name, field_type } if db_name == name => {
+                if let Some(compact_name) = field_type.compact_name() {
+                    map.serialize_entry(name, compact_name)?;
+                } else {
+                    map.serialize_entry(
+                        name,
+                        &FieldNodeInObject {
+                            db_name: None,
+                            field_type,
+                        },
+                    )?;
+                }
+            }
+            ResultNode::Field { db_name, field_type } => {
+                map.serialize_entry(
+                    name,
+                    &FieldNodeInObject {
+                        db_name: Some(db_name),
+                        field_type,
+                    },
+                )?;
+            }
             node => map.serialize_entry(name, node)?,
         }
     }

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use indexmap::IndexMap;
 use query_structure::{FieldTypeInformation, TypeIdentifier};
-use serde::Serialize;
+use serde::{Serialize, Serializer, ser::SerializeMap};
 
 use crate::{data_mapper::FieldType, expression::EnumsMap};
 
@@ -22,8 +22,43 @@ pub enum ResultNode {
 #[serde(rename_all = "camelCase")]
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
+    #[serde(serialize_with = "serialize_fields")]
     fields: IndexMap<Cow<'static, str>, ResultNode>,
     skip_nulls: bool,
+}
+
+fn serialize_fields<S>(fields: &IndexMap<Cow<'static, str>, ResultNode>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut map = serializer.serialize_map(Some(fields.len()))?;
+    for (name, node) in fields {
+        match node {
+            ResultNode::Field { db_name, field_type } if db_name == name => map.serialize_entry(
+                name,
+                &FieldNodeWithDefaultDbName {
+                    node_type: FieldNodeType::Field,
+                    field_type,
+                },
+            )?,
+            node => map.serialize_entry(name, node)?,
+        }
+    }
+    map.end()
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct FieldNodeWithDefaultDbName<'a> {
+    #[serde(rename = "type")]
+    node_type: FieldNodeType,
+    field_type: &'a FieldType,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+enum FieldNodeType {
+    Field,
 }
 
 impl Object {

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -2,29 +2,79 @@ use std::borrow::Cow;
 
 use indexmap::IndexMap;
 use query_structure::{FieldTypeInformation, TypeIdentifier};
-use serde::{Serialize, Serializer, ser::SerializeMap};
+use serde::{Serialize, Serializer, ser::SerializeMap, ser::SerializeStruct, ser::SerializeTuple};
 
 use crate::{data_mapper::FieldType, expression::EnumsMap};
 
-#[derive(Debug, Serialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Debug)]
 pub enum ResultNode {
     AffectedRows,
     Object(Object),
-    #[serde(rename_all = "camelCase")]
     Field {
         db_name: Cow<'static, str>,
         field_type: FieldType,
     },
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+impl Serialize for ResultNode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::AffectedRows => {
+                let mut state = serializer.serialize_struct("ResultNode", 1)?;
+                state.serialize_field("type", "affectedRows")?;
+                state.end()
+            }
+            Self::Object(object) => object.serialize(serializer),
+            Self::Field { db_name, field_type } => {
+                let mut state = serializer.serialize_struct("ResultNode", 3)?;
+                state.serialize_field("type", "field")?;
+                state.serialize_field("dbName", db_name)?;
+                state.serialize_field("fieldType", field_type)?;
+                state.end()
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct Object {
     serialized_name: Option<Cow<'static, str>>,
-    #[serde(serialize_with = "serialize_fields")]
     fields: IndexMap<Cow<'static, str>, ResultNode>,
     skip_nulls: bool,
+}
+
+impl Serialize for Object {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if !self.skip_nulls {
+            let mut tuple = serializer.serialize_tuple(2)?;
+            tuple.serialize_element(&self.serialized_name)?;
+            tuple.serialize_element(&SerializedObjectFields(&self.fields))?;
+            return tuple.end();
+        }
+
+        let mut tuple = serializer.serialize_tuple(3)?;
+        tuple.serialize_element(&self.serialized_name)?;
+        tuple.serialize_element(&SerializedObjectFields(&self.fields))?;
+        tuple.serialize_element(&self.skip_nulls)?;
+        tuple.end()
+    }
+}
+
+struct SerializedObjectFields<'a>(&'a IndexMap<Cow<'static, str>, ResultNode>);
+
+impl Serialize for SerializedObjectFields<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serialize_fields(self.0, serializer)
+    }
 }
 
 fn serialize_fields<S>(fields: &IndexMap<Cow<'static, str>, ResultNode>, serializer: S) -> Result<S::Ok, S::Error>

--- a/query-compiler/query-compiler/src/result_node.rs
+++ b/query-compiler/query-compiler/src/result_node.rs
@@ -34,10 +34,10 @@ where
     let mut map = serializer.serialize_map(Some(fields.len()))?;
     for (name, node) in fields {
         match node {
-            ResultNode::Field { db_name, field_type } if db_name == name => map.serialize_entry(
+            ResultNode::Field { db_name, field_type } => map.serialize_entry(
                 name,
-                &FieldNodeWithDefaultDbName {
-                    node_type: FieldNodeType::Field,
+                &FieldNodeInObject {
+                    db_name: (db_name != name).then_some(db_name),
                     field_type,
                 },
             )?,
@@ -49,16 +49,10 @@ where
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct FieldNodeWithDefaultDbName<'a> {
-    #[serde(rename = "type")]
-    node_type: FieldNodeType,
+struct FieldNodeInObject<'a> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    db_name: Option<&'a Cow<'static, str>>,
     field_type: &'a FieldType,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-enum FieldNodeType {
-    Field,
 }
 
 impl Object {

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -23,6 +23,10 @@ impl FieldSelection {
         self.selections
     }
 
+    pub fn as_slice(&self) -> &[SelectedField] {
+        &self.selections
+    }
+
     /// Returns `true` if self contains (at least) all fields specified in `other`. `false` otherwise.
     /// Recurses into composite selections and ensures that composite selections are supersets as well.
     pub fn is_superset_of(&self, other: &Self) -> bool {


### PR DESCRIPTION
## Summary

/prisma-branch prisma-client-perf-compact-plan-format

Produces the compact query-plan format used by the matching Prisma consumer branch.

This branch replaces internal serialized query-plan shapes in lockstep with the Prisma runtime reader. It deliberately does not keep old/new internal compatibility branches.

## Stack

1. Prisma prerequisite PR: `prisma-client-perf-render-datamapper-prereqs`
2. Prisma compact consumer PR: `prisma-client-perf-compact-plan-format`
3. This PR: engines compact producer

## Validation

- `cargo fmt --check`
- `CARGO_TARGET_DIR=/home/aqrln.guest/prisma/.tmp/compact-plan-engines-target cargo check -p query-core`
- `CARGO_TARGET_DIR=/home/aqrln.guest/prisma/.tmp/compact-plan-engines-target cargo check -p query-compiler`
- `CARGO_TARGET_DIR=/home/aqrln.guest/prisma/.tmp/compact-plan-engines-target cargo test -p query-compiler --test queries`

## Notes

Do not merge this without the matching Prisma compact consumer branch. The `/prisma-branch` command above links engines CI to that Prisma branch.
