### PR TITLE
perf(query-compiler): reduce graph translation allocations

### DIFF
--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -786,10 +786,7 @@ impl QueryGraph {
 
                     for (_, sibling) in siblings {
                         let possible_edge = self.graph.find_edge(node.node_ix, sibling.node_ix);
-                        let is_if_node_child = self.incoming_edges(&sibling).into_iter().any(|edge| {
-                            let content = self.edge_content(&edge).unwrap();
-                            matches!(content, QueryGraphDependency::Then | QueryGraphDependency::Else)
-                        });
+                        let is_if_node_child = self.has_incoming_then_or_else_edge(&sibling);
 
                         if sibling != node
                             && possible_edge.is_none()
@@ -804,6 +801,15 @@ impl QueryGraph {
         }
 
         Ok(())
+    }
+
+    fn has_incoming_then_or_else_edge(&self, node: &NodeRef) -> bool {
+        self.graph.edges_directed(node.node_ix, Direction::Incoming).any(|edge| {
+            matches!(
+                edge.weight().borrow(),
+                Some(QueryGraphDependency::Then | QueryGraphDependency::Else)
+            )
+        })
     }
 
     /// Traverses the graph and ensures that return nodes have correct `ProjectedDataDependency`s on their incoming edges.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -945,7 +945,7 @@ impl QueryGraph {
             let primary_model_id = model.shard_aware_primary_identifier();
 
             let read_query = ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
-                name: "reload".into(),
+                name: String::new(),
                 alias: None,
                 model: model.clone(),
                 args: QueryArguments::new(model),

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -513,6 +513,13 @@ impl QueryGraph {
         self.collect_edges(node, Direction::Incoming)
     }
 
+    /// Returns parent nodes without allocating or sorting edge refs.
+    pub fn parent_nodes(&self, node: &NodeRef) -> impl Iterator<Item = NodeRef> + '_ {
+        self.graph
+            .edges_directed(node.node_ix, Direction::Incoming)
+            .map(|edge| NodeRef { node_ix: edge.source() })
+    }
+
     /// Removes the edge from the graph but leaves the graph intact by keeping the empty
     /// edge in the graph by plucking the content of the edge, but not the edge itself.
     /// Panics if the edge has been already been taken or plucked.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -373,8 +373,8 @@ impl QueryGraph {
         if !self.finalized {
             self.swap_marked()?;
             self.ensure_return_nodes_have_parent_dependency()?;
-            self.normalize_data_dependencies(capabilities)?;
-            self.insert_reloads()?;
+            let reloads = self.normalize_data_dependencies(capabilities)?;
+            self.insert_reloads(reloads)?;
             self.normalize_if_nodes()?;
             self.finalized = true;
         }
@@ -928,9 +928,7 @@ impl QueryGraph {
     ///
     /// The `Reload` node is always a "find many" query.
     /// Unwraps are safe because we're operating on the unprocessed state of the graph (`Expressionista` changes that).
-    fn insert_reloads(&mut self) -> QueryGraphResult<()> {
-        let reloads = self.find_unsatisfied_dependencies();
-
+    fn insert_reloads(&mut self, reloads: Vec<(NodeRef, FieldSelection)>) -> QueryGraphResult<()> {
         for (node, identifiers) in reloads {
             let query = self.node_content(&node).and_then(|node| node.as_query()).unwrap();
 
@@ -1019,8 +1017,12 @@ impl QueryGraph {
     /// This is only possible when the parent node _can_ fulfill the selection set.
     /// In the case of updates and inserts, for instance, only connectors supporting `InsertReturning` and `UpdateReturning` can do it,
     /// or else they're only able to return the primary identifier of the model inserted or updated.
-    fn normalize_data_dependencies(&mut self, capabilities: ConnectorCapabilities) -> QueryGraphResult<()> {
+    fn normalize_data_dependencies(
+        &mut self,
+        capabilities: ConnectorCapabilities,
+    ) -> QueryGraphResult<Vec<(NodeRef, FieldSelection)>> {
         let unsatisfied_deps = self.find_unsatisfied_dependencies();
+        let mut reloads = Vec::new();
 
         for (node, identifiers) in unsatisfied_deps {
             let query = self
@@ -1031,18 +1033,21 @@ impl QueryGraph {
             // If the connector does not support returning more than the primary identifier for an update,
             // do not update the selection set.
             if query.is_update_one() && !capabilities.contains(ConnectorCapability::UpdateReturning) {
+                reloads.push((node, identifiers));
                 continue;
             }
 
             // If the connector does not support returning more than the primary identifier for a create,
             // do not update the selection set.
             if query.is_create_one() && !capabilities.contains(ConnectorCapability::InsertReturning) {
+                reloads.push((node, identifiers));
                 continue;
             }
 
             // If the connector does not support returning more than the primary identifier for a delete,
             // do not update the selection set.
             if query.is_delete_one() && !capabilities.contains(ConnectorCapability::DeleteReturning) {
+                reloads.push((node, identifiers));
                 continue;
             }
 
@@ -1055,7 +1060,7 @@ impl QueryGraph {
             query.satisfy_dependency(identifiers);
         }
 
-        Ok(())
+        Ok(reloads)
     }
 
     /// Traverses the query graph and finds the query nodes that don't fulfill their children data dependencies.

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -131,6 +131,11 @@ impl NodeRef {
     pub fn id(&self) -> String {
         self.node_ix.index().to_string()
     }
+
+    /// Returns the raw index of the Node.
+    pub fn index(&self) -> usize {
+        self.node_ix.index()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/query-compiler/core/src/query_graph_builder/write/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/write/utils.rs
@@ -42,7 +42,7 @@ where
     let filter: Filter = filter.into();
 
     let read_query = ReadQuery::ManyRecordsQuery(ManyRecordsQuery {
-        name: "read_ids_infallible".into(), // this name only eases debugging
+        name: String::new(),
         alias: None,
         model: model.clone(),
         args: (model, filter).into(),
@@ -65,7 +65,7 @@ where
     let filter: Filter = filter.into();
 
     let read_query = ReadQuery::RecordQuery(RecordQuery {
-        name: "read_ids_infallible".into(), // this name only eases debugging
+        name: String::new(),
         alias: None,
         model: model.clone(),
         filter: Some(filter),
@@ -136,7 +136,7 @@ where
     );
 
     let read_children_node = graph.create_node(Query::Read(ReadQuery::RelatedRecordsQuery(RelatedRecordsQuery {
-        name: "find_children_by_parent".to_owned(),
+        name: String::new(),
         alias: None,
         parent_field: parent_relation_field.clone(),
         parent_results: None,

--- a/query-compiler/query-compiler/src/binding.rs
+++ b/query-compiler/query-compiler/src/binding.rs
@@ -16,7 +16,7 @@ pub fn node_result(node: NodeRef) -> Cow<'static, str> {
 }
 
 pub fn projected_dependency(source: NodeRef, field: &SelectedField) -> Cow<'static, str> {
-    format!("{}{FIELD_SEPARATOR}{}", source.id(), field.prisma_name()).into()
+    format!("{}{FIELD_SEPARATOR}{}", source.index(), field.prisma_name()).into()
 }
 
 pub fn join_parent() -> Cow<'static, str> {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -43,6 +43,7 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
     let mut enums = EnumsMap::new();
     let mut result_node_builder = ResultNodeBuilder::new(&mut enums);
     let structure = map_result_structure(&graph, &mut result_node_builder);
+    let result_reachability = ResultReachability::new(&graph);
 
     // Must collect the root nodes first, because the following iteration is mutating the graph
     let root_nodes = {
@@ -62,10 +63,12 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
 
     let root = match root_nodes {
         RootNodes::None => Expression::Seq(Vec::new()),
-        RootNodes::One(node) => NodeTranslator::new(&mut graph, node, &[], builder).translate()?,
+        RootNodes::One(node) => {
+            NodeTranslator::new(&mut graph, node, &[], builder, &result_reachability).translate()?
+        }
         RootNodes::Many(nodes) => nodes
             .into_iter()
-            .map(|node| NodeTranslator::new(&mut graph, node, &[], builder).translate())
+            .map(|node| NodeTranslator::new(&mut graph, node, &[], builder, &result_reachability).translate())
             .collect::<TranslateResult<Vec<_>>>()
             .map(Expression::Seq)?,
     };
@@ -87,11 +90,55 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
     Ok(root)
 }
 
+struct ResultReachability {
+    can_reach_result: Vec<bool>,
+}
+
+impl ResultReachability {
+    fn new(graph: &QueryGraph) -> Self {
+        let mut can_reach_result = Vec::new();
+        let mut pending = graph.result_nodes().collect::<Vec<_>>();
+
+        for node in &pending {
+            Self::mark_reachable(&mut can_reach_result, *node);
+        }
+
+        while let Some(node) = pending.pop() {
+            for parent in graph.parent_nodes(&node) {
+                if Self::mark_reachable(&mut can_reach_result, parent) {
+                    pending.push(parent);
+                }
+            }
+        }
+
+        Self { can_reach_result }
+    }
+
+    fn contains(&self, node: &NodeRef) -> bool {
+        self.can_reach_result.get(node.index()).copied().unwrap_or(false)
+    }
+
+    fn mark_reachable(can_reach_result: &mut Vec<bool>, node: NodeRef) -> bool {
+        let index = node.index();
+        if index >= can_reach_result.len() {
+            can_reach_result.resize(index + 1, false);
+        }
+
+        if can_reach_result[index] {
+            false
+        } else {
+            can_reach_result[index] = true;
+            true
+        }
+    }
+}
+
 struct NodeTranslator<'a, 'b> {
     graph: &'a mut QueryGraph,
     node: NodeRef,
     parent_edges: &'b [EdgeRef],
     query_builder: &'b dyn QueryBuilder,
+    result_reachability: &'b ResultReachability,
 }
 
 impl<'a, 'b> NodeTranslator<'a, 'b> {
@@ -100,12 +147,14 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         node: NodeRef,
         parent_edges: &'b [EdgeRef],
         query_builder: &'b dyn QueryBuilder,
+        result_reachability: &'b ResultReachability,
     ) -> Self {
         Self {
             graph,
             node,
             parent_edges,
             query_builder,
+            result_reachability,
         }
     }
 
@@ -359,7 +408,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .iter()
             .enumerate()
             .filter_map(|(idx, (_, child_node))| {
-                if self.graph.subgraph_contains_result(child_node) {
+                if self.result_reachability.contains(child_node) {
                     Some(idx)
                 } else {
                     None
@@ -510,7 +559,14 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .collect::<Vec<_>>();
 
         // translate plucks the edges coming into node, we need to avoid accessing it afterwards
-        let expr = NodeTranslator::new(self.graph, node, &incoming_edges, self.query_builder).translate()?;
+        let expr = NodeTranslator::new(
+            self.graph,
+            node,
+            &incoming_edges,
+            self.query_builder,
+            self.result_reachability,
+        )
+        .translate()?;
 
         if bindings.is_empty() && validations.is_empty() {
             return Ok(expr);

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -393,6 +393,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
     }
 
     fn fold_result_scopes(&mut self, result_subgraphs: Vec<(EdgeRef, NodeRef)>) -> TranslateResult<Expression> {
+        if let [(_, node)] = &result_subgraphs[..] {
+            return self.process_child_with_dependencies(*node);
+        }
+
         // if the subgraphs all point to the same result node, we fold them in sequence
         // if not, we can separate them with a getfirstnonempty
         let bindings = result_subgraphs

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -405,19 +405,18 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
 
     fn process_child_with_dependencies(&mut self, node: NodeRef) -> TranslateResult<Expression> {
         let create_field_bindings = matches!(self.graph.node_content(&node), Some(Node::Query(_)));
+        let incoming_edges = self.graph.incoming_edges(&node);
 
-        let validations = self
-            .graph
-            .incoming_edges(&node)
-            .into_iter()
+        let validations = incoming_edges
+            .iter()
             .filter_map(|edge| {
                 let Some(QueryGraphDependency::DataDependency(RowCountSink::Discard, expectation)) =
-                    self.graph.edge_content(&edge)
+                    self.graph.edge_content(edge)
                 else {
                     return None;
                 };
                 let mut expr = Expression::Get {
-                    name: binding::node_result(self.graph.edge_source(&edge)),
+                    name: binding::node_result(self.graph.edge_source(edge)),
                 };
                 if let Some(expectation) = expectation {
                     expr = Expression::validate_expectation(expectation, expr);
@@ -426,12 +425,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             })
             .collect_vec();
 
-        let bindings = self
-            .graph
-            .incoming_edges(&node)
-            .into_iter()
+        let bindings = incoming_edges
+            .iter()
             .flat_map(|edge| {
-                let edge_content = self.graph.edge_content(&edge);
+                let edge_content = self.graph.edge_content(edge);
                 let Some(QueryGraphDependency::ProjectedDataDependency(selection, _, expectation)) = edge_content
                 else {
                     return Either::Left(std::iter::empty());
@@ -443,7 +440,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                         if sink.is_unique()
                 );
 
-                let source = self.graph.edge_source(&edge);
+                let source = self.graph.edge_source(edge);
 
                 let expr = Expression::Get {
                     name: binding::node_result(source),
@@ -486,8 +483,7 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .collect::<Vec<_>>();
 
         // translate plucks the edges coming into node, we need to avoid accessing it afterwards
-        let edges = self.graph.incoming_edges(&node);
-        let expr = NodeTranslator::new(self.graph, node, &edges, self.query_builder).translate()?;
+        let expr = NodeTranslator::new(self.graph, node, &incoming_edges, self.query_builder).translate()?;
 
         if bindings.is_empty() && validations.is_empty() {
             return Ok(expr);

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -34,18 +34,41 @@ pub enum TranslateError {
 pub type TranslateResult<T> = Result<T, TranslateError>;
 
 pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> TranslateResult<Expression> {
+    enum RootNodes {
+        None,
+        One(NodeRef),
+        Many(Vec<NodeRef>),
+    }
+
     let mut enums = EnumsMap::new();
     let mut result_node_builder = ResultNodeBuilder::new(&mut enums);
     let structure = map_result_structure(&graph, &mut result_node_builder);
 
     // Must collect the root nodes first, because the following iteration is mutating the graph
-    let root_nodes: Vec<NodeRef> = graph.root_nodes().collect();
+    let root_nodes = {
+        let mut nodes = graph.root_nodes();
+        match (nodes.next(), nodes.next()) {
+            (None, _) => RootNodes::None,
+            (Some(node), None) => RootNodes::One(node),
+            (Some(first), Some(second)) => {
+                let mut roots = Vec::with_capacity(2 + nodes.size_hint().0);
+                roots.push(first);
+                roots.push(second);
+                roots.extend(nodes);
+                RootNodes::Many(roots)
+            }
+        }
+    };
 
-    let root = root_nodes
-        .into_iter()
-        .map(|node| NodeTranslator::new(&mut graph, node, &[], builder).translate())
-        .collect::<TranslateResult<Vec<_>>>()
-        .map(Expression::Seq)?;
+    let root = match root_nodes {
+        RootNodes::None => Expression::Seq(Vec::new()),
+        RootNodes::One(node) => NodeTranslator::new(&mut graph, node, &[], builder).translate()?,
+        RootNodes::Many(nodes) => nodes
+            .into_iter()
+            .map(|node| NodeTranslator::new(&mut graph, node, &[], builder).translate())
+            .collect::<TranslateResult<Vec<_>>>()
+            .map(Expression::Seq)?,
+    };
 
     let mut root = if let Some(structure) = structure {
         Expression::DataMap {


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Reduces query graph translation allocations by reusing graph edges, trimming single-root/single-result scaffolding, caching result reachability, and avoiding synthetic read-query names.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08