### PR TITLE
perf(query-compiler): trim dependency placeholder allocations

### DIFF
--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -403,6 +403,11 @@ impl QueryGraph {
         }
     }
 
+    pub fn reserve_visited_capacity(&mut self) {
+        self.visited
+            .reserve_exact(self.graph.node_count().saturating_sub(self.visited.len()));
+    }
+
     /// Checks if the given node is marked as one of the result nodes in the graph.
     pub fn is_result_node(&self, node: &NodeRef) -> bool {
         self.result_nodes.contains(&node.node_ix)

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -530,6 +530,22 @@ impl QueryGraph {
             .map(|edge| NodeRef { node_ix: edge.source() })
     }
 
+    fn outgoing_projected_data_dependencies(&self, node: &NodeRef) -> impl Iterator<Item = &FieldSelection> {
+        self.graph
+            .edges_directed(node.node_ix, Direction::Outgoing)
+            .filter_map(|edge| match edge.weight().borrow() {
+                Some(QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)) => Some(requested_selection),
+                _ => None,
+            })
+    }
+
+    fn incoming_projected_data_dependency_edge(&self, node: &NodeRef) -> Option<EdgeRef> {
+        self.graph
+            .edges_directed(node.node_ix, Direction::Incoming)
+            .find(|edge| matches!(edge.weight().borrow(), Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))))
+            .map(|edge| EdgeRef { edge_ix: edge.id() })
+    }
+
     /// Removes the edge from the graph but leaves the graph intact by keeping the empty
     /// edge in the graph by plucking the content of the edge, but not the edge itself.
     /// Panics if the edge has been already been taken or plucked.
@@ -846,26 +862,12 @@ impl QueryGraph {
             .collect();
 
         for return_node in return_nodes {
-            let out_edges = self.outgoing_edges(&return_node);
-            let dependencies = FieldSelection::union_iter(out_edges.into_iter().filter_map(|edge| {
-                if let QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _) =
-                    self.edge_content(&edge).unwrap()
-                {
-                    Some(requested_selection.clone())
-                } else {
-                    None
-                }
-            }));
+            let dependencies =
+                FieldSelection::union_iter(self.outgoing_projected_data_dependencies(&return_node).cloned());
 
             // Assumption: We currently always have at most one single incoming ProjectedDataDependency edge
             // connected to return nodes. This will break if we ever have more.
-            let in_edges = self.incoming_edges(&return_node);
-            let incoming_dep_edge = in_edges.into_iter().find(|edge| {
-                matches!(
-                    self.edge_content(edge),
-                    Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))
-                )
-            });
+            let incoming_dep_edge = self.incoming_projected_data_dependency_edge(&return_node);
 
             if let Some(incoming_edge) = incoming_dep_edge {
                 let source = self.edge_source(&incoming_edge);
@@ -1085,18 +1087,10 @@ impl QueryGraph {
                 let node = NodeRef { node_ix: ix };
 
                 if let Node::Query(q) = self.node_content(&node).unwrap() {
-                    let edges = self.outgoing_edges(&node);
-                    let mut unsatisfied_dependencies =
-                        edges
-                            .into_iter()
-                            .filter_map(|edge| match self.edge_content(&edge).unwrap() {
-                                QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)
-                                    if !q.satisfies(requested_selection) =>
-                                {
-                                    Some(requested_selection.clone())
-                                }
-                                _ => None,
-                            });
+                    let mut unsatisfied_dependencies = self
+                        .outgoing_projected_data_dependencies(&node)
+                        .filter(|requested_selection| !q.satisfies(requested_selection))
+                        .cloned();
 
                     let first = unsatisfied_dependencies.next()?;
                     Some((

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -847,19 +847,15 @@ impl QueryGraph {
 
         for return_node in return_nodes {
             let out_edges = self.outgoing_edges(&return_node);
-            let dependencies: Vec<FieldSelection> = out_edges
-                .into_iter()
-                .filter_map(|edge| {
-                    if let QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _) =
-                        self.edge_content(&edge).unwrap()
-                    {
-                        Some(requested_selection.clone())
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            let dependencies = FieldSelection::union(dependencies);
+            let dependencies = FieldSelection::union_iter(out_edges.into_iter().filter_map(|edge| {
+                if let QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _) =
+                    self.edge_content(&edge).unwrap()
+                {
+                    Some(requested_selection.clone())
+                } else {
+                    None
+                }
+            }));
 
             // Assumption: We currently always have at most one single incoming ProjectedDataDependency edge
             // connected to return nodes. This will break if we ever have more.
@@ -1090,23 +1086,23 @@ impl QueryGraph {
 
                 if let Node::Query(q) = self.node_content(&node).unwrap() {
                     let edges = self.outgoing_edges(&node);
-                    let unsatisfied_dependencies: Vec<_> = edges
-                        .into_iter()
-                        .filter_map(|edge| match self.edge_content(&edge).unwrap() {
-                            QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)
-                                if !q.satisfies(requested_selection) =>
-                            {
-                                Some(requested_selection.clone())
-                            }
-                            _ => None,
-                        })
-                        .collect();
+                    let mut unsatisfied_dependencies =
+                        edges
+                            .into_iter()
+                            .filter_map(|edge| match self.edge_content(&edge).unwrap() {
+                                QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)
+                                    if !q.satisfies(requested_selection) =>
+                                {
+                                    Some(requested_selection.clone())
+                                }
+                                _ => None,
+                            });
 
-                    if unsatisfied_dependencies.is_empty() {
-                        None
-                    } else {
-                        Some((node, FieldSelection::union(unsatisfied_dependencies)))
-                    }
+                    let first = unsatisfied_dependencies.next()?;
+                    Some((
+                        node,
+                        FieldSelection::union_iter(std::iter::once(first).chain(unsatisfied_dependencies)),
+                    ))
                 } else {
                     None
                 }

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -505,36 +505,37 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             .iter()
             .flat_map(|edge| {
                 let edge_content = self.graph.edge_content(edge);
-                let Some(QueryGraphDependency::ProjectedDataDependency(selection, _, expectation)) = edge_content
+                let Some(QueryGraphDependency::ProjectedDataDependency(selection, sink, expectation)) = edge_content
                 else {
                     return Either::Left(std::iter::empty());
                 };
 
-                let requires_unique = matches!(
-                    edge_content,
-                    Some(QueryGraphDependency::ProjectedDataDependency(_, sink, _))
-                        if sink.is_unique()
-                );
+                let requires_unique = sink.is_unique();
 
                 let source = self.graph.edge_source(edge);
 
-                let expr = Expression::Get {
-                    name: binding::node_result(source),
-                };
-                let expr = match expectation {
-                    Some(expectation) => Expression::validate_expectation(expectation, expr),
-                    None => expr,
-                };
-                let expr = if requires_unique {
-                    Expression::Unique(expr.into())
-                } else {
-                    expr
-                };
+                let needs_parent_binding = expectation.is_some() || requires_unique;
+                let parent_binding = needs_parent_binding.then(|| {
+                    let expr = Expression::Get {
+                        name: binding::node_result(source),
+                    };
+                    let expr = match expectation {
+                        Some(expectation) => Expression::validate_expectation(expectation, expr),
+                        None => expr,
+                    };
+                    let expr = if requires_unique {
+                        Expression::Unique(expr.into())
+                    } else {
+                        expr
+                    };
 
-                let parent_binding = std::iter::once(Binding::new(source.id(), expr));
+                    Binding::new(source.id(), expr)
+                });
+
+                let parent_bindings = parent_binding.into_iter();
 
                 if create_field_bindings {
-                    Either::Right(Either::Left(parent_binding.chain(selection.selections().map(
+                    Either::Right(Either::Left(parent_bindings.chain(selection.selections().map(
                         move |field| {
                             Binding::new(
                                 binding::projected_dependency(source, field),
@@ -549,12 +550,8 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                         },
                     ))))
                 } else {
-                    Either::Right(Either::Right(parent_binding))
+                    Either::Right(Either::Right(parent_bindings))
                 }
-            })
-            .filter(|binding| match &binding.expr {
-                Expression::Get { name, .. } => name != &binding.name,
-                _ => true,
             })
             .collect::<Vec<_>>();
 

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -61,6 +61,8 @@ pub fn translate(mut graph: QueryGraph, builder: &dyn QueryBuilder) -> Translate
         }
     };
 
+    graph.reserve_visited_capacity();
+
     let root = match root_nodes {
         RootNodes::None => Expression::Seq(Vec::new()),
         RootNodes::One(node) => {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -456,20 +456,18 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             })
             .collect::<TranslateResult<Vec<_>>>()?;
 
-        let result_nodes: Vec<NodeRef> = self.graph.result_nodes().collect();
-        let result_binding_names = bindings.iter().map(|b| b.name.clone()).collect::<Vec<_>>();
+        let has_single_result_node = self.graph.result_nodes().take(2).count() == 1;
 
-        if result_nodes.len() == 1 {
+        if has_single_result_node {
+            let result_binding_name = bindings.last().expect("no binding for result node").name.clone();
             Ok(Expression::Let {
                 bindings,
                 expr: Box::new(Expression::Get {
-                    name: result_binding_names
-                        .into_iter()
-                        .next_back()
-                        .expect("no binding for result node"),
+                    name: result_binding_name,
                 }),
             })
         } else {
+            let result_binding_names = bindings.iter().map(|b| b.name.clone()).collect::<Vec<_>>();
             Ok(Expression::Let {
                 bindings,
                 expr: Box::new(Expression::GetFirstNonEmpty {

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -188,10 +188,29 @@ impl FieldSelection {
     ///
     /// /!\ Important assumption: All selections are on the same model.
     pub fn union(selections: Vec<Self>) -> Self {
-        let chained = selections.into_iter().flatten();
+        Self::union_iter(selections)
+    }
+
+    /// Merges all given `FieldSelection` a set union of all.
+    ///
+    /// /!\ Important assumption: All selections are on the same model.
+    pub fn union_iter(selections: impl IntoIterator<Item = Self>) -> Self {
+        let mut selections = selections.into_iter();
+        let Some(first) = selections.next() else {
+            return Self::default();
+        };
+
+        let Some(second) = selections.next() else {
+            return first;
+        };
 
         FieldSelection {
-            selections: chained.unique().collect(),
+            selections: first
+                .into_iter()
+                .chain(second)
+                .chain(selections.flatten())
+                .unique()
+                .collect(),
         }
     }
 


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on the graph translation cleanup and reduces result-scope binding, visited-vector, identity-binding, dependency-union, and projected-edge overhead.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08