### PR TITLE
perf(query-compiler): store placeholders directly

### DIFF
--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -21,7 +21,7 @@ use petgraph::{
     visit::{EdgeRef as PEdgeRef, NodeIndexable},
     *,
 };
-use query_structure::{FieldSelection, Filter, QueryArguments, SelectionResult, WriteArgs};
+use query_structure::{FieldSelection, Filter, Placeholder, QueryArguments, SelectionResult, WriteArgs};
 
 pub type QueryGraphResult<T> = std::result::Result<T, QueryGraphError>;
 
@@ -67,24 +67,24 @@ impl From<Flow> for Node {
 pub enum Flow {
     /// Expresses a conditional control flow in the graph.
     /// Possible outgoing edges are `then` and `else`, each at most once, with `then` required to be present.
-    If { rule: DataRule, data: Vec<SelectionResult> },
+    If { rule: DataRule, data: Option<Placeholder> },
 
     /// Returns a fixed set of results at runtime.
-    Return(Vec<SelectionResult>),
+    Return(Option<Placeholder>),
 }
 
 impl Flow {
     pub fn if_non_empty() -> Self {
         Self::If {
             rule: DataRule::RowCountNeq(0),
-            data: Vec::new(),
+            data: None,
         }
     }
 
     pub fn if_false() -> Self {
         Self::If {
             rule: DataRule::Never,
-            data: Vec::new(),
+            data: None,
         }
     }
 }
@@ -106,16 +106,16 @@ impl Computation {
 }
 
 pub struct DiffNode {
-    pub left: Vec<SelectionResult>,
-    pub right: Vec<SelectionResult>,
+    pub left: Option<Placeholder>,
+    pub right: Option<Placeholder>,
     pub fields: FieldSelection,
 }
 
 impl DiffNode {
     pub fn new_empty(fields: FieldSelection) -> Self {
         Self {
-            left: Vec::new(),
-            right: Vec::new(),
+            left: None,
+            right: None,
             fields,
         }
     }
@@ -187,6 +187,8 @@ pub enum RowSink {
     AtMostOne(&'static dyn NodeInputField<Vec<SelectionResult>>),
     /// Store an array of exactly one row to the node input field.
     ExactlyOne(&'static dyn NodeInputField<Vec<SelectionResult>>),
+    /// Store a projected placeholder directly to the node input field.
+    ProjectedPlaceholder(&'static dyn NodeInputField<Option<Placeholder>>),
     /// Store a filter representing all rows to the node input field.
     AllFilter(&'static dyn NodeInputField<Filter>),
     /// Store a filter representing exactly one row to the node input field.
@@ -534,7 +536,9 @@ impl QueryGraph {
         self.graph
             .edges_directed(node.node_ix, Direction::Outgoing)
             .filter_map(|edge| match edge.weight().borrow() {
-                Some(QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)) => Some(requested_selection),
+                Some(QueryGraphDependency::ProjectedDataDependency(requested_selection, _, _)) => {
+                    Some(requested_selection)
+                }
                 _ => None,
             })
     }
@@ -542,7 +546,12 @@ impl QueryGraph {
     fn incoming_projected_data_dependency_edge(&self, node: &NodeRef) -> Option<EdgeRef> {
         self.graph
             .edges_directed(node.node_ix, Direction::Incoming)
-            .find(|edge| matches!(edge.weight().borrow(), Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))))
+            .find(|edge| {
+                matches!(
+                    edge.weight().borrow(),
+                    Some(QueryGraphDependency::ProjectedDataDependency(_, _, _))
+                )
+            })
             .map(|edge| EdgeRef { edge_ix: edge.id() })
     }
 
@@ -830,12 +839,14 @@ impl QueryGraph {
     }
 
     fn has_incoming_then_or_else_edge(&self, node: &NodeRef) -> bool {
-        self.graph.edges_directed(node.node_ix, Direction::Incoming).any(|edge| {
-            matches!(
-                edge.weight().borrow(),
-                Some(QueryGraphDependency::Then | QueryGraphDependency::Else)
-            )
-        })
+        self.graph
+            .edges_directed(node.node_ix, Direction::Incoming)
+            .any(|edge| {
+                matches!(
+                    edge.weight().borrow(),
+                    Some(QueryGraphDependency::Then | QueryGraphDependency::Else)
+                )
+            })
     }
 
     /// Traverses the graph and ensures that return nodes have correct `ProjectedDataDependency`s on their incoming edges.

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -1,6 +1,6 @@
 use std::slice;
 
-use query_structure::{Filter, SelectionResult, WriteArgs};
+use query_structure::{Filter, Placeholder, SelectionResult, WriteArgs};
 
 use crate::{Computation, Flow, Node, NodeInputField, Query, ReadQuery, WriteQuery};
 
@@ -84,25 +84,25 @@ node_input_field!(
 
 node_input_field!(
     LeftSideDiffInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Computation(Computation::DiffLeftToRight(diff_node) | Computation::DiffRightToLeft(diff_node)) => &mut diff_node.left
 );
 
 node_input_field!(
     RightSideDiffInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Computation(Computation::DiffLeftToRight(diff_node) | Computation::DiffRightToLeft(diff_node)) => &mut diff_node.right
 );
 
 node_input_field!(
     IfInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Flow(Flow::If { data, .. }) => data
 );
 
 node_input_field!(
     ReturnInput,
-    Vec<SelectionResult>,
+    Option<Placeholder>,
     Node::Flow(Flow::Return(data)) => data
 );
 

--- a/query-compiler/core/src/query_graph_builder/write/create.rs
+++ b/query-compiler/core/src/query_graph_builder/write/create.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    ArgumentListLookup, DataExpectation, ParsedField, ParsedInputList, ParsedInputMap, RowSink,
+    ArgumentListLookup, DataExpectation, ParsedField, ParsedInputMap, RowSink,
     inputs::RecordQueryFilterInput,
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
@@ -63,9 +63,9 @@ pub(crate) fn create_many_records(
 ) -> QueryGraphBuilderResult<()> {
     graph.flag_transactional();
 
-    let data_list: ParsedInputList<'_> = match field.arguments.lookup(args::DATA) {
-        Some(data) => utils::coerce_vec(data.value),
-        None => vec![],
+    let data_list = match field.arguments.lookup(args::DATA) {
+        Some(data) => utils::coerce_values(data.value),
+        None => utils::CoercedParsedInputValues::empty(),
     };
 
     let skip_duplicates: bool = match field.arguments.lookup(args::SKIP_DUPLICATES) {

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_nested.rs
@@ -22,7 +22,7 @@ pub fn nested_connect(
     let relation = parent_relation_field.relation();
 
     // Build all filters upfront.
-    let filters: Vec<Filter> = utils::coerce_vec(value)
+    let filters: Vec<Filter> = utils::coerce_values(value)
         .into_iter()
         .map(|value: ParsedInputValue<'_>| {
             let value: ParsedInputMap<'_> = value.try_into()?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -129,7 +129,7 @@ fn handle_many_to_many(
             &if_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model.shard_aware_primary_identifier(),
-                RowSink::All(&IfInput),
+                RowSink::ProjectedPlaceholder(&IfInput),
                 None,
             ),
         )?;
@@ -280,7 +280,11 @@ fn one_to_many_inlined_child(
         graph.create_edge(
             &read_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_link.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         graph.create_edge(
@@ -392,13 +396,17 @@ fn one_to_many_inlined_parent(
 
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
-    let return_existing = graph.create_node(Flow::Return(Vec::new()));
-    let return_create = graph.create_node(Flow::Return(Vec::new()));
+    let return_existing = graph.create_node(Flow::Return(None));
+    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
@@ -417,13 +425,17 @@ fn one_to_many_inlined_parent(
     graph.create_edge(
         &read_node,
         &return_existing,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
+            None,
+        ),
     )?;
 
     graph.create_edge(
         &create_node,
         &return_create,
-        QueryGraphDependency::ProjectedDataDependency(child_link, RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(child_link, RowSink::ProjectedPlaceholder(&ReturnInput), None),
     )?;
 
     Ok(())
@@ -521,13 +533,17 @@ fn one_to_one_inlined_parent(
 
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_data)?;
-    let return_existing = graph.create_node(Flow::Return(Vec::new()));
-    let return_create = graph.create_node(Flow::Return(Vec::new()));
+    let return_existing = graph.create_node(Flow::Return(None));
+    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // Then branch handling
@@ -544,7 +560,11 @@ fn one_to_one_inlined_parent(
     graph.create_edge(
         &read_node,
         &return_existing,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
+            None,
+        ),
     )?;
 
     // Else branch handling
@@ -552,7 +572,11 @@ fn one_to_one_inlined_parent(
     graph.create_edge(
         &create_node,
         &return_create,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&ReturnInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
+            None,
+        ),
     )?;
 
     if utils::node_is_create(graph, &parent_node) {
@@ -701,7 +725,11 @@ fn one_to_one_inlined_child(
     graph.create_edge(
         &read_new_child_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_link.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // *** Else branch handling ***
@@ -793,7 +821,7 @@ fn one_to_one_inlined_child(
             &diff_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&LeftSideDiffInput),
+                RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
                 None,
             ),
         )?;
@@ -804,7 +832,7 @@ fn one_to_one_inlined_child(
             &diff_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&RightSideDiffInput),
+                RowSink::ProjectedPlaceholder(&RightSideDiffInput),
                 None,
             ),
         )?;
@@ -813,7 +841,11 @@ fn one_to_one_inlined_child(
         graph.create_edge(
             &diff_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         // update old child, set link to null

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -280,11 +280,7 @@ fn one_to_many_inlined_child(
         graph.create_edge(
             &read_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model.shard_aware_primary_identifier(),
-                RowSink::All(&IfInput),
-                None,
-            ),
+            QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
         )?;
 
         graph.create_edge(
@@ -402,11 +398,7 @@ fn one_to_many_inlined_parent(
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model.shard_aware_primary_identifier(),
-            RowSink::All(&IfInput),
-            None,
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
     )?;
 
     graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
@@ -535,11 +527,7 @@ fn one_to_one_inlined_parent(
     graph.create_edge(
         &read_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model.shard_aware_primary_identifier(),
-            RowSink::All(&IfInput),
-            None,
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
     )?;
 
     // Then branch handling
@@ -713,11 +701,7 @@ fn one_to_one_inlined_child(
     graph.create_edge(
         &read_new_child_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model.shard_aware_primary_identifier(),
-            RowSink::All(&IfInput),
-            None,
-        ),
+        QueryGraphDependency::ProjectedDataDependency(child_link.clone(), RowSink::All(&IfInput), None),
     )?;
 
     // *** Else branch handling ***

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -24,7 +24,7 @@ pub(crate) fn nested_connect_or_create(
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
-    let values = utils::coerce_vec(value);
+    let values = utils::coerce_values(value);
 
     if relation.is_many_to_many() {
         handle_many_to_many(
@@ -95,7 +95,7 @@ fn handle_many_to_many(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    values: Vec<ParsedInputValue<'_>>,
+    values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     for value in values {
@@ -147,7 +147,7 @@ fn handle_one_to_many(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    values: Vec<ParsedInputValue<'_>>,
+    values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     if parent_relation_field.is_inlined_on_enclosing_model() {
@@ -177,7 +177,7 @@ fn handle_one_to_one(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    mut values: Vec<ParsedInputValue<'_>>,
+    mut values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let value = values.pop().unwrap();
@@ -248,7 +248,7 @@ fn one_to_many_inlined_child(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    values: Vec<ParsedInputValue<'_>>,
+    values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     for value in values {
@@ -369,7 +369,7 @@ fn one_to_many_inlined_parent(
     query_schema: &QuerySchema,
     parent_node: NodeRef,
     parent_relation_field: &RelationFieldRef,
-    mut values: Vec<ParsedInputValue<'_>>,
+    mut values: utils::CoercedParsedInputValues<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
     let parent_link = parent_relation_field.linking_fields();

--- a/query-compiler/core/src/query_graph_builder/write/nested/create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/create_nested.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{
-    DataExpectation, ParsedInputList, ParsedInputValue, RowSink,
+    DataExpectation, ParsedInputValue, RowSink,
     inputs::{UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput},
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
@@ -24,7 +24,7 @@ pub fn nested_create(
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
 
-    let data_maps = utils::coerce_vec(value)
+    let data_maps = utils::coerce_values(value)
         .into_iter()
         .map(|value| {
             let mut parser = WriteArgsParser::from(child_model, value.try_into()?)?;
@@ -537,7 +537,7 @@ pub fn nested_create_many(
     // Nested input is an object of { data: [...], skipDuplicates: bool }
     let mut obj: ParsedInputMap<'_> = value.try_into()?;
 
-    let data_list: ParsedInputList<'_> = utils::coerce_vec(obj.swap_remove(args::DATA).unwrap());
+    let data_list = utils::coerce_values(obj.swap_remove(args::DATA).unwrap());
     let skip_duplicates: bool = match obj.swap_remove(args::SKIP_DUPLICATES) {
         Some(val) => val.try_into()?,
         None => false,

--- a/query-compiler/core/src/query_graph_builder/write/nested/delete_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/delete_nested.rs
@@ -31,7 +31,7 @@ pub fn nested_delete(
     let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
     if parent_relation_field.is_list() {
-        let filters: Vec<Filter> = utils::coerce_vec(value)
+        let filters: Vec<Filter> = utils::coerce_values(value)
             .into_iter()
             .map(|value: ParsedInputValue<'_>| {
                 let value: ParsedInputMap<'_> = value.try_into()?;
@@ -129,7 +129,7 @@ pub fn nested_delete_many(
 ) -> QueryGraphBuilderResult<()> {
     let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
 
-    for value in utils::coerce_vec(value) {
+    for value in utils::coerce_values(value) {
         let as_map: ParsedInputMap<'_> = value.try_into()?;
         let filter = extract_filter(as_map, child_model)?;
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -23,7 +23,7 @@ pub fn nested_disconnect(
 
     if relation.is_many_to_many() {
         // Build all filters upfront.
-        let filters: Vec<Filter> = utils::coerce_vec(value)
+        let filters: Vec<Filter> = utils::coerce_values(value)
             .into_iter()
             .map(|value: ParsedInputValue<'_>| {
                 let value: ParsedInputMap<'_> = value.try_into()?;
@@ -53,7 +53,7 @@ pub fn nested_disconnect(
             // One-to-many specify a number of finders if the parent side is the to-one.
             // todo check if this if else is really still required.
             if parent_relation_field.is_list() {
-                let filters = utils::coerce_vec(value)
+                let filters = utils::coerce_values(value)
                     .into_iter()
                     .map(|value: ParsedInputValue<'_>| {
                         let value: ParsedInputMap<'_> = value.try_into()?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -8,7 +8,6 @@ use crate::{
     query_ast::*,
     query_graph::*,
 };
-use itertools::Itertools;
 use query_structure::{Filter, Model, RelationFieldRef, SelectionResult, WriteArgs};
 use std::convert::TryInto;
 
@@ -26,17 +25,17 @@ pub fn nested_set(
 ) -> QueryGraphBuilderResult<()> {
     let relation = parent_relation_field.relation();
 
-    // Build all filters upfront.
-    let filters: Vec<Filter> = utils::coerce_vec(value)
-        .into_iter()
-        .map(|value: ParsedInputValue<'_>| {
-            let value: ParsedInputMap<'_> = value.try_into()?;
-            extract_unique_filter(value, child_model)
-        })
-        .collect::<QueryGraphBuilderResult<Vec<Filter>>>()?
-        .into_iter()
-        .unique()
-        .collect();
+    let values = utils::coerce_values(value);
+    let mut filters = Vec::with_capacity(values.len());
+
+    for value in values {
+        let value: ParsedInputMap<'_> = value.try_into()?;
+        let filter = extract_unique_filter(value, child_model)?;
+
+        if !filters.iter().any(|existing| existing == &filter) {
+            filters.push(filter);
+        }
+    }
 
     let filter = Filter::or(filters);
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -232,7 +232,7 @@ fn handle_one_to_many(
         &diff_left_to_right_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&LeftSideDiffInput),
+            RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
             None,
         ),
     )?;
@@ -241,7 +241,7 @@ fn handle_one_to_many(
         &diff_right_to_left_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&LeftSideDiffInput),
+            RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
             None,
         ),
     )?;
@@ -252,7 +252,7 @@ fn handle_one_to_many(
         &diff_left_to_right_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&RightSideDiffInput),
+            RowSink::ProjectedPlaceholder(&RightSideDiffInput),
             None,
         ),
     )?;
@@ -261,7 +261,7 @@ fn handle_one_to_many(
         &diff_right_to_left_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&RightSideDiffInput),
+            RowSink::ProjectedPlaceholder(&RightSideDiffInput),
             None,
         ),
     )?;
@@ -273,7 +273,11 @@ fn handle_one_to_many(
     graph.create_edge(
         &diff_left_to_right_node,
         &connect_if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier.clone(),
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
 
     // Connect to the if node, the parent node (for the inlining ID) and the diff node (to get the IDs to update)
@@ -318,7 +322,7 @@ fn handle_one_to_many(
         &disconnect_if_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&IfInput),
+            RowSink::ProjectedPlaceholder(&IfInput),
             child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
         ),
     )?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -46,7 +46,7 @@ pub fn nested_update(
     value: ParsedInputValue<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    for value in utils::coerce_vec(value) {
+    for value in utils::coerce_values(value) {
         let (data, filter) = if parent_relation_field.is_list() {
             // We have to have a single record filter in "where".
             // This is used to read the children first, to make sure they're actually connected.
@@ -122,7 +122,7 @@ pub fn nested_update_many(
     value: ParsedInputValue<'_>,
     child_model: &Model,
 ) -> QueryGraphBuilderResult<()> {
-    for value in utils::coerce_vec(value) {
+    for value in utils::coerce_values(value) {
         let mut map: ParsedInputMap<'_> = value.try_into()?;
         let where_arg = map.swap_remove(args::WHERE).unwrap();
         let data_value = map.swap_remove(args::DATA).unwrap();

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -150,7 +150,11 @@ pub fn nested_upsert(
         graph.create_edge(
             &read_children_node,
             &if_node,
-            QueryGraphDependency::ProjectedDataDependency(child_model_identifier.clone(), RowSink::All(&IfInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
+            ),
         )?;
 
         graph.create_edge(

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::inputs::{IfInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput, UpdateRecordSelectorsInput};
-use crate::query_graph_builder::write::utils::coerce_vec;
+use crate::query_graph_builder::write::utils::coerce_values;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputMap, ParsedInputValue,
@@ -103,7 +103,7 @@ pub fn nested_upsert(
     let child_model = parent_relation_field.related_model();
     let child_model_identifier = child_model.shard_aware_primary_identifier();
 
-    for value in coerce_vec(value) {
+    for value in coerce_values(value) {
         let parent_link = parent_relation_field.linking_fields();
         let child_link = parent_relation_field.related_field().linking_fields();
 

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -121,7 +121,7 @@ pub(crate) fn upsert_record(
     graph.create_edge(
         &read_parent_records_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::ProjectedPlaceholder(&IfInput), None),
     )?;
 
     // In case the connector doesn't support referential integrity, we add a subtree to the graph that emulates the ON_UPDATE referential action.

--- a/query-compiler/core/src/query_graph_builder/write/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/write/utils.rs
@@ -245,7 +245,7 @@ pub fn insert_1to1_idempotent_connect_checks(
         &diff_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&LeftSideDiffInput),
+            RowSink::ProjectedPlaceholder(&LeftSideDiffInput),
             Some(DataExpectation::non_empty_rows(
                 MissingRelatedRecord::builder()
                     .model(&child_model.clone())
@@ -263,7 +263,7 @@ pub fn insert_1to1_idempotent_connect_checks(
         &diff_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&RightSideDiffInput),
+            RowSink::ProjectedPlaceholder(&RightSideDiffInput),
             None,
         ),
     )?;
@@ -272,7 +272,11 @@ pub fn insert_1to1_idempotent_connect_checks(
     graph.create_edge(
         &diff_node,
         &if_node,
-        QueryGraphDependency::ProjectedDataDependency(child_model_identifier, RowSink::All(&IfInput), None),
+        QueryGraphDependency::ProjectedDataDependency(
+            child_model_identifier,
+            RowSink::ProjectedPlaceholder(&IfInput),
+            None,
+        ),
     )?;
     let empty_node = graph.create_node(Node::Empty);
 
@@ -392,7 +396,7 @@ pub fn insert_existing_1to1_related_model_checks(
         &if_node,
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
-            RowSink::All(&IfInput),
+            RowSink::ProjectedPlaceholder(&IfInput),
             // If the other side ("child") requires the connection, we need to make sure that there isn't a child already connected
             // to the parent, as that would violate the other childs relation side.
             if child_side_required {
@@ -992,14 +996,14 @@ pub fn insert_emulated_on_update_with_intermediary_node(
     let internal_model = &model_to_update.dm;
     let relation_fields = internal_model.fields_pointing_to_model(model_to_update);
 
-    let join_node = graph.create_node(Flow::Return(Vec::new()));
+    let join_node = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         parent_node,
         &join_node,
         QueryGraphDependency::ProjectedDataDependency(
             model_to_update.shard_aware_primary_identifier(),
-            RowSink::All(&ReturnInput),
+            RowSink::ProjectedPlaceholder(&ReturnInput),
             None,
         ),
     )?;

--- a/query-compiler/core/src/query_graph_builder/write/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/write/utils.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Computation, DataExpectation, DataOperation, MissingRelatedRecord, ParsedInputValue, QueryGraphBuilderResult,
-    RelationViolation, RowSink,
+    Computation, DataExpectation, DataOperation, MissingRelatedRecord, ParsedInputList, ParsedInputValue,
+    QueryGraphBuilderResult, RelationViolation, RowSink,
     inputs::{
         DeleteManyRecordsSelectorsInput, IfInput, LeftSideDiffInput, RelatedRecordsSelectorsInput, ReturnInput,
         RightSideDiffInput, UpdateManyRecordsSelectorsInput,
@@ -16,13 +16,83 @@ use query_structure::{
 };
 use schema::QuerySchema;
 
-/// Coerces single values (`ParsedInputValue::Single` and `ParsedInputValue::Map`) into a vector.
+pub(crate) enum CoercedParsedInputValues<'a> {
+    List(ParsedInputList<'a>),
+    Single(Option<ParsedInputValue<'a>>),
+}
+
+impl<'a> CoercedParsedInputValues<'a> {
+    pub(crate) fn empty() -> Self {
+        Self::Single(None)
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::List(values) => values.len(),
+            Self::Single(Some(_)) => 1,
+            Self::Single(None) => 0,
+        }
+    }
+
+    pub(crate) fn pop(&mut self) -> Option<ParsedInputValue<'a>> {
+        match self {
+            Self::List(values) => values.pop(),
+            Self::Single(value) => value.take(),
+        }
+    }
+}
+
+pub(crate) enum CoercedParsedInputValuesIntoIter<'a> {
+    List(std::vec::IntoIter<ParsedInputValue<'a>>),
+    Single(std::option::IntoIter<ParsedInputValue<'a>>),
+}
+
+impl<'a> Iterator for CoercedParsedInputValuesIntoIter<'a> {
+    type Item = ParsedInputValue<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::List(values) => values.next(),
+            Self::Single(value) => value.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::List(values) => values.size_hint(),
+            Self::Single(value) => value.size_hint(),
+        }
+    }
+}
+
+impl ExactSizeIterator for CoercedParsedInputValuesIntoIter<'_> {
+    fn len(&self) -> usize {
+        match self {
+            Self::List(values) => values.len(),
+            Self::Single(value) => value.len(),
+        }
+    }
+}
+
+impl<'a> IntoIterator for CoercedParsedInputValues<'a> {
+    type Item = ParsedInputValue<'a>;
+    type IntoIter = CoercedParsedInputValuesIntoIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        match self {
+            Self::List(values) => CoercedParsedInputValuesIntoIter::List(values.into_iter()),
+            Self::Single(value) => CoercedParsedInputValuesIntoIter::Single(value.into_iter()),
+        }
+    }
+}
+
+/// Coerces single values (`ParsedInputValue::Single` and `ParsedInputValue::Map`) into an iterable collection.
 /// Simply unpacks `ParsedInputValue::List`.
-pub(crate) fn coerce_vec(val: ParsedInputValue<'_>) -> Vec<ParsedInputValue<'_>> {
+/// The singleton path intentionally avoids allocating a one-element `Vec`.
+pub(crate) fn coerce_values(val: ParsedInputValue<'_>) -> CoercedParsedInputValues<'_> {
     match val {
-        ParsedInputValue::List(l) => l,
-        m @ ParsedInputValue::Map(_) => vec![m],
-        single => vec![single],
+        ParsedInputValue::List(l) => CoercedParsedInputValues::List(l),
+        single => CoercedParsedInputValues::Single(Some(single)),
     }
 }
 

--- a/query-compiler/query-compiler/src/selection.rs
+++ b/query-compiler/query-compiler/src/selection.rs
@@ -1,44 +1,10 @@
-use itertools::Itertools;
 use query_core::{QueryGraphBuilderError, QueryGraphError};
-use query_structure::{Placeholder, PrismaValue, SelectionResult};
+use query_structure::Placeholder;
 
 use crate::{TranslateError, translate::TranslateResult};
 
-pub trait SelectionResultExt: Sized {
-    fn into_placeholder(self) -> TranslateResult<Placeholder>;
-}
-
-impl SelectionResultExt for SelectionResult {
-    fn into_placeholder(self) -> TranslateResult<Placeholder> {
-        let (_, pv) = self
-            .pairs
-            .into_iter()
-            .next()
-            .ok_or_else(|| query_graph_error("SelectionResult is expected to have at least one column"))?;
-
-        match pv {
-            PrismaValue::Placeholder(placeholder) => Ok(placeholder),
-            _ => Err(query_graph_error(format!(
-                "SelectionResult value must be a placeholder, got {pv}"
-            ))),
-        }
-    }
-}
-
-pub struct SelectionResults(Vec<SelectionResult>);
-
-impl SelectionResults {
-    pub fn new(results: Vec<SelectionResult>) -> Self {
-        SelectionResults(results)
-    }
-
-    pub fn into_placeholder(self) -> TranslateResult<Placeholder> {
-        self.0
-            .into_iter()
-            .exactly_one()
-            .map_err(|e| query_graph_error(format!("expected only one SelectionResult, got {}", e.count())))?
-            .into_placeholder()
-    }
+pub fn projected_placeholder(placeholder: Option<Placeholder>, label: &str) -> TranslateResult<Placeholder> {
+    placeholder.ok_or_else(|| query_graph_error(format!("{label} node is missing projected placeholder input")))
 }
 
 fn query_graph_error(message: impl Into<String>) -> TranslateError {

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -5,7 +5,7 @@ use crate::binding;
 use crate::data_mapper::map_result_structure;
 use crate::expression::EnumsMap;
 use crate::result_node::ResultNodeBuilder;
-use crate::{Expression::Transaction, selection::SelectionResults};
+use crate::{Expression::Transaction, selection::projected_placeholder};
 use itertools::{Either, Itertools};
 use query::translate_query;
 use query_builder::QueryBuilder;
@@ -276,12 +276,10 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         let Node::Flow(Flow::If { rule, data }) = node else {
             panic!("current node must be Flow::If");
         };
+        let placeholder = projected_placeholder(data, "If")?;
 
         let expr = Expression::If {
-            value: Expression::Get {
-                name: SelectionResults::new(data).into_placeholder()?.name,
-            }
-            .into(),
+            value: Expression::Get { name: placeholder.name }.into(),
             rule,
             then: then_expr.into(),
             r#else: else_expr.into(),
@@ -299,10 +297,9 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         let Node::Flow(Flow::Return(data)) = node else {
             panic!("current node must be Flow::Return");
         };
+        let placeholder = projected_placeholder(data, "Return")?;
 
-        let expr = Expression::Get {
-            name: SelectionResults::new(data).into_placeholder()?.name,
-        };
+        let expr = Expression::Get { name: placeholder.name };
 
         Ok(self.wrap_children_with_expr(expr, children))
     }
@@ -317,15 +314,12 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             panic!("current node must be Computation::DiffLeftToRight");
         };
 
+        let from = projected_placeholder(diff.left, "DiffLeftToRight.left")?;
+        let to = projected_placeholder(diff.right, "DiffLeftToRight.right")?;
+
         let expr = Expression::Diff {
-            from: Expression::Get {
-                name: SelectionResults::new(diff.left).into_placeholder()?.name,
-            }
-            .into(),
-            to: Expression::Get {
-                name: SelectionResults::new(diff.right).into_placeholder()?.name,
-            }
-            .into(),
+            from: Expression::Get { name: from.name }.into(),
+            to: Expression::Get { name: to.name }.into(),
             fields: diff.fields.db_names().collect(),
         };
 
@@ -342,15 +336,12 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             panic!("current node must be Computation::DiffRightToLeft");
         };
 
+        let from = projected_placeholder(diff.right, "DiffRightToLeft.right")?;
+        let to = projected_placeholder(diff.left, "DiffRightToLeft.left")?;
+
         let expr = Expression::Diff {
-            from: Expression::Get {
-                name: SelectionResults::new(diff.right).into_placeholder()?.name,
-            }
-            .into(),
-            to: Expression::Get {
-                name: SelectionResults::new(diff.left).into_placeholder()?.name,
-            }
-            .into(),
+            from: Expression::Get { name: from.name }.into(),
+            to: Expression::Get { name: to.name }.into(),
             fields: diff.fields.db_names().collect(),
         };
 
@@ -360,35 +351,39 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
     fn transform_node(&mut self, mut node: Node) -> TranslateResult<Node> {
         for edge in self.parent_edges {
             match self.graph.take_edge(edge) {
-                Some(QueryGraphDependency::ProjectedDataDependency(selection, sink, _)) => {
-                    let fields = self.process_edge_selections(edge, &node, selection);
-
-                    match sink {
-                        RowSink::All(field) | RowSink::ExactlyOne(field) | RowSink::AtMostOne(field) => {
-                            *field.node_input_field(&mut node) = vec![SelectionResult::new(fields)];
-                        }
-                        RowSink::Single(field) => {
-                            *field.node_input_field(&mut node) = Some(SelectionResult::new(fields));
-                        }
-                        RowSink::AllFilter(field) | RowSink::ExactlyOneFilter(field) => {
-                            *field.node_input_field(&mut node) = SelectionResult::new(fields).filter();
-                        }
-                        RowSink::ExactlyOneWriteArgs(selection, field) => {
-                            let result = SelectionResult::new(fields);
-                            let model = node.as_query().map(Query::model);
-                            let args = field.node_input_field(&mut node);
-                            for arg in args {
-                                arg.inject(selection.assimilate(result.clone()).map_err(|err| {
-                                    TranslateError::GraphBuildError(QueryGraphBuilderError::DomainError(err))
-                                })?);
-                                if let Some(model) = &model {
-                                    arg.update_datetimes(model);
-                                }
+                Some(QueryGraphDependency::ProjectedDataDependency(projected_selection, sink, _)) => match sink {
+                    RowSink::All(field) | RowSink::ExactlyOne(field) | RowSink::AtMostOne(field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        *field.node_input_field(&mut node) = vec![SelectionResult::new(fields)];
+                    }
+                    RowSink::Single(field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        *field.node_input_field(&mut node) = Some(SelectionResult::new(fields));
+                    }
+                    RowSink::ProjectedPlaceholder(field) => {
+                        *field.node_input_field(&mut node) =
+                            Some(self.process_edge_placeholder(edge, &node, projected_selection)?);
+                    }
+                    RowSink::AllFilter(field) | RowSink::ExactlyOneFilter(field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        *field.node_input_field(&mut node) = SelectionResult::new(fields).filter();
+                    }
+                    RowSink::ExactlyOneWriteArgs(write_arg_selection, field) => {
+                        let fields = self.process_edge_selections(edge, &node, projected_selection);
+                        let result = SelectionResult::new(fields);
+                        let model = node.as_query().map(Query::model);
+                        let args = field.node_input_field(&mut node);
+                        for arg in args {
+                            arg.inject(write_arg_selection.assimilate(result.clone()).map_err(|err| {
+                                TranslateError::GraphBuildError(QueryGraphBuilderError::DomainError(err))
+                            })?);
+                            if let Some(model) = &model {
+                                arg.update_datetimes(model);
                             }
                         }
-                        RowSink::Discard => {}
                     }
-                }
+                    RowSink::Discard => {}
+                },
 
                 Some(QueryGraphDependency::DataDependency(_, _)) => todo!(),
 
@@ -617,5 +612,40 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 )
             })
             .collect_vec()
+    }
+
+    fn process_edge_placeholder(
+        &mut self,
+        edge: &EdgeRef,
+        node: &Node,
+        selection: FieldSelection,
+    ) -> TranslateResult<Placeholder> {
+        let bindings_refer_to_fields = matches!(node, Node::Query(_));
+        let binding_is_unique = matches!(node, Node::Query(q) if q.is_unique());
+        let field = selection.selections().next().ok_or_else(|| {
+            TranslateError::GraphBuildError(QueryGraphBuilderError::QueryGraphError(
+                QueryGraphError::InvariantViolation("Projected placeholder sink requires at least one field".into()),
+            ))
+        })?;
+
+        let r#type = field
+            .type_info()
+            .as_ref()
+            .map(FieldTypeInformation::to_prisma_type)
+            .unwrap_or(PrismaValueType::Any);
+        let r#type = if binding_is_unique {
+            r#type
+        } else {
+            PrismaValueType::List(r#type.into())
+        };
+
+        Ok(Placeholder {
+            name: if bindings_refer_to_fields {
+                binding::projected_dependency(self.graph.edge_source(edge), field)
+            } else {
+                binding::node_result(self.graph.edge_source(edge))
+            },
+            r#type,
+        })
     }
 }


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on the dependency cleanup and stores Flow/Diff placeholder identifiers directly to avoid wrapper allocation and cloning in translation paths.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08