### PR TITLE
perf(query-compiler): prune m2m set and disconnect phases

### DIFF
--- a/query-compiler/core/src/query_ast/write.rs
+++ b/query-compiler/core/src/query_ast/write.rs
@@ -14,6 +14,7 @@ pub enum WriteQuery {
     DeleteManyRecords(DeleteManyRecords),
     ConnectRecords(ConnectRecords),
     DisconnectRecords(DisconnectRecords),
+    DisconnectAllRecords(DisconnectAllRecords),
     ExecuteRaw(RawQuery),
     QueryRaw(RawQuery),
     Upsert(NativeUpsert),
@@ -29,6 +30,7 @@ impl WriteQuery {
             | Self::DeleteManyRecords(_)
             | Self::ConnectRecords(_)
             | Self::DisconnectRecords(_)
+            | Self::DisconnectAllRecords(_)
             | Self::ExecuteRaw(_)
             | Self::QueryRaw(_) => false,
         }
@@ -79,6 +81,7 @@ impl WriteQuery {
             Self::DeleteManyRecords(_) => None,
             Self::ConnectRecords(_) => None,
             Self::DisconnectRecords(_) => None,
+            Self::DisconnectAllRecords(_) => None,
             Self::ExecuteRaw(_) => None,
             Self::QueryRaw(_) => None,
             Self::Upsert(upsert) => Some(&upsert.selected_fields),
@@ -110,6 +113,7 @@ impl WriteQuery {
             Self::DeleteManyRecords(_) => (),
             Self::ConnectRecords(_) => (),
             Self::DisconnectRecords(_) => (),
+            Self::DisconnectAllRecords(_) => (),
             Self::ExecuteRaw(_) => (),
             Self::QueryRaw(_) => (),
             Self::Upsert(_) => (),
@@ -127,6 +131,7 @@ impl WriteQuery {
             Self::DeleteManyRecords(q) => q.model.clone(),
             Self::ConnectRecords(q) => q.relation_field.model(),
             Self::DisconnectRecords(q) => q.relation_field.model(),
+            Self::DisconnectAllRecords(q) => q.relation_field.model(),
             Self::ExecuteRaw(_) => unimplemented!(),
             Self::QueryRaw(_) => unimplemented!(),
         }
@@ -198,6 +203,7 @@ impl std::fmt::Display for WriteQuery {
             Self::DeleteManyRecords(q) => write!(f, "DeleteManyRecords: {}", q.model.name()),
             Self::ConnectRecords(_) => write!(f, "ConnectRecords"),
             Self::DisconnectRecords(_) => write!(f, "DisconnectRecords"),
+            Self::DisconnectAllRecords(_) => write!(f, "DisconnectAllRecords"),
             Self::ExecuteRaw(r) => write!(f, "ExecuteRaw: {:?}", r.inputs),
             Self::QueryRaw(r) => write!(f, "QueryRaw: {:?}", r.inputs),
             Self::Upsert(q) => write!(
@@ -236,6 +242,7 @@ impl ToGraphviz for WriteQuery {
             Self::DeleteManyRecords(q) => format!("DeleteManyRecords: {}", q.model.name()),
             Self::ConnectRecords(_) => "ConnectRecords".to_string(),
             Self::DisconnectRecords(_) => "DisconnectRecords".to_string(),
+            Self::DisconnectAllRecords(_) => "DisconnectAllRecords".to_string(),
             Self::ExecuteRaw(r) => format!("ExecuteRaw: {:#?}", r.inputs),
             Self::QueryRaw(r) => format!("QueryRaw: {:#?}", r.inputs),
             Self::Upsert(q) => format!("Upsert(model: {}", q.model().name()),
@@ -401,6 +408,12 @@ pub struct ConnectRecords {
 pub struct DisconnectRecords {
     pub parent_id: Option<SelectionResult>,
     pub child_ids: Vec<SelectionResult>,
+    pub relation_field: RelationFieldRef,
+}
+
+#[derive(Debug, Clone)]
+pub struct DisconnectAllRecords {
+    pub parent_id: Option<SelectionResult>,
     pub relation_field: RelationFieldRef,
 }
 

--- a/query-compiler/core/src/query_graph_builder/error.rs
+++ b/query-compiler/core/src/query_graph_builder/error.rs
@@ -334,7 +334,6 @@ impl From<DataOperation> for String {
 #[serde(into = "String")]
 pub(crate) enum DependentOperation {
     NestedUpdate,
-    DisconnectRecords,
     FindRecords { model: String },
     InlineRelation { model: String },
     UpdateInlinedRelation { model: String },
@@ -345,10 +344,6 @@ pub(crate) enum DependentOperation {
 impl DependentOperation {
     pub fn nested_update() -> Self {
         Self::NestedUpdate
-    }
-
-    pub fn disconnect_records() -> Self {
-        Self::DisconnectRecords
     }
 
     pub fn find_records(model: &Model) -> Self {
@@ -386,7 +381,6 @@ impl fmt::Display for DependentOperation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::NestedUpdate => write!(f, "perform a nested update"),
-            Self::DisconnectRecords => write!(f, "disconnect existing child records"),
             Self::FindRecords { model } => write!(f, "find '{model}' record(s)"),
             Self::InlineRelation { model } => write!(f, "inline the relation on '{model}' record(s)"),
             Self::UpdateInlinedRelation { model } => {

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -131,6 +131,12 @@ node_input_field!(
 );
 
 node_input_field!(
+    DisconnectAllParentInput,
+    Option<SelectionResult>,
+    Node::Query(Query::Write(WriteQuery::DisconnectAllRecords(dr))) => &mut dr.parent_id
+);
+
+node_input_field!(
     DisconnectChildrenInput,
     Vec<SelectionResult>,
     Node::Query(Query::Write(WriteQuery::DisconnectRecords(dr))) => &mut dr.child_ids

--- a/query-compiler/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-compiler/core/src/query_graph_builder/write/disconnect.rs
@@ -4,7 +4,7 @@ use crate::{
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
-use query_structure::RelationFieldRef;
+use query_structure::{RelationFieldRef, SelectionResult};
 
 /// Only for many to many relations.
 ///
@@ -74,6 +74,43 @@ pub(crate) fn disconnect_records_node(
         child_node,
         &disconnect_node,
         QueryGraphDependency::ProjectedDataDependency(child_model_id, RowSink::All(&DisconnectChildrenInput), None),
+    )?;
+
+    Ok(disconnect_node)
+}
+
+pub(crate) fn disconnect_records_node_with_child_ids(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+    child_ids: Vec<SelectionResult>,
+) -> QueryGraphBuilderResult<NodeRef> {
+    assert!(parent_relation_field.relation().is_many_to_many());
+
+    let parent_model_id = parent_relation_field.model().shard_aware_primary_identifier();
+
+    let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
+        parent_id: None,
+        child_ids,
+        relation_field: parent_relation_field.clone(),
+    });
+
+    let disconnect_node = graph.create_node(Query::Write(disconnect));
+
+    graph.create_edge(
+        parent_node,
+        &disconnect_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            parent_model_id,
+            RowSink::Single(&DisconnectParentInput),
+            Some(DataExpectation::non_empty_rows(
+                MissingRelatedRecord::builder()
+                    .model(&parent_relation_field.model())
+                    .relation(&parent_relation_field.relation())
+                    .operation(DataOperation::Disconnect)
+                    .build(),
+            )),
+        ),
     )?;
 
     Ok(disconnect_node)

--- a/query-compiler/core/src/query_graph_builder/write/disconnect.rs
+++ b/query-compiler/core/src/query_graph_builder/write/disconnect.rs
@@ -1,6 +1,6 @@
 use crate::{
     DataExpectation, DataOperation, MissingRelatedRecord, QueryGraphBuilderResult, RowSink,
-    inputs::{DisconnectChildrenInput, DisconnectParentInput},
+    inputs::{DisconnectAllParentInput, DisconnectChildrenInput, DisconnectParentInput},
     query_ast::*,
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
@@ -108,6 +108,41 @@ pub(crate) fn disconnect_records_node_with_child_ids(
                     .model(&parent_relation_field.model())
                     .relation(&parent_relation_field.relation())
                     .operation(DataOperation::Disconnect)
+                    .build(),
+            )),
+        ),
+    )?;
+
+    Ok(disconnect_node)
+}
+
+pub(crate) fn disconnect_all_records_node(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+) -> QueryGraphBuilderResult<NodeRef> {
+    assert!(parent_relation_field.relation().is_many_to_many());
+
+    let parent_model_id = parent_relation_field.model().shard_aware_primary_identifier();
+
+    let disconnect = WriteQuery::DisconnectAllRecords(DisconnectAllRecords {
+        parent_id: None,
+        relation_field: parent_relation_field.clone(),
+    });
+
+    let disconnect_node = graph.create_node(Query::Write(disconnect));
+
+    graph.create_edge(
+        parent_node,
+        &disconnect_node,
+        QueryGraphDependency::ProjectedDataDependency(
+            parent_model_id,
+            RowSink::Single(&DisconnectAllParentInput),
+            Some(DataExpectation::non_empty_rows(
+                MissingRelatedRecord::builder()
+                    .model(&parent_relation_field.model())
+                    .relation(&parent_relation_field.relation())
+                    .operation(DataOperation::NestedSet)
                     .build(),
             )),
         ),

--- a/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/disconnect_nested.rs
@@ -5,7 +5,9 @@ use crate::{
     query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
 };
 use itertools::Itertools;
-use query_structure::{Filter, Model, PrismaValue, RelationCompare, RelationFieldRef, SelectionResult, WriteArgs};
+use query_structure::{
+    Filter, Model, PrismaValue, RelationCompare, RelationFieldRef, ScalarFieldRef, SelectionResult, WriteArgs,
+};
 use std::convert::TryInto;
 
 /// Handles nested disconnect cases.
@@ -22,13 +24,34 @@ pub fn nested_disconnect(
     let relation = parent_relation_field.relation();
 
     if relation.is_many_to_many() {
-        // Build all filters upfront.
-        let filters: Vec<Filter> = utils::coerce_values(value)
+        let values = utils::coerce_values(value);
+        let mut selectors = Vec::with_capacity(values.len());
+
+        for value in values {
+            selectors.push(value.try_into()?);
+        }
+
+        if let Some(child_id_field) = child_model.single_primary_identifier_scalar() {
+            let mut child_ids = Vec::with_capacity(selectors.len());
+
+            for selector in &selectors {
+                let Some(child_id) = try_extract_child_primary_identifier(selector, &child_id_field)? else {
+                    child_ids.clear();
+                    break;
+                };
+
+                child_ids.push(child_id);
+            }
+
+            if child_ids.len() == selectors.len() {
+                let child_ids = child_ids.into_iter().unique().collect();
+                return handle_many_to_many_with_child_ids(graph, &parent_node, parent_relation_field, child_ids);
+            }
+        }
+
+        let filters: Vec<Filter> = selectors
             .into_iter()
-            .map(|value: ParsedInputValue<'_>| {
-                let value: ParsedInputMap<'_> = value.try_into()?;
-                extract_unique_filter(value, child_model)
-            })
+            .map(|value| extract_unique_filter(value, child_model))
             .collect::<QueryGraphBuilderResult<Vec<Filter>>>()?
             .into_iter()
             .unique()
@@ -74,6 +97,27 @@ pub fn nested_disconnect(
     }
 }
 
+fn try_extract_child_primary_identifier(
+    selector: &ParsedInputMap<'_>,
+    child_id_field: &ScalarFieldRef,
+) -> QueryGraphBuilderResult<Option<SelectionResult>> {
+    if selector.len() != 1 {
+        return Ok(None);
+    }
+
+    let Some((field_name, value)) = selector.iter().next() else {
+        return Ok(None);
+    };
+
+    if field_name.as_ref() != child_id_field.name() {
+        return Ok(None);
+    }
+
+    let value: PrismaValue = value.clone().try_into()?;
+
+    Ok(Some(SelectionResult::new(vec![(child_id_field.clone(), value)])))
+}
+
 /// Handles a nested many-to-many disconnect.
 ///
 /// Creates a disconnect node in the graph and creates edges to `parent_node` and `child_node`.
@@ -115,6 +159,20 @@ fn handle_many_to_many(
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, filter)?;
 
     disconnect::disconnect_records_node(graph, parent_node, &find_child_records_node, parent_relation_field)?;
+    Ok(())
+}
+
+fn handle_many_to_many_with_child_ids(
+    graph: &mut QueryGraph,
+    parent_node: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+    child_ids: Vec<SelectionResult>,
+) -> QueryGraphBuilderResult<()> {
+    if child_ids.is_empty() {
+        return Ok(());
+    }
+
+    disconnect::disconnect_records_node_with_child_ids(graph, parent_node, parent_relation_field, child_ids)?;
     Ok(())
 }
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -93,11 +93,18 @@ fn handle_many_to_many(
     parent_relation_field: &RelationFieldRef,
     filter: Filter,
 ) -> QueryGraphBuilderResult<()> {
-    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
     let child_model = parent_relation_field.related_model();
-    let child_model_identifier = child_model.shard_aware_primary_identifier();
+
+    if filter.size() == 0 {
+        disconnect::disconnect_all_records_node(graph, parent_node, parent_relation_field)?;
+        return Ok(());
+    }
+
     let read_old_node =
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
+
+    let child_model_identifier = child_model.shard_aware_primary_identifier();
+    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
 
     let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
         parent_id: None,
@@ -107,7 +114,6 @@ fn handle_many_to_many(
 
     let disconnect_node = graph.create_node(Query::Write(disconnect));
 
-    // Edge from parent to disconnect
     graph.create_edge(
         parent_node,
         &disconnect_node,
@@ -125,7 +131,6 @@ fn handle_many_to_many(
         ),
     )?;
 
-    // Edge from read to disconnect.
     graph.create_edge(
         &read_old_node,
         &disconnect_node,
@@ -136,21 +141,19 @@ fn handle_many_to_many(
         ),
     )?;
 
-    if filter.size() > 0 {
-        let expected_connects = filter.size();
-        let read_new_query = utils::read_ids_infallible(child_model, child_model_identifier, filter);
-        let read_new_node = graph.create_node(read_new_query);
+    let expected_connects = filter.size();
+    let read_new_query = utils::read_ids_infallible(child_model, child_model_identifier, filter);
+    let read_new_node = graph.create_node(read_new_query);
 
-        graph.create_edge(&disconnect_node, &read_new_node, QueryGraphDependency::ExecutionOrder)?;
+    graph.create_edge(&disconnect_node, &read_new_node, QueryGraphDependency::ExecutionOrder)?;
 
-        connect::connect_records_node(
-            graph,
-            parent_node,
-            &read_new_node,
-            parent_relation_field,
-            expected_connects,
-        )?;
-    }
+    connect::connect_records_node(
+        graph,
+        parent_node,
+        &read_new_node,
+        parent_relation_field,
+        expected_connects,
+    )?;
 
     Ok(())
 }

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -2,8 +2,7 @@ use super::*;
 use crate::{
     ParsedInputValue,
     inputs::{
-        DisconnectChildrenInput, DisconnectParentInput, IfInput, LeftSideDiffInput, RightSideDiffInput,
-        UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
+        IfInput, LeftSideDiffInput, RightSideDiffInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
     },
     query_graph::*,
 };

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -5,7 +5,6 @@ use crate::{
         DisconnectChildrenInput, DisconnectParentInput, IfInput, LeftSideDiffInput, RightSideDiffInput,
         UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput,
     },
-    query_ast::*,
     query_graph::*,
 };
 use query_structure::{Filter, Model, RelationFieldRef, SelectionResult, WriteArgs};
@@ -59,16 +58,9 @@ pub fn nested_set(
 /// │           │           │
 /// │           │           │         │
 /// │           ▼           │         ▼
-/// │  ┌─────────────────┐  │  ┌ ─ ─ ─ ─ ─ ─ ┐
-/// │  │Read old children│  │      Result
-/// │  └─────────────────┘  │  └ ─ ─ ─ ─ ─ ─ ┘
-/// │           │           │
-/// │           │           │
-/// │           │           │
-/// │           ▼           │
-/// │  ┌─────────────────┐  │
-/// │  │   Disconnect    │◀─┘
-/// │  └─────────────────┘
+/// │  ┌─────────────────┐     ┌ ─ ─ ─ ─ ─ ─ ┐
+/// │  │ Disconnect all  │        Result
+/// │  └─────────────────┘     └ ─ ─ ─ ─ ─ ─ ┘
 /// │           │
 /// │           │
 /// │           │
@@ -95,52 +87,13 @@ fn handle_many_to_many(
 ) -> QueryGraphBuilderResult<()> {
     let child_model = parent_relation_field.related_model();
 
+    let disconnect_node = disconnect::disconnect_all_records_node(graph, parent_node, parent_relation_field)?;
+
     if filter.size() == 0 {
-        disconnect::disconnect_all_records_node(graph, parent_node, parent_relation_field)?;
         return Ok(());
     }
 
-    let read_old_node =
-        utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
-
     let child_model_identifier = child_model.shard_aware_primary_identifier();
-    let parent_model_identifier = parent_relation_field.model().shard_aware_primary_identifier();
-
-    let disconnect = WriteQuery::DisconnectRecords(DisconnectRecords {
-        parent_id: None,
-        child_ids: vec![],
-        relation_field: parent_relation_field.clone(),
-    });
-
-    let disconnect_node = graph.create_node(Query::Write(disconnect));
-
-    graph.create_edge(
-        parent_node,
-        &disconnect_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            parent_model_identifier,
-            RowSink::Single(&DisconnectParentInput),
-            Some(DataExpectation::non_empty_rows(
-                MissingRelatedRecord::builder()
-                    .model(&parent_relation_field.model())
-                    .relation(&parent_relation_field.relation())
-                    .needed_for(DependentOperation::disconnect_records())
-                    .operation(DataOperation::NestedSet)
-                    .build(),
-            )),
-        ),
-    )?;
-
-    graph.create_edge(
-        &read_old_node,
-        &disconnect_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_model_identifier.clone(),
-            RowSink::All(&DisconnectChildrenInput),
-            None,
-        ),
-    )?;
-
     let expected_connects = filter.size();
     let read_new_query = utils::read_ids_infallible(child_model, child_model_identifier, filter);
     let read_new_node = graph.create_node(read_new_query);

--- a/query-compiler/query-builders/query-builder/src/lib.rs
+++ b/query-compiler/query-builders/query-builder/src/lib.rs
@@ -95,6 +95,12 @@ pub trait QueryBuilder {
         child_ids: &[SelectionResult],
     ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>>;
 
+    fn build_m2m_disconnect_all(
+        &self,
+        field: RelationField,
+        parent_id: &SelectionResult,
+    ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>>;
+
     fn build_delete(
         &self,
         model: &Model,

--- a/query-compiler/query-builders/sql-query-builder/src/lib.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/lib.rs
@@ -453,6 +453,17 @@ impl<'a, V: Visitor<'a>> QueryBuilder for SqlQueryBuilder<'a, V> {
         self.convert_query(query, chunkable)
     }
 
+    fn build_m2m_disconnect_all(
+        &self,
+        field: RelationField,
+        parent_id: &SelectionResult,
+    ) -> Result<DbQuery, Box<dyn std::error::Error + Send + Sync>> {
+        // Delete by parent id is always chunkable.
+        let chunkable = Chunkable::Yes;
+        let query = write::delete_relation_table_records_for_parent(&field, parent_id, &self.context);
+        self.convert_query(query, chunkable)
+    }
+
     fn build_delete(
         &self,
         model: &Model,

--- a/query-compiler/query-builders/sql-query-builder/src/write.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/write.rs
@@ -373,6 +373,21 @@ pub fn delete_relation_table_records(
         .add_traceparent(ctx.traceparent)
 }
 
+pub fn delete_relation_table_records_for_parent(
+    parent_field: &RelationFieldRef,
+    parent_id: &SelectionResult,
+    ctx: &Context<'_>,
+) -> Delete<'static> {
+    let relation = parent_field.relation();
+
+    let parent_column = parent_field.related_field().m2m_column(ctx);
+    let parent_id_values = parent_id.db_values(ctx);
+
+    Delete::from_table(relation.as_table(ctx))
+        .so_that(parent_column.equals(parent_id_values))
+        .add_traceparent(ctx.traceparent)
+}
+
 /// Generates a list of insert statements to execute. If `selected_fields` is set, insert statements
 /// will return the specified columns of inserted rows.
 pub fn generate_insert_statements(

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -106,6 +106,7 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         WriteQuery::DeleteManyRecords(_) => None, // No result data
         WriteQuery::ConnectRecords(_) => None,    // No result data
         WriteQuery::DisconnectRecords(_) => None, // No result data
+        WriteQuery::DisconnectAllRecords(_) => None, // No result data
         WriteQuery::ExecuteRaw(_) => None,        // No data mapping
         WriteQuery::QueryRaw(_) => None,          // No data mapping
         WriteQuery::Upsert(q) => get_result_node()

--- a/query-compiler/query-compiler/src/data_mapper.rs
+++ b/query-compiler/query-compiler/src/data_mapper.rs
@@ -103,12 +103,12 @@ fn map_write_query(query: &WriteQuery, builder: &mut ResultNodeBuilder) -> Optio
         }
         WriteQuery::DeleteRecord(q) => get_result_node_for_delete(q.selected_fields.as_ref(), builder),
         WriteQuery::UpdateManyRecords(q) => get_result_node_for_update_many(q.selected_fields.as_ref(), builder),
-        WriteQuery::DeleteManyRecords(_) => None, // No result data
-        WriteQuery::ConnectRecords(_) => None,    // No result data
-        WriteQuery::DisconnectRecords(_) => None, // No result data
+        WriteQuery::DeleteManyRecords(_) => None,    // No result data
+        WriteQuery::ConnectRecords(_) => None,       // No result data
+        WriteQuery::DisconnectRecords(_) => None,    // No result data
         WriteQuery::DisconnectAllRecords(_) => None, // No result data
-        WriteQuery::ExecuteRaw(_) => None,        // No data mapping
-        WriteQuery::QueryRaw(_) => None,          // No data mapping
+        WriteQuery::ExecuteRaw(_) => None,           // No data mapping
+        WriteQuery::QueryRaw(_) => None,             // No data mapping
         WriteQuery::Upsert(q) => get_result_node()
             .field_selection(&q.selected_fields)
             .selection_order(&q.selection_order)

--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -1,8 +1,8 @@
 use itertools::{Either, Itertools};
 use query_builder::{CreateRecord, CreateRecordDefaultsQuery, QueryBuilder};
 use query_core::{
-    ConnectRecords, DeleteManyRecords, DeleteRecord, DisconnectRecords, RawQuery, UpdateManyRecords, UpdateRecord,
-    UpdateRecordWithSelection, UpdateRecordWithoutSelection, WriteQuery,
+    ConnectRecords, DeleteManyRecords, DeleteRecord, DisconnectAllRecords, DisconnectRecords, RawQuery,
+    UpdateManyRecords, UpdateRecord, UpdateRecordWithSelection, UpdateRecordWithoutSelection, WriteQuery,
 };
 use query_structure::{
     FieldSelection, Filter, IntoFilter, Model, PrismaValue, PrismaValueType, QueryArguments, RecordFilter,
@@ -362,6 +362,17 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
             let parent_id = parent_id.as_ref().expect("should have parent ID for disconnect");
             let query = builder
                 .build_m2m_disconnect(relation_field, parent_id, &child_ids)
+                .map_err(TranslateError::QueryBuildFailure)?;
+            Expression::Execute(query)
+        }
+
+        WriteQuery::DisconnectAllRecords(DisconnectAllRecords {
+            parent_id,
+            relation_field,
+        }) => {
+            let parent_id = parent_id.as_ref().expect("should have parent ID for disconnect-all");
+            let query = builder
+                .build_m2m_disconnect_all(relation_field, parent_id)
                 .map_err(TranslateError::QueryBuildFailure)?;
             Expression::Execute(query)
         }

--- a/query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
+++ b/query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "Post",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "id": 1 },
+      "data": { "categories": { "set": [] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "categories": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/update-m2m-set.json
+++ b/query-compiler/query-compiler/tests/data/update-m2m-set.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "Post",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "id": 1 },
+      "data": { "categories": { "set": [{ "id": 1 }, { "id": 2 }] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "categories": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -15,22 +15,14 @@ transaction
                           $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
-   in let 0$id = mapField id (get 0)
-      in let 1 = query «SELECT "public"."Category"."id", "t0"."B" AS
-                        "CategoryToPost@Post" FROM "public"."Category" INNER
-                        JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
-                        "public"."Category"."id" WHERE ("public"."Category"."id"
-                        = $1 AND 1=1 AND "t0"."B" IN [$2,*]) OFFSET $3»
-                 params [const(BigInt(1)), var(0$id as Int), const(BigInt(0))]
-         in let 0 = unique (validate (get 0)
-                [ rowCountNeq 0
-                ] orRaise "MISSING_RELATED_RECORD");
-                0$id = mapField id (get 0);
-                1$id = mapField id (get 1)
-            in execute «DELETE FROM "public"."_CategoryToPost" WHERE
-                        ("public"."_CategoryToPost"."B" = ($1) AND
-                        "public"."_CategoryToPost"."A" IN [$2,*])»
-               params [var(0$id as Int), var(1$id as Int)];
+   in let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RELATED_RECORD");
+          0$id = mapField id (get 0)
+      in execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                  ("public"."_CategoryToPost"."B" = ($1) AND
+                  "public"."_CategoryToPost"."A" IN ($2))»
+         params [var(0$id as Int), const(BigInt(1))];
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
@@ -1,5 +1,6 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
 snapshot_kind: text
@@ -16,7 +17,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
                           "public"."Post"."userId" FROM "public"."Post" WHERE
-                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                          ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0 = unique (validate (get 0)
@@ -30,47 +32,20 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
-                                     "public"."Post"."title",
-                                     "public"."Post"."userId" FROM
-                                     "public"."Post" WHERE "public"."Post"."id"
-                                     = $1 LIMIT $2 OFFSET $3»
-                              params [var(0$id as Int), const(BigInt(1)),
-                                      const(BigInt(0))]
-                              fields {
-                                  id: 0
-                                  title: 1
-                                  userId: 2
-                              }
-                              relations [categories on left.0 = right.2 many (query
-                                                                              «SELECT
-                                                                               "public"."Category"."id",
-                                                                               "public"."Category"."name",
-                                                                               "t0"."B"
-                                                                               AS
-                                                                               "CategoryToPost@Post"
-                                                                               FROM
-                                                                               "public"."Category"
-                                                                               INNER
-                                                                               JOIN
-                                                                               "public"."_CategoryToPost"
-                                                                               AS
-                                                                               "t0"
-                                                                               ON
-                                                                               "t0"."A"
-                                                                               =
-                                                                               "public"."Category"."id"
-                                                                               WHERE
-                                                                               (1=1
-                                                                               AND
-                                                                               "t0"."B"
-                                                                               =
-                                                                               $1)
-                                                                               OFFSET
-                                                                               $2»
-                                                                              params [var(@parent$id as Int),
-                                                                                      const(BigInt(0))]
-                                                                              fields {
-                                                                                  id: 0
-                                                                                  name: 1
-                                                                              })])
+      in let @parent = unique (query «SELECT "public"."Post"."id",
+                                      "public"."Post"."title",
+                                      "public"."Post"."userId" FROM
+                                      "public"."Post" WHERE "public"."Post"."id"
+                                      = $1 LIMIT $2 OFFSET $3»
+                               params [var(0$id as Int), const(BigInt(1)),
+                                       const(BigInt(0))])
+         in let @parent$id = mapField id (get @parent)
+            in join (get @parent)
+               with (query «SELECT "public"."Category"."id",
+                            "public"."Category"."name", "t0"."B" AS
+                            "CategoryToPost@Post" FROM "public"."Category" INNER
+                            JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A"
+                            = "public"."Category"."id" WHERE (1=1 AND "t0"."B" =
+                            $1) OFFSET $2»
+                     params [var(@parent$id as Int),
+                             const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
@@ -1,0 +1,76 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       title: String (title)
+       userId: Int (userId)
+       categories (from @nested$categories): {
+           id: Int (id)
+           name: String (name)
+       }
+   }
+   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                          "public"."Post"."userId" FROM "public"."Post" WHERE
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RELATED_RECORD");
+          0$id = mapField id (get 0)
+      in execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                  "public"."_CategoryToPost"."B" = ($1)»
+         params [var(0$id as Int)];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                     "public"."Post"."title",
+                                     "public"."Post"."userId" FROM
+                                     "public"."Post" WHERE "public"."Post"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  title: 1
+                                  userId: 2
+                              }
+                              relations [categories on left.0 = right.2 many (query
+                                                                              «SELECT
+                                                                               "public"."Category"."id",
+                                                                               "public"."Category"."name",
+                                                                               "t0"."B"
+                                                                               AS
+                                                                               "CategoryToPost@Post"
+                                                                               FROM
+                                                                               "public"."Category"
+                                                                               INNER
+                                                                               JOIN
+                                                                               "public"."_CategoryToPost"
+                                                                               AS
+                                                                               "t0"
+                                                                               ON
+                                                                               "t0"."A"
+                                                                               =
+                                                                               "public"."Category"."id"
+                                                                               WHERE
+                                                                               (1=1
+                                                                               AND
+                                                                               "t0"."B"
+                                                                               =
+                                                                               $1)
+                                                                               OFFSET
+                                                                               $2»
+                                                                              params [var(@parent$id as Int),
+                                                                                      const(BigInt(0))]
+                                                                              fields {
+                                                                                  id: 0
+                                                                                  name: 1
+                                                                              })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
@@ -1,0 +1,92 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-m2m-set.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       title: String (title)
+       userId: Int (userId)
+       categories (from @nested$categories): {
+           id: Int (id)
+           name: String (name)
+       }
+   }
+   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
+                          "public"."Post"."userId" FROM "public"."Post" WHERE
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RELATED_RECORD");
+          0$id = mapField id (get 0)
+      in let 1 = execute «DELETE FROM "public"."_CategoryToPost" WHERE
+                          "public"."_CategoryToPost"."B" = ($1)»
+                 params [var(0$id as Int)]
+         in let 2 = query «SELECT "public"."Category"."id" FROM
+                           "public"."Category" WHERE ("public"."Category"."id" =
+                           $1 OR "public"."Category"."id" = $2) OFFSET $3»
+                    params [const(BigInt(1)), const(BigInt(2)),
+                            const(BigInt(0))]
+            in let 0 = unique (validate (get 0)
+                   [ rowCountNeq 0
+                   ] orRaise "MISSING_RELATED_RECORD");
+                   0$id = mapField id (get 0);
+                   2 = validate (get 2)
+                   [ rowCountEq 2
+                   ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                   2$id = mapField id (get 2)
+               in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                           VALUES [($1),*],* ON CONFLICT DO NOTHING»
+                  params [product(var(0$id as Int[]), var(2$id as Int[]))];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
+                                     "public"."Post"."title",
+                                     "public"."Post"."userId" FROM
+                                     "public"."Post" WHERE "public"."Post"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  title: 1
+                                  userId: 2
+                              }
+                              relations [categories on left.0 = right.2 many (query
+                                                                              «SELECT
+                                                                               "public"."Category"."id",
+                                                                               "public"."Category"."name",
+                                                                               "t0"."B"
+                                                                               AS
+                                                                               "CategoryToPost@Post"
+                                                                               FROM
+                                                                               "public"."Category"
+                                                                               INNER
+                                                                               JOIN
+                                                                               "public"."_CategoryToPost"
+                                                                               AS
+                                                                               "t0"
+                                                                               ON
+                                                                               "t0"."A"
+                                                                               =
+                                                                               "public"."Category"."id"
+                                                                               WHERE
+                                                                               (1=1
+                                                                               AND
+                                                                               "t0"."B"
+                                                                               =
+                                                                               $1)
+                                                                               OFFSET
+                                                                               $2»
+                                                                              params [var(@parent$id as Int),
+                                                                                      const(BigInt(0))]
+                                                                              fields {
+                                                                                  id: 0
+                                                                                  name: 1
+                                                                              })])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
@@ -1,5 +1,6 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
+assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-set.json
 snapshot_kind: text
@@ -16,7 +17,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
                           "public"."Post"."userId" FROM "public"."Post" WHERE
-                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
+                          ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0 = unique (validate (get 0)
@@ -27,8 +29,9 @@ transaction
                           "public"."_CategoryToPost"."B" = ($1)»
                  params [var(0$id as Int)]
          in let 2 = query «SELECT "public"."Category"."id" FROM
-                           "public"."Category" WHERE ("public"."Category"."id" =
-                           $1 OR "public"."Category"."id" = $2) OFFSET $3»
+                           "public"."Category" WHERE (("public"."Category"."id"
+                           = $1 AND 1=1) OR ("public"."Category"."id" = $2 AND
+                           1=1)) OFFSET $3»
                     params [const(BigInt(1)), const(BigInt(2)),
                             const(BigInt(0))]
             in let 0 = unique (validate (get 0)
@@ -46,47 +49,20 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in rawNestedReadUnique (query «SELECT "public"."Post"."id",
-                                     "public"."Post"."title",
-                                     "public"."Post"."userId" FROM
-                                     "public"."Post" WHERE "public"."Post"."id"
-                                     = $1 LIMIT $2 OFFSET $3»
-                              params [var(0$id as Int), const(BigInt(1)),
-                                      const(BigInt(0))]
-                              fields {
-                                  id: 0
-                                  title: 1
-                                  userId: 2
-                              }
-                              relations [categories on left.0 = right.2 many (query
-                                                                              «SELECT
-                                                                               "public"."Category"."id",
-                                                                               "public"."Category"."name",
-                                                                               "t0"."B"
-                                                                               AS
-                                                                               "CategoryToPost@Post"
-                                                                               FROM
-                                                                               "public"."Category"
-                                                                               INNER
-                                                                               JOIN
-                                                                               "public"."_CategoryToPost"
-                                                                               AS
-                                                                               "t0"
-                                                                               ON
-                                                                               "t0"."A"
-                                                                               =
-                                                                               "public"."Category"."id"
-                                                                               WHERE
-                                                                               (1=1
-                                                                               AND
-                                                                               "t0"."B"
-                                                                               =
-                                                                               $1)
-                                                                               OFFSET
-                                                                               $2»
-                                                                              params [var(@parent$id as Int),
-                                                                                      const(BigInt(0))]
-                                                                              fields {
-                                                                                  id: 0
-                                                                                  name: 1
-                                                                              })])
+      in let @parent = unique (query «SELECT "public"."Post"."id",
+                                      "public"."Post"."title",
+                                      "public"."Post"."userId" FROM
+                                      "public"."Post" WHERE "public"."Post"."id"
+                                      = $1 LIMIT $2 OFFSET $3»
+                               params [var(0$id as Int), const(BigInt(1)),
+                                       const(BigInt(0))])
+         in let @parent$id = mapField id (get @parent)
+            in join (get @parent)
+               with (query «SELECT "public"."Category"."id",
+                            "public"."Category"."name", "t0"."B" AS
+                            "CategoryToPost@Post" FROM "public"."Category" INNER
+                            JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A"
+                            = "public"."Category"."id" WHERE (1=1 AND "t0"."B" =
+                            $1) OFFSET $2»
+                     params [var(@parent$id as Int),
+                             const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories

--- a/query-compiler/query-structure/src/model.rs
+++ b/query-compiler/query-structure/src/model.rs
@@ -20,6 +20,17 @@ impl Model {
             .into()
     }
 
+    pub fn single_primary_identifier_scalar(&self) -> Option<ScalarFieldRef> {
+        let mut ids = self.primary_identifier_scalars();
+        let id = ids.next()?;
+
+        if ids.next().is_some() {
+            return None;
+        }
+
+        Some(self.dm.clone().zip(ScalarFieldId::InModel(id)))
+    }
+
     fn primary_identifier_scalars(&self) -> impl Iterator<Item = psl::parser_database::ScalarFieldId> + use<'_> {
         match self.walker().required_unique_criterias().next() {
             Some(unique) => Either::Left(unique.fields().map(|f| {


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on direct placeholder storage and removes unnecessary many-to-many set/disconnect child-read phases for the proved relation-table shapes.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08