### PR TITLE
perf(query-compiler): specialize empty required set paths

### DIFF
--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -165,7 +165,6 @@ fn handle_one_to_many(
     let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
     let child_link = parent_relation_field.related_field().linking_fields();
     let parent_link = parent_relation_field.linking_fields();
-    let empty_child_link = SelectionResult::from(&child_link);
     let child_side_required = parent_relation_field.related_field().is_required();
 
     let child_model = parent_relation_field.related_model();
@@ -173,21 +172,24 @@ fn handle_one_to_many(
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
 
     if filter.size() == 0 {
+        if child_side_required {
+            insert_required_relation_disconnect_check(graph, &read_old_node, parent_relation_field)?;
+            return Ok(());
+        }
+
         let disconnect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
+        let empty_child_link = SelectionResult::from(&child_link);
         let write_args = WriteArgs::from_result(empty_child_link, crate::request_context::get_request_now());
         let update_disconnect_node =
             utils::update_records_node_placeholder_with_args(graph, Filter::empty(), child_model, write_args);
-
-        let child_side_required = parent_relation_field.related_field().is_required();
-        let rf = parent_relation_field.clone();
 
         graph.create_edge(
             &read_old_node,
             &disconnect_if_node,
             QueryGraphDependency::ProjectedDataDependency(
                 child_model_identifier.clone(),
-                RowSink::All(&IfInput),
-                child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
+                RowSink::ProjectedPlaceholder(&IfInput),
+                None,
             ),
         )?;
 
@@ -306,6 +308,7 @@ fn handle_one_to_many(
     // Update (connect) case: Check left diff IDs
     let connect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
     let update_connect_node = utils::update_records_node_placeholder(graph, Filter::empty(), child_model.clone());
+    let empty_child_link = (!child_side_required).then(|| SelectionResult::from(&child_link));
 
     graph.create_edge(
         &diff_left_to_right_node,
@@ -346,12 +349,18 @@ fn handle_one_to_many(
     )?;
 
     // Update (disconnect) case: Check right diff IDs.
+    if child_side_required {
+        insert_required_relation_disconnect_check(graph, &diff_right_to_left_node, parent_relation_field)?;
+        return Ok(());
+    }
+
     let disconnect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
-    let write_args = WriteArgs::from_result(empty_child_link, crate::request_context::get_request_now());
+    let write_args = WriteArgs::from_result(
+        empty_child_link.expect("optional child side needs null write args"),
+        crate::request_context::get_request_now(),
+    );
     let update_disconnect_node =
         utils::update_records_node_placeholder_with_args(graph, Filter::empty(), child_model, write_args);
-
-    let rf = parent_relation_field.clone();
 
     graph.create_edge(
         &diff_right_to_left_node,
@@ -359,7 +368,7 @@ fn handle_one_to_many(
         QueryGraphDependency::ProjectedDataDependency(
             child_model_identifier.clone(),
             RowSink::ProjectedPlaceholder(&IfInput),
-            child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
+            None,
         ),
     )?;
 
@@ -372,6 +381,27 @@ fn handle_one_to_many(
             child_model_identifier,
             RowSink::All(&UpdateManyRecordsSelectorsInput),
             None,
+        ),
+    )?;
+
+    Ok(())
+}
+
+fn insert_required_relation_disconnect_check(
+    graph: &mut QueryGraph,
+    node_providing_ids: &NodeRef,
+    parent_relation_field: &RelationFieldRef,
+) -> QueryGraphBuilderResult<()> {
+    let check_node = graph.create_node(Node::Empty);
+
+    graph.create_edge(
+        node_providing_ids,
+        &check_node,
+        QueryGraphDependency::DataDependency(
+            RowCountSink::Discard,
+            Some(DataExpectation::empty_rows(RelationViolation::from(
+                parent_relation_field.clone(),
+            ))),
         ),
     )?;
 

--- a/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/set_nested.rs
@@ -172,6 +172,39 @@ fn handle_one_to_many(
     let read_old_node =
         utils::insert_find_children_by_parent_node(graph, parent_node, parent_relation_field, Filter::empty())?;
 
+    if filter.size() == 0 {
+        let disconnect_if_node = graph.create_node(Node::Flow(Flow::if_non_empty()));
+        let write_args = WriteArgs::from_result(empty_child_link, crate::request_context::get_request_now());
+        let update_disconnect_node =
+            utils::update_records_node_placeholder_with_args(graph, Filter::empty(), child_model, write_args);
+
+        let child_side_required = parent_relation_field.related_field().is_required();
+        let rf = parent_relation_field.clone();
+
+        graph.create_edge(
+            &read_old_node,
+            &disconnect_if_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::All(&IfInput),
+                child_side_required.then(|| DataExpectation::empty_rows(RelationViolation::from(rf))),
+            ),
+        )?;
+
+        graph.create_edge(&disconnect_if_node, &update_disconnect_node, QueryGraphDependency::Then)?;
+        graph.create_edge(
+            &read_old_node,
+            &update_disconnect_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier,
+                RowSink::All(&UpdateManyRecordsSelectorsInput),
+                None,
+            ),
+        )?;
+
+        return Ok(());
+    }
+
     let read_new_query = utils::read_ids_infallible(child_model.clone(), child_model_identifier.clone(), filter);
     let read_new_node = graph.create_node(read_new_query);
 

--- a/query-compiler/query-compiler/tests/data/update-set-nested-empty.json
+++ b/query-compiler/query-compiler/tests/data/update-set-nested-empty.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "User",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1737556028164@prisma.io" },
+      "data": { "posts": { "set": [] } }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "posts": {
+        "arguments": {},
+        "selection": { "$composites": true, "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
@@ -23,7 +23,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
                           "public"."User"."role"::text FROM "public"."User"
-                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
+                          OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)
@@ -31,53 +32,26 @@ transaction
                         FROM "public"."Post" WHERE (1=1 AND
                         "public"."Post"."userId" IN [$1,*]) OFFSET $2»
                  params [var(0$id as Int), const(BigInt(0))]
-         in let 1 = validate (get 1)
-                [ rowCountEq 0
-                ] orRaise "RELATION_VIOLATION"
-            in if (rowCountNeq 0 (get 1))
-               then let 1$id = mapField id (get 1)
-                    in execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                                ("public"."Post"."id" IN [$2,*] AND 1=1)»
-                       params [const(Null), var(1$id as Int)]
-               else ();
+         in validate (get 1)
+            [ rowCountEq 0
+            ] orRaise "RELATION_VIOLATION";
+            ();
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in rawNestedReadUnique (query «SELECT "public"."User"."id",
-                                     "public"."User"."email",
-                                     "public"."User"."role"::text FROM
-                                     "public"."User" WHERE "public"."User"."id"
-                                     = $1 LIMIT $2 OFFSET $3»
-                              params [var(0$id as Int), const(BigInt(1)),
-                                      const(BigInt(0))]
-                              fields {
-                                  id: 0
-                                  email: 1
-                                  role: 2
-                              }
-                              relations [posts on left.0 = right.2 many (query
-                                                                         «SELECT
-                                                                          "public"."Post"."id",
-                                                                          "public"."Post"."title",
-                                                                          "public"."Post"."userId"
-                                                                          FROM
-                                                                          "public"."Post"
-                                                                          WHERE
-                                                                          "public"."Post"."userId"
-                                                                          = $1
-                                                                          OFFSET
-                                                                          $2»
-                                                                         params [var(@parent$id as Int),
-                                                                                 const(BigInt(0))]
-                                                                         fields {
-                                                                             id: 0
-                                                                             title: 1
-                                                                             userId: 2
-                                                                         })])
-         enums {
-             Role: {
-                 admin: ADMIN
-                 user: USER
-             }
-         }
+      in let @parent = unique (query «SELECT "public"."User"."id",
+                                      "public"."User"."email",
+                                      "public"."User"."role"::text FROM
+                                      "public"."User" WHERE "public"."User"."id"
+                                      = $1 LIMIT $2 OFFSET $3»
+                               params [var(0$id as Int), const(BigInt(1)),
+                                       const(BigInt(0))])
+         in let @parent$id = mapField id (get @parent)
+            in join (get @parent)
+               with (query «SELECT "public"."Post"."id",
+                            "public"."Post"."title", "public"."Post"."userId"
+                            FROM "public"."Post" WHERE "public"."Post"."userId"
+                            = $1 OFFSET $2»
+                     params [var(@parent$id as Int),
+                             const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
@@ -1,0 +1,83 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-set-nested-empty.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+       posts (from @nested$posts): {
+           id: Int (id)
+           title: String (title)
+           userId: Int (userId)
+       }
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
+                          "public"."User"."role"::text FROM "public"."User"
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+                   params [const(String("user.1737556028164@prisma.io")),
+                           const(BigInt(1)), const(BigInt(0))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = query «SELECT "public"."Post"."id", "public"."Post"."userId"
+                        FROM "public"."Post" WHERE (1=1 AND
+                        "public"."Post"."userId" IN [$1,*]) OFFSET $2»
+                 params [var(0$id as Int), const(BigInt(0))]
+         in let 1 = validate (get 1)
+                [ rowCountEq 0
+                ] orRaise "RELATION_VIOLATION"
+            in if (rowCountNeq 0 (get 1))
+               then let 1$id = mapField id (get 1)
+                    in execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
+                                ("public"."Post"."id" IN [$2,*] AND 1=1)»
+                       params [const(Null), var(1$id as Int)]
+               else ();
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  email: 1
+                                  role: 2
+                              }
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         })])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-set-nested.json
+snapshot_kind: text
 ---
 transaction
    dataMap {


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on required set pruning and specializes empty required set paths to avoid redundant graph phases.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08