### PR TITLE
perf(query-compiler): prune connect-or-create branches

### DIFF
--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -68,8 +68,13 @@ impl From<Flow> for Node {
 
 pub enum Flow {
     /// Expresses a conditional control flow in the graph.
-    /// Possible outgoing edges are `then` and `else`, each at most once, with `then` required to be present.
-    If { rule: DataRule, data: Option<Placeholder> },
+    /// Possible outgoing edges are `then` and `else`, each at most once.
+    /// `then` is required unless `then_returns_condition` is set, in which case the condition input is also the then-branch result.
+    If {
+        rule: DataRule,
+        data: Option<Placeholder>,
+        then_returns_condition: bool,
+    },
 
     /// Returns a fixed set of results at runtime.
     Return(Option<Placeholder>),
@@ -80,6 +85,15 @@ impl Flow {
         Self::If {
             rule: DataRule::RowCountNeq(0),
             data: None,
+            then_returns_condition: false,
+        }
+    }
+
+    pub fn if_non_empty_returning_condition() -> Self {
+        Self::If {
+            rule: DataRule::RowCountNeq(0),
+            data: None,
+            then_returns_condition: true,
         }
     }
 
@@ -87,6 +101,7 @@ impl Flow {
         Self::If {
             rule: DataRule::Never,
             data: None,
+            then_returns_condition: false,
         }
     }
 }

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -108,34 +108,51 @@ fn handle_many_to_many(
         let create_map: ParsedInputMap<'_> = create_arg.try_into()?;
 
         let filter = extract_unique_filter(where_map, child_model)?;
+        let child_model_identifier = child_model.shard_aware_primary_identifier();
         let read_node = graph.create_node(utils::read_id_infallible(
             child_model.clone(),
-            child_model.shard_aware_primary_identifier(),
+            child_model_identifier.clone(),
             filter,
         ));
 
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let if_node = graph.create_node(Flow::if_non_empty());
-
-        let connect_exists_node =
-            connect::connect_records_node(graph, &parent_node, &read_node, parent_relation_field, 1)?;
-
-        let _connect_create_node =
-            connect::connect_records_node(graph, &parent_node, &create_node, parent_relation_field, 1)?;
+        let return_existing = graph.create_node(Flow::Return(None));
+        let return_create = graph.create_node(Flow::Return(None));
 
         graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
         graph.create_edge(
             &read_node,
             &if_node,
             QueryGraphDependency::ProjectedDataDependency(
-                child_model.shard_aware_primary_identifier(),
+                child_model_identifier.clone(),
                 RowSink::ProjectedPlaceholder(&IfInput),
                 None,
             ),
         )?;
 
-        graph.create_edge(&if_node, &connect_exists_node, QueryGraphDependency::Then)?;
+        graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
         graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
+        graph.create_edge(
+            &read_node,
+            &return_existing,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier.clone(),
+                RowSink::ProjectedPlaceholder(&ReturnInput),
+                None,
+            ),
+        )?;
+        graph.create_edge(
+            &create_node,
+            &return_create,
+            QueryGraphDependency::ProjectedDataDependency(
+                child_model_identifier,
+                RowSink::ProjectedPlaceholder(&ReturnInput),
+                None,
+            ),
+        )?;
+
+        connect::connect_records_node(graph, &parent_node, &if_node, parent_relation_field, 1)?;
     }
 
     Ok(())

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -116,9 +116,7 @@ fn handle_many_to_many(
         ));
 
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
-        let if_node = graph.create_node(Flow::if_non_empty());
-        let return_existing = graph.create_node(Flow::Return(None));
-        let return_create = graph.create_node(Flow::Return(None));
+        let if_node = graph.create_node(Flow::if_non_empty_returning_condition());
 
         graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
         graph.create_edge(
@@ -131,26 +129,7 @@ fn handle_many_to_many(
             ),
         )?;
 
-        graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
         graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
-        graph.create_edge(
-            &read_node,
-            &return_existing,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model_identifier.clone(),
-                RowSink::ProjectedPlaceholder(&ReturnInput),
-                None,
-            ),
-        )?;
-        graph.create_edge(
-            &create_node,
-            &return_create,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model_identifier,
-                RowSink::ProjectedPlaceholder(&ReturnInput),
-                None,
-            ),
-        )?;
 
         connect::connect_records_node(graph, &parent_node, &if_node, parent_relation_field, 1)?;
     }
@@ -411,9 +390,8 @@ fn one_to_many_inlined_parent(
     graph.mark_nodes(&parent_node, &read_node);
     graph.create_edge(&parent_node, &read_node, QueryGraphDependency::ExecutionOrder)?;
 
-    let if_node = graph.create_node(Flow::if_non_empty());
+    let if_node = graph.create_node(Flow::if_non_empty_returning_condition());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
-    let return_existing = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
@@ -425,7 +403,6 @@ fn one_to_many_inlined_parent(
         ),
     )?;
 
-    graph.create_edge(&if_node, &return_existing, QueryGraphDependency::Then)?;
     graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
 
     graph.create_edge(
@@ -434,16 +411,6 @@ fn one_to_many_inlined_parent(
         QueryGraphDependency::ProjectedDataDependency(
             child_link.clone(),
             RowSink::ExactlyOneWriteArgs(parent_link, &UpdateOrCreateArgsInput),
-            None,
-        ),
-    )?;
-
-    graph.create_edge(
-        &read_node,
-        &return_existing,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_link.clone(),
-            RowSink::ProjectedPlaceholder(&ReturnInput),
             None,
         ),
     )?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/connect_or_create_nested.rs
@@ -414,7 +414,6 @@ fn one_to_many_inlined_parent(
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
     let return_existing = graph.create_node(Flow::Return(None));
-    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
@@ -447,12 +446,6 @@ fn one_to_many_inlined_parent(
             RowSink::ProjectedPlaceholder(&ReturnInput),
             None,
         ),
-    )?;
-
-    graph.create_edge(
-        &create_node,
-        &return_create,
-        QueryGraphDependency::ProjectedDataDependency(child_link, RowSink::ProjectedPlaceholder(&ReturnInput), None),
     )?;
 
     Ok(())
@@ -551,7 +544,6 @@ fn one_to_one_inlined_parent(
     let if_node = graph.create_node(Flow::if_non_empty());
     let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_data)?;
     let return_existing = graph.create_node(Flow::Return(None));
-    let return_create = graph.create_node(Flow::Return(None));
 
     graph.create_edge(
         &read_node,
@@ -586,16 +578,6 @@ fn one_to_one_inlined_parent(
 
     // Else branch handling
     graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
-    graph.create_edge(
-        &create_node,
-        &return_create,
-        QueryGraphDependency::ProjectedDataDependency(
-            child_link.clone(),
-            RowSink::ProjectedPlaceholder(&ReturnInput),
-            None,
-        ),
-    )?;
-
     if utils::node_is_create(graph, &parent_node) {
         // No need to perform checks, a child can't exist if the parent is just getting created. Simply inject.
         graph.create_edge(

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -253,8 +253,16 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             }
         }
 
+        let then_returns_condition = match self.graph.node_content(&self.node) {
+            Some(Node::Flow(Flow::If {
+                then_returns_condition, ..
+            })) => *then_returns_condition,
+            _ => false,
+        };
+
         let then_expr = match then_node {
-            Some(node) => self.process_child_with_dependencies(node)?,
+            Some(node) => Some(self.process_child_with_dependencies(node)?),
+            None if then_returns_condition => None,
             None => {
                 return Err(TranslateError::GraphBuildError(
                     QueryGraphBuilderError::QueryGraphError(QueryGraphError::InvariantViolation(
@@ -274,10 +282,13 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         let node = self.graph.pluck_node(&self.node);
         let node = self.transform_node(node)?;
 
-        let Node::Flow(Flow::If { rule, data }) = node else {
+        let Node::Flow(Flow::If { rule, data, .. }) = node else {
             panic!("current node must be Flow::If");
         };
         let placeholder = projected_placeholder(data, "If")?;
+        let then_expr = then_expr.unwrap_or_else(|| Expression::Get {
+            name: placeholder.name.clone(),
+        });
 
         let expr = Expression::If {
             value: Expression::Get { name: placeholder.name }.into(),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -43,14 +43,14 @@ transaction
                                    "public"."Post"."id"»
                             params [const(String("Quantum Topological Embeddings of Mycorrhizal Networks: A Fractal Analysis of Phyllotaxic Algorithms in Non-Euclidean Plant Informatic")),
                                     var(2$id as Int)])
-            in let 5 = unique (query «SELECT "public"."Category"."id" FROM
+            in let 4 = unique (query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
                                       ("public"."Category"."id" = $1 AND 1=1)
                                       LIMIT $2 OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
-               in let 7 = if (rowCountNeq 0 (get 5))
-                      then get 5
+               in let 6 = if (rowCountNeq 0 (get 4))
+                      then get 4
                       else unique (query «INSERT INTO "public"."Category"
                                           ("id","name") VALUES ($1,$2) RETURNING
                                           "public"."Category"."id"»
@@ -60,15 +60,15 @@ transaction
                          [ rowCountNeq 0
                          ] orRaise "MISSING_RELATED_RECORD");
                          0$id = mapField id (get 0);
-                         7 = validate (get 7)
+                         6 = validate (get 6)
                          [ rowCountEq 1
                          ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                         7$id = mapField id (get 7)
+                         6$id = mapField id (get 6)
                      in execute «INSERT INTO "public"."_CategoryToPost"
                                  ("B","A") VALUES [($1),*],* ON CONFLICT DO
                                  NOTHING»
                         params [product(var(0$id as Int[]),
-                                        var(7$id as Int[]))];
+                                        var(6$id as Int[]))];
                let 0 = unique (validate (get 0)
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -43,14 +43,14 @@ transaction
                                    "public"."Post"."id"»
                             params [const(String("Quantum Topological Embeddings of Mycorrhizal Networks: A Fractal Analysis of Phyllotaxic Algorithms in Non-Euclidean Plant Informatic")),
                                     var(2$id as Int)])
-            in let 6 = unique (query «SELECT "public"."Category"."id" FROM
+            in let 5 = unique (query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
                                       ("public"."Category"."id" = $1 AND 1=1)
                                       LIMIT $2 OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
-               in let 8 = if (rowCountNeq 0 (get 6))
-                      then get 6
+               in let 7 = if (rowCountNeq 0 (get 5))
+                      then get 5
                       else unique (query «INSERT INTO "public"."Category"
                                           ("id","name") VALUES ($1,$2) RETURNING
                                           "public"."Category"."id"»
@@ -60,15 +60,15 @@ transaction
                          [ rowCountNeq 0
                          ] orRaise "MISSING_RELATED_RECORD");
                          0$id = mapField id (get 0);
-                         8 = validate (get 8)
+                         7 = validate (get 7)
                          [ rowCountEq 1
                          ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                         8$id = mapField id (get 8)
+                         7$id = mapField id (get 7)
                      in execute «INSERT INTO "public"."_CategoryToPost"
                                  ("B","A") VALUES [($1),*],* ON CONFLICT DO
                                  NOTHING»
                         params [product(var(0$id as Int[]),
-                                        var(8$id as Int[]))];
+                                        var(7$id as Int[]))];
                let 0 = unique (validate (get 0)
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -49,39 +49,26 @@ transaction
                                       LIMIT $2 OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
-               in if (rowCountNeq 0 (get 6))
-                  then let 0 = unique (validate (get 0)
-                           [ rowCountNeq 0
-                           ] orRaise "MISSING_RELATED_RECORD");
-                           0$id = mapField id (get 0);
-                           6 = validate (get 6)
-                           [ rowCountEq 1
-                           ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                           6$id = mapField id (get 6)
-                       in execute «INSERT INTO "public"."_CategoryToPost"
-                                   ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                   NOTHING»
-                          params [product(var(0$id as Int[]),
-                                          var(6$id as Int[]))]
-                  else let 7 = unique (query «INSERT INTO "public"."Category"
-                                              ("id","name") VALUES ($1,$2)
-                                              RETURNING
-                                              "public"."Category"."id"»
-                                       params [const(BigInt(10)),
-                                               const(String("Mushrooms"))])
-                       in let 0 = unique (validate (get 0)
-                              [ rowCountNeq 0
-                              ] orRaise "MISSING_RELATED_RECORD");
-                              0$id = mapField id (get 0);
-                              7 = validate (get 7)
-                              [ rowCountEq 1
-                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                              7$id = mapField id (get 7)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                      NOTHING»
-                             params [product(var(0$id as Int[]),
-                                             var(7$id as Int[]))];
+               in let 8 = if (rowCountNeq 0 (get 6))
+                      then get 6
+                      else unique (query «INSERT INTO "public"."Category"
+                                          ("id","name") VALUES ($1,$2) RETURNING
+                                          "public"."Category"."id"»
+                                   params [const(BigInt(10)),
+                                           const(String("Mushrooms"))])
+                  in let 0 = unique (validate (get 0)
+                         [ rowCountNeq 0
+                         ] orRaise "MISSING_RELATED_RECORD");
+                         0$id = mapField id (get 0);
+                         8 = validate (get 8)
+                         [ rowCountEq 1
+                         ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                         8$id = mapField id (get 8)
+                     in execute «INSERT INTO "public"."_CategoryToPost"
+                                 ("B","A") VALUES [($1),*],* ON CONFLICT DO
+                                 NOTHING»
+                        params [product(var(0$id as Int[]),
+                                        var(8$id as Int[]))];
                let 0 = unique (validate (get 0)
                    [ rowCountNeq 0
                    ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -43,36 +43,24 @@ transaction
                                    $2 OFFSET $3»
                             params [const(BigInt(10)), const(BigInt(1)),
                                     const(BigInt(0))])
-            in if (rowCountNeq 0 (get 2))
-               then let 0 = unique (validate (get 0)
-                        [ rowCountNeq 0
-                        ] orRaise "MISSING_RELATED_RECORD");
-                        0$id = mapField id (get 0);
-                        2 = validate (get 2)
-                        [ rowCountEq 1
-                        ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                        2$id = mapField id (get 2)
-                    in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
-                                VALUES [($1),*],* ON CONFLICT DO NOTHING»
-                       params [product(var(0$id as Int[]), var(2$id as Int[]))]
-               else let 3 = unique (query «INSERT INTO "public"."Category"
-                                           ("id","name") VALUES ($1,$2)
-                                           RETURNING "public"."Category"."id"»
-                                    params [const(BigInt(10)),
-                                            const(String("JavaScript"))])
-                    in let 0 = unique (validate (get 0)
-                           [ rowCountNeq 0
-                           ] orRaise "MISSING_RELATED_RECORD");
-                           0$id = mapField id (get 0);
-                           3 = validate (get 3)
-                           [ rowCountEq 1
-                           ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                           3$id = mapField id (get 3)
-                       in execute «INSERT INTO "public"."_CategoryToPost"
-                                   ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                   NOTHING»
-                          params [product(var(0$id as Int[]),
-                                          var(3$id as Int[]))];
+            in let 4 = if (rowCountNeq 0 (get 2))
+                   then get 2
+                   else unique (query «INSERT INTO "public"."Category"
+                                       ("id","name") VALUES ($1,$2) RETURNING
+                                       "public"."Category"."id"»
+                                params [const(BigInt(10)),
+                                        const(String("JavaScript"))])
+               in let 0 = unique (validate (get 0)
+                      [ rowCountNeq 0
+                      ] orRaise "MISSING_RELATED_RECORD");
+                      0$id = mapField id (get 0);
+                      4 = validate (get 4)
+                      [ rowCountEq 1
+                      ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                      4$id = mapField id (get 4)
+                  in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                              VALUES [($1),*],* ON CONFLICT DO NOTHING»
+                     params [product(var(0$id as Int[]), var(4$id as Int[]))];
             let 0 = unique (validate (get 0)
                 [ rowCountNeq 0
                 ] orRaise "MISSING_RECORD");


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on empty required set pruning and trims connect-or-create branch scaffolding where create/connect results can be joined or passed through directly.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08