### PR TITLE
perf(query-compiler): prune update and upsert graph phases

### DIFF
--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -1,10 +1,11 @@
 use super::*;
-use crate::inputs::{UpdateManyRecordsSelectorsInput, UpdateRecordSelectorsInput};
+use crate::inputs::{ReturnInput, UpdateManyRecordsSelectorsInput, UpdateRecordSelectorsInput};
+use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::query_graph_builder::write::update::UpdateManyRecordNodeOptionals;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputValue,
-    query_graph::{NodeRef, QueryGraph, QueryGraphDependency},
+    query_graph::{Flow, NodeRef, QueryGraph, QueryGraphDependency},
 };
 use query_structure::{Filter, Model, RelationFieldRef};
 use schema::constants::args;
@@ -89,8 +90,37 @@ pub fn nested_update(
         let find_child_records_node =
             utils::insert_find_children_by_parent_node(graph, parent, parent_relation_field, filter.clone())?;
 
-        let update_node = update::update_record_node(graph, query_schema, filter, child_model.clone(), data_map, None)?;
         let child_model_identifier = parent_relation_field.related_model().shard_aware_primary_identifier();
+        let update_args = WriteArgsParser::from(child_model, data_map)?;
+
+        if update_args.args.is_empty() && !update_args.nested.is_empty() {
+            let return_node = graph.create_node(Flow::Return(Vec::new()));
+
+            graph.create_edge(
+                &find_child_records_node,
+                &return_node,
+                QueryGraphDependency::ProjectedDataDependency(
+                    child_model_identifier,
+                    RowSink::All(&ReturnInput),
+                    Some(DataExpectation::non_empty_rows(
+                        MissingRelatedRecord::builder()
+                            .model(child_model)
+                            .relation(&parent_relation_field.relation())
+                            .operation(DataOperation::NestedUpdate)
+                            .build(),
+                    )),
+                ),
+            )?;
+
+            for (relation_field, data_map) in update_args.nested {
+                connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+            }
+
+            continue;
+        }
+
+        let update_node =
+            update::update_record_node_from_args(graph, query_schema, filter, child_model.clone(), update_args, None)?;
 
         graph.create_edge(
             &find_child_records_node,

--- a/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/update_nested.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::inputs::{ReturnInput, UpdateManyRecordsSelectorsInput, UpdateRecordSelectorsInput};
-use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::query_graph_builder::write::update::UpdateManyRecordNodeOptionals;
+use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputValue,
@@ -94,14 +94,14 @@ pub fn nested_update(
         let update_args = WriteArgsParser::from(child_model, data_map)?;
 
         if update_args.args.is_empty() && !update_args.nested.is_empty() {
-            let return_node = graph.create_node(Flow::Return(Vec::new()));
+            let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
                 &find_child_records_node,
                 &return_node,
                 QueryGraphDependency::ProjectedDataDependency(
                     child_model_identifier,
-                    RowSink::All(&ReturnInput),
+                    RowSink::ProjectedPlaceholder(&ReturnInput),
                     Some(DataExpectation::non_empty_rows(
                         MissingRelatedRecord::builder()
                             .model(child_model)

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -1,6 +1,9 @@
 use super::*;
-use crate::inputs::{IfInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput, UpdateRecordSelectorsInput};
+use crate::inputs::{
+    IfInput, ReturnInput, UpdateManyRecordsSelectorsInput, UpdateOrCreateArgsInput, UpdateRecordSelectorsInput,
+};
 use crate::query_graph_builder::write::utils::coerce_values;
+use crate::query_graph_builder::write::write_args_parser::WriteArgsParser;
 use crate::{DataExpectation, RowSink};
 use crate::{
     ParsedInputMap, ParsedInputValue,
@@ -138,14 +141,9 @@ pub fn nested_upsert(
         let if_node = graph.create_node(Flow::if_non_empty());
         let create_node =
             create::create_record_node(graph, query_schema, child_model.clone(), create_input.try_into()?)?;
-        let update_node = update::update_record_node(
-            graph,
-            query_schema,
-            filter.clone(),
-            child_model.clone(),
-            update_input.try_into()?,
-            None,
-        )?;
+        let update_map: ParsedInputMap<'_> = update_input.try_into()?;
+        let update_args = WriteArgsParser::from(&child_model, update_map)?;
+        let is_nested_only_update = update_args.args.is_empty() && !update_args.nested.is_empty();
 
         graph.create_edge(
             &read_children_node,
@@ -157,41 +155,77 @@ pub fn nested_upsert(
             ),
         )?;
 
-        graph.create_edge(
-            &read_children_node,
-            &update_node,
-            QueryGraphDependency::ProjectedDataDependency(
-                child_model_identifier.clone(),
-                RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
-                Some(DataExpectation::non_empty_rows(
-                    MissingRelatedRecord::builder()
-                        .model(&child_model)
-                        .relation(&parent_relation_field.relation())
-                        .needed_for(DependentOperation::nested_update())
-                        .operation(DataOperation::NestedUpsert)
-                        .build(),
-                )),
-            ),
-        )?;
+        let then_node = if is_nested_only_update {
+            let return_node = graph.create_node(Flow::Return(Vec::new()));
 
-        // In case the connector doesn't support referential integrity, we add a subtree to the graph that emulates the ON_UPDATE referential action.
-        // When that's the case, we create an intermediary node to which we connect all the nodes reponsible for emulating the referential action
-        // Then, we connect the if node to that intermediary emulation node. This enables performing the emulation only in case the graph traverses
-        // the update path (if the children already exists and goes to the THEN node).
-        // It's only after we've executed the emulation that it'll traverse the update node, hence the ExecutionOrder between
-        // the emulation node and the update node.
-        let then_node = if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
-            graph,
-            query_schema,
-            &child_model,
-            &read_children_node,
-            &update_node,
-        )? {
-            graph.create_edge(&emulation_node, &update_node, QueryGraphDependency::ExecutionOrder)?;
+            graph.create_edge(
+                &read_children_node,
+                &return_node,
+                QueryGraphDependency::ProjectedDataDependency(
+                    child_model_identifier.clone(),
+                    RowSink::All(&ReturnInput),
+                    Some(DataExpectation::non_empty_rows(
+                        MissingRelatedRecord::builder()
+                            .model(&child_model)
+                            .relation(&parent_relation_field.relation())
+                            .needed_for(DependentOperation::nested_update())
+                            .operation(DataOperation::NestedUpsert)
+                            .build(),
+                    )),
+                ),
+            )?;
 
-            emulation_node
+            for (relation_field, data_map) in update_args.nested {
+                connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+            }
+
+            return_node
         } else {
-            update_node
+            let update_node = update::update_record_node_from_args(
+                graph,
+                query_schema,
+                filter.clone(),
+                child_model.clone(),
+                update_args,
+                None,
+            )?;
+
+            graph.create_edge(
+                &read_children_node,
+                &update_node,
+                QueryGraphDependency::ProjectedDataDependency(
+                    child_model_identifier.clone(),
+                    RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
+                    Some(DataExpectation::non_empty_rows(
+                        MissingRelatedRecord::builder()
+                            .model(&child_model)
+                            .relation(&parent_relation_field.relation())
+                            .needed_for(DependentOperation::nested_update())
+                            .operation(DataOperation::NestedUpsert)
+                            .build(),
+                    )),
+                ),
+            )?;
+
+            // In case the connector doesn't support referential integrity, we add a subtree to the graph that emulates the ON_UPDATE referential action.
+            // When that's the case, we create an intermediary node to which we connect all the nodes reponsible for emulating the referential action
+            // Then, we connect the if node to that intermediary emulation node. This enables performing the emulation only in case the graph traverses
+            // the update path (if the children already exists and goes to the THEN node).
+            // It's only after we've executed the emulation that it'll traverse the update node, hence the ExecutionOrder between
+            // the emulation node and the update node.
+            if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
+                graph,
+                query_schema,
+                &child_model,
+                &read_children_node,
+                &update_node,
+            )? {
+                graph.create_edge(&emulation_node, &update_node, QueryGraphDependency::ExecutionOrder)?;
+
+                emulation_node
+            } else {
+                update_node
+            }
         };
 
         graph.create_edge(&if_node, &then_node, QueryGraphDependency::Then)?;

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -156,14 +156,14 @@ pub fn nested_upsert(
         )?;
 
         let then_node = if is_nested_only_update {
-            let return_node = graph.create_node(Flow::Return(Vec::new()));
+            let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
                 &read_children_node,
                 &return_node,
                 QueryGraphDependency::ProjectedDataDependency(
                     child_model_identifier.clone(),
-                    RowSink::All(&ReturnInput),
+                    RowSink::ProjectedPlaceholder(&ReturnInput),
                     Some(DataExpectation::non_empty_rows(
                         MissingRelatedRecord::builder()
                             .model(&child_model)

--- a/query-compiler/core/src/query_graph_builder/write/update.rs
+++ b/query-compiler/core/src/query_graph_builder/write/update.rs
@@ -190,6 +190,21 @@ where
     T: Clone + Into<Filter>,
 {
     let update_args = WriteArgsParser::from(&model, data_map)?;
+
+    update_record_node_from_args(graph, query_schema, filter, model, update_args, field)
+}
+
+pub(crate) fn update_record_node_from_args<T>(
+    graph: &mut QueryGraph,
+    query_schema: &QuerySchema,
+    filter: T,
+    model: Model,
+    update_args: WriteArgsParser<'_>,
+    field: Option<&ParsedField<'_>>,
+) -> QueryGraphBuilderResult<NodeRef>
+where
+    T: Clone + Into<Filter>,
+{
     let mut args = update_args.args;
 
     args.update_datetimes(&model);

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -104,12 +104,16 @@ pub(crate) fn upsert_record(
     let update_args = WriteArgsParser::from(&model, update_argument)?;
     let is_noop_update = update_args.args.is_empty();
     let update_node = if is_noop_update {
-        let return_node = graph.create_node(Flow::Return(Vec::new()));
+        let return_node = graph.create_node(Flow::Return(None));
 
         graph.create_edge(
             &read_parent_records_node,
             &return_node,
-            QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::All(&ReturnInput), None),
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id.clone(),
+                RowSink::ProjectedPlaceholder(&ReturnInput),
+                None,
+            ),
         )?;
 
         for (relation_field, data_map) in update_args.nested {

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -1,7 +1,7 @@
 use super::{write_args_parser::WriteArgsParser, *};
 use crate::{
     DataExpectation, ParsedField, ParsedInputMap, ParsedInputValue, ParsedObject, RowSink,
-    inputs::{IfInput, RecordQueryFilterInput, UpdateRecordSelectorsInput},
+    inputs::{IfInput, RecordQueryFilterInput, ReturnInput, UpdateRecordSelectorsInput},
     query_ast::*,
     query_graph::{Flow, QueryGraph, QueryGraphDependency},
 };
@@ -101,14 +101,25 @@ pub(crate) fn upsert_record(
 
     let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
 
-    let update_node = update::update_record_node(
-        graph,
-        query_schema,
-        filter,
-        model.clone(),
-        update_argument,
-        Some(&field),
-    )?;
+    let update_args = WriteArgsParser::from(&model, update_argument)?;
+    let is_noop_update = update_args.args.is_empty();
+    let update_node = if is_noop_update {
+        let return_node = graph.create_node(Flow::Return(Vec::new()));
+
+        graph.create_edge(
+            &read_parent_records_node,
+            &return_node,
+            QueryGraphDependency::ProjectedDataDependency(model_id.clone(), RowSink::All(&ReturnInput), None),
+        )?;
+
+        for (relation_field, data_map) in update_args.nested {
+            nested::connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
+        }
+
+        return_node
+    } else {
+        update::update_record_node_from_args(graph, query_schema, filter, model.clone(), update_args, Some(&field))?
+    };
 
     let read_node_create = graph.create_node(Query::Read(read_query.clone()));
     let read_node_update = graph.create_node(Query::Read(read_query));
@@ -130,7 +141,9 @@ pub(crate) fn upsert_record(
     // the update path (if the children already exists and goes to the THEN node).
     // It's only after we've executed the emulation that it'll traverse the update node, hence the ExecutionOrder between
     // the emulation node and the update node.
-    if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
+    if is_noop_update {
+        graph.create_edge(&if_node, &update_node, QueryGraphDependency::Then)?;
+    } else if let Some(emulation_node) = utils::insert_emulated_on_update_with_intermediary_node(
         graph,
         query_schema,
         &model,
@@ -145,16 +158,18 @@ pub(crate) fn upsert_record(
 
     graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
 
-    // Pass-in the read parent record result to the update node RecordFilter to avoid a redundant read.
-    graph.create_edge(
-        &read_parent_records_node,
-        &update_node,
-        QueryGraphDependency::ProjectedDataDependency(
-            model_id.clone(),
-            RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
-            None,
-        ),
-    )?;
+    if !is_noop_update {
+        // Pass-in the read parent record result to the update node RecordFilter to avoid a redundant read.
+        graph.create_edge(
+            &read_parent_records_node,
+            &update_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id.clone(),
+                RowSink::ExactlyOne(&UpdateRecordSelectorsInput),
+                None,
+            ),
+        )?;
+    }
 
     graph.create_edge(
         &update_node,

--- a/query-compiler/query-compiler/tests/data/nested-upsert-nested-only.json
+++ b/query-compiler/query-compiler/tests/data/nested-upsert-nested-only.json
@@ -1,0 +1,43 @@
+{
+  "modelName": "User",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1737556028164@prisma.io" },
+      "data": {
+        "posts": {
+          "upsert": {
+            "where": { "id": 11 },
+            "update": {
+              "categories": {
+                "connect": { "id": 10 }
+              }
+            },
+            "create": {
+              "title": "Nested upsert created post",
+              "categories": {
+                "connect": { "id": 10 }
+              }
+            }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true,
+      "posts": {
+        "arguments": {},
+        "selection": {
+          "$composites": true,
+          "$scalars": true,
+          "categories": {
+            "arguments": {},
+            "selection": { "$composites": true, "$scalars": true }
+          }
+        }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/upsert-empty-update.json
+++ b/query-compiler/query-compiler/tests/data/upsert-empty-update.json
@@ -1,0 +1,15 @@
+{
+  "modelName": "User",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1@prisma.io" },
+      "update": {},
+      "create": { "email": "user.1@prisma.io" }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/upsert-nested-only-update.json
+++ b/query-compiler/query-compiler/tests/data/upsert-nested-only-update.json
@@ -1,0 +1,23 @@
+{
+  "modelName": "User",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user.1@prisma.io" },
+      "update": {
+        "posts": {
+          "create": { "title": "Nested upsert update post" }
+        }
+      },
+      "create": { "email": "user.1@prisma.io" }
+    },
+    "selection": {
+      "$scalars": true,
+      "posts": {
+        "arguments": {},
+        "selection": { "$scalars": true }
+      }
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -27,13 +27,15 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
                           "public"."User"."role"::text FROM "public"."User"
-                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
+                          OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)
       in let 1 = query «SELECT "public"."Post"."id", "public"."Post"."userId"
-                        FROM "public"."Post" WHERE ("public"."Post"."id" = $1
-                        AND "public"."Post"."userId" IN [$2,*]) OFFSET $3»
+                        FROM "public"."Post" WHERE (("public"."Post"."id" = $1
+                        AND 1=1) AND "public"."Post"."userId" IN [$2,*]) OFFSET
+                        $3»
                  params [const(BigInt(11)), var(0$id as Int), const(BigInt(0))]
          in if (rowCountNeq 0 (get 1))
             then let 1 = validate (get 1)
@@ -42,7 +44,8 @@ transaction
                  in let 6 = get 1
                     in let 7 = query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
-                                      "public"."Category"."id" = $1 OFFSET $2»
+                                      ("public"."Category"."id" = $1 AND 1=1)
+                                      OFFSET $2»
                                params [const(BigInt(10)), const(BigInt(0))]
                        in let 6 = unique (validate (get 6)
                               [ rowCountNeq 0
@@ -68,7 +71,8 @@ transaction
                                             var(0$id as Int)])
                     in let 4 = query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
-                                      "public"."Category"."id" = $1 OFFSET $2»
+                                      ("public"."Category"."id" = $1 AND 1=1)
+                                      OFFSET $2»
                                params [const(BigInt(10)), const(BigInt(0))]
                        in let 3 = unique (validate (get 3)
                               [ rowCountNeq 0
@@ -87,72 +91,31 @@ transaction
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");
           0$id = mapField id (get 0)
-      in rawNestedReadUnique (query «SELECT "public"."User"."id",
-                                     "public"."User"."email",
-                                     "public"."User"."role"::text FROM
-                                     "public"."User" WHERE "public"."User"."id"
-                                     = $1 LIMIT $2 OFFSET $3»
-                              params [var(0$id as Int), const(BigInt(1)),
-                                      const(BigInt(0))]
-                              fields {
-                                  id: 0
-                                  email: 1
-                                  role: 2
-                              }
-                              relations [posts on left.0 = right.2 many (query
-                                                                         «SELECT
-                                                                          "public"."Post"."id",
-                                                                          "public"."Post"."title",
-                                                                          "public"."Post"."userId"
-                                                                          FROM
-                                                                          "public"."Post"
-                                                                          WHERE
-                                                                          "public"."Post"."userId"
-                                                                          = $1
-                                                                          OFFSET
-                                                                          $2»
-                                                                         params [var(@parent$id as Int),
-                                                                                 const(BigInt(0))]
-                                                                         fields {
-                                                                             id: 0
-                                                                             title: 1
-                                                                             userId: 2
-                                                                         }
-                                                                         relations [categories on left.0 = right.2 many (query
-                                                                                                                         «SELECT
-                                                                                                                          "public"."Category"."id",
-                                                                                                                          "public"."Category"."name",
-                                                                                                                          "t0"."B"
-                                                                                                                          AS
-                                                                                                                          "CategoryToPost@Post"
-                                                                                                                          FROM
-                                                                                                                          "public"."Category"
-                                                                                                                          INNER
-                                                                                                                          JOIN
-                                                                                                                          "public"."_CategoryToPost"
-                                                                                                                          AS
-                                                                                                                          "t0"
-                                                                                                                          ON
-                                                                                                                          "t0"."A"
-                                                                                                                          =
-                                                                                                                          "public"."Category"."id"
-                                                                                                                          WHERE
-                                                                                                                          (1=1
-                                                                                                                          AND
-                                                                                                                          "t0"."B"
-                                                                                                                          IN
-                                                                                                                          [$1,*])
-                                                                                                                          OFFSET
-                                                                                                                          $2»
-                                                                                                                         params [var(@parent$id as Int),
-                                                                                                                                 const(BigInt(0))]
-                                                                                                                         fields {
-                                                                                                                             id: 0
-                                                                                                                             name: 1
-                                                                                                                         })])])
-         enums {
-             Role: {
-                 admin: ADMIN
-                 user: USER
-             }
-         }
+      in let @parent = unique (query «SELECT "public"."User"."id",
+                                      "public"."User"."email",
+                                      "public"."User"."role"::text FROM
+                                      "public"."User" WHERE "public"."User"."id"
+                                      = $1 LIMIT $2 OFFSET $3»
+                               params [var(0$id as Int), const(BigInt(1)),
+                                       const(BigInt(0))])
+         in let @parent$id = mapField id (get @parent)
+            in join (get @parent)
+               with (let @parent = query «SELECT "public"."Post"."id",
+                                          "public"."Post"."title",
+                                          "public"."Post"."userId" FROM
+                                          "public"."Post" WHERE
+                                          "public"."Post"."userId" = $1 OFFSET
+                                          $2»
+                                   params [var(@parent$id as Int),
+                                           const(BigInt(0))]
+                    in let @parent$id = mapField id (get @parent)
+                       in join (get @parent)
+                          with (query «SELECT "public"."Category"."id",
+                                       "public"."Category"."name", "t0"."B" AS
+                                       "CategoryToPost@Post" FROM
+                                       "public"."Category" INNER JOIN
+                                       "public"."_CategoryToPost" AS "t0" ON
+                                       "t0"."A" = "public"."Category"."id" WHERE
+                                       (1=1 AND "t0"."B" IN [$1,*]) OFFSET $2»
+                                params [var(@parent$id as Int),
+                                        const(BigInt(0))]) on left.(id) = right.(CategoryToPost@Post) as @nested$categories) on left.(id) = right.(userId) as @nested$posts

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -1,0 +1,158 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/nested-upsert-nested-only.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+       posts (from @nested$posts): {
+           id: Int (id)
+           title: String (title)
+           userId: Int (userId)
+           categories (from @nested$categories): {
+               id: Int (id)
+               name: String (name)
+           }
+       }
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
+                          "public"."User"."role"::text FROM "public"."User"
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
+                   params [const(String("user.1737556028164@prisma.io")),
+                           const(BigInt(1)), const(BigInt(0))])
+   in let 0$id = mapField id (get 0)
+      in let 1 = query «SELECT "public"."Post"."id", "public"."Post"."userId"
+                        FROM "public"."Post" WHERE ("public"."Post"."id" = $1
+                        AND "public"."Post"."userId" IN [$2,*]) OFFSET $3»
+                 params [const(BigInt(11)), var(0$id as Int), const(BigInt(0))]
+         in if (rowCountNeq 0 (get 1))
+            then let 1 = validate (get 1)
+                     [ rowCountNeq 0
+                     ] orRaise "MISSING_RELATED_RECORD"
+                 in let 6 = get 1
+                    in let 7 = query «SELECT "public"."Category"."id" FROM
+                                      "public"."Category" WHERE
+                                      "public"."Category"."id" = $1 OFFSET $2»
+                               params [const(BigInt(10)), const(BigInt(0))]
+                       in let 6 = unique (validate (get 6)
+                              [ rowCountNeq 0
+                              ] orRaise "MISSING_RELATED_RECORD");
+                              6$id = mapField id (get 6);
+                              7 = validate (get 7)
+                              [ rowCountEq 1
+                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                              7$id = mapField id (get 7)
+                          in execute «INSERT INTO "public"."_CategoryToPost"
+                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
+                                      NOTHING»
+                             params [product(var(6$id as Int[]),
+                                             var(7$id as Int[]))]
+            else let 0 = unique (validate (get 0)
+                     [ rowCountNeq 0
+                     ] orRaise "MISSING_RELATED_RECORD");
+                     0$id = mapField id (get 0)
+                 in let 3 = unique (query «INSERT INTO "public"."Post"
+                                           ("title","userId") VALUES ($1,$2)
+                                           RETURNING "public"."Post"."id"»
+                                    params [const(String("Nested upsert created post")),
+                                            var(0$id as Int)])
+                    in let 4 = query «SELECT "public"."Category"."id" FROM
+                                      "public"."Category" WHERE
+                                      "public"."Category"."id" = $1 OFFSET $2»
+                               params [const(BigInt(10)), const(BigInt(0))]
+                       in let 3 = unique (validate (get 3)
+                              [ rowCountNeq 0
+                              ] orRaise "MISSING_RELATED_RECORD");
+                              3$id = mapField id (get 3);
+                              4 = validate (get 4)
+                              [ rowCountEq 1
+                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                              4$id = mapField id (get 4)
+                          in execute «INSERT INTO "public"."_CategoryToPost"
+                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
+                                      NOTHING»
+                             params [product(var(3$id as Int[]),
+                                             var(4$id as Int[]))];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                     "public"."User"."email",
+                                     "public"."User"."role"::text FROM
+                                     "public"."User" WHERE "public"."User"."id"
+                                     = $1 LIMIT $2 OFFSET $3»
+                              params [var(0$id as Int), const(BigInt(1)),
+                                      const(BigInt(0))]
+                              fields {
+                                  id: 0
+                                  email: 1
+                                  role: 2
+                              }
+                              relations [posts on left.0 = right.2 many (query
+                                                                         «SELECT
+                                                                          "public"."Post"."id",
+                                                                          "public"."Post"."title",
+                                                                          "public"."Post"."userId"
+                                                                          FROM
+                                                                          "public"."Post"
+                                                                          WHERE
+                                                                          "public"."Post"."userId"
+                                                                          = $1
+                                                                          OFFSET
+                                                                          $2»
+                                                                         params [var(@parent$id as Int),
+                                                                                 const(BigInt(0))]
+                                                                         fields {
+                                                                             id: 0
+                                                                             title: 1
+                                                                             userId: 2
+                                                                         }
+                                                                         relations [categories on left.0 = right.2 many (query
+                                                                                                                         «SELECT
+                                                                                                                          "public"."Category"."id",
+                                                                                                                          "public"."Category"."name",
+                                                                                                                          "t0"."B"
+                                                                                                                          AS
+                                                                                                                          "CategoryToPost@Post"
+                                                                                                                          FROM
+                                                                                                                          "public"."Category"
+                                                                                                                          INNER
+                                                                                                                          JOIN
+                                                                                                                          "public"."_CategoryToPost"
+                                                                                                                          AS
+                                                                                                                          "t0"
+                                                                                                                          ON
+                                                                                                                          "t0"."A"
+                                                                                                                          =
+                                                                                                                          "public"."Category"."id"
+                                                                                                                          WHERE
+                                                                                                                          (1=1
+                                                                                                                          AND
+                                                                                                                          "t0"."B"
+                                                                                                                          IN
+                                                                                                                          [$1,*])
+                                                                                                                          OFFSET
+                                                                                                                          $2»
+                                                                                                                         params [var(@parent$id as Int),
+                                                                                                                                 const(BigInt(0))]
+                                                                                                                         fields {
+                                                                                                                             id: 0
+                                                                                                                             name: 1
+                                                                                                                         })])])
+         enums {
+             Role: {
+                 admin: ADMIN
+                 user: USER
+             }
+         }

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
@@ -20,16 +20,10 @@ transaction
                                 WHERE (1=1 AND "public"."User"."id" IN [$1,*])
                                 OFFSET $2»
                          params [var(0$userId as Int), const(BigInt(0))])
-         in let 1 = unique (validate (get 1)
+         in let 1 = validate (get 1)
                 [ rowCountNeq 0
-                ] orRaise "MISSING_RELATED_RECORD");
-                1$id = mapField id (get 1)
-            in let 2 = unique (query «SELECT "public"."User"."id" FROM
-                                      "public"."User" WHERE (1=1 AND
-                                      "public"."User"."id" IN [$1,*]) LIMIT $2
-                                      OFFSET $3»
-                               params [var(1$id as Int), const(BigInt(1)),
-                                       const(BigInt(0))])
+                ] orRaise "MISSING_RELATED_RECORD"
+            in let 2 = get 1
                in let 2$id = mapField id (get 2)
                   in let 3 = unique (query «SELECT
                                             "public"."NotificationSettings"."userId"

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
@@ -17,7 +17,7 @@ transaction
        }
    }
    let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                  "public"."User"."email" = $1 OFFSET $2»
+                  ("public"."User"."email" = $1 AND 1=1) OFFSET $2»
            params [const(String("user.1@prisma.io")), const(BigInt(0))]
    in if (rowCountNeq 0 (get 0))
       then let 2 = get 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
@@ -1,0 +1,50 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-empty-update.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                  "public"."User"."email" = $1 OFFSET $2»
+           params [const(String("user.1@prisma.io")), const(BigInt(0))]
+   in if (rowCountNeq 0 (get 0))
+      then let 2 = get 0
+           in let 2 = unique (validate (get 2)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  2$id = mapField id (get 2)
+              in unique (query «SELECT "public"."User"."id",
+                                "public"."User"."email",
+                                "public"."User"."role"::text FROM
+                                "public"."User" WHERE "public"."User"."id" = $1
+                                LIMIT $2 OFFSET $3»
+                         params [var(2$id as Int), const(BigInt(1)),
+                                 const(BigInt(0))])
+      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
+                                  VALUES ($1,CAST($2::text AS "public"."Role"))
+                                  RETURNING "public"."User"."id"»
+                           params [const(String("user.1@prisma.io")),
+                                   const(String("user"))])
+           in let 1 = unique (validate (get 1)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  1$id = mapField id (get 1)
+              in unique (query «SELECT "public"."User"."id",
+                                "public"."User"."email",
+                                "public"."User"."role"::text FROM
+                                "public"."User" WHERE "public"."User"."id" = $1
+                                LIMIT $2 OFFSET $3»
+                         params [var(1$id as Int), const(BigInt(1)),
+                                 const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
@@ -22,7 +22,7 @@ transaction
        }
    }
    let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                  "public"."User"."email" = $1 OFFSET $2»
+                  ("public"."User"."email" = $1 AND 1=1) OFFSET $2»
            params [const(String("user.1@prisma.io")), const(BigInt(0))]
    in if (rowCountNeq 0 (get 0))
       then let 2 = get 0
@@ -38,46 +38,24 @@ transaction
                   [ rowCountNeq 0
                   ] orRaise "MISSING_RECORD");
                   2$id = mapField id (get 2)
-              in rawNestedReadUnique (query «SELECT "public"."User"."id",
-                                             "public"."User"."email",
-                                             "public"."User"."role"::text FROM
-                                             "public"."User" WHERE
-                                             "public"."User"."id" = $1 LIMIT $2
-                                             OFFSET $3»
-                                      params [var(2$id as Int),
-                                              const(BigInt(1)),
-                                              const(BigInt(0))]
-                                      fields {
-                                          id: 0
-                                          email: 1
-                                          role: 2
-                                      }
-                                      relations [posts on left.0 = right.2 many (query
-                                                                                 «SELECT
-                                                                                  "public"."Post"."id",
-                                                                                  "public"."Post"."title",
-                                                                                  "public"."Post"."userId"
-                                                                                  FROM
-                                                                                  "public"."Post"
-                                                                                  WHERE
-                                                                                  "public"."Post"."userId"
-                                                                                  =
-                                                                                  $1
-                                                                                  OFFSET
-                                                                                  $2»
-                                                                                 params [var(@parent$id as Int),
-                                                                                         const(BigInt(0))]
-                                                                                 fields {
-                                                                                     id: 0
-                                                                                     title: 1
-                                                                                     userId: 2
-                                                                                 })])
-                 enums {
-                     Role: {
-                         admin: ADMIN
-                         user: USER
-                     }
-                 }
+              in let @parent = unique (query «SELECT "public"."User"."id",
+                                              "public"."User"."email",
+                                              "public"."User"."role"::text FROM
+                                              "public"."User" WHERE
+                                              "public"."User"."id" = $1 LIMIT $2
+                                              OFFSET $3»
+                                       params [var(2$id as Int),
+                                               const(BigInt(1)),
+                                               const(BigInt(0))])
+                 in let @parent$id = mapField id (get @parent)
+                    in join (get @parent)
+                       with (query «SELECT "public"."Post"."id",
+                                    "public"."Post"."title",
+                                    "public"."Post"."userId" FROM
+                                    "public"."Post" WHERE
+                                    "public"."Post"."userId" = $1 OFFSET $2»
+                             params [var(@parent$id as Int),
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
       else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
                                   VALUES ($1,CAST($2::text AS "public"."Role"))
                                   RETURNING "public"."User"."id"»
@@ -87,43 +65,21 @@ transaction
                   [ rowCountNeq 0
                   ] orRaise "MISSING_RECORD");
                   1$id = mapField id (get 1)
-              in rawNestedReadUnique (query «SELECT "public"."User"."id",
-                                             "public"."User"."email",
-                                             "public"."User"."role"::text FROM
-                                             "public"."User" WHERE
-                                             "public"."User"."id" = $1 LIMIT $2
-                                             OFFSET $3»
-                                      params [var(1$id as Int),
-                                              const(BigInt(1)),
-                                              const(BigInt(0))]
-                                      fields {
-                                          id: 0
-                                          email: 1
-                                          role: 2
-                                      }
-                                      relations [posts on left.0 = right.2 many (query
-                                                                                 «SELECT
-                                                                                  "public"."Post"."id",
-                                                                                  "public"."Post"."title",
-                                                                                  "public"."Post"."userId"
-                                                                                  FROM
-                                                                                  "public"."Post"
-                                                                                  WHERE
-                                                                                  "public"."Post"."userId"
-                                                                                  =
-                                                                                  $1
-                                                                                  OFFSET
-                                                                                  $2»
-                                                                                 params [var(@parent$id as Int),
-                                                                                         const(BigInt(0))]
-                                                                                 fields {
-                                                                                     id: 0
-                                                                                     title: 1
-                                                                                     userId: 2
-                                                                                 })])
-                 enums {
-                     Role: {
-                         admin: ADMIN
-                         user: USER
-                     }
-                 }
+              in let @parent = unique (query «SELECT "public"."User"."id",
+                                              "public"."User"."email",
+                                              "public"."User"."role"::text FROM
+                                              "public"."User" WHERE
+                                              "public"."User"."id" = $1 LIMIT $2
+                                              OFFSET $3»
+                                       params [var(1$id as Int),
+                                               const(BigInt(1)),
+                                               const(BigInt(0))])
+                 in let @parent$id = mapField id (get @parent)
+                    in join (get @parent)
+                       with (query «SELECT "public"."Post"."id",
+                                    "public"."Post"."title",
+                                    "public"."Post"."userId" FROM
+                                    "public"."Post" WHERE
+                                    "public"."Post"."userId" = $1 OFFSET $2»
+                             params [var(@parent$id as Int),
+                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
@@ -1,0 +1,129 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-nested-only-update.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       role: Enum<Role> (role)
+       posts (from @nested$posts): {
+           id: Int (id)
+           title: String (title)
+           userId: Int (userId)
+       }
+   }
+   enums {
+       Role: {
+           admin: ADMIN
+           user: USER
+       }
+   }
+   let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                  "public"."User"."email" = $1 OFFSET $2»
+           params [const(String("user.1@prisma.io")), const(BigInt(0))]
+   in if (rowCountNeq 0 (get 0))
+      then let 2 = get 0
+           in let 2 = unique (validate (get 2)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RELATED_RECORD");
+                  2$id = mapField id (get 2)
+              in unique (query «INSERT INTO "public"."Post" ("title","userId")
+                                VALUES ($1,$2) RETURNING "public"."Post"."id"»
+                         params [const(String("Nested upsert update post")),
+                                 var(2$id as Int)]);
+              let 2 = unique (validate (get 2)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  2$id = mapField id (get 2)
+              in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                             "public"."User"."email",
+                                             "public"."User"."role"::text FROM
+                                             "public"."User" WHERE
+                                             "public"."User"."id" = $1 LIMIT $2
+                                             OFFSET $3»
+                                      params [var(2$id as Int),
+                                              const(BigInt(1)),
+                                              const(BigInt(0))]
+                                      fields {
+                                          id: 0
+                                          email: 1
+                                          role: 2
+                                      }
+                                      relations [posts on left.0 = right.2 many (query
+                                                                                 «SELECT
+                                                                                  "public"."Post"."id",
+                                                                                  "public"."Post"."title",
+                                                                                  "public"."Post"."userId"
+                                                                                  FROM
+                                                                                  "public"."Post"
+                                                                                  WHERE
+                                                                                  "public"."Post"."userId"
+                                                                                  =
+                                                                                  $1
+                                                                                  OFFSET
+                                                                                  $2»
+                                                                                 params [var(@parent$id as Int),
+                                                                                         const(BigInt(0))]
+                                                                                 fields {
+                                                                                     id: 0
+                                                                                     title: 1
+                                                                                     userId: 2
+                                                                                 })])
+                 enums {
+                     Role: {
+                         admin: ADMIN
+                         user: USER
+                     }
+                 }
+      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
+                                  VALUES ($1,CAST($2::text AS "public"."Role"))
+                                  RETURNING "public"."User"."id"»
+                           params [const(String("user.1@prisma.io")),
+                                   const(String("user"))])
+           in let 1 = unique (validate (get 1)
+                  [ rowCountNeq 0
+                  ] orRaise "MISSING_RECORD");
+                  1$id = mapField id (get 1)
+              in rawNestedReadUnique (query «SELECT "public"."User"."id",
+                                             "public"."User"."email",
+                                             "public"."User"."role"::text FROM
+                                             "public"."User" WHERE
+                                             "public"."User"."id" = $1 LIMIT $2
+                                             OFFSET $3»
+                                      params [var(1$id as Int),
+                                              const(BigInt(1)),
+                                              const(BigInt(0))]
+                                      fields {
+                                          id: 0
+                                          email: 1
+                                          role: 2
+                                      }
+                                      relations [posts on left.0 = right.2 many (query
+                                                                                 «SELECT
+                                                                                  "public"."Post"."id",
+                                                                                  "public"."Post"."title",
+                                                                                  "public"."Post"."userId"
+                                                                                  FROM
+                                                                                  "public"."Post"
+                                                                                  WHERE
+                                                                                  "public"."Post"."userId"
+                                                                                  =
+                                                                                  $1
+                                                                                  OFFSET
+                                                                                  $2»
+                                                                                 params [var(@parent$id as Int),
+                                                                                         const(BigInt(0))]
+                                                                                 fields {
+                                                                                     id: 0
+                                                                                     title: 1
+                                                                                     userId: 2
+                                                                                 })])
+                 enums {
+                     Role: {
+                         admin: ADMIN
+                         user: USER
+                     }
+                 }


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on connect-or-create pruning and removes redundant update/upsert graph phases, including narrow shared final-read and nested-only pass-through shapes.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08