### PR TITLE
perf(query-compiler): share upsert result reads

### DIFF
--- a/query-compiler/core/src/query_graph/formatters.rs
+++ b/query-compiler/core/src/query_graph/formatters.rs
@@ -57,6 +57,7 @@ impl Display for Flow {
         match self {
             Self::If { rule, .. } => write!(f, "If {rule:?}"),
             Self::Return(_) => write!(f, "Return"),
+            Self::ReturnPreservingResult(_) => write!(f, "ReturnPreservingResult"),
         }
     }
 }

--- a/query-compiler/core/src/query_graph/mod.rs
+++ b/query-compiler/core/src/query_graph/mod.rs
@@ -78,6 +78,9 @@ pub enum Flow {
 
     /// Returns a fixed set of results at runtime.
     Return(Option<Placeholder>),
+
+    /// Runs child nodes, then returns the same fixed set of results.
+    ReturnPreservingResult(Option<Placeholder>),
 }
 
 impl Flow {
@@ -103,6 +106,10 @@ impl Flow {
             data: None,
             then_returns_condition: false,
         }
+    }
+
+    pub fn return_preserving_result() -> Self {
+        Self::ReturnPreservingResult(None)
     }
 }
 
@@ -945,7 +952,7 @@ impl QueryGraph {
                 let node = NodeRef { node_ix: ix };
 
                 match self.node_content(&node).unwrap() {
-                    Node::Flow(Flow::Return(_)) => Some(node),
+                    Node::Flow(Flow::Return(_) | Flow::ReturnPreservingResult(_)) => Some(node),
                     _ => None,
                 }
             })

--- a/query-compiler/core/src/query_graph_builder/inputs.rs
+++ b/query-compiler/core/src/query_graph_builder/inputs.rs
@@ -115,7 +115,7 @@ node_input_field!(
 node_input_field!(
     ReturnInput,
     Option<Placeholder>,
-    Node::Flow(Flow::Return(data)) => data
+    Node::Flow(Flow::Return(data) | Flow::ReturnPreservingResult(data)) => data
 );
 
 node_input_field!(

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -9,9 +9,9 @@ use crate::{
     ParsedInputMap, ParsedInputValue,
     query_graph::{Flow, NodeRef, QueryGraph, QueryGraphDependency},
 };
-use query_structure::{Filter, RelationFieldRef};
-use schema::constants::args;
-use std::convert::TryInto;
+use query_structure::{Filter, Model, RelationFieldRef};
+use schema::constants::{args, operations};
+use std::{borrow::Cow, convert::TryInto};
 
 /// Handles a nested upsert.
 /// The constructed query graph can have different shapes based on the relation
@@ -114,6 +114,9 @@ pub fn nested_upsert(
         let create_input = as_map.swap_remove(args::CREATE).expect("create argument is missing");
         let update_input = as_map.swap_remove(args::UPDATE).expect("update argument is missing");
         let where_input = as_map.swap_remove(args::WHERE);
+        let mut create_map: ParsedInputMap<'_> = create_input.try_into()?;
+        let mut update_map: ParsedInputMap<'_> = update_input.try_into()?;
+        let shared_connect = extract_common_m2m_connect(&child_model, &mut create_map, &mut update_map);
 
         // Read child(ren) node
         let filter = match (where_input, parent_relation_field.is_list()) {
@@ -139,11 +142,11 @@ pub fn nested_upsert(
             utils::insert_find_children_by_parent_node(graph, &parent_node, parent_relation_field, filter.clone())?;
 
         let if_node = graph.create_node(Flow::if_non_empty());
-        let create_node =
-            create::create_record_node(graph, query_schema, child_model.clone(), create_input.try_into()?)?;
-        let update_map: ParsedInputMap<'_> = update_input.try_into()?;
+        let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let update_args = WriteArgsParser::from(&child_model, update_map)?;
         let is_nested_only_update = update_args.args.is_empty() && !update_args.nested.is_empty();
+        let is_shared_connect_only_update =
+            shared_connect.is_some() && update_args.args.is_empty() && update_args.nested.is_empty();
 
         graph.create_edge(
             &read_children_node,
@@ -155,7 +158,7 @@ pub fn nested_upsert(
             ),
         )?;
 
-        let then_node = if is_nested_only_update {
+        let then_node = if is_nested_only_update || is_shared_connect_only_update {
             let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
@@ -299,7 +302,71 @@ pub fn nested_upsert(
                 ),
             )?;
         }
+
+        if let Some((relation_field, connect_value)) = shared_connect {
+            connect_nested_query(
+                graph,
+                query_schema,
+                if_node,
+                relation_field,
+                [(Cow::Borrowed(operations::CONNECT), connect_value)]
+                    .into_iter()
+                    .collect(),
+            )?;
+        }
     }
 
     Ok(())
+}
+
+fn extract_common_m2m_connect<'a>(
+    child_model: &Model,
+    create_map: &mut ParsedInputMap<'a>,
+    update_map: &mut ParsedInputMap<'a>,
+) -> Option<(RelationFieldRef, ParsedInputValue<'a>)> {
+    if update_map.len() != 1 {
+        return None;
+    }
+
+    let (create_field_name, create_relation_field, create_connect) = single_m2m_connect(child_model, create_map)?;
+    let (update_field_name, _, update_connect) = single_m2m_connect(child_model, update_map)?;
+
+    if create_field_name != update_field_name || create_connect != update_connect {
+        return None;
+    }
+
+    create_map.shift_remove(create_field_name.as_ref())?;
+    update_map.shift_remove(update_field_name.as_ref())?;
+
+    Some((create_relation_field, update_connect))
+}
+
+fn single_m2m_connect<'a>(
+    model: &Model,
+    map: &ParsedInputMap<'a>,
+) -> Option<(Cow<'a, str>, RelationFieldRef, ParsedInputValue<'a>)> {
+    let mut connect = None;
+
+    for (field_name, value) in map.iter() {
+        let Ok(relation_field) = model.fields().find_from_relation_fields(field_name) else {
+            continue;
+        };
+
+        if connect.is_some() || !relation_field.relation().is_many_to_many() {
+            return None;
+        }
+
+        let ParsedInputValue::Map(envelope) = value else {
+            return None;
+        };
+
+        if envelope.len() != 1 {
+            return None;
+        }
+
+        let connect_value = envelope.get(operations::CONNECT)?.clone();
+        connect = Some((field_name.clone(), relation_field, connect_value));
+    }
+
+    connect
 }

--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -141,12 +141,16 @@ pub fn nested_upsert(
         let read_children_node =
             utils::insert_find_children_by_parent_node(graph, &parent_node, parent_relation_field, filter.clone())?;
 
-        let if_node = graph.create_node(Flow::if_non_empty());
         let create_node = create::create_record_node(graph, query_schema, child_model.clone(), create_map)?;
         let update_args = WriteArgsParser::from(&child_model, update_map)?;
         let is_nested_only_update = update_args.args.is_empty() && !update_args.nested.is_empty();
         let is_shared_connect_only_update =
             shared_connect.is_some() && update_args.args.is_empty() && update_args.nested.is_empty();
+        let if_node = graph.create_node(if is_shared_connect_only_update {
+            Flow::if_non_empty_returning_condition()
+        } else {
+            Flow::if_non_empty()
+        });
 
         graph.create_edge(
             &read_children_node,
@@ -158,7 +162,9 @@ pub fn nested_upsert(
             ),
         )?;
 
-        let then_node = if is_nested_only_update || is_shared_connect_only_update {
+        let then_node = if is_shared_connect_only_update {
+            None
+        } else if is_nested_only_update {
             let return_node = graph.create_node(Flow::Return(None));
 
             graph.create_edge(
@@ -182,7 +188,7 @@ pub fn nested_upsert(
                 connect_nested_query(graph, query_schema, return_node, relation_field, data_map)?;
             }
 
-            return_node
+            Some(return_node)
         } else {
             let update_node = update::update_record_node_from_args(
                 graph,
@@ -228,10 +234,14 @@ pub fn nested_upsert(
                 emulation_node
             } else {
                 update_node
-            }
+            };
+
+            Some(update_node)
         };
 
-        graph.create_edge(&if_node, &then_node, QueryGraphDependency::Then)?;
+        if let Some(then_node) = then_node {
+            graph.create_edge(&if_node, &then_node, QueryGraphDependency::Then)?;
+        }
         graph.create_edge(&if_node, &create_node, QueryGraphDependency::Else)?;
 
         // Specific handling based on relation type and inlining side.

--- a/query-compiler/core/src/query_graph_builder/write/update.rs
+++ b/query-compiler/core/src/query_graph_builder/write/update.rs
@@ -206,6 +206,7 @@ where
     T: Clone + Into<Filter>,
 {
     let mut args = update_args.args;
+    let nested = update_args.nested;
 
     args.update_datetimes(&model);
 
@@ -217,9 +218,19 @@ where
     let update_parent = if query_schema.has_capability(ConnectorCapability::UpdateReturning) {
         // If there's a selected field, fulfill the scalar selection set.
         if let Some(field) = field.cloned() {
-            let nested_fields = field.nested_fields.unwrap().fields;
-            let selection_order: Vec<String> = read::utils::collect_selection_order(&nested_fields);
-            let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
+            let (selected_fields, selection_order) =
+                if args.is_empty() && (field.has_nested_selection() || !nested.is_empty()) {
+                    let selected_fields = model.shard_aware_primary_identifier();
+                    let selection_order = selected_fields.db_names().collect();
+
+                    (selected_fields, selection_order)
+                } else {
+                    let nested_fields = field.nested_fields.unwrap().fields;
+                    let selection_order = read::utils::collect_selection_order(&nested_fields);
+                    let selected_fields = read::utils::collect_selected_scalars(&nested_fields, &model);
+
+                    (selected_fields, selection_order)
+                };
 
             Query::Write(WriteQuery::UpdateRecord(UpdateRecord::WithSelection(
                 UpdateRecordWithSelection {
@@ -259,7 +270,7 @@ where
 
     let update_node = graph.create_node(update_parent);
 
-    for (relation_field, data_map) in update_args.nested {
+    for (relation_field, data_map) in nested {
         nested::connect_nested_query(graph, query_schema, update_node, relation_field, data_map)?;
     }
 

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -99,10 +99,13 @@ pub(crate) fn upsert_record(
     let read_parent_records = utils::read_ids_infallible(model.clone(), model_id.clone(), filter.clone());
     let read_parent_records_node = graph.create_node(read_parent_records);
 
-    let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
-
     let update_args = WriteArgsParser::from(&model, update_argument)?;
     let is_noop_update = update_args.args.is_empty();
+    let update_has_nested = !update_args.nested.is_empty();
+    let can_share_result_read =
+        is_noop_update && !update_has_nested && !WriteArgsParser::has_nested_operation(&model, &create_argument);
+
+    let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
     let update_node = if is_noop_update {
         let return_node = graph.create_node(Flow::Return(None));
 
@@ -125,11 +128,26 @@ pub(crate) fn upsert_record(
         update::update_record_node_from_args(graph, query_schema, filter, model.clone(), update_args, Some(&field))?
     };
 
-    let read_node_create = graph.create_node(Query::Read(read_query.clone()));
-    let read_node_update = graph.create_node(Query::Read(read_query));
+    let mut read_query = Some(read_query);
+    let read_node_shared = if can_share_result_read {
+        let read_node = graph.create_node(Query::Read(read_query.take().unwrap()));
+        graph.add_result_node(&read_node);
+        Some(read_node)
+    } else {
+        None
+    };
+    let branch_read_nodes = if can_share_result_read {
+        None
+    } else {
+        let read_query = read_query.take().unwrap();
+        let read_node_create = graph.create_node(Query::Read(read_query.clone()));
+        let read_node_update = graph.create_node(Query::Read(read_query));
 
-    graph.add_result_node(&read_node_create);
-    graph.add_result_node(&read_node_update);
+        graph.add_result_node(&read_node_create);
+        graph.add_result_node(&read_node_update);
+
+        Some((read_node_create, read_node_update))
+    };
 
     let if_node = graph.create_node(Flow::if_non_empty());
 
@@ -175,29 +193,43 @@ pub(crate) fn upsert_record(
         )?;
     }
 
-    graph.create_edge(
-        &update_node,
-        &read_node_update,
-        QueryGraphDependency::ProjectedDataDependency(
-            model_id.clone(),
-            RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
-            Some(DataExpectation::non_empty_rows(
-                MissingRecord::builder().operation(DataOperation::Upsert).build(),
-            )),
-        ),
-    )?;
+    if let Some(read_node) = read_node_shared {
+        graph.create_edge(
+            &if_node,
+            &read_node,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id,
+                RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
+                Some(DataExpectation::non_empty_rows(
+                    MissingRecord::builder().operation(DataOperation::Upsert).build(),
+                )),
+            ),
+        )?;
+    } else if let Some((read_node_create, read_node_update)) = branch_read_nodes {
+        graph.create_edge(
+            &update_node,
+            &read_node_update,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id.clone(),
+                RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
+                Some(DataExpectation::non_empty_rows(
+                    MissingRecord::builder().operation(DataOperation::Upsert).build(),
+                )),
+            ),
+        )?;
 
-    graph.create_edge(
-        &create_node,
-        &read_node_create,
-        QueryGraphDependency::ProjectedDataDependency(
-            model_id,
-            RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
-            Some(DataExpectation::non_empty_rows(
-                MissingRecord::builder().operation(DataOperation::Upsert).build(),
-            )),
-        ),
-    )?;
+        graph.create_edge(
+            &create_node,
+            &read_node_create,
+            QueryGraphDependency::ProjectedDataDependency(
+                model_id,
+                RowSink::ExactlyOneFilter(&RecordQueryFilterInput),
+                Some(DataExpectation::non_empty_rows(
+                    MissingRecord::builder().operation(DataOperation::Upsert).build(),
+                )),
+            ),
+        )?;
+    }
 
     Ok(())
 }

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -101,13 +101,20 @@ pub(crate) fn upsert_record(
 
     let update_args = WriteArgsParser::from(&model, update_argument)?;
     let is_noop_update = update_args.args.is_empty();
-    let update_has_nested = !update_args.nested.is_empty();
+    let update_nested_count = update_args.nested.len();
+    let update_has_nested = update_nested_count != 0;
+    let create_has_nested = WriteArgsParser::has_nested_operation(&model, &create_argument);
+    let can_preserve_update_result = update_nested_count == 1;
     let can_share_result_read =
-        is_noop_update && !update_has_nested && !WriteArgsParser::has_nested_operation(&model, &create_argument);
+        is_noop_update && !create_has_nested && (!update_has_nested || can_preserve_update_result);
 
     let create_node = create::create_record_node(graph, query_schema, model.clone(), create_argument)?;
     let update_node = if is_noop_update {
-        let return_node = graph.create_node(Flow::Return(None));
+        let return_node = if update_has_nested && can_share_result_read {
+            graph.create_node(Flow::return_preserving_result())
+        } else {
+            graph.create_node(Flow::Return(None))
+        };
 
         graph.create_edge(
             &read_parent_records_node,

--- a/query-compiler/query-compiler/src/translate.rs
+++ b/query-compiler/query-compiler/src/translate.rs
@@ -178,7 +178,8 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
                 })
             }
             Node::Flow(Flow::If { .. }) => self.translate_if(),
-            Node::Flow(Flow::Return(_)) => self.translate_return(),
+            Node::Flow(Flow::Return(_)) => self.translate_return(false),
+            Node::Flow(Flow::ReturnPreservingResult(_)) => self.translate_return(true),
             Node::Computation(Computation::DiffLeftToRight(_)) => self.translate_diff_left_to_right(),
             Node::Computation(Computation::DiffRightToLeft(_)) => self.translate_diff_right_to_left(),
             Node::Computation(Computation::RequiredOneToManySet(_)) => self.translate_required_one_to_many_set(),
@@ -206,6 +207,22 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
             } else {
                 Expression::Seq(children).into()
             },
+        }
+    }
+
+    fn wrap_children_preserving_expr(&self, expr: Expression, mut children: Vec<Expression>) -> Expression {
+        if children.is_empty() {
+            return expr;
+        }
+
+        let result_name = binding::node_result(self.node);
+        children.push(Expression::Get {
+            name: result_name.clone(),
+        });
+
+        Expression::Let {
+            bindings: vec![Binding::new(result_name, expr)],
+            expr: Expression::Seq(children).into(),
         }
     }
 
@@ -300,20 +317,24 @@ impl<'a, 'b> NodeTranslator<'a, 'b> {
         Ok(self.wrap_children_with_expr(expr, children))
     }
 
-    fn translate_return(&mut self) -> TranslateResult<Expression> {
+    fn translate_return(&mut self, preserve_result_after_children: bool) -> TranslateResult<Expression> {
         let children = self.translate_children()?;
 
         let node = self.graph.pluck_node(&self.node);
         let node = self.transform_node(node)?;
 
-        let Node::Flow(Flow::Return(data)) = node else {
+        let Node::Flow(Flow::Return(data) | Flow::ReturnPreservingResult(data)) = node else {
             panic!("current node must be Flow::Return");
         };
         let placeholder = projected_placeholder(data, "Return")?;
 
         let expr = Expression::Get { name: placeholder.name };
 
-        Ok(self.wrap_children_with_expr(expr, children))
+        if preserve_result_after_children {
+            Ok(self.wrap_children_preserving_expr(expr, children))
+        } else {
+            Ok(self.wrap_children_with_expr(expr, children))
+        }
     }
 
     fn translate_diff_left_to_right(&mut self) -> TranslateResult<Expression> {

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@nested-upsert-nested-only.json.snap
@@ -25,10 +25,9 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)
@@ -37,56 +36,32 @@ transaction
                         AND 1=1) AND "public"."Post"."userId" IN [$2,*]) OFFSET
                         $3»
                  params [const(BigInt(11)), var(0$id as Int), const(BigInt(0))]
-         in if (rowCountNeq 0 (get 1))
-            then let 1 = validate (get 1)
-                     [ rowCountNeq 0
-                     ] orRaise "MISSING_RELATED_RECORD"
-                 in let 6 = get 1
-                    in let 7 = query «SELECT "public"."Category"."id" FROM
-                                      "public"."Category" WHERE
-                                      ("public"."Category"."id" = $1 AND 1=1)
-                                      OFFSET $2»
-                               params [const(BigInt(10)), const(BigInt(0))]
-                       in let 6 = unique (validate (get 6)
-                              [ rowCountNeq 0
-                              ] orRaise "MISSING_RELATED_RECORD");
-                              6$id = mapField id (get 6);
-                              7 = validate (get 7)
-                              [ rowCountEq 1
-                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                              7$id = mapField id (get 7)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                      NOTHING»
-                             params [product(var(6$id as Int[]),
-                                             var(7$id as Int[]))]
-            else let 0 = unique (validate (get 0)
-                     [ rowCountNeq 0
-                     ] orRaise "MISSING_RELATED_RECORD");
-                     0$id = mapField id (get 0)
-                 in let 3 = unique (query «INSERT INTO "public"."Post"
-                                           ("title","userId") VALUES ($1,$2)
-                                           RETURNING "public"."Post"."id"»
-                                    params [const(String("Nested upsert created post")),
-                                            var(0$id as Int)])
-                    in let 4 = query «SELECT "public"."Category"."id" FROM
-                                      "public"."Category" WHERE
-                                      ("public"."Category"."id" = $1 AND 1=1)
-                                      OFFSET $2»
-                               params [const(BigInt(10)), const(BigInt(0))]
-                       in let 3 = unique (validate (get 3)
-                              [ rowCountNeq 0
-                              ] orRaise "MISSING_RELATED_RECORD");
-                              3$id = mapField id (get 3);
-                              4 = validate (get 4)
-                              [ rowCountEq 1
-                              ] orRaise "INCOMPLETE_CONNECT_INPUT";
-                              4$id = mapField id (get 4)
-                          in execute «INSERT INTO "public"."_CategoryToPost"
-                                      ("B","A") VALUES [($1),*],* ON CONFLICT DO
-                                      NOTHING»
-                             params [product(var(3$id as Int[]),
-                                             var(4$id as Int[]))];
+         in let 3 = if (rowCountNeq 0 (get 1))
+                then get 1
+                else let 0 = unique (validate (get 0)
+                         [ rowCountNeq 0
+                         ] orRaise "MISSING_RELATED_RECORD");
+                         0$id = mapField id (get 0)
+                     in unique (query «INSERT INTO "public"."Post"
+                                       ("title","userId") VALUES ($1,$2)
+                                       RETURNING "public"."Post"."id"»
+                                params [const(String("Nested upsert created post")),
+                                        var(0$id as Int)])
+            in let 4 = query «SELECT "public"."Category"."id" FROM
+                              "public"."Category" WHERE
+                              ("public"."Category"."id" = $1 AND 1=1) OFFSET $2»
+                       params [const(BigInt(10)), const(BigInt(0))]
+               in let 3 = unique (validate (get 3)
+                      [ rowCountNeq 0
+                      ] orRaise "MISSING_RELATED_RECORD");
+                      3$id = mapField id (get 3);
+                      4 = validate (get 4)
+                      [ rowCountEq 1
+                      ] orRaise "INCOMPLETE_CONNECT_INPUT";
+                      4$id = mapField id (get 4)
+                  in execute «INSERT INTO "public"."_CategoryToPost" ("B","A")
+                              VALUES [($1),*],* ON CONFLICT DO NOTHING»
+                     params [product(var(3$id as Int[]), var(4$id as Int[]))];
       let 0 = unique (validate (get 0)
           [ rowCountNeq 0
           ] orRaise "MISSING_RECORD");

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
@@ -2,14 +2,14 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect-child-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
        id: Int (id)
        managerId: Int? (managerId)
    }
-   let 0 = unique (query «SELECT "public"."Employee"."id",
-                          "public"."Employee"."managerId" FROM
+   let 0 = unique (query «SELECT "public"."Employee"."id" FROM
                           "public"."Employee" WHERE ("public"."Employee"."id" =
                           $1 AND 1=1) LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect-parent-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -19,8 +20,7 @@ transaction
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
                                 WHERE ("public"."Employee"."id" = $2 AND 1=1)
-                                RETURNING "public"."Employee"."id",
-                                "public"."Employee"."managerId"»
+                                RETURNING "public"."Employee"."id"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)
                 [ rowCountNeq 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-connect.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -20,10 +21,9 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
@@ -2,14 +2,14 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-create-child-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
        id: Int (id)
        managerId: Int? (managerId)
    }
-   let 0 = unique (query «SELECT "public"."Employee"."id",
-                          "public"."Employee"."managerId" FROM
+   let 0 = unique (query «SELECT "public"."Employee"."id" FROM
                           "public"."Employee" WHERE ("public"."Employee"."id" =
                           $1 AND 1=1) LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-create-parent-one2m.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -17,8 +18,7 @@ transaction
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
                                 WHERE ("public"."Employee"."id" = $2 AND 1=1)
-                                RETURNING "public"."Employee"."id",
-                                "public"."Employee"."managerId"»
+                                RETURNING "public"."Employee"."id"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)
                 [ rowCountNeq 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -2,6 +2,7 @@
 source: query-compiler/query-compiler/tests/queries.rs
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-disconnect.json
+snapshot_kind: text
 ---
 transaction
    dataMap {
@@ -9,8 +10,7 @@ transaction
        title: String (title)
        userId: Int (userId)
    }
-   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                          "public"."Post"."userId" FROM "public"."Post" WHERE
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
                           ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
                           $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set-empty.json.snap
@@ -1,6 +1,5 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
-assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-set-empty.json
 snapshot_kind: text
@@ -15,8 +14,7 @@ transaction
            name: String (name)
        }
    }
-   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                          "public"."Post"."userId" FROM "public"."Post" WHERE
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
                           ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
                           $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-set.json.snap
@@ -1,6 +1,5 @@
 ---
 source: query-compiler/query-compiler/tests/queries.rs
-assertion_line: 76
 expression: pretty
 input_file: query-compiler/query-compiler/tests/data/update-m2m-set.json
 snapshot_kind: text
@@ -15,8 +14,7 @@ transaction
            name: String (name)
        }
    }
-   let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
-                          "public"."Post"."userId" FROM "public"."Post" WHERE
+   let 0 = unique (query «SELECT "public"."Post"."id" FROM "public"."Post" WHERE
                           ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
                           $3»
                    params [const(BigInt(1)), const(BigInt(1)),

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-empty.json.snap
@@ -21,10 +21,9 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -21,10 +21,9 @@ transaction
            user: USER
        }
    }
-   let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
-                          "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+   let 0 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
+                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
+                          $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-empty-update.json.snap
@@ -19,32 +19,19 @@ transaction
    let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
                   ("public"."User"."email" = $1 AND 1=1) OFFSET $2»
            params [const(String("user.1@prisma.io")), const(BigInt(0))]
-   in if (rowCountNeq 0 (get 0))
-      then let 2 = get 0
-           in let 2 = unique (validate (get 2)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  2$id = mapField id (get 2)
-              in unique (query «SELECT "public"."User"."id",
-                                "public"."User"."email",
-                                "public"."User"."role"::text FROM
-                                "public"."User" WHERE "public"."User"."id" = $1
-                                LIMIT $2 OFFSET $3»
-                         params [var(2$id as Int), const(BigInt(1)),
-                                 const(BigInt(0))])
-      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
-                                  VALUES ($1,CAST($2::text AS "public"."Role"))
-                                  RETURNING "public"."User"."id"»
-                           params [const(String("user.1@prisma.io")),
-                                   const(String("user"))])
-           in let 1 = unique (validate (get 1)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  1$id = mapField id (get 1)
-              in unique (query «SELECT "public"."User"."id",
-                                "public"."User"."email",
-                                "public"."User"."role"::text FROM
-                                "public"."User" WHERE "public"."User"."id" = $1
-                                LIMIT $2 OFFSET $3»
-                         params [var(1$id as Int), const(BigInt(1)),
-                                 const(BigInt(0))])
+   in let 4 = if (rowCountNeq 0 (get 0))
+          then get 0
+          else unique (query «INSERT INTO "public"."User" ("email","role")
+                              VALUES ($1,CAST($2::text AS "public"."Role"))
+                              RETURNING "public"."User"."id"»
+                       params [const(String("user.1@prisma.io")),
+                               const(String("user"))])
+      in let 4 = unique (validate (get 4)
+             [ rowCountNeq 0
+             ] orRaise "MISSING_RECORD");
+             4$id = mapField id (get 4)
+         in unique (query «SELECT "public"."User"."id", "public"."User"."email",
+                           "public"."User"."role"::text FROM "public"."User"
+                           WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
+                    params [var(4$id as Int), const(BigInt(1)),
+                            const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-nested-only-update.json.snap
@@ -24,62 +24,40 @@ transaction
    let 0 = query «SELECT "public"."User"."id" FROM "public"."User" WHERE
                   ("public"."User"."email" = $1 AND 1=1) OFFSET $2»
            params [const(String("user.1@prisma.io")), const(BigInt(0))]
-   in if (rowCountNeq 0 (get 0))
-      then let 2 = get 0
-           in let 2 = unique (validate (get 2)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RELATED_RECORD");
-                  2$id = mapField id (get 2)
-              in unique (query «INSERT INTO "public"."Post" ("title","userId")
-                                VALUES ($1,$2) RETURNING "public"."Post"."id"»
-                         params [const(String("Nested upsert update post")),
-                                 var(2$id as Int)]);
-              let 2 = unique (validate (get 2)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  2$id = mapField id (get 2)
-              in let @parent = unique (query «SELECT "public"."User"."id",
-                                              "public"."User"."email",
-                                              "public"."User"."role"::text FROM
-                                              "public"."User" WHERE
-                                              "public"."User"."id" = $1 LIMIT $2
-                                              OFFSET $3»
-                                       params [var(2$id as Int),
-                                               const(BigInt(1)),
-                                               const(BigInt(0))])
-                 in let @parent$id = mapField id (get @parent)
-                    in join (get @parent)
-                       with (query «SELECT "public"."Post"."id",
-                                    "public"."Post"."title",
-                                    "public"."Post"."userId" FROM
-                                    "public"."Post" WHERE
-                                    "public"."Post"."userId" = $1 OFFSET $2»
-                             params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
-      else let 1 = unique (query «INSERT INTO "public"."User" ("email","role")
-                                  VALUES ($1,CAST($2::text AS "public"."Role"))
-                                  RETURNING "public"."User"."id"»
-                           params [const(String("user.1@prisma.io")),
-                                   const(String("user"))])
-           in let 1 = unique (validate (get 1)
-                  [ rowCountNeq 0
-                  ] orRaise "MISSING_RECORD");
-                  1$id = mapField id (get 1)
-              in let @parent = unique (query «SELECT "public"."User"."id",
-                                              "public"."User"."email",
-                                              "public"."User"."role"::text FROM
-                                              "public"."User" WHERE
-                                              "public"."User"."id" = $1 LIMIT $2
-                                              OFFSET $3»
-                                       params [var(1$id as Int),
-                                               const(BigInt(1)),
-                                               const(BigInt(0))])
-                 in let @parent$id = mapField id (get @parent)
-                    in join (get @parent)
-                       with (query «SELECT "public"."Post"."id",
-                                    "public"."Post"."title",
-                                    "public"."Post"."userId" FROM
-                                    "public"."Post" WHERE
-                                    "public"."Post"."userId" = $1 OFFSET $2»
-                             params [var(@parent$id as Int),
-                                     const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts
+   in let 5 = if (rowCountNeq 0 (get 0))
+          then let 2 = get 0
+               in let 2 = unique (validate (get 2)
+                      [ rowCountNeq 0
+                      ] orRaise "MISSING_RELATED_RECORD");
+                      2$id = mapField id (get 2)
+                  in unique (query «INSERT INTO "public"."Post"
+                                    ("title","userId") VALUES ($1,$2) RETURNING
+                                    "public"."Post"."id"»
+                             params [const(String("Nested upsert update post")),
+                                     var(2$id as Int)]);
+                  get 2
+          else unique (query «INSERT INTO "public"."User" ("email","role")
+                              VALUES ($1,CAST($2::text AS "public"."Role"))
+                              RETURNING "public"."User"."id"»
+                       params [const(String("user.1@prisma.io")),
+                               const(String("user"))])
+      in let 5 = unique (validate (get 5)
+             [ rowCountNeq 0
+             ] orRaise "MISSING_RECORD");
+             5$id = mapField id (get 5)
+         in let @parent = unique (query «SELECT "public"."User"."id",
+                                         "public"."User"."email",
+                                         "public"."User"."role"::text FROM
+                                         "public"."User" WHERE
+                                         "public"."User"."id" = $1 LIMIT $2
+                                         OFFSET $3»
+                                  params [var(5$id as Int), const(BigInt(1)),
+                                          const(BigInt(0))])
+            in let @parent$id = mapField id (get @parent)
+               in join (get @parent)
+                  with (query «SELECT "public"."Post"."id",
+                               "public"."Post"."title", "public"."Post"."userId"
+                               FROM "public"."Post" WHERE
+                               "public"."Post"."userId" = $1 OFFSET $2»
+                        params [var(@parent$id as Int),
+                                const(BigInt(0))]) on left.(id) = right.(userId) as @nested$posts


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on update/upsert pruning and shares upsert result reads for the proved branch shapes instead of duplicating branch-local final reads.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08