### PR TITLE
perf(query-compiler): trim read selection extraction

### DIFF
--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -230,6 +230,10 @@ pub(crate) fn merge_relation_selections(
         selected_fields
     };
 
+    if nested_queries.is_empty() {
+        return selected_fields;
+    }
+
     let nested: Vec<_> = nested_queries
         .iter()
         .map(|nested_query| {

--- a/query-compiler/core/src/query_graph_builder/read/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/read/utils.rs
@@ -78,7 +78,7 @@ where
 
     let parent = parent.into();
 
-    let mut selected_fields = Vec::new();
+    let mut selected_fields = Vec::with_capacity(pairs.len());
 
     for pair in pairs {
         let field = parent.find_field(&pair.parsed_field.name);

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -122,18 +122,20 @@ pub(super) fn add_inmemory_join(
     nested: Vec<ReadQuery>,
     builder: &dyn QueryBuilder,
 ) -> TranslateResult<Expression> {
-    let all_linking_fields = nested
+    let mut all_linking_fields = nested
         .iter()
         .flat_map(|nested| match nested {
             ReadQuery::RelatedRecordsQuery(rrq) => rrq.parent_field.left_scalars(),
             _ => unreachable!(),
         })
-        .unique()
-        .sorted_by(|a, b| a.name().cmp(b.name()));
+        .collect::<Vec<_>>();
+    all_linking_fields.sort_by(|a, b| a.name().cmp(b.name()));
+    all_linking_fields.dedup_by(|a, b| a.name() == b.name());
 
     let linking_fields_bindings = all_linking_fields
+        .iter()
         .map(|sf| Binding {
-            name: binding::join_parent_field(&sf),
+            name: binding::join_parent_field(sf),
             expr: Expression::MapField {
                 field: sf.db_name().into(),
                 records: Box::new(Expression::Get {

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -310,7 +310,7 @@ fn build_read_one2m_query(
 ) -> TranslateResult<(Expression, JoinMetadata)> {
     let (field, conditions_per_field) = linkage.into_parent_field_and_conditions();
 
-    let filters = args
+    let mut filters = args
         .filter
         .take()
         .into_iter()
@@ -322,10 +322,21 @@ fn build_read_one2m_query(
                     mode: QueryMode::Default,
                 })
             })
-        }))
-        .collect_vec();
+        }));
 
-    args.filter = Some(Filter::And(filters));
+    let filter = match (filters.next(), filters.next()) {
+        (None, _) => Filter::And(Vec::new()),
+        (Some(filter), None) => filter,
+        (Some(first), Some(second)) => {
+            let mut all_filters = Vec::with_capacity(2 + filters.size_hint().0);
+            all_filters.push(first);
+            all_filters.push(second);
+            all_filters.extend(filters);
+            Filter::And(all_filters)
+        }
+    };
+
+    args.filter = Some(filter);
 
     let expr = build_get_records(
         builder,

--- a/query-compiler/query-compiler/src/translate/query/read.rs
+++ b/query-compiler/query-compiler/src/translate/query/read.rs
@@ -22,7 +22,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
         ReadQuery::RecordQuery(mut rq) => {
             let selected_fields = match rq.relation_load_strategy {
                 RelationLoadStrategy::Join => rq.selected_fields.into_virtuals_last(),
-                RelationLoadStrategy::Query => rq.selected_fields.without_relations().into_virtuals_last(),
+                RelationLoadStrategy::Query => rq.selected_fields.into_without_relations().into_virtuals_last(),
             };
 
             let mut args = QueryArguments::from((
@@ -53,7 +53,7 @@ pub(crate) fn translate_read_query(query: ReadQuery, builder: &dyn QueryBuilder)
 
             let selected_fields = match mrq.relation_load_strategy {
                 RelationLoadStrategy::Join => mrq.selected_fields.into_virtuals_last(),
-                RelationLoadStrategy::Query => mrq.selected_fields.without_relations().into_virtuals_last(),
+                RelationLoadStrategy::Query => mrq.selected_fields.into_without_relations().into_virtuals_last(),
             };
 
             let take = mrq.args.take;
@@ -243,7 +243,7 @@ fn build_read_related_records(
         }
     }
 
-    let selected_fields = rrq.selected_fields.without_relations().into_virtuals_last();
+    let selected_fields = rrq.selected_fields.into_without_relations().into_virtuals_last();
 
     let mut in_memory_ops =
         in_memory_processing::extract_in_memory_ops_for_nested_query(&mut rrq.args, has_unique_parent);

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -64,6 +64,15 @@ impl FieldSelection {
         )
     }
 
+    pub fn into_without_relations(self) -> Self {
+        FieldSelection::new(
+            self.selections
+                .into_iter()
+                .filter(|field| !matches!(field, SelectedField::Relation(_)))
+                .collect(),
+        )
+    }
+
     pub fn into_virtuals_last(self) -> Self {
         let virtual_count = self
             .selections

--- a/query-compiler/query-structure/src/field_selection.rs
+++ b/query-compiler/query-structure/src/field_selection.rs
@@ -227,6 +227,22 @@ impl FieldSelection {
     /// occurrence of the first field in order from left (`self`) to right (`other`)
     /// is retained. Assumes that both selections reason over the same model.
     pub fn merge(self, other: FieldSelection) -> FieldSelection {
+        if other.selections.is_empty() {
+            return self;
+        }
+
+        if self.selections.is_empty() {
+            return other;
+        }
+
+        if other
+            .selections
+            .iter()
+            .all(|selection| self.selections.contains(selection))
+        {
+            return self;
+        }
+
         let selections = self.selections.into_iter().chain(other.selections).unique().collect();
 
         FieldSelection { selections }


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Stacks on selection/aggregate cleanups and reduces read selection extraction overhead for scalar/relation selection paths.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08