### PR TITLE
perf(query-compiler): reduce filter extraction allocations

### DIFF
--- a/query-compiler/core/src/query_document/mod.rs
+++ b/query-compiler/core/src/query_document/mod.rs
@@ -30,7 +30,7 @@ pub(crate) use parser::*;
 
 use crate::{
     query_ast::{QueryOption, QueryOptions},
-    query_graph_builder::resolve_compound_field,
+    query_graph_builder::is_compound_field,
 };
 use itertools::Itertools;
 use query_structure::Model;
@@ -91,7 +91,7 @@ impl BatchDocument {
 
         where_obj.iter().any(|(key, val)| match val {
             // If it's a compound, then it's still considered as scalar
-            ArgumentValue::Object(_) if resolve_compound_field(key, &model).is_some() => false,
+            ArgumentValue::Object(_) if is_compound_field(key, &model) => false,
             // Otherwise, we just look for a scalar field inside the model. If it's not one, then we break.
             val => match model.fields().find_from_scalar(key) {
                 Ok(sf) => match val {
@@ -319,7 +319,7 @@ fn extract_filter(where_obj: ArgumentValueObject, model: &Model) -> Vec<Selectio
         .into_iter()
         .flat_map(|(key, val)| match val {
             // This means our query has a compound field in the form of: {co1_col2: { col1_col2: { col1: <val>, col2: <val> } }}
-            ArgumentValue::Object(obj) if resolve_compound_field(&key, model).is_some() => obj.into_iter().collect(),
+            ArgumentValue::Object(obj) if is_compound_field(&key, model) => obj.into_iter().collect(),
             // This means our query has a scalar filter in the form of {col1: { equals: <val> }}
             ArgumentValue::Object(obj) => {
                 // This is safe because it's been validated before in the `.can_compact` method.

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -242,7 +242,7 @@ fn merge_search_filters(filter: Filter) -> Filter {
 fn fold_search_filters(filters: &[Filter]) -> Vec<Filter> {
     let mut filters_by_val: HashMap<PrismaValue, &Filter> = HashMap::new();
     let mut projections_by_val: HashMap<PrismaValue, Vec<ScalarProjection>> = HashMap::new();
-    let mut output: Vec<Filter> = vec![];
+    let mut output: Vec<Filter> = Vec::with_capacity(filters.len());
 
     // Gather search filters that have the same condition
     for filter in filters.iter() {

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -23,7 +23,7 @@ pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> Qu
             .fields()
             .find_from_scalar(field_name)
             .is_ok_and(|field| field.unique())
-            || utils::resolve_compound_field(field_name, model).is_some()
+            || utils::is_compound_field(field_name, model)
     }) {
         return internal_extract_unique_filter(value_map, model);
     }
@@ -36,7 +36,7 @@ pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> Qu
             .into_iter()
             .partition(|(field_name, _)| match model.fields().find_from_scalar(field_name) {
                 Ok(field) => field.unique(),
-                Err(_) => utils::resolve_compound_field(field_name, model).is_some(),
+                Err(_) => utils::is_compound_field(field_name, model),
             });
     let mut unique_map = ParsedInputMap::from(unique_map);
     let mut rest_map = ParsedInputMap::from(rest_map);

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -228,6 +228,10 @@ where
 /// 3. We reconstruct the filter tree and merge the search filters that have the same query along the way
 ///    eg: `Filter(And([SearchFilter("query", [FieldA]), SearchFilter("query", [FieldB])]))` -> `Filter(And([SearchFilter("query", [FieldA, FieldB])]))`
 fn merge_search_filters(filter: Filter) -> Filter {
+    if matches!(filter, Filter::And(_) | Filter::Or(_) | Filter::Not(_)) && !contains_search_filter(&filter) {
+        return filter;
+    }
+
     // The filter tree _needs_ to be flattened for the merge to work properly
     let flattened = fold_filter(filter);
 
@@ -236,6 +240,19 @@ fn merge_search_filters(filter: Filter) -> Filter {
         Filter::Or(or) => Filter::Or(fold_search_filters(&or)),
         Filter::Not(not) => Filter::Not(fold_search_filters(&not)),
         _ => flattened,
+    }
+}
+
+fn contains_search_filter(filter: &Filter) -> bool {
+    match filter {
+        Filter::Scalar(sf) => matches!(
+            sf.condition,
+            ScalarCondition::Search(..) | ScalarCondition::NotSearch(..)
+        ),
+        Filter::And(filters) | Filter::Or(filters) | Filter::Not(filters) => {
+            filters.iter().any(contains_search_filter)
+        }
+        _ => false,
     }
 }
 

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/mod.rs
@@ -18,6 +18,16 @@ use std::{borrow::Cow, collections::HashMap, convert::TryInto, str::FromStr};
 
 /// Extracts a filter for a unique selector, i.e. a filter that selects exactly one record.
 pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> QueryGraphBuilderResult<Filter> {
+    if value_map.iter().all(|(field_name, _)| {
+        model
+            .fields()
+            .find_from_scalar(field_name)
+            .is_ok_and(|field| field.unique())
+            || utils::resolve_compound_field(field_name, model).is_some()
+    }) {
+        return internal_extract_unique_filter(value_map, model);
+    }
+
     let tag = value_map.tag.clone();
     // Partition the input into a map containing only the unique fields and one containing all the other filters
     // so that we can parse them separately and ensure we AND both filters
@@ -42,29 +52,48 @@ pub fn extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> Qu
 /// Extracts a filter for a unique selector, i.e. a filter that selects exactly one record.
 /// The input map must only contain unique & compound unique fields.
 fn internal_extract_unique_filter(value_map: ParsedInputMap<'_>, model: &Model) -> QueryGraphBuilderResult<Filter> {
-    let filters = value_map
-        .into_iter()
-        .map(|(field_name, value): (Cow<'_, str>, ParsedInputValue<'_>)| {
-            // Always try to resolve regular fields first. If that fails, try to resolve compound fields.
-            match model.fields().find_from_scalar(&field_name) {
-                Ok(field) => {
-                    let value: PrismaValue = value.try_into()?;
-                    Ok(field.equals(value))
-                }
-                Err(_) => utils::resolve_compound_field(&field_name, model)
-                    .ok_or_else(|| {
-                        QueryGraphBuilderError::AssertionError(format!(
-                            "Unable to resolve field {} to a field or set of scalar fields on model {}",
-                            field_name,
-                            model.name()
-                        ))
-                    })
-                    .and_then(|fields| handle_compound_field(fields, value)),
-            }
-        })
-        .collect::<QueryGraphBuilderResult<Vec<Filter>>>()?;
+    let mut input = value_map.into_iter();
+    let Some((field_name, value)) = input.next() else {
+        return Ok(Filter::And(Vec::new()));
+    };
+
+    let first = extract_unique_filter_field(field_name, value, model)?;
+
+    if input.len() == 0 {
+        return Ok(first);
+    }
+
+    let mut filters = Vec::with_capacity(input.len() + 1);
+    filters.push(first);
+
+    for (field_name, value) in input {
+        filters.push(extract_unique_filter_field(field_name, value, model)?);
+    }
 
     Ok(Filter::and(filters))
+}
+
+fn extract_unique_filter_field(
+    field_name: Cow<'_, str>,
+    value: ParsedInputValue<'_>,
+    model: &Model,
+) -> QueryGraphBuilderResult<Filter> {
+    // Always try to resolve regular fields first. If that fails, try to resolve compound fields.
+    match model.fields().find_from_scalar(&field_name) {
+        Ok(field) => {
+            let value: PrismaValue = value.try_into()?;
+            Ok(field.equals(value))
+        }
+        Err(_) => utils::resolve_compound_field(&field_name, model)
+            .ok_or_else(|| {
+                QueryGraphBuilderError::AssertionError(format!(
+                    "Unable to resolve field {} to a field or set of scalar fields on model {}",
+                    field_name,
+                    model.name()
+                ))
+            })
+            .and_then(|fields| handle_compound_field(fields, value)),
+    }
 }
 
 fn handle_compound_field(fields: Vec<ScalarFieldRef>, value: ParsedInputValue<'_>) -> QueryGraphBuilderResult<Filter> {

--- a/query-compiler/core/src/query_graph_builder/extractors/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/mod.rs
@@ -6,6 +6,6 @@ mod utils;
 pub(crate) use filters::*;
 pub(crate) use query_arguments::*;
 pub(crate) use rel_aggregations::*;
-pub(crate) use utils::resolve_compound_field;
+pub(crate) use utils::is_compound_field;
 
 use crate::query_document::*;

--- a/query-compiler/core/src/query_graph_builder/extractors/utils.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/utils.rs
@@ -1,5 +1,10 @@
 use query_structure::{Model, ScalarFieldRef};
 
+/// Checks whether a field name resolves to a compound field without materializing the fields.
+pub fn is_compound_field(name: &str, model: &Model) -> bool {
+    is_compound_id(name, model) || is_index_field(name, model)
+}
+
 /// Attempts to resolve a field name to a compound field.
 pub fn resolve_compound_field(name: &str, model: &Model) -> Option<Vec<ScalarFieldRef>> {
     resolve_compound_id(name, model).or_else(|| resolve_index_fields(name, model))
@@ -7,20 +12,63 @@ pub fn resolve_compound_field(name: &str, model: &Model) -> Option<Vec<ScalarFie
 
 /// Attempts to match a given name to the (schema) name of a compound id field on the model.
 pub fn resolve_compound_id(name: &str, model: &Model) -> Option<Vec<ScalarFieldRef>> {
-    model.fields().compound_id().and_then(|pk| {
-        (name == schema::compound_id_field_name(model.walker().primary_key().unwrap())).then(|| pk.collect())
-    })
+    model
+        .fields()
+        .compound_id()
+        .and_then(|pk| is_compound_id(name, model).then(|| pk.collect()))
 }
 
 /// Attempts to match a given name to the (schema) name of a compound indexes on the model and returns the first match.
 pub fn resolve_index_fields(name: &str, model: &Model) -> Option<Vec<ScalarFieldRef>> {
     model
         .unique_indexes()
-        .find(|index| schema::compound_index_field_name(*index) == name)
+        .find(|index| index_field_name_matches(name, *index))
         .map(|index| {
             index
                 .fields()
                 .map(|f| ScalarFieldRef::from((model.dm.clone(), f)))
                 .collect()
         })
+}
+
+fn is_compound_id(name: &str, model: &Model) -> bool {
+    model.fields().compound_id().is_some()
+        && model.walker().primary_key().is_some_and(|pk| match pk.name() {
+            Some(pk_name) => name == pk_name,
+            None => compound_field_name_matches(name, pk.fields().map(|field| field.name())),
+        })
+}
+
+fn is_index_field(name: &str, model: &Model) -> bool {
+    model
+        .unique_indexes()
+        .any(|index| index_field_name_matches(name, index))
+}
+
+fn index_field_name_matches(name: &str, index: psl::parser_database::walkers::IndexWalker<'_>) -> bool {
+    match index.name() {
+        Some(index_name) => name == index_name,
+        None => compound_field_name_matches(name, index.fields().map(|field| field.name())),
+    }
+}
+
+fn compound_field_name_matches<'a>(mut name: &str, fields: impl Iterator<Item = &'a str>) -> bool {
+    let mut first = true;
+
+    for field in fields {
+        if first {
+            first = false;
+        } else if let Some(rest) = name.strip_prefix('_') {
+            name = rest;
+        } else {
+            return false;
+        }
+
+        let Some(rest) = name.strip_prefix(field) else {
+            return false;
+        };
+        name = rest;
+    }
+
+    !first && name.is_empty()
 }

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -232,7 +232,7 @@ fn can_use_connector_native_upsert<'a>(
 fn is_unique_field(field_name: &str, model: &Model) -> bool {
     match model.fields().find_from_scalar(field_name) {
         Ok(field) => field.unique(),
-        Err(_) => resolve_compound_field(field_name, model).is_some(),
+        Err(_) => is_compound_field(field_name, model),
     }
 }
 

--- a/query-compiler/query-compiler/tests/data/query-compound-id.json
+++ b/query-compiler/query-compiler/tests/data/query-compound-id.json
@@ -1,0 +1,19 @@
+{
+  "modelName": "ParentModelWithCompositeId",
+  "action": "findUnique",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": {
+        "a_b": {
+          "a": 1,
+          "b": 1
+        }
+      }
+    },
+    "selection": {
+      "$composites": true,
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connect.json.snap
@@ -30,9 +30,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           0$id = mapField id (get 0)
       in let 1 = execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                          (("public"."Post"."id" = $2 AND 1=1) OR
-                          ("public"."Post"."id" = $3 AND 1=1) OR
-                          ("public"."Post"."id" = $4 AND 1=1))»
+                          ("public"."Post"."id" = $2 OR "public"."Post"."id" =
+                          $3 OR "public"."Post"."id" = $4)»
                  params [var(0$id as Int), const(BigInt(8)), const(BigInt(9)),
                          const(BigInt(10))]
          in validate (get 1)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-m2one.json.snap
@@ -21,8 +21,7 @@ transaction
        }
    }
    let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("john@example.com")), const(BigInt(1)),
                            const(BigInt(0))])
    in let 2 = if (rowCountNeq 0 (get 1))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-mixed.json.snap
@@ -25,8 +25,7 @@ transaction
        }
    }
    let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                          ("public"."User"."email" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("john@example.com")), const(BigInt(1)),
                            const(BigInt(0))])
    in let 2 = if (rowCountNeq 0 (get 1))
@@ -45,8 +44,8 @@ transaction
                                     var(2$id as Int)])
             in let 6 = unique (query «SELECT "public"."Category"."id" FROM
                                       "public"."Category" WHERE
-                                      ("public"."Category"."id" = $1 AND 1=1)
-                                      LIMIT $2 OFFSET $3»
+                                      "public"."Category"."id" = $1 LIMIT $2
+                                      OFFSET $3»
                                params [const(BigInt(10)), const(BigInt(1)),
                                        const(BigInt(0))])
                in if (rowCountNeq 0 (get 6))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@create-nested-connectOrCreate-one2m.json.snap
@@ -25,8 +25,7 @@ transaction
        }
    }
    let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User" WHERE
-                          ("public"."User"."id" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 1 = unique (validate (get 1)
@@ -39,8 +38,8 @@ transaction
                                  var(1$id as Int)])
          in let 2 = unique (query «SELECT "public"."Category"."id" FROM
                                    "public"."Category" WHERE
-                                   ("public"."Category"."id" = $1 AND 1=1) LIMIT
-                                   $2 OFFSET $3»
+                                   "public"."Category"."id" = $1 LIMIT $2 OFFSET
+                                   $3»
                             params [const(BigInt(10)), const(BigInt(1)),
                                     const(BigInt(0))])
             in if (rowCountNeq 0 (get 2))

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@delete-one.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@delete-one.json.snap
@@ -8,8 +8,8 @@ dataMap {
     title: String (title)
     userId: Int (userId)
 }
-let 0 = unique (query «DELETE FROM "public"."Post" WHERE ("public"."Post"."id" =
-                       $1 AND 1=1) RETURNING "public"."Post"."id",
+let 0 = unique (query «DELETE FROM "public"."Post" WHERE "public"."Post"."id" =
+                       $1 RETURNING "public"."Post"."id",
                        "public"."Post"."title", "public"."Post"."userId"»
                 params [const(BigInt(1))])
 in let 0 = validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-compound-id.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-compound-id.json.snap
@@ -1,0 +1,18 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/query-compound-id.json
+snapshot_kind: text
+---
+dataMap {
+    a: Int (a)
+    b: Int (b)
+}
+unique (query «SELECT "public"."ParentModelWithCompositeId"."a",
+               "public"."ParentModelWithCompositeId"."b" FROM
+               "public"."ParentModelWithCompositeId" WHERE
+               ("public"."ParentModelWithCompositeId"."a" = $1 AND
+               "public"."ParentModelWithCompositeId"."b" = $2) LIMIT $3 OFFSET
+               $4»
+        params [const(BigInt(1)), const(BigInt(1)), const(BigInt(1)),
+                const(BigInt(0))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-m2m.json.snap
@@ -14,8 +14,8 @@ dataMap {
 }
 let @parent = unique (query «SELECT "public"."Post"."id",
                              "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE ("public"."Post"."id" =
-                             $1 AND 1=1) LIMIT $2 OFFSET $3»
+                             FROM "public"."Post" WHERE "public"."Post"."id" =
+                             $1 LIMIT $2 OFFSET $3»
                       params [const(BigInt(1)), const(BigInt(1)),
                               const(BigInt(0))])
 in let @parent$id = mapField id (get @parent)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-one2m.json.snap
@@ -21,8 +21,8 @@ enums {
 }
 let @parent = unique (query «SELECT "public"."Post"."id",
                              "public"."Post"."title", "public"."Post"."userId"
-                             FROM "public"."Post" WHERE ("public"."Post"."id" =
-                             $1 AND 1=1) LIMIT $2 OFFSET $3»
+                             FROM "public"."Post" WHERE "public"."Post"."id" =
+                             $1 LIMIT $2 OFFSET $3»
                       params [const(BigInt(1)), const(BigInt(1)),
                               const(BigInt(0))])
 in let @parent$userId = mapField userId (get @parent)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@query-unique-one2m-pagination.json.snap
@@ -20,8 +20,7 @@ enums {
 let @parent = unique (query «SELECT "public"."User"."id",
                              "public"."User"."email",
                              "public"."User"."role"::text FROM "public"."User"
-                             WHERE ("public"."User"."id" = $1 AND 1=1) LIMIT $2
-                             OFFSET $3»
+                             WHERE "public"."User"."id" = $1 LIMIT $2 OFFSET $3»
                       params [const(BigInt(1)), const(BigInt(1)),
                               const(BigInt(0))])
 in let @parent$id = mapField id (get @parent)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-child-one2m.json.snap
@@ -10,8 +10,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Employee"."id",
                           "public"."Employee"."managerId" FROM
-                          "public"."Employee" WHERE ("public"."Employee"."id" =
-                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                          "public"."Employee" WHERE "public"."Employee"."id" =
+                          $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0 = unique (validate (get 0)
@@ -19,8 +19,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           0$id = mapField id (get 0)
       in let 1 = execute «UPDATE "public"."Employee" SET "managerId" = $1 WHERE
-                          (("public"."Employee"."id" = $2 AND 1=1) OR
-                          ("public"."Employee"."id" = $3 AND 1=1))»
+                          ("public"."Employee"."id" = $2 OR
+                          "public"."Employee"."id" = $3)»
                  params [var(0$id as Int), const(BigInt(2)), const(BigInt(3))]
          in validate (get 1)
             [ affectedRowCountEq 2

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect-parent-one2m.json.snap
@@ -9,8 +9,8 @@ transaction
        managerId: Int? (managerId)
    }
    let 1 = unique (query «SELECT "public"."Employee"."id" FROM
-                          "public"."Employee" WHERE ("public"."Employee"."id" =
-                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                          "public"."Employee" WHERE "public"."Employee"."id" =
+                          $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(2)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 1 = unique (validate (get 1)
@@ -18,8 +18,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
-                                WHERE ("public"."Employee"."id" = $2 AND 1=1)
-                                RETURNING "public"."Employee"."id",
+                                WHERE "public"."Employee"."id" = $2 RETURNING
+                                "public"."Employee"."id",
                                 "public"."Employee"."managerId"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-connect.json.snap
@@ -22,8 +22,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
                           "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0 = unique (validate (get 0)
@@ -31,7 +30,7 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           0$id = mapField id (get 0)
       in let 1 = execute «UPDATE "public"."Post" SET "userId" = $1 WHERE
-                          ("public"."Post"."id" = $2 AND 1=1)»
+                          "public"."Post"."id" = $2»
                  params [var(0$id as Int), const(BigInt(11))]
          in validate (get 1)
             [ affectedRowCountEq 1

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-child-one2m.json.snap
@@ -10,8 +10,8 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Employee"."id",
                           "public"."Employee"."managerId" FROM
-                          "public"."Employee" WHERE ("public"."Employee"."id" =
-                          $1 AND 1=1) LIMIT $2 OFFSET $3»
+                          "public"."Employee" WHERE "public"."Employee"."id" =
+                          $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-create-parent-one2m.json.snap
@@ -16,8 +16,8 @@ transaction
           ] orRaise "MISSING_RELATED_RECORD");
           1$id = mapField id (get 1)
       in let 0 = unique (query «UPDATE "public"."Employee" SET "managerId" = $1
-                                WHERE ("public"."Employee"."id" = $2 AND 1=1)
-                                RETURNING "public"."Employee"."id",
+                                WHERE "public"."Employee"."id" = $2 RETURNING
+                                "public"."Employee"."id",
                                 "public"."Employee"."managerId"»
                          params [var(1$id as Int), const(BigInt(1))])
          in let 0 = unique (validate (get 0)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-m2m-disconnect.json.snap
@@ -11,8 +11,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Post"."id", "public"."Post"."title",
                           "public"."Post"."userId" FROM "public"."Post" WHERE
-                          ("public"."Post"."id" = $1 AND 1=1) LIMIT $2 OFFSET
-                          $3»
+                          "public"."Post"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0$id = mapField id (get 0)
@@ -20,7 +19,7 @@ transaction
                         "CategoryToPost@Post" FROM "public"."Category" INNER
                         JOIN "public"."_CategoryToPost" AS "t0" ON "t0"."A" =
                         "public"."Category"."id" WHERE ("public"."Category"."id"
-                        = $1 AND 1=1 AND "t0"."B" IN [$2,*]) OFFSET $3»
+                        = $1 AND "t0"."B" IN [$2,*]) OFFSET $3»
                  params [const(BigInt(1)), var(0$id as Int), const(BigInt(0))]
          in let 0 = unique (validate (get 0)
                 [ rowCountNeq 0

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-one-returning.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-one-returning.json.snap
@@ -7,7 +7,7 @@ dataMap {
     email: String (email)
 }
 let 0 = unique (query «UPDATE "public"."User" SET "email" = $1 WHERE
-                       ("public"."User"."email" = $2 AND 1=1) RETURNING
+                       "public"."User"."email" = $2 RETURNING
                        "public"."User"."id", "public"."User"."email"»
                 params [const(String("user.2737556028164@prisma.io")),
                         const(String("user.1737556028164@prisma.io"))])

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-push.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-push.json.snap
@@ -10,7 +10,7 @@ dataMap {
 }
 let 0 = unique (query «UPDATE "public"."DataTypes" SET "intArray" =
                        "public"."DataTypes"."intArray" || $1 WHERE
-                       ("public"."DataTypes"."id" = $2 AND 1=1) RETURNING
+                       "public"."DataTypes"."id" = $2 RETURNING
                        "public"."DataTypes"."id",
                        "public"."DataTypes"."optString",
                        "public"."DataTypes"."intArray"»

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested-prisma#27650.json.snap
@@ -10,8 +10,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."Patient"."id",
                           "public"."Patient"."userId" FROM "public"."Patient"
-                          WHERE ("public"."Patient"."id" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+                          WHERE "public"."Patient"."id" = $1 LIMIT $2 OFFSET $3»
                    params [const(BigInt(1)), const(BigInt(1)),
                            const(BigInt(0))])
    in let 0$id = mapField id (get 0);

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-set-nested.json.snap
@@ -22,8 +22,7 @@ transaction
    }
    let 0 = unique (query «SELECT "public"."User"."id", "public"."User"."email",
                           "public"."User"."role"::text FROM "public"."User"
-                          WHERE ("public"."User"."email" = $1 AND 1=1) LIMIT $2
-                          OFFSET $3»
+                          WHERE "public"."User"."email" = $1 LIMIT $2 OFFSET $3»
                    params [const(String("user.1737556028164@prisma.io")),
                            const(BigInt(1)), const(BigInt(0))])
    in let 0$id = mapField id (get 0)
@@ -32,8 +31,8 @@ transaction
                         "public"."Post"."userId" IN [$1,*]) OFFSET $2»
                  params [var(0$id as Int), const(BigInt(0))]
          in let 2 = query «SELECT "public"."Post"."id" FROM "public"."Post"
-                           WHERE (("public"."Post"."id" = $1 AND 1=1) OR
-                           ("public"."Post"."id" = $2 AND 1=1)) OFFSET $3»
+                           WHERE ("public"."Post"."id" = $1 OR
+                           "public"."Post"."id" = $2) OFFSET $3»
                     params [const(BigInt(11)), const(BigInt(12)),
                             const(BigInt(0))]
             in let 3 = diff (get 2) (get 1)

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert.json.snap
@@ -16,8 +16,8 @@ enums {
 }
 unique (query «INSERT INTO "public"."User" ("email","role") VALUES
                ($1,CAST($2::text AS "public"."Role")) ON CONFLICT ("email") DO
-               UPDATE SET "email" = $3 WHERE ("public"."User"."email" = $4 AND
-               1=1) RETURNING "public"."User"."id", "public"."User"."email",
+               UPDATE SET "email" = $3 WHERE "public"."User"."email" = $4
+               RETURNING "public"."User"."id", "public"."User"."email",
                "public"."User"."role"::text»
         params [const(String("user.1@prisma.io")), const(String("user")),
                 const(String("user.2@prisma.io")),


### PR DESCRIPTION
Stacked performance split from the ongoing Prisma Client performance work.

What changed:
- Reduces filter extraction allocations, including compound-selector checks and related parser/extractor helpers, without pulling in unrelated selection cleanups.

Why:
- Keeps this review unit small while preserving the measured allocation/runtime cleanup from the larger performance branch.

Validation:
- See wip/client-performance-pr-stack.md on the Prisma status branch for the exact local check set recorded for this split.

CI linkage:
/prisma-branch prisma-client-performance-2026-06-08