### PR TITLE
chore(psl): unhide the typedSql preview feature

### DIFF
--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -164,6 +164,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                  | SchemaEngineDriverAdapters
                  | ShardKeys
                  | StrictUndefinedChecks
+                 | TypedSql
                  | Views
             }),
             native: HashMap::from([
@@ -231,7 +232,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                 | TransactionApi
                 | UncheckedScalarInputs
             }),
-            hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative | TypedSql}),
+            hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative}),
         };
 
         Self {

--- a/psl/psl-core/src/common/preview_features.rs
+++ b/psl/psl-core/src/common/preview_features.rs
@@ -232,7 +232,7 @@ impl<'a> FeatureMapWithProvider<'a> {
                 | TransactionApi
                 | UncheckedScalarInputs
             }),
-            hidden: enumflags2::make_bitflags!(PreviewFeature::{ReactNative}),
+            hidden: enumflags2::make_bitflags!(PreviewFeature::ReactNative),
         };
 
         Self {

--- a/psl/psl/tests/config/generators.rs
+++ b/psl/psl/tests/config/generators.rs
@@ -256,7 +256,7 @@ fn nice_error_for_unknown_generator_preview_feature() {
         .unwrap_err();
 
     let expectation = expect![[r#"
-        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: nativeDistinct, partialIndexes, postgresqlExtensions, relationJoins, schemaEngineDriverAdapters, shardKeys, strictUndefinedChecks, views[0m
+        [1;91merror[0m: [1mThe preview feature "foo" is not known. Expected one of: nativeDistinct, partialIndexes, postgresqlExtensions, relationJoins, schemaEngineDriverAdapters, shardKeys, strictUndefinedChecks, typedSql, views[0m
           [1;94m-->[0m  [4mschema.prisma:3[0m
         [1;94m   | [0m
         [1;94m 2 | [0m  provider = "prisma-client"

--- a/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
+++ b/psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma
@@ -13,7 +13,7 @@ model Blog {
   title   String
   @@fulltext([content, title])
 }
-// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: nativeDistinct, partialIndexes, postgresqlExtensions, relationJoins, schemaEngineDriverAdapters, shardKeys, strictUndefinedChecks, views[0m
+// [1;91merror[0m: [1mThe preview feature "fullTextSearchPostgres" is not known. Expected one of: nativeDistinct, partialIndexes, postgresqlExtensions, relationJoins, schemaEngineDriverAdapters, shardKeys, strictUndefinedChecks, typedSql, views[0m
 //   [1;94m-->[0m  [4mschema.prisma:3[0m
 // [1;94m   | [0m
 // [1;94m 2 | [0m  provider        = "prisma-client"


### PR DESCRIPTION
## What

Moves the `TypedSql` preview feature from the **hidden** set to the **active** set in `psl-core`'s feature classification (`psl/psl-core/src/common/preview_features.rs`).

This is a **visibility-only change — no behavior changes**. `typedSql` was already a valid, fully functional preview feature when enabled explicitly in a schema; being hidden only meant it was excluded from tooling surfaces (autocomplete in language tools) and from the "Expected one of: ..." list in validation error messages. After this change it appears in both.

The two tests that embed the rendered list of visible preview features (`psl/psl/tests/config/generators.rs` and `psl/psl/tests/validation/preview_features/native_full_text_search_postgres/mysql.prisma`) gain `typedSql` in their expected output. No other test or snapshot in the repository pins the classification (verified by sweeping for the rendered list and for `TypedSql` references).

## Why now

Prisma ORM's agent-native documentation work recommends TypedSQL as the escape hatch for several known pitfalls (e.g. full-text search on PostgreSQL), but neither users nor AI agents can discover a hidden flag: it never shows up in autocomplete or in the valid-feature listings that errors print. Making the feature visible closes that discoverability gap.

## What stays as is

- `reactNative` remains hidden.
- GA/stabilization of `typedSql` is explicitly out of scope — that would make `$queryRawTyped` generation unconditional and is a separate decision with its own compatibility questions.

## Validation

- `CLICOLOR_FORCE=1 cargo test -p psl --features all` — 1,297 tests green (`CLICOLOR_FORCE` matches the CI unit-test environment; the expect-test snapshots embed ANSI colors).
- `cargo test -p psl-core --all-features` — green.
- `cargo fmt --check -p psl-core` — clean.
- CI (`make test-unit`, workspace-wide with `--all-features`) is the authoritative surface for the remaining crates; a repository-wide sweep found no other snapshot embedding the visible-features list.
