### PR TITLE
test: update unique constraint error expectations

### DIFF
--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
@@ -44,6 +44,20 @@ mod byoid {
         schema.to_owned()
     }
 
+    fn id_unique_constraint_target(runner: &Runner, model: &str) -> String {
+        match runner.connector_version() {
+            ConnectorVersion::MySql(_)
+            | ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
+                "constraint: `PRIMARY`".to_owned()
+            }
+            ConnectorVersion::Postgres(_) | ConnectorVersion::CockroachDb(_) => {
+                std::format!("constraint: `{model}_pkey`")
+            }
+            ConnectorVersion::Vitess(_) => "(not available)".to_owned(),
+            _ => "fields: (`id`)".to_owned(),
+        }
+    }
+
     // "A Create Mutation" should "create and return item with own Id"
     #[connector_test(schema(schema_1), only(MySql, Postgres, Sqlite, Vitess))]
     async fn create_and_return_item_woi_1(runner: Runner) -> TestResult<()> {
@@ -54,14 +68,7 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id"}}}"###
         );
 
-        let error_target = match runner.connector_version() {
-            query_engine_tests::ConnectorVersion::MySql(_)
-            | query_engine_tests::ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
-                "constraint: `PRIMARY`"
-            }
-            query_engine_tests::ConnectorVersion::Vitess(_) => "(not available)",
-            _ => "fields: (`id`)",
-        };
+        let error_target = id_unique_constraint_target(&runner, "Parent");
 
         assert_error!(
             &runner,
@@ -85,14 +92,7 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id"}}}"###
         );
 
-        let error_target = match runner.connector_version() {
-            query_engine_tests::ConnectorVersion::MySql(_)
-            | query_engine_tests::ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
-                "constraint: `PRIMARY`"
-            }
-            ConnectorVersion::Vitess(_) => "(not available)",
-            _ => "fields: (`id`)",
-        };
+        let error_target = id_unique_constraint_target(&runner, "Parent");
 
         assert_error!(
             &runner,
@@ -146,14 +146,7 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id","childOpt":{"c":"Child","id":"Own Child Id"}}}}"###
         );
 
-        let error_target = match runner.connector_version() {
-            query_engine_tests::ConnectorVersion::MySql(_)
-            | query_engine_tests::ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
-                "constraint: `PRIMARY`"
-            }
-            ConnectorVersion::Vitess(_) => "(not available)",
-            _ => "fields: (`id`)",
-        };
+        let error_target = id_unique_constraint_target(&runner, "Child");
 
         assert_error!(
             &runner,
@@ -177,14 +170,7 @@ mod byoid {
           @r###"{"data":{"createOneParent":{"p":"Parent","id":"Own Id","childOpt":{"c":"Child","id":"Own Child Id"}}}}"###
         );
 
-        let error_target = match runner.connector_version() {
-            query_engine_tests::ConnectorVersion::MySql(_)
-            | query_engine_tests::ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
-                "constraint: `PRIMARY`"
-            }
-            ConnectorVersion::Vitess(_) => "(not available)",
-            _ => "fields: (`id`)",
-        };
+        let error_target = id_unique_constraint_target(&runner, "Child");
 
         assert_error!(
             &runner,

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
@@ -50,7 +50,8 @@ mod byoid {
             | ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
                 "constraint: `PRIMARY`".to_owned()
             }
-            ConnectorVersion::Postgres(_) | ConnectorVersion::CockroachDb(_) => {
+            ConnectorVersion::Postgres(Some(query_tests_setup::PostgresVersion::PgJsWasm))
+            | ConnectorVersion::CockroachDb(Some(query_tests_setup::CockroachDbVersion::PgJsWasm)) => {
                 std::format!("constraint: `{model}_pkey`")
             }
             ConnectorVersion::Vitess(_) => "(not available)".to_owned(),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
@@ -1,6 +1,6 @@
 use query_engine_tests::*;
 
-#[test_suite(only(MySql, Postgres, Sqlite, Vitess))]
+#[test_suite(only(MySql, Postgres, Sqlite, Vitess, CockroachDb))]
 //  bring_your_own_id
 mod byoid {
     use indoc::indoc;
@@ -59,7 +59,7 @@ mod byoid {
     }
 
     // "A Create Mutation" should "create and return item with own Id"
-    #[connector_test(schema(schema_1), only(MySql, Postgres, Sqlite, Vitess))]
+    #[connector_test(schema(schema_1), only(MySql, Postgres, Sqlite, Vitess, CockroachDb))]
     async fn create_and_return_item_woi_1(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -83,7 +83,7 @@ mod byoid {
     }
 
     // "A Create Mutation" should "create and return item with own Id"
-    #[connector_test(schema(schema_2), only(MySql, Postgres, Sqlite, Vitess))]
+    #[connector_test(schema(schema_2), only(MySql, Postgres, Sqlite, Vitess, CockroachDb))]
     async fn create_and_return_item_woi_2(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -137,7 +137,7 @@ mod byoid {
     }
 
     // "A Nested Create Mutation" should "create and return item with own Id"
-    #[connector_test(schema(schema_1), only(MySql, Postgres, Sqlite, Vitess))]
+    #[connector_test(schema(schema_1), only(MySql, Postgres, Sqlite, Vitess, CockroachDb))]
     async fn nested_create_return_item_woi_1(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {
@@ -161,7 +161,7 @@ mod byoid {
     }
 
     // "A Nested Create Mutation" should "create and return item with own Id"
-    #[connector_test(schema(schema_2), only(MySql, Postgres, Sqlite, Vitess))]
+    #[connector_test(schema(schema_2), only(MySql, Postgres, Sqlite, Vitess, CockroachDb))]
     async fn nested_create_return_item_woi_2(runner: Runner) -> TestResult<()> {
         insta::assert_snapshot!(
           run_query!(&runner, r#"mutation {

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/writes/ids/byoid.rs
@@ -50,8 +50,7 @@ mod byoid {
             | ConnectorVersion::Vitess(Some(query_tests_setup::VitessVersion::PlanetscaleJsWasm)) => {
                 "constraint: `PRIMARY`".to_owned()
             }
-            ConnectorVersion::Postgres(Some(query_tests_setup::PostgresVersion::PgJsWasm))
-            | ConnectorVersion::CockroachDb(Some(query_tests_setup::CockroachDbVersion::PgJsWasm)) => {
+            connector_version if connector_version.is_pg_driver_adapter() => {
                 std::format!("constraint: `{model}_pkey`")
             }
             ConnectorVersion::Vitess(_) => "(not available)".to_owned(),

--- a/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
+++ b/query-engine/connector-test-kit-rs/query-tests-setup/src/connector_tag/mod.rs
@@ -271,6 +271,14 @@ impl ConnectorVersion {
         }
     }
 
+    /// Determines if the connector uses the pg driver adapter.
+    pub fn is_pg_driver_adapter(&self) -> bool {
+        matches!(
+            self,
+            Self::Postgres(Some(PostgresVersion::PgJsWasm)) | Self::CockroachDb(Some(CockroachDbVersion::PgJsWasm))
+        )
+    }
+
     /// Determines if the connector uses a driver adapter implemented in Wasm.
     /// Do not delete! This is used because the `#[cfg(target_arch = "wasm32")]` conditional compilation
     /// directive doesn't work in the test runner.


### PR DESCRIPTION
Updates connector-test-kit assertions to match the intentional pg driver-adapter P2002 error target change from field names to database constraint names.

## Changes

- **Unique constraint expectations**: Centralizes provider-specific target formatting in the by-OID tests. The pg adapter for PostgreSQL and CockroachDB now asserts model-specific `Parent_pkey` or `Child_pkey` constraints, while Neon and providers that still expose field metadata keep their existing expectations.
- **Test support**: Adds `ConnectorVersion::is_pg_driver_adapter()` so tests can distinguish the pg adapter without exposing private connector-version enums.

## Why

The pg driver adapter now intentionally preserves the database constraint name for unique violations, while Neon still reports constrained fields. The tests need to distinguish those adapters rather than applying one PostgreSQL-wide expectation.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- Editor diagnostics for the changed test module
- Local Cargo checks remain blocked because `openssl-sys` cannot find OpenSSL development headers or `openssl.pc`; CI provides the compile validation.
