### PR TITLE
fix(postgres): preserve aggregate and array cast arity

### DIFF
--- a/quaint/src/visitor/postgres.rs
+++ b/quaint/src/visitor/postgres.rs
@@ -27,16 +27,24 @@ impl<'a> Postgres<'a> {
         match expr.kind() {
             ExpressionKind::Column(col) => match (col.type_family.as_ref(), col.native_type.as_deref()) {
                 (Some(TypeFamily::Decimal(_)), Some("MONEY")) => {
+                    let is_list = col.is_list;
                     self.visit_expression(expr)?;
                     self.write("::numeric")?;
+                    if is_list {
+                        self.write("[]")?;
+                    }
 
                     Ok(())
                 }
                 // Cast BigInt to text to preserve precision when parsed by JavaScript.
                 // JavaScript's JSON.parse loses precision for integers > 2^53-1.
                 (Some(TypeFamily::Int), Some("BIGINT" | "INT8")) => {
+                    let is_list = col.is_list;
                     self.visit_expression(expr)?;
                     self.write("::text")?;
+                    if is_list {
+                        self.write("[]")?;
+                    }
 
                     Ok(())
                 }
@@ -1443,6 +1451,22 @@ mod tests {
         }
 
         #[test]
+        fn money_array() {
+            let build_json = json_build_object(vec![(
+                "money".into(),
+                Column::from("money")
+                    .native_column_type(Some("money"))
+                    .type_family(TypeFamily::Decimal(None))
+                    .set_is_list(true)
+                    .into(),
+            )]);
+            let query = Select::default().value(build_json);
+            let (sql, _) = Postgres::build(query).unwrap();
+
+            assert_eq!(sql, "SELECT JSONB_BUILD_OBJECT('money', \"money\"::numeric[])");
+        }
+
+        #[test]
         fn bigint() {
             let build_json = json_build_object(vec![(
                 "id".into(),
@@ -1455,6 +1479,22 @@ mod tests {
             let (sql, _) = Postgres::build(query).unwrap();
 
             assert_eq!(sql, "SELECT JSONB_BUILD_OBJECT('id', \"id\"::text)");
+        }
+
+        #[test]
+        fn bigint_array() {
+            let build_json = json_build_object(vec![(
+                "id".into(),
+                Column::from("id")
+                    .native_column_type(Some("BigInt"))
+                    .type_family(TypeFamily::Int)
+                    .set_is_list(true)
+                    .into(),
+            )]);
+            let query = Select::default().value(build_json);
+            let (sql, _) = Postgres::build(query).unwrap();
+
+            assert_eq!(sql, "SELECT JSONB_BUILD_OBJECT('id', \"id\"::text[])");
         }
 
         #[test]

--- a/query-compiler/query-builders/sql-query-builder/src/read.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/read.rs
@@ -242,7 +242,8 @@ fn apply_aggregate_selections(
                     .field
                     .as_scalar()
                     .unwrap()
-                    .as_column_with_style(ctx, col_style))
+                    .as_column_with_style(ctx, col_style)
+                    .set_is_selected(true))
                 .alias(next_field.db_alias().into_owned()),
             )
         }),
@@ -253,7 +254,8 @@ fn apply_aggregate_selections(
                     .field
                     .as_scalar()
                     .unwrap()
-                    .as_column_with_style(ctx, col_style))
+                    .as_column_with_style(ctx, col_style)
+                    .set_is_selected(true))
                 .alias(next_field.db_alias().into_owned()),
             )
         }),

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/queries/data_types/native/postgres.rs
@@ -163,6 +163,24 @@ mod postgres_money {
 
         Ok(())
     }
+
+    #[connector_test(schema(schema_decimal))]
+    async fn native_money_aggregates(runner: Runner) -> TestResult<()> {
+        runner
+            .raw_execute(
+                r#"INSERT INTO "Table" ("id", "money", "moneyList") VALUES
+                    (1, '$10.25', ARRAY[]::money[]),
+                    (2, '$20.75', ARRAY[]::money[]);"#,
+            )
+            .await?;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, r#"{ aggregateTable { _sum { money } _avg { money } } }"#),
+          @r###"{"data":{"aggregateTable":{"_sum":{"money":"31"},"_avg":{"money":"15.5"}}}}"###
+        );
+
+        Ok(())
+    }
 }
 
 #[test_suite(only(Postgres))]

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
@@ -974,7 +974,7 @@ fn render_postgres_alter_enum(
             let sql = format!(
                 "ALTER TABLE {table_name} \
                             ALTER COLUMN {column_name} TYPE {tmp_name}{array} \
-                                USING ({column_name}::text::{tmp_name}{array})",
+                                USING ({column_name}::text{array}::{tmp_name}{array})",
                 table_name = QuotedWithPrefix::pg_from_table_walker(column.table()),
                 column_name = Quoted::postgres_ident(column.name()),
                 array = array,

--- a/schema-engine/sql-migration-tests/tests/migrations/enums.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/enums.rs
@@ -542,6 +542,8 @@ fn enum_array_modification_should_work(api: TestApi) {
         .send_sync()
         .assert_applied_migrations(&["01init"]);
 
+    api.raw_cmd(r#"INSERT INTO "Test" ("positions") VALUES (ARRAY['First', 'Second']::"Position"[])"#);
+
     let dm = r#"
         datasource test {
             provider = "postgres"
@@ -623,8 +625,9 @@ fn alter_enum_and_change_default_must_work(api: TestApi) {
             provider = "postgres"
         }
         model Cat {
-            id      Int    @id
-            moods   Mood[] @default([])
+            id    Int    @id
+            mood  Mood
+            moods Mood[] @default([])
         }
         enum Mood {
             SLEEPY
@@ -639,8 +642,9 @@ fn alter_enum_and_change_default_must_work(api: TestApi) {
             provider = "postgres"
         }
         model Cat {
-            id      Int    @id
-            moods   Mood[] @default([SLEEPY])
+            id    Int    @id
+            mood  Mood
+            moods Mood[] @default([SLEEPY])
         }
         enum Mood {
             HUNGRY
@@ -682,7 +686,8 @@ fn alter_enum_and_change_default_must_work(api: TestApi) {
                 BEGIN;
                 CREATE TYPE "Mood_new" AS ENUM ('HUNGRY', 'SLEEPY');
                 ALTER TABLE "public"."Cat" ALTER COLUMN "moods" DROP DEFAULT;
-                ALTER TABLE "Cat" ALTER COLUMN "moods" TYPE "Mood_new"[] USING ("moods"::text::"Mood_new"[]);
+                ALTER TABLE "Cat" ALTER COLUMN "mood" TYPE "Mood_new" USING ("mood"::text::"Mood_new");
+                ALTER TABLE "Cat" ALTER COLUMN "moods" TYPE "Mood_new"[] USING ("moods"::text[]::"Mood_new"[]);
                 ALTER TYPE "Mood" RENAME TO "Mood_old";
                 ALTER TYPE "Mood_new" RENAME TO "Mood";
                 DROP TYPE "public"."Mood_old";


### PR DESCRIPTION
Addresses the remaining PostgreSQL type-conversion gaps surfaced by MONEY aggregates in [prisma/prisma#28681](https://github.com/prisma/prisma/pull/28681#issuecomment-4943761658) and related array-cast paths.

## Changes

- **Query compiler**: Mark MONEY `_sum` and `_avg` inputs for result coercion so PostgreSQL evaluates `SUM(column::numeric)` and `AVG(column::numeric)`.
- **Relation joins**: Preserve list arity when serializing MONEY and BigInt fields through PostgreSQL JSON, producing `numeric[]` and `text[]` casts for list fields.
- **Schema engine**: Migrate enum arrays through `text[]` while retaining scalar `text` casts for scalar enum columns.

## Why

PostgreSQL resolves aggregate overloads from their input types, while JSON serialization and enum migrations must preserve whether the source is scalar or an array. Carrying arity through each renderer avoids locale-dependent MONEY output and prevents arrays from being coerced through scalar text representations.

## Verification

- `cargo fmt -- --check`
- Quaint PostgreSQL JSON build-object tests
- `cargo test -p sql-query-builder --lib`
- PostgreSQL QC connector regression for MONEY `_sum` and `_avg`
- Enum-array migration test compiled, but runtime execution was blocked because PostgreSQL was unavailable at `localhost:5438`