### PR TITLE
fix(psl): validate partial index raw predicate arity

### DIFF
--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -640,16 +640,16 @@ fn parse_where_clause(model_id: crate::ModelId, ctx: &mut Context<'_>) -> Option
 
 /// Parse raw("...") where clause.
 fn parse_raw_where_clause(args: &[ast::Argument], ctx: &mut Context<'_>) -> Option<WhereClause> {
-    let Some(first_arg) = args.first() else {
+    let [arg] = args else {
         ctx.push_attribute_validation_error(
-            "The `where` argument must be a raw() function with a string argument, e.g. `where: raw(\"status = 'active'\")`.",
+            "The `where` argument must be a raw() function with exactly one string argument, e.g. `where: raw(\"status = 'active'\")`.",
         );
         return None;
     };
 
-    let Some(predicate) = coerce::string(&first_arg.value, ctx.diagnostics) else {
+    let Some(predicate) = coerce::string(&arg.value, ctx.diagnostics) else {
         ctx.push_attribute_validation_error(
-            "The `where` argument must be a raw() function with a string argument, e.g. `where: raw(\"status = 'active'\")`.",
+            "The `where` argument must be a raw() function with exactly one string argument, e.g. `where: raw(\"status = 'active'\")`.",
         );
         return None;
     };

--- a/psl/psl/tests/attributes/partial_index.rs
+++ b/psl/psl/tests/attributes/partial_index.rs
@@ -166,11 +166,35 @@ fn partial_index_raw_requires_string_argument() {
 
     let err = parse_unwrap_err(&with_header(dml, Provider::Postgres, &["partialIndexes"]));
     let expected = expect![[r#"
-        [1;91merror[0m: [1mError parsing attribute "@unique": The `where` argument must be a raw() function with a string argument, e.g. `where: raw("status = 'active'")`.[0m
+        [1;91merror[0m: [1mError parsing attribute "@unique": The `where` argument must be a raw() function with exactly one string argument, e.g. `where: raw("status = 'active'")`.[0m
           [1;94m-->[0m  [4mschema.prisma:15[0m
         [1;94m   | [0m
         [1;94m14 | [0m
         [1;94m15 | [0m    [1;91m@@unique([email], where: raw())[0m
+        [1;94m   | [0m
+    "#]];
+    expected.assert_eq(&err);
+}
+
+#[test]
+fn partial_index_raw_rejects_multiple_arguments() {
+    let dml = indoc! {r#"
+        model User {
+            id        Int    @id
+            email     String
+            status    String
+
+            @@unique([email], where: raw("status = 'active'", "email IS NOT NULL"))
+        }
+    "#};
+
+    let err = parse_unwrap_err(&with_header(dml, Provider::Postgres, &["partialIndexes"]));
+    let expected = expect![[r#"
+        [1;91merror[0m: [1mError parsing attribute "@unique": The `where` argument must be a raw() function with exactly one string argument, e.g. `where: raw("status = 'active'")`.[0m
+          [1;94m-->[0m  [4mschema.prisma:15[0m
+        [1;94m   | [0m
+        [1;94m14 | [0m
+        [1;94m15 | [0m    [1;91m@@unique([email], where: raw("status = 'active'", "email IS NOT NULL"))[0m
         [1;94m   | [0m
     "#]];
     expected.assert_eq(&err);


### PR DESCRIPTION
Rejects malformed partial-index `raw()` predicates that provide zero or multiple arguments.

## Changes

- **Partial-index parsing**: Require `raw()` to contain exactly one string argument instead of reading only the first argument and silently ignoring extras.
- **Diagnostics and tests**: Clarify the exact-one-argument contract and cover both missing and additional arguments.

## Why

Accepting extra arguments makes an invalid schema appear valid while discarding part of the user input. Enforcing the function arity during PSL parsing keeps the rendered predicate unambiguous.

## Verification

- `cargo test -p psl -F all partial_index_raw_`
- `cargo fmt -- --check`