### PR TITLE
feat(quaint): expose pool health check options as connection string parameters

### DIFF
--- a/quaint/src/connector/mssql/url.rs
+++ b/quaint/src/connector/mssql/url.rs
@@ -68,6 +68,8 @@ pub(crate) struct MssqlQueryParams {
     pub(crate) transaction_isolation_level: Option<IsolationLevel>,
     pub(crate) max_connection_lifetime: Option<Duration>,
     pub(crate) max_idle_connection_lifetime: Option<Duration>,
+    pub(crate) test_on_check_out: bool,
+    pub(crate) health_check_interval: Option<Duration>,
 }
 
 impl MssqlUrl {
@@ -158,6 +160,16 @@ impl MssqlUrl {
     pub fn max_idle_connection_lifetime(&self) -> Option<Duration> {
         self.query_params.max_idle_connection_lifetime()
     }
+
+    /// Whether the health of a connection is verified before handing it out of the pool
+    pub fn test_on_check_out(&self) -> bool {
+        self.query_params.test_on_check_out()
+    }
+
+    /// Interval of how often a connection's health is checked when handed out of the pool
+    pub fn health_check_interval(&self) -> Option<Duration> {
+        self.query_params.health_check_interval()
+    }
 }
 
 impl MssqlQueryParams {
@@ -219,6 +231,14 @@ impl MssqlQueryParams {
 
     fn max_idle_connection_lifetime(&self) -> Option<Duration> {
         self.max_idle_connection_lifetime
+    }
+
+    fn test_on_check_out(&self) -> bool {
+        self.test_on_check_out
+    }
+
+    fn health_check_interval(&self) -> Option<Duration> {
+        self.health_check_interval
     }
 }
 
@@ -345,6 +365,23 @@ impl MssqlUrl {
             _ => (),
         }
 
+        let test_on_check_out = props
+            .remove("testoncheckout")
+            .or_else(|| props.remove("test_on_check_out"))
+            .map(|param| param.parse())
+            .transpose()?
+            .unwrap_or(false);
+
+        let mut health_check_interval = props
+            .remove("healthcheckinterval")
+            .or_else(|| props.remove("health_check_interval"))
+            .map(|param| param.parse().map(Duration::from_secs))
+            .transpose()?;
+
+        if health_check_interval.is_some_and(|dur| dur.as_secs() == 0) {
+            health_check_interval = None;
+        }
+
         Ok(MssqlQueryParams {
             encrypt,
             port,
@@ -362,14 +399,59 @@ impl MssqlUrl {
             transaction_isolation_level,
             max_connection_lifetime,
             max_idle_connection_lifetime,
+            test_on_check_out,
+            health_check_interval,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::MssqlUrl;
     use crate::tests::test_api::mssql::CONN_STR;
     use crate::{error::*, single::Quaint};
+    use std::time::Duration;
+
+    #[test]
+    fn should_parse_pool_health_check_params() {
+        let url = MssqlUrl::new(
+            "jdbc:sqlserver://localhost:1433;database=master;user=SA;password=pw;testOnCheckOut=true;healthCheckInterval=30",
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(Some(Duration::from_secs(30)), url.health_check_interval());
+    }
+
+    #[test]
+    fn should_parse_pool_health_check_params_snake_case() {
+        let url = MssqlUrl::new(
+            "jdbc:sqlserver://localhost:1433;database=master;user=SA;password=pw;test_on_check_out=true;health_check_interval=30",
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(Some(Duration::from_secs(30)), url.health_check_interval());
+    }
+
+    #[test]
+    fn health_check_should_be_disabled_by_default() {
+        let url = MssqlUrl::new("jdbc:sqlserver://localhost:1433;database=master;user=SA;password=pw").unwrap();
+
+        assert!(!url.test_on_check_out());
+        assert_eq!(None, url.health_check_interval());
+    }
+
+    #[test]
+    fn zero_health_check_interval_should_check_every_checkout() {
+        let url = MssqlUrl::new(
+            "jdbc:sqlserver://localhost:1433;database=master;user=SA;password=pw;testOnCheckOut=true;healthCheckInterval=0",
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(None, url.health_check_interval());
+    }
 
     #[tokio::test]
     async fn should_map_wrong_credentials_error() {

--- a/quaint/src/connector/mysql/url.rs
+++ b/quaint/src/connector/mysql/url.rs
@@ -132,6 +132,16 @@ impl MysqlUrl {
         self.query_params.max_idle_connection_lifetime
     }
 
+    /// Whether the health of a connection is verified before handing it out of the pool
+    pub fn test_on_check_out(&self) -> bool {
+        self.query_params.test_on_check_out
+    }
+
+    /// Interval of how often a connection's health is checked when handed out of the pool
+    pub fn health_check_interval(&self) -> Option<Duration> {
+        self.query_params.health_check_interval
+    }
+
     pub(crate) fn statement_cache_size(&self) -> usize {
         self.query_params.statement_cache_size
     }
@@ -152,6 +162,8 @@ impl MysqlUrl {
         let mut pool_timeout = Some(Duration::from_secs(10));
         let mut max_connection_lifetime = None;
         let mut max_idle_connection_lifetime = Some(Duration::from_secs(300));
+        let mut test_on_check_out = false;
+        let mut health_check_interval = None;
         let mut prefer_socket = None;
         let mut statement_cache_size = 100;
         let mut identity: Option<(Option<PathBuf>, Option<String>)> = None;
@@ -269,6 +281,22 @@ impl MysqlUrl {
                         max_idle_connection_lifetime = Some(Duration::from_secs(as_int));
                     }
                 }
+                "test_on_check_out" => {
+                    test_on_check_out = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+                }
+                "health_check_interval" => {
+                    let as_int = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+
+                    if as_int == 0 {
+                        health_check_interval = None;
+                    } else {
+                        health_check_interval = Some(Duration::from_secs(as_int));
+                    }
+                }
                 _ => {
                     tracing::trace!(message = "Discarding connection string param", param = &*k);
                 }
@@ -303,6 +331,8 @@ impl MysqlUrl {
             pool_timeout,
             max_connection_lifetime,
             max_idle_connection_lifetime,
+            test_on_check_out,
+            health_check_interval,
             prefer_socket,
             statement_cache_size,
         })
@@ -328,6 +358,8 @@ pub(crate) struct MysqlUrlQueryParams {
     pub(crate) pool_timeout: Option<Duration>,
     pub(crate) max_connection_lifetime: Option<Duration>,
     pub(crate) max_idle_connection_lifetime: Option<Duration>,
+    pub(crate) test_on_check_out: bool,
+    pub(crate) health_check_interval: Option<Duration>,
     pub(crate) prefer_socket: Option<bool>,
     pub(crate) statement_cache_size: usize,
 
@@ -347,6 +379,36 @@ mod tests {
         let url = MysqlUrl::new(Url::parse("mysql://root@localhost/dbname?socket=(/tmp/mysql.sock)").unwrap()).unwrap();
         assert_eq!(Some("dbname"), url.dbname());
         assert_eq!(&Some(String::from("/tmp/mysql.sock")), url.socket());
+    }
+
+    #[test]
+    fn should_parse_pool_health_check_params() {
+        let url = MysqlUrl::new(
+            Url::parse("mysql://root@localhost/db?test_on_check_out=true&health_check_interval=30").unwrap(),
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(Some(std::time::Duration::from_secs(30)), url.health_check_interval());
+    }
+
+    #[test]
+    fn health_check_should_be_disabled_by_default() {
+        let url = MysqlUrl::new(Url::parse("mysql://root@localhost/db").unwrap()).unwrap();
+
+        assert!(!url.test_on_check_out());
+        assert_eq!(None, url.health_check_interval());
+    }
+
+    #[test]
+    fn zero_health_check_interval_should_check_every_checkout() {
+        let url = MysqlUrl::new(
+            Url::parse("mysql://root@localhost/db?test_on_check_out=true&health_check_interval=0").unwrap(),
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(None, url.health_check_interval());
     }
 
     #[test]

--- a/quaint/src/connector/postgres/url.rs
+++ b/quaint/src/connector/postgres/url.rs
@@ -265,6 +265,16 @@ impl PostgresNativeUrl {
         self.query_params.max_idle_connection_lifetime
     }
 
+    /// Whether the health of a connection is verified before handing it out of the pool
+    pub fn test_on_check_out(&self) -> bool {
+        self.query_params.test_on_check_out
+    }
+
+    /// Interval of how often a connection's health is checked when handed out of the pool
+    pub fn health_check_interval(&self) -> Option<Duration> {
+        self.query_params.health_check_interval
+    }
+
     /// The custom application name
     pub fn application_name(&self) -> Option<&str> {
         self.query_params.application_name.as_deref()
@@ -311,6 +321,8 @@ impl PostgresNativeUrl {
         let mut statement_cache_size = 100;
         let mut max_connection_lifetime = None;
         let mut max_idle_connection_lifetime = Some(Duration::from_secs(300));
+        let mut test_on_check_out = false;
+        let mut health_check_interval = None;
         let mut options = None;
         let mut single_use_connections = false;
 
@@ -431,6 +443,22 @@ impl PostgresNativeUrl {
                         max_idle_connection_lifetime = Some(Duration::from_secs(as_int));
                     }
                 }
+                "test_on_check_out" => {
+                    test_on_check_out = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+                }
+                "health_check_interval" => {
+                    let as_int = v
+                        .parse()
+                        .map_err(|_| Error::builder(ErrorKind::InvalidConnectionArguments).build())?;
+
+                    if as_int == 0 {
+                        health_check_interval = None;
+                    } else {
+                        health_check_interval = Some(Duration::from_secs(as_int));
+                    }
+                }
                 "application_name" => {
                     application_name = Some(v.to_string());
                 }
@@ -479,6 +507,8 @@ impl PostgresNativeUrl {
             statement_cache_size,
             max_connection_lifetime,
             max_idle_connection_lifetime,
+            test_on_check_out,
+            health_check_interval,
             application_name,
             options,
             #[cfg(feature = "postgresql-native")]
@@ -516,6 +546,8 @@ pub(crate) struct PostgresUrlQueryParams {
     pub(crate) statement_cache_size: usize,
     pub(crate) max_connection_lifetime: Option<Duration>,
     pub(crate) max_idle_connection_lifetime: Option<Duration>,
+    pub(crate) test_on_check_out: bool,
+    pub(crate) health_check_interval: Option<Duration>,
     pub(crate) application_name: Option<String>,
     pub(crate) options: Option<String>,
     pub(crate) single_use_connections: bool,
@@ -594,6 +626,38 @@ mod tests {
         let url = PostgresNativeUrl::new(Url::parse("postgresql:///dbname?host=/var/run/psql.sock").unwrap()).unwrap();
         assert_eq!("dbname", url.dbname());
         assert_eq!("/var/run/psql.sock", url.host());
+    }
+
+    #[test]
+    fn should_parse_pool_health_check_params() {
+        let url = PostgresNativeUrl::new(
+            Url::parse("postgresql://user:pass@localhost:5432/db?test_on_check_out=true&health_check_interval=30")
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(Some(Duration::from_secs(30)), url.health_check_interval());
+    }
+
+    #[test]
+    fn health_check_should_be_disabled_by_default() {
+        let url = PostgresNativeUrl::new(Url::parse("postgresql://user:pass@localhost:5432/db").unwrap()).unwrap();
+
+        assert!(!url.test_on_check_out());
+        assert_eq!(None, url.health_check_interval());
+    }
+
+    #[test]
+    fn zero_health_check_interval_should_check_every_checkout() {
+        let url = PostgresNativeUrl::new(
+            Url::parse("postgresql://user:pass@localhost:5432/db?test_on_check_out=true&health_check_interval=0")
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert!(url.test_on_check_out());
+        assert_eq!(None, url.health_check_interval());
     }
 
     #[test]

--- a/quaint/src/pooled.rs
+++ b/quaint/src/pooled.rs
@@ -25,6 +25,16 @@
 //!
 //! - `connection_limit` defines the maximum number of connections opened to the
 //!   database.
+//! - `test_on_check_out` either `true` or `false` (default: `false`). When
+//!   enabled, the health of a connection is verified with a lightweight
+//!   `SELECT 1` query before handing it out of the pool. A connection that was
+//!   silently closed by the server or a network device while sitting idle in
+//!   the pool is then discarded and replaced with a fresh one, instead of
+//!   failing the query with a connection error. Not supported for SQLite.
+//! - `health_check_interval` defined in seconds. Only effective together with
+//!   `test_on_check_out=true`: a connection is health-checked at most once per
+//!   given interval, avoiding the extra round-trip on every checkout. If set
+//!   to zero or omitted, every checkout is verified.
 //!
 //! ## SQLite
 //!
@@ -395,6 +405,8 @@ impl Quaint {
                 let pool_timeout = url.pool_timeout();
                 let max_connection_lifetime = url.max_connection_lifetime();
                 let max_idle_connection_lifetime = url.max_idle_connection_lifetime();
+                let test_on_check_out = url.test_on_check_out();
+                let health_check_interval = url.health_check_interval();
 
                 if is_tracing_enabled {
                     url.query_params.statement_cache_size = 0;
@@ -419,6 +431,14 @@ impl Quaint {
                     builder.max_idle_lifetime(max_idle_lifetime);
                 }
 
+                if test_on_check_out {
+                    builder.test_on_check_out(true);
+                }
+
+                if let Some(interval) = health_check_interval {
+                    builder.health_check_interval(interval);
+                }
+
                 Ok(builder)
             }
             #[cfg(feature = "postgresql")]
@@ -428,6 +448,8 @@ impl Quaint {
                 let pool_timeout = url.pool_timeout();
                 let max_connection_lifetime = url.max_connection_lifetime();
                 let max_idle_connection_lifetime = url.max_idle_connection_lifetime();
+                let test_on_check_out = url.test_on_check_out();
+                let health_check_interval = url.health_check_interval();
 
                 let tls_manager = crate::connector::MakeTlsConnectorManager::new(url.clone()).into();
                 let manager = QuaintManager::Postgres {
@@ -453,6 +475,14 @@ impl Quaint {
                     builder.max_idle_lifetime(max_idle_lifetime);
                 }
 
+                if test_on_check_out {
+                    builder.test_on_check_out(true);
+                }
+
+                if let Some(interval) = health_check_interval {
+                    builder.health_check_interval(interval);
+                }
+
                 Ok(builder)
             }
             #[cfg(feature = "mssql")]
@@ -462,6 +492,8 @@ impl Quaint {
                 let pool_timeout = url.pool_timeout();
                 let max_connection_lifetime = url.max_connection_lifetime();
                 let max_idle_connection_lifetime = url.max_idle_connection_lifetime();
+                let test_on_check_out = url.test_on_check_out();
+                let health_check_interval = url.health_check_interval();
 
                 let manager = QuaintManager::Mssql { url };
                 let mut builder = Builder::new(s, manager)?;
@@ -480,6 +512,14 @@ impl Quaint {
 
                 if let Some(max_idle_lifetime) = max_idle_connection_lifetime {
                     builder.max_idle_lifetime(max_idle_lifetime);
+                }
+
+                if test_on_check_out {
+                    builder.test_on_check_out(true);
+                }
+
+                if let Some(interval) = health_check_interval {
+                    builder.health_check_interval(interval);
                 }
 
                 Ok(builder)


### PR DESCRIPTION
## Overview

The pooled `Builder` has long supported `test_on_check_out` and `health_check_interval`, and `QuaintManager::check` is already implemented as a `SELECT 1` ping — but no connector URL parser exposes either option. Since Prisma builds its pool exclusively from the datasource URL via `Quaint::builder_with_tracing`, the health-check machinery is effectively dead code for Prisma users.

This PR makes both options parseable from the connection string for PostgreSQL, MySQL and SQL Server, following the exact pattern of the existing `max_connection_lifetime` / `max_idle_connection_lifetime` parameters.

## New parameters

| Parameter | Type | Default | Behavior |
|---|---|---|---|
| `test_on_check_out` | bool | `false` | When `true`, a connection is verified with `SELECT 1` before being handed out of the pool. A connection that was silently severed while idle (NAT/LB idle timeout, server-side reset) is discarded and transparently replaced instead of failing the query with a connection error. |
| `health_check_interval` | seconds | none | Only meaningful with `test_on_check_out=true`: rate-limits the check to at most once per interval per connection (mobc marks the connection checked). `0` or omitted = verify every checkout. |

SQL Server also accepts `testOnCheckOut` / `healthCheckInterval`, consistent with its other JDBC-style parameters (keys are case-normalized by the JDBC parser).

SQLite is intentionally excluded: an embedded file database has no network path that can go stale.

## Why

Long-running deployments (ECS/Fargate, EC2, Kubernetes) hold pooled connections long enough for middleboxes or the server to sever them while idle. The next checkout hands out a dead connection and the query fails with an intermittent, hard-to-reproduce `P1001`/`P1017` — the recurring theme behind reports like prisma/prisma#13770. Borrow-time validation is the standard remedy in every mainstream pool (HikariCP `connectionTestQuery`, pgbouncer `server_check_query`, tarn/knex `afterCreate` validation, etc.); quaint already has the mechanism, it just cannot be switched on.

Companion issue with a fully-correlated production trace (app logs + RDS `system_health` Extended Events): prisma/prisma#29786

## Changes

- `quaint/src/connector/postgres/url.rs` — parse both params + getters
- `quaint/src/connector/mysql/url.rs` — parse both params + getters
- `quaint/src/connector/mssql/url.rs` — parse both params (camelCase + snake_case) + getters
- `quaint/src/pooled.rs` — wire both params into the `Builder` in `builder_with_tracing` for the three connectors; document the parameters in the module docs

No behavior change for existing connection strings (both options default to off; `Builder` defaults are untouched).

## Testing

- 10 new unit tests covering: parse with values, defaults (disabled), `0` interval normalization, and mssql camelCase/snake_case spellings
  - `cargo test -p quaint --features "pooled,all-native" --lib health_check` → 10 passed
- `cargo clippy -p quaint --features "pooled,all-native"` → no warnings
- `cargo fmt` clean
