### PR TITLE
fix: support `DROP INDEX CONCURRENTLY` in migration script splitting

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/native/mod.rs
@@ -237,8 +237,28 @@ impl Connection {
 /// If the script cannot be parsed, returns an iterator with the original script as the only item.
 fn split_script_into_statements(script: &str) -> impl Iterator<Item = &str> {
     use sqlparser::dialect::PostgreSqlDialect;
+    use sqlparser::keywords::Keyword;
     use sqlparser::parser::{Parser, ParserError};
     use sqlparser::tokenizer::{Location, Token};
+
+    /// Consumes statements that are valid PostgreSQL syntax but that sqlparser cannot parse
+    /// yet, returning whether one was consumed. It is important not to bail out of splitting
+    /// the script when encountering them: `DROP INDEX CONCURRENTLY` cannot run inside a
+    /// transaction block, so submitting the whole script as a single implicitly transactional
+    /// batch would make it fail on the database side.
+    ///
+    /// The statements handled here cannot contain a semicolon anywhere except at the very end
+    /// (quoted identifiers and string literals are single tokens), so skipping to the next
+    /// semicolon token consumes exactly one statement.
+    fn consume_statement_unsupported_by_parser(parser: &mut Parser<'_>) -> bool {
+        if !parser.parse_keywords(&[Keyword::DROP, Keyword::INDEX, Keyword::CONCURRENTLY]) {
+            return false;
+        }
+        while !matches!(parser.peek_token_ref().token, Token::SemiColon | Token::EOF) {
+            parser.advance_token();
+        }
+        true
+    }
 
     fn detect_statement_terminators(mut parser: Parser<'_>) -> Result<Vec<Location>, ParserError> {
         let mut terminators = vec![];
@@ -247,7 +267,9 @@ fn split_script_into_statements(script: &str) -> impl Iterator<Item = &str> {
             // because the `span` in the returned AST does not actually represent the entire
             // statement. It only accounts for a union of the spans of all user-provided
             // identifiers and constants, excluding keywords and some other tokens.
-            parser.parse_statement()?;
+            if !consume_statement_unsupported_by_parser(&mut parser) {
+                parser.parse_statement()?;
+            }
             terminators.push(parser.peek_token_ref().span.start);
             let _ = parser.consume_token(&Token::SemiColon);
         }
@@ -594,6 +616,65 @@ mod tests {
                 "-- This is a comment\nCREATE TABLE test (id INT);",
                 " /* block comment */\nINSERT INTO test VALUES (1);"
             ]
+        );
+    }
+
+    #[test]
+    fn split_script_into_statements_multiple_drop_index_concurrently() {
+        let script = "DROP INDEX CONCURRENTLY \"idx_one\";\nDROP INDEX CONCURRENTLY IF EXISTS \"idx_two\";";
+        let statements: Vec<&str> = split_script_into_statements(script).collect();
+        assert_eq!(
+            statements,
+            vec![
+                "DROP INDEX CONCURRENTLY \"idx_one\";",
+                "\nDROP INDEX CONCURRENTLY IF EXISTS \"idx_two\";"
+            ]
+        );
+    }
+
+    #[test]
+    fn split_script_into_statements_drop_index_concurrently_mixed_with_other_statements() {
+        let script = indoc! {r#"
+            -- DropIndex
+            DROP INDEX CONCURRENTLY "users_name_idx";
+
+            CREATE INDEX CONCURRENTLY "users_email_idx" ON "users"("email");
+
+            DROP INDEX CONCURRENTLY "public"."users_age_idx" RESTRICT;
+        "#};
+        let statements: Vec<&str> = split_script_into_statements(script).collect();
+        assert_eq!(
+            statements,
+            vec![
+                indoc! {r#"
+                    -- DropIndex
+                    DROP INDEX CONCURRENTLY "users_name_idx";"#},
+                "\n\nCREATE INDEX CONCURRENTLY \"users_email_idx\" ON \"users\"(\"email\");",
+                "\n\nDROP INDEX CONCURRENTLY \"public\".\"users_age_idx\" RESTRICT;"
+            ]
+        );
+    }
+
+    #[test]
+    fn split_script_into_statements_drop_index_concurrently_without_trailing_semicolon() {
+        let script = "DROP INDEX CONCURRENTLY \"idx_one\";\nDROP INDEX CONCURRENTLY \"idx_two\"";
+        let statements: Vec<&str> = split_script_into_statements(script).collect();
+        assert_eq!(
+            statements,
+            vec![
+                "DROP INDEX CONCURRENTLY \"idx_one\";",
+                "\nDROP INDEX CONCURRENTLY \"idx_two\""
+            ]
+        );
+    }
+
+    #[test]
+    fn split_script_into_statements_drop_index_without_concurrently_is_unaffected() {
+        let script = "DROP INDEX \"idx_one\";\nDROP INDEX IF EXISTS \"idx_two\";";
+        let statements: Vec<&str> = split_script_into_statements(script).collect();
+        assert_eq!(
+            statements,
+            vec!["DROP INDEX \"idx_one\";", "\nDROP INDEX IF EXISTS \"idx_two\";"]
         );
     }
 }

--- a/schema-engine/sql-migration-tests/tests/migrations/postgres.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/postgres.rs
@@ -1164,3 +1164,35 @@ ALTER TABLE "Person" ADD COLUMN     "role" {added_type};
             ))
         });
 }
+
+#[test_connector(tags(Postgres))]
+fn postgres_apply_migrations_works_with_multiple_drop_index_concurrently_statements(api: TestApi) {
+    let dm = "";
+    let migrations_directory = api.create_migrations_directory();
+
+    let migration = r#"
+        CREATE TABLE "Person" (
+            id TEXT PRIMARY KEY,
+            "firstName" TEXT NOT NULL,
+            "lastName" TEXT NOT NULL
+        );
+
+        CREATE INDEX CONCURRENTLY "Person_firstName_idx" ON "Person"("firstName");
+        CREATE INDEX CONCURRENTLY "Person_lastName_idx" ON "Person"("lastName");
+
+        DROP INDEX CONCURRENTLY "Person_firstName_idx";
+        DROP INDEX CONCURRENTLY "Person_lastName_idx";
+    "#;
+
+    api.create_migration("01init", dm, &migrations_directory)
+        .draft(true)
+        .send_sync()
+        .modify_migration(|contents| {
+            contents.clear();
+            contents.push_str(migration);
+        });
+
+    api.apply_migrations(&migrations_directory)
+        .send_sync()
+        .assert_applied_migrations(&["01init"]);
+}


### PR DESCRIPTION
Follow-up to #5767 and #5799.

### Problem

A migration containing more than one `DROP INDEX CONCURRENTLY` statement — or a single one mixed with any other statement — fails to apply:

```
Error: P3018

Migration name: 20260103000000_drop_multiple_indexes

Database error code: 25001

Database error:
ERROR: DROP INDEX CONCURRENTLY cannot run inside a transaction block
```

A migration with multiple `CREATE INDEX CONCURRENTLY` statements works fine since #5767, so this is surprising and asymmetric. A migration whose *only* statement is a single `DROP INDEX CONCURRENTLY` also happens to work, which makes the failure look nondeterministic to users.

### Root cause

`split_script_into_statements` relies on sqlparser successfully parsing every statement in the script to find statement boundaries. sqlparser (up to and including 0.62) supports the `CONCURRENTLY` keyword in `CREATE INDEX` but not in `DROP INDEX`:

```
sql parser error: Expected: end of statement, found: "idx1" at Line: 1, Column: 25
```

When parsing fails, the splitter falls back to submitting the whole script as a single simple-query batch. PostgreSQL wraps a multi-statement simple-query batch in an implicit transaction, and `DROP INDEX CONCURRENTLY` cannot run inside a transaction block. (A single-statement script survives the fallback only because a one-statement batch is not wrapped.)

Note the parse failure poisons the entire script: one `DROP INDEX CONCURRENTLY` in a migration also breaks `CREATE INDEX CONCURRENTLY` statements that would otherwise be handled.

### Fix

Teach `detect_statement_terminators` to recognize the `DROP INDEX CONCURRENTLY` token sequence and consume the statement's tokens up to the next semicolon manually instead of calling `Parser::parse_statement`. This is safe because a `DROP INDEX CONCURRENTLY` statement cannot contain a semicolon anywhere except as its terminator (quoted identifiers and string literals are single tokens).

Everything else is unchanged, including the whole-script fallback for genuinely unparseable scripts.

If sqlparser gains support for `DROP INDEX CONCURRENTLY` upstream, this special case can be removed.

### Tests

- 4 new unit tests for `split_script_into_statements` (multiple drops, mixed with other statements, `IF EXISTS`, no trailing semicolon, plain `DROP INDEX` unaffected).
- New integration test `postgres_apply_migrations_works_with_multiple_drop_index_concurrently_statements`, which fails with `25001` before this change and passes after.
- Verified end to end with the Prisma CLI 7.8.0 against PostgreSQL 15: a previously failing `migrate deploy` with two `DROP INDEX CONCURRENTLY` statements succeeds with a patched `schema-engine` binary.

This fixes the `DROP INDEX` counterpart of https://github.com/prisma/prisma/issues/14456.