### PR TITLE
chore: update Rust to 1.97.1

### DIFF
--- a/libs/driver-adapters/src/conversion/mysql.rs
+++ b/libs/driver-adapters/src/conversion/mysql.rs
@@ -98,7 +98,7 @@ mod test {
         for (val, expected) in test_cases {
             let actual = value_to_js_arg(&val.clone().into_value()).unwrap();
             if actual != expected {
-                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", &val, expected, actual));
+                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", val, expected, actual));
             }
         }
         assert_eq!(errors.len(), 0, "{}", errors.join("\n"));

--- a/libs/driver-adapters/src/conversion/mysql.rs
+++ b/libs/driver-adapters/src/conversion/mysql.rs
@@ -98,7 +98,7 @@ mod test {
         for (val, expected) in test_cases {
             let actual = value_to_js_arg(&val.clone().into_value()).unwrap();
             if actual != expected {
-                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", val, expected, actual));
+                errors.push(format!("transforming: {val:?}, expected: {expected:?}, actual: {actual:?}"));
             }
         }
         assert_eq!(errors.len(), 0, "{}", errors.join("\n"));

--- a/libs/driver-adapters/src/conversion/postgres.rs
+++ b/libs/driver-adapters/src/conversion/postgres.rs
@@ -100,7 +100,7 @@ mod test {
         for (val, expected) in test_cases {
             let actual = value_to_js_arg(&val).unwrap();
             if actual != expected {
-                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", val, expected, actual));
+                errors.push(format!("transforming: {val:?}, expected: {expected:?}, actual: {actual:?}"));
             }
         }
         assert_eq!(errors.len(), 0, "{}", errors.join("\n"));

--- a/libs/driver-adapters/src/conversion/postgres.rs
+++ b/libs/driver-adapters/src/conversion/postgres.rs
@@ -100,7 +100,7 @@ mod test {
         for (val, expected) in test_cases {
             let actual = value_to_js_arg(&val).unwrap();
             if actual != expected {
-                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", &val, expected, actual));
+                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", val, expected, actual));
             }
         }
         assert_eq!(errors.len(), 0, "{}", errors.join("\n"));

--- a/libs/driver-adapters/src/conversion/sqlite.rs
+++ b/libs/driver-adapters/src/conversion/sqlite.rs
@@ -105,7 +105,7 @@ mod test {
         for (val, expected) in test_cases {
             let actual = value_to_js_arg(&val.clone().into_value()).unwrap();
             if actual != expected {
-                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", val, expected, actual));
+                errors.push(format!("transforming: {val:?}, expected: {expected:?}, actual: {actual:?}"));
             }
         }
         assert_eq!(errors.len(), 0, "{}", errors.join("\n"));

--- a/libs/driver-adapters/src/conversion/sqlite.rs
+++ b/libs/driver-adapters/src/conversion/sqlite.rs
@@ -105,7 +105,7 @@ mod test {
         for (val, expected) in test_cases {
             let actual = value_to_js_arg(&val.clone().into_value()).unwrap();
             if actual != expected {
-                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", &val, expected, actual));
+                errors.push(format!("transforming: {:?}, expected: {:?}, actual: {:?}", val, expected, actual));
             }
         }
         assert_eq!(errors.len(), 0, "{}", errors.join("\n"));

--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -204,7 +204,7 @@ impl ValidationError {
             let err_msg = err.to_string();
             let message = format!(
                 "Invalid argument value. `{}` is not a valid `{}`. Underlying error: {}",
-                value, expected_argument_type, &err_msg
+                value, expected_argument_type, err_msg
             );
             let argument = ArgumentDescription::new(*argument_name, vec![Cow::Borrowed(expected_argument_type)]);
             let meta = json!({"argumentPath": argument_path, "argument": argument, "selectionPath": selection_path, "underlyingError": &err_msg});
@@ -212,7 +212,7 @@ impl ValidationError {
         } else {
             let message = format!(
                 "Invalid argument value. `{}` is not a valid `{}`",
-                value, &expected_argument_type
+                value, expected_argument_type
             );
             let argument = ArgumentDescription::new(*argument_name, vec![Cow::Borrowed(expected_argument_type)]);
             let meta = json!({"argumentPath": argument_path, "argument": argument, "selectionPath": selection_path, "underlyingError": serde_json::Value::Null});
@@ -469,7 +469,7 @@ impl ValidationError {
     ///     }
     /// }
     pub fn selection_set_on_scalar(field_name: String, selection_path: Vec<&str>) -> Self {
-        let message = format!("Cannot select over scalar field '{}'", &field_name);
+        let message = format!("Cannot select over scalar field '{}'", field_name);
         ValidationError {
             kind: ValidationErrorKind::SelectionSetOnScalar,
             message,

--- a/libs/user-facing-errors/src/query_engine/validation.rs
+++ b/libs/user-facing-errors/src/query_engine/validation.rs
@@ -203,17 +203,13 @@ impl ValidationError {
         let (message, meta) = if let Some(err) = underlying_err {
             let err_msg = err.to_string();
             let message = format!(
-                "Invalid argument value. `{}` is not a valid `{}`. Underlying error: {}",
-                value, expected_argument_type, err_msg
+                "Invalid argument value. `{value}` is not a valid `{expected_argument_type}`. Underlying error: {err_msg}"
             );
             let argument = ArgumentDescription::new(*argument_name, vec![Cow::Borrowed(expected_argument_type)]);
             let meta = json!({"argumentPath": argument_path, "argument": argument, "selectionPath": selection_path, "underlyingError": &err_msg});
             (message, Some(meta))
         } else {
-            let message = format!(
-                "Invalid argument value. `{}` is not a valid `{}`",
-                value, expected_argument_type
-            );
+            let message = format!("Invalid argument value. `{value}` is not a valid `{expected_argument_type}`");
             let argument = ArgumentDescription::new(*argument_name, vec![Cow::Borrowed(expected_argument_type)]);
             let meta = json!({"argumentPath": argument_path, "argument": argument, "selectionPath": selection_path, "underlyingError": serde_json::Value::Null});
             (message, Some(meta))
@@ -469,7 +465,7 @@ impl ValidationError {
     ///     }
     /// }
     pub fn selection_set_on_scalar(field_name: String, selection_path: Vec<&str>) -> Self {
-        let message = format!("Cannot select over scalar field '{}'", field_name);
+        let message = format!("Cannot select over scalar field '{field_name}'");
         ValidationError {
             kind: ValidationErrorKind::SelectionSetOnScalar,
             message,

--- a/libs/user-facing-errors/src/schema_engine.rs
+++ b/libs/user-facing-errors/src/schema_engine.rs
@@ -71,7 +71,7 @@ impl crate::UserFacingError for MigrationDoesNotApplyCleanly {
                 message: _,
                 meta: _,
                 error_code,
-            }) => format!("Error code: {}\n", error_code),
+            }) => format!("Error code: {error_code}\n"),
             crate::ErrorType::Unknown(_) => String::new(),
         };
 
@@ -170,7 +170,7 @@ impl crate::UserFacingError for ShadowDbCreationError {
                 message: _,
                 meta: _,
                 error_code,
-            }) => format!("Error code: {}\n", error_code),
+            }) => format!("Error code: {error_code}\n"),
             crate::ErrorType::Unknown(_) => String::new(),
         };
 
@@ -205,7 +205,7 @@ impl crate::UserFacingError for SoftResetFailed {
                 message: _,
                 meta: _,
                 error_code,
-            }) => format!("Error code: {}\n", error_code),
+            }) => format!("Error code: {error_code}\n"),
             crate::ErrorType::Unknown(_) => String::new(),
         };
 

--- a/libs/user-facing-errors/src/schema_engine.rs
+++ b/libs/user-facing-errors/src/schema_engine.rs
@@ -71,7 +71,7 @@ impl crate::UserFacingError for MigrationDoesNotApplyCleanly {
                 message: _,
                 meta: _,
                 error_code,
-            }) => format!("Error code: {}\n", &error_code),
+            }) => format!("Error code: {}\n", error_code),
             crate::ErrorType::Unknown(_) => String::new(),
         };
 
@@ -170,7 +170,7 @@ impl crate::UserFacingError for ShadowDbCreationError {
                 message: _,
                 meta: _,
                 error_code,
-            }) => format!("Error code: {}\n", &error_code),
+            }) => format!("Error code: {}\n", error_code),
             crate::ErrorType::Unknown(_) => String::new(),
         };
 
@@ -205,7 +205,7 @@ impl crate::UserFacingError for SoftResetFailed {
                 message: _,
                 meta: _,
                 error_code,
-            }) => format!("Error code: {}\n", &error_code),
+            }) => format!("Error code: {}\n", error_code),
             crate::ErrorType::Unknown(_) => String::new(),
         };
 

--- a/psl/parser-database/src/attributes.rs
+++ b/psl/parser-database/src/attributes.rs
@@ -361,7 +361,7 @@ fn visit_relation_field_attributes(rfid: RelationFieldId, ctx: &mut Context<'_>)
     if ctx.visit_optional_single_attr("id") {
         let msg = format!(
             "The field `{}` is a relation field and cannot be marked with `@id`. Only scalar fields can be declared as id.",
-            &ast_field.name(),
+            ast_field.name(),
         );
         ctx.push_attribute_validation_error(&msg);
         ctx.discard_arguments();

--- a/psl/psl-core/src/datamodel_connector/native_types.rs
+++ b/psl/psl-core/src/datamodel_connector/native_types.rs
@@ -164,7 +164,7 @@ impl NativeTypeArguments for (u32, u32) {
 
     fn from_parts(parts: &[String]) -> Option<Self> {
         match parts {
-            [a, b] => a.parse().ok().and_then(|a| b.parse().ok().map(|b| (a, b))),
+            [a, b] => a.parse().ok().zip(b.parse().ok()),
             _ => None,
         }
     }

--- a/psl/psl-core/src/validate/datasource_loader.rs
+++ b/psl/psl-core/src/validate/datasource_loader.rs
@@ -166,7 +166,7 @@ fn lift_datasource(
                     return None;
                 }
 
-                schemas.sort_by(|(a, _), (b, _)| a.cmp(b));
+                schemas.sort_by_key(|(a, _)| *a);
 
                 for pair in schemas.windows(2) {
                     if pair[0].0 == pair[1].0 {

--- a/psl/psl-core/src/validate/validation_pipeline/validations/fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/fields.rs
@@ -364,8 +364,7 @@ pub(super) fn validate_unsupported_field_type(field: ScalarFieldWalker<'_>, ctx:
             && let Some(prisma_type) = connector.scalar_type_for_native_type(&native_type, ctx.extension_types)
         {
             let msg = format!(
-                "The type `Unsupported(\"{}\")` you specified in the type definition for the field `{}` is supported as a native type by Prisma. Please use the native type notation `{} @{}.{}` for full support.",
-                unsupported_lit,
+                "The type `Unsupported(\"{unsupported_lit}\")` you specified in the type definition for the field `{}` is supported as a native type by Prisma. Please use the native type notation `{} @{}.{}` for full support.",
                 field.name(),
                 prisma_type.display(ctx.db),
                 source.name,

--- a/psl/psl-core/src/validate/validation_pipeline/validations/fields.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/fields.rs
@@ -295,20 +295,20 @@ pub(super) fn validate_scalar_field_connector_specific(field: ScalarFieldWalker<
             }
         }
 
-        ScalarFieldType::BuiltInScalar(ScalarType::Decimal) => {
-            if !ctx.has_capability(ConnectorCapability::DecimalType) {
-                ctx.push_error(DatamodelError::new_field_validation_error(
-                    &format!(
-                        "Field `{}` in {container} `{}` can't be of type Decimal. The current connector does not support the Decimal type.",
-                        field.name(),
-                        field.model().name(),
-                    ),
-                    container,
-                    field.model().name(),
+        ScalarFieldType::BuiltInScalar(ScalarType::Decimal)
+            if !ctx.has_capability(ConnectorCapability::DecimalType) =>
+        {
+            ctx.push_error(DatamodelError::new_field_validation_error(
+                &format!(
+                    "Field `{}` in {container} `{}` can't be of type Decimal. The current connector does not support the Decimal type.",
                     field.name(),
-                    field.ast_field().span(),
-                ));
-            }
+                    field.model().name(),
+                ),
+                container,
+                field.model().name(),
+                field.name(),
+                field.ast_field().span(),
+            ));
         }
 
         _ => (),
@@ -368,7 +368,7 @@ pub(super) fn validate_unsupported_field_type(field: ScalarFieldWalker<'_>, ctx:
                 unsupported_lit,
                 field.name(),
                 prisma_type.display(ctx.db),
-                &source.name,
+                source.name,
                 connector.native_type_to_string(&native_type)
             );
 

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/many_to_many/implicit.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/many_to_many/implicit.rs
@@ -14,9 +14,9 @@ pub(crate) fn validate_singular_id(relation: ImplicitManyToManyRelationWalker<'_
 
             let message = format!(
                 "The relation field `{}` on {container} `{}` references `{}` which does not have an `@id` field. Models without `@id` cannot be part of a many to many relation. Use an explicit intermediate Model to represent this relationship.",
-                &relation_field.name(),
-                &relation_field.model().name(),
-                &relation_field.related_model().name(),
+                relation_field.name(),
+                relation_field.model().name(),
+                relation_field.related_model().name(),
             );
 
             ctx.push_error(DatamodelError::new_field_validation_error(
@@ -34,7 +34,7 @@ pub(crate) fn validate_singular_id(relation: ImplicitManyToManyRelationWalker<'_
             ctx.push_error(DatamodelError::new_validation_error(
             &format!(
                 "Implicit many-to-many relations must always reference the id field of the related model. Change the argument `references` to use the id field of the related model `{}`. But it is referencing the following fields that are not the id: {}",
-                &relation_field.related_model().name(),
+                relation_field.related_model().name(),
                 relation_field.referenced_fields().into_iter().flatten().map(|f| f.name()).collect::<Vec<_>>().join(", ")
             ),
             relation_field.ast_field().span())

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_many.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_many.rs
@@ -17,9 +17,9 @@ pub(crate) fn both_sides_are_defined(relation: InlineRelationWalker<'_>, ctx: &m
 
         let message = format!(
             "The relation field `{}` on {container} `{}` is missing an opposite relation field on the model `{}`. Either run `prisma format` or add it manually.",
-            &relation_field.name(),
-            &relation_field.model().name(),
-            &relation_field.related_model().name(),
+            relation_field.name(),
+            relation_field.model().name(),
+            relation_field.related_model().name(),
         );
 
         ctx.push_error(DatamodelError::new_field_validation_error(

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
@@ -41,12 +41,11 @@ pub(crate) fn fields_and_references_are_defined(relation: InlineRelationWalker<'
 
     if is_empty_fields(forward.referencing_fields()) && is_empty_fields(back.referencing_fields()) {
         let message = format!(
-            "The relation fields `{}` on Model `{}` and `{}` on Model `{}` do not provide the `fields` argument in the {} attribute. You have to provide it on one of the two fields.",
+            "The relation fields `{}` on Model `{}` and `{}` on Model `{}` do not provide the `fields` argument in the {RELATION_ATTRIBUTE_NAME} attribute. You have to provide it on one of the two fields.",
             forward.name(),
             forward.model().name(),
             back.name(),
             back.model().name(),
-            RELATION_ATTRIBUTE_NAME
         );
 
         ctx.push_error(DatamodelError::new_attribute_validation_error(

--- a/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
+++ b/psl/psl-core/src/validate/validation_pipeline/validations/relations/one_to_one.rs
@@ -45,7 +45,7 @@ pub(crate) fn fields_and_references_are_defined(relation: InlineRelationWalker<'
             forward.name(),
             forward.model().name(),
             back.name(),
-            &back.model().name(),
+            back.model().name(),
             RELATION_ATTRIBUTE_NAME
         );
 

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -116,7 +116,7 @@ impl WarningAsserts for Vec<DatamodelWarning> {
             self.len(),
             1,
             "Expected exactly one validation warning. Warnings are: {:?}",
-            &self
+            self
         );
         assert_eq!(self[0], warning);
         self
@@ -696,7 +696,7 @@ impl DefaultValueAssert for ast::Expression {
                 panic!("Expected a numeric value for the `cuid()` version.");
             }
         } else {
-            panic!("Expected `cuid()` to be a function, got {}", &self);
+            panic!("Expected `cuid()` to be a function, got {}", self);
         }
 
         self
@@ -720,7 +720,7 @@ impl DefaultValueAssert for ast::Expression {
                 panic!("Expected a numeric value for the `uuid()` version.");
             }
         } else {
-            panic!("Expected `cuid()` to be a function, got {}", &self);
+            panic!("Expected `cuid()` to be a function, got {}", self);
         }
 
         self

--- a/psl/psl/tests/common/asserts.rs
+++ b/psl/psl/tests/common/asserts.rs
@@ -115,8 +115,7 @@ impl WarningAsserts for Vec<DatamodelWarning> {
         assert_eq!(
             self.len(),
             1,
-            "Expected exactly one validation warning. Warnings are: {:?}",
-            self
+            "Expected exactly one validation warning. Warnings are: {self:?}"
         );
         assert_eq!(self[0], warning);
         self
@@ -696,7 +695,7 @@ impl DefaultValueAssert for ast::Expression {
                 panic!("Expected a numeric value for the `cuid()` version.");
             }
         } else {
-            panic!("Expected `cuid()` to be a function, got {}", self);
+            panic!("Expected `cuid()` to be a function, got {self}");
         }
 
         self
@@ -720,7 +719,7 @@ impl DefaultValueAssert for ast::Expression {
                 panic!("Expected a numeric value for the `uuid()` version.");
             }
         } else {
-            panic!("Expected `cuid()` to be a function, got {}", self);
+            panic!("Expected `cuid()` to be a function, got {self}");
         }
 
         self

--- a/quaint/src/ast/values.rs
+++ b/quaint/src/ast/values.rs
@@ -1476,10 +1476,7 @@ impl<'a> Values<'a> {
         let mut result = Row::with_capacity(self.len());
 
         for mut row in self.rows.into_iter() {
-            match row.pop() {
-                Some(value) => result.push(value),
-                None => return None,
-            }
+            result.push(row.pop()?);
         }
 
         Some(result)

--- a/quaint/src/tests/query.rs
+++ b/quaint/src/tests/query.rs
@@ -1683,11 +1683,11 @@ async fn op_test_div_one_level(api: &mut dyn TestApi) -> crate::Result<()> {
 #[test_each_connector(tags("postgresql"))]
 async fn enum_values(api: &mut dyn TestApi) -> crate::Result<()> {
     let type_name = api.get_name();
-    let create_type = format!("CREATE TYPE {} AS ENUM ('A', 'B')", &type_name);
+    let create_type = format!("CREATE TYPE {} AS ENUM ('A', 'B')", type_name);
     api.conn().raw_cmd(&create_type).await?;
 
     let table = api
-        .create_temp_table(&format!("id SERIAL PRIMARY KEY, value {}", &type_name))
+        .create_temp_table(&format!("id SERIAL PRIMARY KEY, value {}", type_name))
         .await?;
 
     api.conn()

--- a/quaint/src/tests/query.rs
+++ b/quaint/src/tests/query.rs
@@ -1683,11 +1683,11 @@ async fn op_test_div_one_level(api: &mut dyn TestApi) -> crate::Result<()> {
 #[test_each_connector(tags("postgresql"))]
 async fn enum_values(api: &mut dyn TestApi) -> crate::Result<()> {
     let type_name = api.get_name();
-    let create_type = format!("CREATE TYPE {} AS ENUM ('A', 'B')", type_name);
+    let create_type = format!("CREATE TYPE {type_name} AS ENUM ('A', 'B')");
     api.conn().raw_cmd(&create_type).await?;
 
     let table = api
-        .create_temp_table(&format!("id SERIAL PRIMARY KEY, value {}", type_name))
+        .create_temp_table(&format!("id SERIAL PRIMARY KEY, value {type_name}"))
         .await?;
 
     api.conn()

--- a/quaint/src/tests/query/error.rs
+++ b/quaint/src/tests/query/error.rs
@@ -240,7 +240,7 @@ async fn foreign_key_constraint_violation(api: &mut dyn TestApi) -> crate::Resul
     let parent = api.create_temp_table("id smallint not null primary key").await?;
     let foreign_key = api.foreign_key(&parent, "id", "parent_id");
     let child = api
-        .create_temp_table(&format!("parent_id smallint not null, {}", foreign_key))
+        .create_temp_table(&format!("parent_id smallint not null, {foreign_key}"))
         .await?;
 
     let insert = Insert::single_into(&child).value("parent_id", 10);
@@ -267,11 +267,10 @@ async fn ms_my_foreign_key_constraint_violation(api: &mut dyn TestApi) -> crate:
 
     let create_table = format!(
         r#"
-        CREATE TABLE {} (
+        CREATE TABLE {child_table} (
             parent_id smallint not null,
-            CONSTRAINT {} FOREIGN KEY (parent_id) REFERENCES {}(id))
-        "#,
-        child_table, constraint, parent_table
+            CONSTRAINT {constraint} FOREIGN KEY (parent_id) REFERENCES {parent_table}(id))
+        "#
     );
 
     api.conn().raw_cmd(&create_table).await?;
@@ -284,8 +283,8 @@ async fn ms_my_foreign_key_constraint_violation(api: &mut dyn TestApi) -> crate:
     let err = result.unwrap_err();
     assert!(matches!(err.kind(), ErrorKind::ForeignKeyConstraintViolation { .. }));
 
-    api.conn().raw_cmd(&format!("DROP TABLE {}", child_table)).await?;
-    api.conn().raw_cmd(&format!("DROP TABLE {}", parent_table)).await?;
+    api.conn().raw_cmd(&format!("DROP TABLE {child_table}")).await?;
+    api.conn().raw_cmd(&format!("DROP TABLE {parent_table}")).await?;
 
     Ok(())
 }
@@ -405,10 +404,7 @@ async fn unsupported_column_type(api: &mut dyn TestApi) -> crate::Result<()> {
     let table = api.create_temp_table("point point, points point[]").await?;
     api.conn()
         .query_raw(
-            &format!(
-                r#"INSERT INTO {} ("point", "points") VALUES (Point(1,2), '{{"(1, 2)", "(2, 3)"}}')"#,
-                table
-            ),
+            &format!(r#"INSERT INTO {table} ("point", "points") VALUES (Point(1,2), '{{"(1, 2)", "(2, 3)"}}')"#),
             &[],
         )
         .await?;

--- a/quaint/src/tests/query/error.rs
+++ b/quaint/src/tests/query/error.rs
@@ -240,7 +240,7 @@ async fn foreign_key_constraint_violation(api: &mut dyn TestApi) -> crate::Resul
     let parent = api.create_temp_table("id smallint not null primary key").await?;
     let foreign_key = api.foreign_key(&parent, "id", "parent_id");
     let child = api
-        .create_temp_table(&format!("parent_id smallint not null, {}", &foreign_key))
+        .create_temp_table(&format!("parent_id smallint not null, {}", foreign_key))
         .await?;
 
     let insert = Insert::single_into(&child).value("parent_id", 10);
@@ -271,7 +271,7 @@ async fn ms_my_foreign_key_constraint_violation(api: &mut dyn TestApi) -> crate:
             parent_id smallint not null,
             CONSTRAINT {} FOREIGN KEY (parent_id) REFERENCES {}(id))
         "#,
-        &child_table, &constraint, &parent_table
+        child_table, constraint, parent_table
     );
 
     api.conn().raw_cmd(&create_table).await?;
@@ -284,8 +284,8 @@ async fn ms_my_foreign_key_constraint_violation(api: &mut dyn TestApi) -> crate:
     let err = result.unwrap_err();
     assert!(matches!(err.kind(), ErrorKind::ForeignKeyConstraintViolation { .. }));
 
-    api.conn().raw_cmd(&format!("DROP TABLE {}", &child_table)).await?;
-    api.conn().raw_cmd(&format!("DROP TABLE {}", &parent_table)).await?;
+    api.conn().raw_cmd(&format!("DROP TABLE {}", child_table)).await?;
+    api.conn().raw_cmd(&format!("DROP TABLE {}", parent_table)).await?;
 
     Ok(())
 }
@@ -407,7 +407,7 @@ async fn unsupported_column_type(api: &mut dyn TestApi) -> crate::Result<()> {
         .query_raw(
             &format!(
                 r#"INSERT INTO {} ("point", "points") VALUES (Point(1,2), '{{"(1, 2)", "(2, 3)"}}')"#,
-                &table
+                table
             ),
             &[],
         )

--- a/quaint/src/tests/test_api/mssql.rs
+++ b/quaint/src/tests/test_api/mssql.rs
@@ -102,10 +102,7 @@ impl TestApi for MsSql<'_> {
     fn foreign_key(&mut self, parent_table: &str, parent_column: &str, child_column: &str) -> String {
         let name = self.get_name();
 
-        format!(
-            "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}({})",
-            name, child_column, parent_table, parent_column
-        )
+        format!("CONSTRAINT {name} FOREIGN KEY ({child_column}) REFERENCES {parent_table}({parent_column})")
     }
 
     fn autogen_id(&self, name: &str) -> String {

--- a/quaint/src/tests/test_api/mssql.rs
+++ b/quaint/src/tests/test_api/mssql.rs
@@ -104,7 +104,7 @@ impl TestApi for MsSql<'_> {
 
         format!(
             "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}({})",
-            &name, child_column, parent_table, parent_column
+            name, child_column, parent_table, parent_column
         )
     }
 

--- a/quaint/src/tests/test_api/mysql.rs
+++ b/quaint/src/tests/test_api/mysql.rs
@@ -139,10 +139,7 @@ impl TestApi for MySql<'_> {
     fn foreign_key(&mut self, parent_table: &str, parent_column: &str, child_column: &str) -> String {
         let name = self.get_name();
 
-        format!(
-            "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}({})",
-            name, child_column, parent_table, parent_column
-        )
+        format!("CONSTRAINT {name} FOREIGN KEY ({child_column}) REFERENCES {parent_table}({parent_column})")
     }
 
     fn autogen_id(&self, name: &str) -> String {

--- a/quaint/src/tests/test_api/mysql.rs
+++ b/quaint/src/tests/test_api/mysql.rs
@@ -141,7 +141,7 @@ impl TestApi for MySql<'_> {
 
         format!(
             "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}({})",
-            &name, child_column, parent_table, parent_column
+            name, child_column, parent_table, parent_column
         )
     }
 

--- a/quaint/src/tests/test_api/postgres.rs
+++ b/quaint/src/tests/test_api/postgres.rs
@@ -97,10 +97,7 @@ impl TestApi for PostgreSql<'_> {
     fn foreign_key(&mut self, parent_table: &str, parent_column: &str, child_column: &str) -> String {
         let name = self.get_name();
 
-        format!(
-            "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}({})",
-            name, child_column, parent_table, parent_column
-        )
+        format!("CONSTRAINT {name} FOREIGN KEY ({child_column}) REFERENCES {parent_table}({parent_column})")
     }
 
     fn autogen_id(&self, name: &str) -> String {

--- a/quaint/src/tests/test_api/postgres.rs
+++ b/quaint/src/tests/test_api/postgres.rs
@@ -99,7 +99,7 @@ impl TestApi for PostgreSql<'_> {
 
         format!(
             "CONSTRAINT {} FOREIGN KEY ({}) REFERENCES {}({})",
-            &name, child_column, parent_table, parent_column
+            name, child_column, parent_table, parent_column
         )
     }
 

--- a/quaint/src/tests/types/sqlite.rs
+++ b/quaint/src/tests/types/sqlite.rs
@@ -126,7 +126,7 @@ async fn test_type_text_datetime_rfc3339(api: &mut dyn TestApi) -> crate::Result
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (?)", table),
+            &format!("INSERT INTO {table} (value) VALUES (?)"),
             &[Value::text(dt.to_rfc3339())],
         )
         .await?;
@@ -149,7 +149,7 @@ async fn test_type_text_datetime_rfc2822(api: &mut dyn TestApi) -> crate::Result
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (?)", table),
+            &format!("INSERT INTO {table} (value) VALUES (?)"),
             &[Value::text(dt.to_rfc2822())],
         )
         .await?;
@@ -170,7 +170,7 @@ async fn test_type_text_datetime_custom(api: &mut dyn TestApi) -> crate::Result<
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (?)", table),
+            &format!("INSERT INTO {table} (value) VALUES (?)"),
             &[Value::text("2020-04-20 16:20:00")],
         )
         .await?;
@@ -194,7 +194,7 @@ async fn test_get_int64_from_int32_field_fails(api: &mut dyn TestApi) -> crate::
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (9223372036854775807)", table),
+            &format!("INSERT INTO {table} (value) VALUES (9223372036854775807)"),
             &[],
         )
         .await?;

--- a/quaint/src/tests/types/sqlite.rs
+++ b/quaint/src/tests/types/sqlite.rs
@@ -126,7 +126,7 @@ async fn test_type_text_datetime_rfc3339(api: &mut dyn TestApi) -> crate::Result
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (?)", &table),
+            &format!("INSERT INTO {} (value) VALUES (?)", table),
             &[Value::text(dt.to_rfc3339())],
         )
         .await?;
@@ -149,7 +149,7 @@ async fn test_type_text_datetime_rfc2822(api: &mut dyn TestApi) -> crate::Result
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (?)", &table),
+            &format!("INSERT INTO {} (value) VALUES (?)", table),
             &[Value::text(dt.to_rfc2822())],
         )
         .await?;
@@ -170,7 +170,7 @@ async fn test_type_text_datetime_custom(api: &mut dyn TestApi) -> crate::Result<
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (?)", &table),
+            &format!("INSERT INTO {} (value) VALUES (?)", table),
             &[Value::text("2020-04-20 16:20:00")],
         )
         .await?;
@@ -194,7 +194,7 @@ async fn test_get_int64_from_int32_field_fails(api: &mut dyn TestApi) -> crate::
 
     api.conn()
         .execute_raw(
-            &format!("INSERT INTO {} (value) VALUES (9223372036854775807)", &table),
+            &format!("INSERT INTO {} (value) VALUES (9223372036854775807)", table),
             &[],
         )
         .await?;

--- a/quaint/src/visitor/mssql.rs
+++ b/quaint/src/visitor/mssql.rs
@@ -718,7 +718,7 @@ impl<'a> Visitor<'a> for Mssql<'a> {
         self.surround_with("(", ")", |this| {
             for (i, row) in right.into_iter().enumerate() {
                 this.surround_with("(", ")", |se| {
-                    let row_and_vals = left.values.clone().into_iter().zip(row.values.into_iter());
+                    let row_and_vals = left.values.clone().into_iter().zip(row.values);
 
                     for (j, (expr, val)) in row_and_vals.enumerate() {
                         se.visit_expression(expr)?;

--- a/query-compiler/core/src/query_document/selection.rs
+++ b/query-compiler/core/src/query_document/selection.rs
@@ -220,11 +220,7 @@ impl QuerySingle {
         let mut result = QuerySingle(key.clone(), vec![value.clone()]);
 
         for filters in query_filters.iter().skip(1) {
-            if let Some(single) = QuerySingle::push(result, filters) {
-                result = single;
-            } else {
-                return None;
-            }
+            result = QuerySingle::push(result, filters)?;
         }
 
         Some(result)

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -489,9 +489,8 @@ impl<'a> ScalarFilterParser<'a> {
                         "Expected a referenced scalar field {field_ref} but found a composite field."
                     ))),
                     None => Err(QueryGraphBuilderError::InputError(format!(
-                        "The referenced scalar field {}.{} does not exist.",
-                        field.container().name(),
-                        field_ref_name
+                        "The referenced scalar field {}.{field_ref_name} does not exist.",
+                        field.container().name()
                     ))),
                 }
             }
@@ -529,9 +528,8 @@ impl<'a> ScalarFilterParser<'a> {
                         "Expected a referenced scalar list field {cf} but found a composite field."
                     ))),
                     _ => Err(QueryGraphBuilderError::InputError(format!(
-                        "The referenced scalar list field {}.{} does not exist.",
-                        field.container().name(),
-                        field_ref_name
+                        "The referenced scalar list field {}.{field_ref_name} does not exist.",
+                        field.container().name()
                     ))),
                 }
             }

--- a/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/filters/scalar.rs
@@ -491,7 +491,7 @@ impl<'a> ScalarFilterParser<'a> {
                     None => Err(QueryGraphBuilderError::InputError(format!(
                         "The referenced scalar field {}.{} does not exist.",
                         field.container().name(),
-                        &field_ref_name
+                        field_ref_name
                     ))),
                 }
             }
@@ -531,7 +531,7 @@ impl<'a> ScalarFilterParser<'a> {
                     _ => Err(QueryGraphBuilderError::InputError(format!(
                         "The referenced scalar list field {}.{} does not exist.",
                         field.container().name(),
-                        &field_ref_name
+                        field_ref_name
                     ))),
                 }
             }

--- a/query-compiler/query-builders/sql-query-builder/src/join_utils.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/join_utils.rs
@@ -24,7 +24,7 @@ pub(crate) fn compute_aggr_join(
     previous_join: Option<&str>,
     ctx: &Context<'_>,
 ) -> AliasedJoin {
-    let join_alias = format!("{}_{}", join_alias, rf.related_model().name());
+    let join_alias = format!("{join_alias}_{}", rf.related_model().name());
 
     if rf.relation().is_many_to_many() {
         compute_aggr_join_m2m(

--- a/query-compiler/query-builders/sql-query-builder/src/join_utils.rs
+++ b/query-compiler/query-builders/sql-query-builder/src/join_utils.rs
@@ -24,7 +24,7 @@ pub(crate) fn compute_aggr_join(
     previous_join: Option<&str>,
     ctx: &Context<'_>,
 ) -> AliasedJoin {
-    let join_alias = format!("{}_{}", join_alias, &rf.related_model().name());
+    let join_alias = format!("{}_{}", join_alias, rf.related_model().name());
 
     if rf.relation().is_many_to_many() {
         compute_aggr_join_m2m(

--- a/query-compiler/query-structure/src/record.rs
+++ b/query-compiler/query-structure/src/record.rs
@@ -240,7 +240,7 @@ impl Record {
             Err(DomainError::FieldNotFound {
                 name: field.to_string(),
                 container_type: "field",
-                container_name: format!("Record values: {:?}. Field names: {:?}.", self, field_names),
+                container_name: format!("Record values: {self:?}. Field names: {field_names:?}."),
             })
         })?;
 

--- a/query-compiler/query-structure/src/record.rs
+++ b/query-compiler/query-structure/src/record.rs
@@ -240,7 +240,7 @@ impl Record {
             Err(DomainError::FieldNotFound {
                 name: field.to_string(),
                 container_type: "field",
-                container_name: format!("Record values: {:?}. Field names: {:?}.", &self, &field_names),
+                container_name: format!("Record values: {:?}. Field names: {:?}.", self, field_names),
             })
         })?;
 

--- a/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -146,7 +146,7 @@ impl<'a> JsonProtocolAdapter<'a> {
     }
 
     fn convert_argument(value: JsonValue) -> crate::Result<ArgumentValue> {
-        let err_message = format!("Could not convert argument value {:?} to ArgumentValue.", &value);
+        let err_message = format!("Could not convert argument value {:?} to ArgumentValue.", value);
         let build_err = || HandlerError::query_conversion(err_message.clone());
 
         match value {

--- a/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
+++ b/query-compiler/request-handlers/src/protocols/json/protocol_adapter.rs
@@ -146,7 +146,7 @@ impl<'a> JsonProtocolAdapter<'a> {
     }
 
     fn convert_argument(value: JsonValue) -> crate::Result<ArgumentValue> {
-        let err_message = format!("Could not convert argument value {:?} to ArgumentValue.", value);
+        let err_message = format!("Could not convert argument value {value:?} to ArgumentValue.");
         let build_err = || HandlerError::query_conversion(err_message.clone());
 
         match value {

--- a/query-engine/connector-test-kit-rs/qe-setup/src/driver_adapters.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/driver_adapters.rs
@@ -31,7 +31,7 @@ pub enum DriverAdapter {
 impl From<String> for DriverAdapter {
     fn from(s: String) -> Self {
         let s = s.as_str();
-        serde_json::from_str(s).unwrap_or_else(|_| panic!("Unknown driver adapter: {}", s))
+        serde_json::from_str(s).unwrap_or_else(|_| panic!("Unknown driver adapter: {s}"))
     }
 }
 

--- a/query-engine/connector-test-kit-rs/qe-setup/src/driver_adapters.rs
+++ b/query-engine/connector-test-kit-rs/qe-setup/src/driver_adapters.rs
@@ -31,7 +31,7 @@ pub enum DriverAdapter {
 impl From<String> for DriverAdapter {
     fn from(s: String) -> Self {
         let s = s.as_str();
-        serde_json::from_str(s).unwrap_or_else(|_| panic!("Unknown driver adapter: {}", &s))
+        serde_json::from_str(s).unwrap_or_else(|_| panic!("Unknown driver adapter: {}", s))
     }
 }
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_expression.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_expression.rs
@@ -32,7 +32,7 @@ impl IntoUpdateExpression for GenericOperation {
 impl IntoUpdateExpressions for Upsert {
     fn into_update_expressions(self) -> crate::Result<Vec<UpdateExpression>> {
         let should_set_id = format!("__prisma_should_set__{}", self.field_path.identifier());
-        let should_set_ref_id = format!("${}", should_set_id);
+        let should_set_ref_id = format!("${should_set_id}");
 
         let mut expressions: Vec<UpdateExpression> = vec![];
 
@@ -94,9 +94,9 @@ impl IntoUpdateExpression for UpdateMany {
         // The alias that will be used in the `$map` operation
         let elem_alias = self.elem_alias.clone();
         // A reference to that alias
-        let ref_elem_alias = format!("$${}", elem_alias);
+        let ref_elem_alias = format!("$${elem_alias}");
 
-        let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${}", elem_alias), false)
+        let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${elem_alias}"), false)
             .visit(self.filter.clone())?
             .render();
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_expression.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_expression.rs
@@ -31,8 +31,8 @@ impl IntoUpdateExpression for GenericOperation {
 
 impl IntoUpdateExpressions for Upsert {
     fn into_update_expressions(self) -> crate::Result<Vec<UpdateExpression>> {
-        let should_set_id = format!("__prisma_should_set__{}", &self.field_path.identifier());
-        let should_set_ref_id = format!("${}", &should_set_id);
+        let should_set_id = format!("__prisma_should_set__{}", self.field_path.identifier());
+        let should_set_ref_id = format!("${}", should_set_id);
 
         let mut expressions: Vec<UpdateExpression> = vec![];
 
@@ -94,9 +94,9 @@ impl IntoUpdateExpression for UpdateMany {
         // The alias that will be used in the `$map` operation
         let elem_alias = self.elem_alias.clone();
         // A reference to that alias
-        let ref_elem_alias = format!("$${}", &elem_alias);
+        let ref_elem_alias = format!("$${}", elem_alias);
 
-        let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${}", &elem_alias), false)
+        let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${}", elem_alias), false)
             .visit(self.filter.clone())?
             .render();
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
@@ -102,7 +102,7 @@ impl IntoUpdateOperation for CompositeWriteOperation {
             }
             CompositeWriteOperation::DeleteMany { filter } => {
                 let elem_alias = format!("{}_item", path.identifier());
-                let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${}", &elem_alias), true)
+                let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${}", elem_alias), true)
                     .visit(filter)?
                     .render();
 

--- a/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/root_queries/update/into_operation.rs
@@ -102,7 +102,7 @@ impl IntoUpdateOperation for CompositeWriteOperation {
             }
             CompositeWriteOperation::DeleteMany { filter } => {
                 let elem_alias = format!("{}_item", path.identifier());
-                let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${}", elem_alias), true)
+                let (filter_doc, _) = filter::MongoFilterVisitor::new(format!("${elem_alias}"), true)
                     .visit(filter)?
                     .render();
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.97.1"
 components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # Wasm target for serverless and edge environments.

--- a/schema-engine/cli/tests/cli_tests.rs
+++ b/schema-engine/cli/tests/cli_tests.rs
@@ -458,7 +458,7 @@ fn basic_jsonrpc_roundtrip_works_with_params(_api: TestApi) {
                 })
                 .to_string();
 
-                writeln!(stdin, "{}", &params_template).unwrap();
+                writeln!(stdin, "{}", params_template).unwrap();
 
                 let mut response = String::new();
                 stdout.read_line(&mut response).unwrap();
@@ -928,7 +928,7 @@ fn get_database_version_multi_file(_api: TestApi) {
                 })
                 .to_string();
 
-                writeln!(stdin, "{}", &params_template).unwrap();
+                writeln!(stdin, "{}", params_template).unwrap();
 
                 let mut response = String::new();
                 stdout.read_line(&mut response).unwrap();

--- a/schema-engine/cli/tests/cli_tests.rs
+++ b/schema-engine/cli/tests/cli_tests.rs
@@ -458,7 +458,7 @@ fn basic_jsonrpc_roundtrip_works_with_params(_api: TestApi) {
                 })
                 .to_string();
 
-                writeln!(stdin, "{}", params_template).unwrap();
+                writeln!(stdin, "{params_template}").unwrap();
 
                 let mut response = String::new();
                 stdout.read_line(&mut response).unwrap();
@@ -928,7 +928,7 @@ fn get_database_version_multi_file(_api: TestApi) {
                 })
                 .to_string();
 
-                writeln!(stdin, "{}", params_template).unwrap();
+                writeln!(stdin, "{params_template}").unwrap();
 
                 let mut response = String::new();
                 stdout.read_line(&mut response).unwrap();

--- a/schema-engine/connectors/mongodb-schema-connector/src/sampler/statistics.rs
+++ b/schema-engine/connectors/mongodb-schema-connector/src/sampler/statistics.rs
@@ -178,8 +178,8 @@ impl<'a> Statistics<'a> {
 
         let mut types: BTreeMap<&str, renderer::datamodel::CompositeType<'_>> = self
             .models
-            .iter()
-            .flat_map(|(name, _)| name.as_type_name())
+            .keys()
+            .flat_map(|name| name.as_type_name())
             .filter(|name| self.types_with_fields.contains(*name))
             .map(|name| (name, renderer::datamodel::CompositeType::new(name)))
             .collect();

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -315,7 +315,7 @@ impl SqlConnector for MssqlConnector {
                     let ns = row.get("namespace").and_then(|s| s.to_string());
                     let table_name = row.get("table_name").and_then(|s| s.to_string());
 
-                    ns.and_then(|ns| table_name.map(|table_name| (ns, table_name)))
+                    ns.zip(table_name)
                 })
                 .filter(|(ns, table_name)| {
                     namespaces.contains(ns)

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql/renderer.rs
@@ -293,7 +293,7 @@ impl SqlRenderer for MssqlRenderer {
         for redefine_table in tables {
             let tables = schemas.walk(redefine_table.table_ids);
             // This is a copy of our new modified table.
-            let temporary_table_name = format!("_prisma_new_{}", &tables.next.name());
+            let temporary_table_name = format!("_prisma_new_{}", tables.next.name());
 
             // If any of the columns is an identity, we should know about it.
             let needs_autoincrement = redefine_table

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres.rs
@@ -424,7 +424,7 @@ impl SqlConnector for PostgresConnector {
                     let ns = row.get("table_namespace").and_then(|s| s.to_string());
                     let table_name = row.get("table_name").and_then(|s| s.to_string());
 
-                    ns.and_then(|ns| table_name.map(|table_name| (ns, table_name)))
+                    ns.zip(table_name)
                 })
                 .filter(|(ns, table_name)| {
                     !self
@@ -748,15 +748,8 @@ async fn setup_connection(
 
     let version = schema_exists_result
         .first()
-        .and_then(|row| {
-            row.at(1)
-                .and_then(|ver_str| row.at(2).map(|ver_num| (ver_str, ver_num)))
-        })
-        .and_then(|(ver_str, ver_num)| {
-            ver_str
-                .to_string()
-                .and_then(|version| ver_num.as_integer().map(|version_number| (version, version_number)))
-        });
+        .and_then(|row| row.at(1).zip(row.at(2)))
+        .and_then(|(ver_str, ver_num)| ver_str.to_string().zip(ver_num.as_integer()));
 
     match version {
         Some((version, version_num)) => {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
@@ -716,7 +716,7 @@ fn render_alter_column(
     for step in steps {
         match step {
             PostgresAlterColumn::DropDefault => {
-                clauses.push(format!("{} DROP DEFAULT", alter_column_prefix));
+                clauses.push(format!("{alter_column_prefix} DROP DEFAULT"));
 
                 // We also need to drop the sequence, in case it isn't used by any other column.
                 if let Some(DefaultKind::Sequence(sequence_name)) = columns.previous.default().map(|d| d.kind()) {
@@ -728,15 +728,13 @@ fn render_alter_column(
                 }
             }
             PostgresAlterColumn::SetDefault(new_default) => clauses.push(format!(
-                "{} SET DEFAULT {}",
-                alter_column_prefix,
+                "{alter_column_prefix} SET DEFAULT {}",
                 render_default(&new_default, &render_column_type(columns.next, renderer))
             )),
-            PostgresAlterColumn::DropNotNull => clauses.push(format!("{} DROP NOT NULL", alter_column_prefix)),
-            PostgresAlterColumn::SetNotNull => clauses.push(format!("{} SET NOT NULL", alter_column_prefix)),
+            PostgresAlterColumn::DropNotNull => clauses.push(format!("{alter_column_prefix} DROP NOT NULL")),
+            PostgresAlterColumn::SetNotNull => clauses.push(format!("{alter_column_prefix} SET NOT NULL")),
             PostgresAlterColumn::SetType => clauses.push(format!(
-                "{} SET DATA TYPE {}",
-                alter_column_prefix,
+                "{alter_column_prefix} SET DATA TYPE {}",
                 render_column_type(columns.next, renderer)
             )),
             PostgresAlterColumn::AddSequence => {

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/renderer.rs
@@ -468,7 +468,7 @@ impl SqlRenderer for PostgresRenderer {
 
         for redefine_table in tables {
             let tables = schemas.walk(redefine_table.table_ids);
-            let temporary_table_name = format!("_prisma_new_{}", &tables.next.name());
+            let temporary_table_name = format!("_prisma_new_{}", tables.next.name());
             let quoted_temporary_table = QuotedWithPrefix(
                 tables.next.explicit_namespace().map(Quoted::postgres_ident),
                 Quoted::postgres_ident(&temporary_table_name),
@@ -716,7 +716,7 @@ fn render_alter_column(
     for step in steps {
         match step {
             PostgresAlterColumn::DropDefault => {
-                clauses.push(format!("{} DROP DEFAULT", &alter_column_prefix));
+                clauses.push(format!("{} DROP DEFAULT", alter_column_prefix));
 
                 // We also need to drop the sequence, in case it isn't used by any other column.
                 if let Some(DefaultKind::Sequence(sequence_name)) = columns.previous.default().map(|d| d.kind()) {
@@ -729,14 +729,14 @@ fn render_alter_column(
             }
             PostgresAlterColumn::SetDefault(new_default) => clauses.push(format!(
                 "{} SET DEFAULT {}",
-                &alter_column_prefix,
+                alter_column_prefix,
                 render_default(&new_default, &render_column_type(columns.next, renderer))
             )),
-            PostgresAlterColumn::DropNotNull => clauses.push(format!("{} DROP NOT NULL", &alter_column_prefix)),
-            PostgresAlterColumn::SetNotNull => clauses.push(format!("{} SET NOT NULL", &alter_column_prefix)),
+            PostgresAlterColumn::DropNotNull => clauses.push(format!("{} DROP NOT NULL", alter_column_prefix)),
+            PostgresAlterColumn::SetNotNull => clauses.push(format!("{} SET NOT NULL", alter_column_prefix)),
             PostgresAlterColumn::SetType => clauses.push(format!(
                 "{} SET DATA TYPE {}",
-                &alter_column_prefix,
+                alter_column_prefix,
                 render_column_type(columns.next, renderer)
             )),
             PostgresAlterColumn::AddSequence => {
@@ -930,9 +930,9 @@ fn render_postgres_alter_enum(
 
     let mut stmts = Vec::with_capacity(10);
 
-    let temporary_enum_name = format!("{}_new", &enums.next.name());
+    let temporary_enum_name = format!("{}_new", enums.next.name());
     let tmp_name = QuotedWithPrefix::pg_new(enums.next.explicit_namespace(), temporary_enum_name.as_str());
-    let tmp_old_name = format!("{}_old", &enums.previous.name());
+    let tmp_old_name = format!("{}_old", enums.previous.name());
 
     stmts.push("BEGIN".to_string());
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/renderer.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/renderer.rs
@@ -202,7 +202,7 @@ impl SqlRenderer for SqliteRenderer {
 
         for redefine_table in tables {
             let tables = schemas.walk(redefine_table.table_ids);
-            let temporary_table_name = format!("new_{}", &tables.next.name());
+            let temporary_table_name = format!("new_{}", tables.next.name());
 
             // maybe use render_create_table_for_migration?
             result.push(self.render_create_table_as(

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ.rs
@@ -236,7 +236,7 @@ fn added_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
     let from_psl_change = differ
         .created_primary_key()
         .map(|_| TableChange::AddPrimaryKey)
-        .or_else(|| Some(TableChange::AddPrimaryKey).filter(|_| differ.primary_key_changed()));
+        .or_else(|| differ.primary_key_changed().then_some(TableChange::AddPrimaryKey));
 
     if differ.db.flavour.should_recreate_the_primary_key_on_column_recreate() {
         from_psl_change.or_else(|| {
@@ -263,7 +263,7 @@ fn dropped_primary_key(differ: &TableDiffer<'_, '_>) -> Option<TableChange> {
     let from_psl_change = differ
         .dropped_primary_key()
         .map(|_pk| TableChange::DropPrimaryKey)
-        .or_else(|| Some(TableChange::DropPrimaryKey).filter(|_| differ.primary_key_changed()));
+        .or_else(|| differ.primary_key_changed().then_some(TableChange::DropPrimaryKey));
 
     // ALTER PRIMARY KEY instead where possible (e.g. cockroachdb)
     if differ.tables.previous.primary_key().is_some()

--- a/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/differ_database.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/sql_schema_differ/differ_database.rs
@@ -166,7 +166,7 @@ impl<'a> DifferDatabase<'a> {
     }
 
     pub(crate) fn all_column_pairs(&self) -> impl Iterator<Item = MigrationPair<TableColumnId>> + '_ {
-        self.columns.iter().filter_map(|(_, cols)| cols.transpose())
+        self.columns.values().filter_map(|cols| cols.transpose())
     }
 
     pub(crate) fn column_pairs(

--- a/schema-engine/datamodel-renderer/src/configuration.rs
+++ b/schema-engine/datamodel-renderer/src/configuration.rs
@@ -63,13 +63,13 @@ impl<'a> Configuration<'a> {
 
 impl fmt::Display for Configuration<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (_, generators) in self.generators.iter() {
+        for generators in self.generators.values() {
             for generator in generators {
                 generator.fmt(f)?
             }
         }
 
-        for (_, datasources) in self.datasources.iter() {
+        for datasources in self.datasources.values() {
             for datasource in datasources {
                 datasource.fmt(f)?;
             }

--- a/schema-engine/sql-introspection-tests/src/test_api.rs
+++ b/schema-engine/sql-introspection-tests/src/test_api.rs
@@ -399,11 +399,7 @@ impl TestApi {
     }
 
     pub fn pure_config(&self) -> String {
-        format!(
-            "{}\n{}",
-            &self.datasource_block_string(),
-            &self.generator_block_string()
-        )
+        format!("{}\n{}", self.datasource_block_string(), self.generator_block_string())
     }
 
     pub fn configuration(&self) -> Configuration {

--- a/schema-engine/sql-migration-tests/src/assertions.rs
+++ b/schema-engine/sql-migration-tests/src/assertions.rs
@@ -286,7 +286,7 @@ impl SchemaAssertion {
     }
 
     pub fn debug_print(self) -> Self {
-        println!("{:?}", &self.schema);
+        println!("{:?}", self.schema);
 
         self
     }

--- a/schema-engine/sql-schema-describer/src/getters.rs
+++ b/schema-engine/sql-schema-describer/src/getters.rs
@@ -21,7 +21,7 @@ impl Getter for ResultRow {
     fn get_expect_string(&self, name: &str) -> String {
         self.get(name)
             .and_then(|x| x.to_string())
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as String failed", name, &self))
+            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as String failed", name, self))
             .unwrap()
     }
 
@@ -29,7 +29,7 @@ impl Getter for ResultRow {
     fn get_expect_char(&self, name: &str) -> char {
         self.get(name)
             .and_then(|x| x.as_char())
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as char failed", name, &self))
+            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as char failed", name, self))
             .unwrap()
     }
 
@@ -37,14 +37,14 @@ impl Getter for ResultRow {
     fn get_expect_i64(&self, name: &str) -> i64 {
         self.get(name)
             .and_then(|x| x.as_integer())
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as i64 failed", name, &self))
+            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as i64 failed", name, self))
             .unwrap()
     }
 
     #[track_caller]
     fn get_expect_bool(&self, name: &str) -> bool {
         self.get_bool(name)
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as bool failed", name, &self))
+            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as bool failed", name, self))
             .unwrap()
     }
 

--- a/schema-engine/sql-schema-describer/src/getters.rs
+++ b/schema-engine/sql-schema-describer/src/getters.rs
@@ -21,7 +21,7 @@ impl Getter for ResultRow {
     fn get_expect_string(&self, name: &str) -> String {
         self.get(name)
             .and_then(|x| x.to_string())
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as String failed", name, self))
+            .ok_or_else(|| format!("Getting {name} from Resultrow {self:?} as String failed"))
             .unwrap()
     }
 
@@ -29,7 +29,7 @@ impl Getter for ResultRow {
     fn get_expect_char(&self, name: &str) -> char {
         self.get(name)
             .and_then(|x| x.as_char())
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as char failed", name, self))
+            .ok_or_else(|| format!("Getting {name} from Resultrow {self:?} as char failed"))
             .unwrap()
     }
 
@@ -37,14 +37,14 @@ impl Getter for ResultRow {
     fn get_expect_i64(&self, name: &str) -> i64 {
         self.get(name)
             .and_then(|x| x.as_integer())
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as i64 failed", name, self))
+            .ok_or_else(|| format!("Getting {name} from Resultrow {self:?} as i64 failed"))
             .unwrap()
     }
 
     #[track_caller]
     fn get_expect_bool(&self, name: &str) -> bool {
         self.get_bool(name)
-            .ok_or_else(|| format!("Getting {} from Resultrow {:?} as bool failed", name, self))
+            .ok_or_else(|| format!("Getting {name} from Resultrow {self:?} as bool failed"))
             .unwrap()
     }
 


### PR DESCRIPTION
## Overview

Bumps the pinned toolchain in `rust-toolchain.toml` from 1.92.0 to 1.97.1 and fixes everything the new Clippy complains about, so `make pedantic` is green again.

## Changes

The bulk of the diff is the new lint against redundant references in formatting macro arguments. `format!`, `panic!` and `assert_eq!` already take their arguments by reference, so the explicit `&` was pointless. Purely mechanical, no behaviour change.

The rest, one by one:

- **`sql_schema_differ.rs`** — `Some(TableChange::…).filter(|_| differ.primary_key_changed())` becomes `differ.primary_key_changed().then_some(TableChange::…)`. The lint warns that this reorders the condition against the value; harmless here, since the value is a unit variant and the predicate is a pure query.
- **`native_types.rs`, `flavour/postgres.rs`** — `a.and_then(|a| b.map(|b| (a, b)))` becomes `a.zip(b)`.
- **`datasource_loader.rs`** — `sort_by(|(a, _), (b, _)| a.cmp(b))` becomes `sort_by_key`.
- **`validations/fields.rs`** — the `DecimalType` capability check moves from an `if` inside the match arm into a match guard.
- **`quaint/src/ast/values.rs`, `query_document/selection.rs`** — two blocks that returned `None` on the miss now use `?`.
- **`configuration.rs`, `statistics.rs`, `differ_database.rs`** — `iter().map(|(_, v)| …)` over maps becomes `values()`.
- **`visitor/mssql.rs`** — drop a no-op `into_iter()` on an argument that already accepts `IntoIterator`.

## Inlined format arguments

Since the redundant-reference fix was already rewriting those formatting macro calls, the second commit captures their arguments in the format string as well — `panic!("Unknown driver adapter: {}", s)` becomes `panic!("Unknown driver adapter: {s}")`.

This is scoped to the lines this PR already touches. Every argument that *can* be captured is, including in calls that also carry arguments that cannot be, so a few strings mix the two styles:

```rust
format!("{alter_column_prefix} SET DATA TYPE {}", render_column_type(columns.next, renderer))
```

What stays positional is only what the language cannot capture: method calls (`field.name()`) and field accesses (`self.schema`).

Note that `clippy::uninlined_format_args` only fires when *all* of a call's arguments are capturable, so the mixed cases above are beyond what the lint would ask for. With this PR applied, no fully-capturable call remains on any line it touches.

## Verification

- `make pedantic` passes (both the native and the `wasm32-unknown-unknown` Clippy passes).
- `make test-unit` passes: 112 test binaries, no failures.