### PR TITLE
ci: track prisma/prisma's v7 branch for driver-adapter tests

### DIFF
--- a/.github/workflows/select-prisma-branch.yml
+++ b/.github/workflows/select-prisma-branch.yml
@@ -13,8 +13,8 @@ jobs:
     outputs:
       prismaBranch: ${{ steps.setPrismaBranch.outputs.prismaBranch }}
     steps:
-      - name: Default to the main branch
-        run: echo "PRISMA_BRANCH=main" >> "$GITHUB_ENV"
+      - name: Default to the v7 branch
+        run: echo "PRISMA_BRANCH=v7" >> "$GITHUB_ENV"
 
       - name: Extract Prisma branch name from PR description
         env:
@@ -30,7 +30,7 @@ jobs:
           )
         run: |
           BRANCH_NAME=$(echo "$PR_BODY" | sed -n 's|.*\/prisma-branch \([^[:space:]]\+\).*|\1|p' | head -n 1)
-          if [ -n "$BRANCH_NAME" ] && [ "$BRANCH_NAME" != "main" ]; then
+          if [ -n "$BRANCH_NAME" ] && [ "$BRANCH_NAME" != "v7" ]; then
             echo "PRISMA_BRANCH=$BRANCH_NAME" >> "$GITHUB_ENV"
           fi
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 CONFIG_PATH = ./query-engine/connector-test-kit-rs/test-configs
 CONFIG_FILE = .test_config
 DEV_SCHEMA_FILE = dev_datamodel.prisma
-PRISMA_BRANCH ?= main
+PRISMA_BRANCH ?= v7
 ENGINE_SIZE_OUTPUT ?= /dev/stdout
 QE_WASM_VERSION ?= 0.0.0
 SCHEMA_WASM_VERSION ?= 0.0.0
@@ -460,10 +460,10 @@ build-driver-adapters: ensure-prisma-present
 
 ensure-prisma-present:
 	@if [ -d ../prisma ]; then \
-		cd "$(realpath ../prisma)" && git fetch origin main; \
-		LOCAL_CHANGES=$$(git diff --name-only HEAD origin/main -- 'packages/*adapter*'); \
+		cd "$(realpath ../prisma)" && git fetch origin $(PRISMA_BRANCH); \
+		LOCAL_CHANGES=$$(git diff --name-only HEAD origin/$(PRISMA_BRANCH) -- 'packages/*adapter*'); \
 		if [ -n "$$LOCAL_CHANGES" ]; then \
-		  echo "⚠️ ../prisma diverges from prisma/prisma main branch. Test results might diverge from those in CI ⚠️ "; \
+		  echo "⚠️ ../prisma diverges from prisma/prisma $(PRISMA_BRANCH) branch. Test results might diverge from those in CI ⚠️ "; \
 		fi \
 	else \
 		echo "git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(PRISMA_BRANCH) ../prisma"; \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,9 @@ REPO_ROOT := $(shell git rev-parse --show-toplevel)
 CONFIG_PATH = ./query-engine/connector-test-kit-rs/test-configs
 CONFIG_FILE = .test_config
 DEV_SCHEMA_FILE = dev_datamodel.prisma
-PRISMA_BRANCH ?= v7
+# Exported rather than interpolated into recipes: in CI the value can come from
+# the per-PR branch override, so it must reach the shell as data, not as source.
+export PRISMA_BRANCH ?= v7
 ENGINE_SIZE_OUTPUT ?= /dev/stdout
 QE_WASM_VERSION ?= 0.0.0
 SCHEMA_WASM_VERSION ?= 0.0.0
@@ -460,14 +462,14 @@ build-driver-adapters: ensure-prisma-present
 
 ensure-prisma-present:
 	@if [ -d ../prisma ]; then \
-		cd "$(realpath ../prisma)" && git fetch origin $(PRISMA_BRANCH); \
-		LOCAL_CHANGES=$$(git diff --name-only HEAD origin/$(PRISMA_BRANCH) -- 'packages/*adapter*'); \
+		cd "$(realpath ../prisma)" && git fetch origin "$${PRISMA_BRANCH}"; \
+		LOCAL_CHANGES=$$(git diff --name-only HEAD "origin/$${PRISMA_BRANCH}" -- 'packages/*adapter*'); \
 		if [ -n "$$LOCAL_CHANGES" ]; then \
-		  echo "⚠️ ../prisma diverges from prisma/prisma $(PRISMA_BRANCH) branch. Test results might diverge from those in CI ⚠️ "; \
+		  echo "⚠️ ../prisma diverges from prisma/prisma $${PRISMA_BRANCH} branch. Test results might diverge from those in CI ⚠️ "; \
 		fi \
 	else \
-		echo "git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(PRISMA_BRANCH) ../prisma"; \
-		git clone --depth=1 https://github.com/prisma/prisma.git --branch=$(PRISMA_BRANCH) "../prisma" && echo "Prisma repository has been cloned to ../prisma"; \
+		echo "git clone --depth=1 https://github.com/prisma/prisma.git --branch=$${PRISMA_BRANCH} ../prisma"; \
+		git clone --depth=1 https://github.com/prisma/prisma.git --branch="$${PRISMA_BRANCH}" "../prisma" && echo "Prisma repository has been cloned to ../prisma"; \
 	fi;
 
 ## OpenTelemetry

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ PRs in `prisma/prisma` and `prisma/prisma-engines`. Locally, each time you run
 clone.
 
 In CI we need to denote which branch of `prisma/prisma` should be consumed. By default CI clones the
-`main` branch, which will not include your local adapter changes. To test in integration, add the
+`v7` branch, which will not include your local adapter changes. To test in integration, add the
 following tag to your PR description on a separate line:
 
 ```
@@ -250,7 +250,7 @@ Replace `your/branch` with the name of your branch in the `prisma` repository.
 
 GitHub actions will then pick up the branch name and use it to clone that branch's code of prisma/prisma, and build the driver adapters code from there.
 
-When it's time to merge the sibling PRs, you'll need to merge the prisma/prisma PR first, so when merging the engines PR you have the code of the adapters ready in prisma/prisma `main` branch.
+When it's time to merge the sibling PRs, you'll need to merge the prisma/prisma PR first, so when merging the engines PR you have the code of the adapters ready in prisma/prisma `v7` branch.
 
 ### Testing engines in `prisma/prisma`
 


### PR DESCRIPTION
The Prisma 7 codebase is moving from prisma/prisma’s `main` branch to a `v7` branch; prisma-next’s tree will become prisma/prisma’s new `main`.

This repository clones prisma/prisma to build the driver-adapter test kit used by the query-compiler tests, and consumes the checkout through the relative package paths in `libs/driver-adapters/pnpm-workspace.yaml`. Those paths only resolve against the Prisma 7 package layout, so after the swap a clone of `main` would no longer satisfy the workspace and the whole QC suite would fail to build. Hence the default branch here is load-bearing, not cosmetic.

## Changes

- `Makefile`: `PRISMA_BRANCH ?= v7`, and `ensure-prisma-present` now fetches/diffs against `origin/$(PRISMA_BRANCH)` instead of a hardcoded `main` (including the divergence warning text).
- `.github/workflows/select-prisma-branch.yml`: the default is `v7`, including the guard that skips redundant overrides.
- `README.md`: the driver-adapter/QC testing section and the sibling-PR merge order now refer to prisma/prisma’s `v7` branch. References to this repository’s own `main` branch are untouched.

## Notes

- **Safe to merge immediately.** `v7` already exists on prisma/prisma and currently points at the same commit as `main`, so nothing changes behaviourally until the swap happens.
- **The per-PR branch override is unaffected.** A branch named explicitly in the PR description (the slash command documented in the README) still wins over the default.
- Companion PRs: prisma/prisma (workflow triggers for the `v7` branch) and prisma/engines-wrapper (dispatch with `ref: v7`).
