### PR TITLE
fix(schema-engine): refuse a shadow database that is the main database

### DIFF
--- a/libs/user-facing-errors/src/schema_engine.rs
+++ b/libs/user-facing-errors/src/schema_engine.rs
@@ -301,6 +301,13 @@ pub struct MissingNamespaceInExternalTables;
 pub struct UnexpectedNamespaceInExternalTables;
 
 #[derive(Debug, SimpleUserFacingError)]
+#[user_facing(
+    code = "P3025",
+    message = "The shadow database you configured appears to be the same as the main database. Please specify another shadow database."
+)]
+pub struct ShadowDbSameAsMainDb;
+
+#[derive(Debug, SimpleUserFacingError)]
 #[user_facing(code = "P4001", message = "The introspected database was empty.")]
 pub struct IntrospectionResultEmpty;
 

--- a/schema-engine/connectors/sql-schema-connector/src/flavour.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour.rs
@@ -30,7 +30,7 @@ use crate::{
     sql_destructive_change_checker::DestructiveChangeCheckerFlavour, sql_renderer::SqlRenderer,
     sql_schema_calculator::SqlSchemaCalculatorFlavour, sql_schema_differ::SqlSchemaDifferFlavour,
 };
-use psl::{PreviewFeatures, ValidatedSchema};
+use psl::{PreviewFeatures, ValidatedSchema, datamodel_connector::Flavour};
 use quaint::prelude::{NativeConnectionInfo, Table};
 use schema_connector::{
     BoxFuture, ConnectorError, ConnectorResult, IntrospectionContext, MigrationRecord, Namespaces,
@@ -340,10 +340,17 @@ pub(crate) trait SqlConnector: Send + Sync + Debug {
     fn dispose(&mut self) -> BoxFuture<'_, ConnectorResult<()>>;
 }
 
-// Utility function shared by multiple dialects to compare shadow database and main connection.
-fn validate_connection_infos_do_not_match(previous: &str, next: &str) -> ConnectorResult<()> {
-    if previous == next {
-        Err(ConnectorError::from_msg("The shadow database you configured appears to be the same as the main database. Please specify another shadow database.".into()))
+/// Refuses a shadow database that is the same database as the main one. Writing the migration
+/// history to the main database would destroy the data it holds.
+fn validate_connection_infos_do_not_match(
+    flavour: Flavour,
+    main_url: &str,
+    shadow_db_url: &str,
+) -> ConnectorResult<()> {
+    if crate::same_database::urls_denote_same_database(flavour, main_url, shadow_db_url) {
+        Err(ConnectorError::user_facing(
+            user_facing_errors::schema_engine::ShadowDbSameAsMainDb,
+        ))
     } else {
         Ok(())
     }

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mssql.rs
@@ -12,6 +12,7 @@ use connector::{Connection, generic_apply_migration_script, shadow_db};
 use connector::{Connection, generic_apply_migration_script, shadow_db};
 use destructive_change_checker::MssqlDestructiveChangeCheckerFlavour;
 use indoc::formatdoc;
+use psl::datamodel_connector::Flavour;
 use quaint::{
     connector::{DEFAULT_MSSQL_SCHEMA, MssqlUrl},
     prelude::Table,
@@ -40,7 +41,11 @@ struct Params {
 impl Params {
     fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         if let Some(shadow_db_url) = &connector_params.shadow_database_connection_string {
-            super::validate_connection_infos_do_not_match(&connector_params.connection_string, shadow_db_url)?;
+            super::validate_connection_infos_do_not_match(
+                Flavour::Sqlserver,
+                &connector_params.connection_string,
+                shadow_db_url,
+            )?;
         }
 
         let url = MssqlUrl::new(&connector_params.connection_string).map_err(ConnectorError::url_parse_error)?;

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/mysql.rs
@@ -10,7 +10,7 @@ use connector::{Connection, shadow_db};
 use destructive_change_checker::MysqlDestructiveChangeCheckerFlavour;
 use enumflags2::BitFlags;
 use indoc::indoc;
-use psl::{ValidatedSchema, datamodel_connector, parser_database::ScalarType};
+use psl::{ValidatedSchema, datamodel_connector, datamodel_connector::Flavour, parser_database::ScalarType};
 use quaint::connector::MysqlUrl;
 use regex::{Regex, RegexSet};
 use renderer::MysqlRenderer;
@@ -38,7 +38,11 @@ struct Params {
 impl Params {
     fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         if let Some(shadow_db_url) = &connector_params.shadow_database_connection_string {
-            super::validate_connection_infos_do_not_match(&connector_params.connection_string, shadow_db_url)?;
+            super::validate_connection_infos_do_not_match(
+                Flavour::Mysql,
+                &connector_params.connection_string,
+                shadow_db_url,
+            )?;
         }
 
         let url = connector_params

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/connector/native/mod.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, iter};
 use either::Either;
 use enumflags2::BitFlags;
 use indoc::indoc;
-use psl::PreviewFeature;
+use psl::{PreviewFeature, datamodel_connector::Flavour};
 use quaint::{
     connector::{self, MakeTlsConnectorManager, PostgresUrl, tokio_postgres::error::ErrorPosition},
     prelude::{NativeConnectionInfo, Queryable},
@@ -38,7 +38,11 @@ pub struct Params {
 impl Params {
     pub fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         if let Some(shadow_db_url) = &connector_params.shadow_database_connection_string {
-            validate_connection_infos_do_not_match(&connector_params.connection_string, shadow_db_url)?;
+            validate_connection_infos_do_not_match(
+                Flavour::Postgres,
+                &connector_params.connection_string,
+                shadow_db_url,
+            )?;
         }
 
         let url = connection_string::parse(&connector_params.connection_string)?;

--- a/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connector/native/mod.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/sqlite/connector/native/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) use quaint::connector::rusqlite;
 
+use psl::datamodel_connector::Flavour;
 use quaint::connector::{AdapterName, ColumnType, DescribedColumn, DescribedParameter, GetRow, ToColumnNames};
 use schema_connector::{BoxFuture, ConnectorError, ConnectorParams, ConnectorResult};
 use sql_schema_describer::SqlSchema;
@@ -22,7 +23,11 @@ pub struct Params {
 impl Params {
     pub fn new(connector_params: ConnectorParams) -> ConnectorResult<Self> {
         if let Some(shadow_db_url) = &connector_params.shadow_database_connection_string {
-            validate_connection_infos_do_not_match(&connector_params.connection_string, shadow_db_url)?;
+            validate_connection_infos_do_not_match(
+                Flavour::Sqlite,
+                &connector_params.connection_string,
+                shadow_db_url,
+            )?;
         }
 
         let quaint::connector::SqliteParams { file_path, .. } =

--- a/schema-engine/connectors/sql-schema-connector/src/lib.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod flavour;
 mod introspection;
 mod migration_pair;
+mod same_database;
 mod sql_destructive_change_checker;
 mod sql_doc_parser;
 mod sql_migration;
@@ -32,6 +33,8 @@ use sql_doc_parser::{parse_sql_doc, sanitize_sql};
 use sql_migration::{DropUserDefinedType, DropView, SqlMigration, SqlMigrationStep};
 use sql_schema_describer as sql;
 use std::{future, sync::Arc};
+
+pub use same_database::urls_denote_same_database;
 
 const MIGRATIONS_TABLE_NAME: &str = "_prisma_migrations";
 

--- a/schema-engine/connectors/sql-schema-connector/src/same_database.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/same_database.rs
@@ -1,0 +1,333 @@
+//! Deciding whether two connection strings point at the same database.
+
+use psl::datamodel_connector::Flavour;
+
+/// Returns `true` when both connection strings denote the same database, i.e. when writing to one
+/// of them is observable through the other.
+///
+/// The comparison is flavour-aware and normalizing: it parses both connection strings the way the
+/// respective connector does and compares the host (case-insensitively), the port (with the
+/// flavour's default applied) and the database name. Everything else — credentials, connection
+/// pool settings, TLS parameters and the PostgreSQL `schema` selector — is ignored, so two
+/// connection strings that differ only in those still denote the same database.
+///
+/// When either connection string cannot be parsed, the comparison degrades to exact string
+/// equality: a caller that refuses to proceed on `true` must not refuse a working configuration
+/// because of a parsing quirk, and a connection string that is genuinely broken fails when the
+/// connection is opened.
+pub fn urls_denote_same_database(flavour: Flavour, first: &str, second: &str) -> bool {
+    compare_urls(flavour, first, second).unwrap_or(first == second)
+}
+
+/// `None` means "cannot tell", which leaves the decision to the caller of the comparison.
+fn compare_urls(flavour: Flavour, first: &str, second: &str) -> Option<bool> {
+    match flavour {
+        #[cfg(any(feature = "postgresql", feature = "cockroachdb"))]
+        Flavour::Postgres | Flavour::Cockroach => compare_postgres_urls(first, second),
+
+        #[cfg(feature = "mysql")]
+        Flavour::Mysql => compare_mysql_urls(first, second),
+
+        #[cfg(feature = "mssql")]
+        Flavour::Sqlserver => compare_mssql_urls(first, second),
+
+        #[cfg(feature = "sqlite")]
+        Flavour::Sqlite => compare_sqlite_urls(first, second),
+
+        _ => None,
+    }
+}
+
+#[cfg(any(feature = "postgresql", feature = "cockroachdb"))]
+fn compare_postgres_urls(first: &str, second: &str) -> Option<bool> {
+    let first = parse_postgres_url(first)?;
+    let second = parse_postgres_url(second)?;
+
+    Some(hosts_match(first.host(), second.host()) && first.port() == second.port() && first.dbname() == second.dbname())
+}
+
+#[cfg(any(feature = "postgresql", feature = "cockroachdb"))]
+fn parse_postgres_url(url: &str) -> Option<quaint::connector::PostgresNativeUrl> {
+    const PRISMA_POSTGRES_SCHEME: &str = "prisma+postgres";
+
+    let url: url::Url = url.parse().ok()?;
+
+    // Prisma Postgres connection strings identify the database through the `api_key` parameter
+    // rather than through the host and the path, so two of them that agree on host, port and
+    // database name can still point at different databases.
+    if url.scheme() == PRISMA_POSTGRES_SCHEME {
+        return None;
+    }
+
+    quaint::connector::PostgresNativeUrl::new(url).ok()
+}
+
+#[cfg(feature = "mysql")]
+fn compare_mysql_urls(first: &str, second: &str) -> Option<bool> {
+    let first = parse_mysql_url(first)?;
+    let second = parse_mysql_url(second)?;
+
+    Some(hosts_match(first.host(), second.host()) && first.port() == second.port() && first.dbname() == second.dbname())
+}
+
+#[cfg(feature = "mysql")]
+fn parse_mysql_url(url: &str) -> Option<quaint::connector::MysqlUrl> {
+    quaint::connector::MysqlUrl::new(url.parse().ok()?).ok()
+}
+
+#[cfg(feature = "mssql")]
+fn compare_mssql_urls(first: &str, second: &str) -> Option<bool> {
+    let first = quaint::connector::MssqlUrl::new(first).ok()?;
+    let second = quaint::connector::MssqlUrl::new(second).ok()?;
+
+    Some(hosts_match(first.host(), second.host()) && first.port() == second.port() && first.dbname() == second.dbname())
+}
+
+#[cfg(feature = "sqlite")]
+fn compare_sqlite_urls(first: &str, second: &str) -> Option<bool> {
+    let first = quaint::connector::SqliteParams::try_from(first).ok()?;
+    let second = quaint::connector::SqliteParams::try_from(second).ok()?;
+
+    // An anonymous in-memory database is private to the connection that opened it, so it is never
+    // the same database as anything else, not even as another connection to `:memory:`.
+    if is_anonymous_in_memory(&first.file_path) || is_anonymous_in_memory(&second.file_path) {
+        return Some(false);
+    }
+
+    Some(resolve_sqlite_path(&first.file_path) == resolve_sqlite_path(&second.file_path))
+}
+
+#[cfg(feature = "sqlite")]
+fn is_anonymous_in_memory(file_path: &str) -> bool {
+    file_path == ":memory:"
+}
+
+#[cfg(feature = "sqlite")]
+fn resolve_sqlite_path(file_path: &str) -> std::path::PathBuf {
+    let path = std::path::Path::new(file_path);
+
+    // `canonicalize` needs the file to exist, which is not the case for a database that is yet to
+    // be created, hence the lexical fallback.
+    std::fs::canonicalize(path)
+        .or_else(|_| std::path::absolute(path))
+        .unwrap_or_else(|_| path.to_owned())
+}
+
+#[cfg(any(
+    feature = "postgresql",
+    feature = "cockroachdb",
+    feature = "mysql",
+    feature = "mssql"
+))]
+fn hosts_match(first: &str, second: &str) -> bool {
+    first.eq_ignore_ascii_case(second)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unparseable_connection_strings_are_compared_verbatim() {
+        assert!(urls_denote_same_database(
+            Flavour::Postgres,
+            "not a connection string",
+            "not a connection string"
+        ));
+        assert!(!urls_denote_same_database(
+            Flavour::Postgres,
+            "not a connection string",
+            "not a connection string either"
+        ));
+        assert!(!urls_denote_same_database(
+            Flavour::Postgres,
+            "postgres://example.com/db",
+            "not a connection string"
+        ));
+    }
+
+    #[cfg(feature = "postgresql")]
+    mod postgres {
+        use super::*;
+
+        fn same(first: &str, second: &str) -> bool {
+            urls_denote_same_database(Flavour::Postgres, first, second)
+        }
+
+        #[test]
+        fn scheme_aliases_denote_the_same_database() {
+            assert!(same("postgres://example.com/mydb", "postgresql://example.com/mydb"));
+        }
+
+        #[test]
+        fn host_comparison_is_case_insensitive() {
+            assert!(same("postgres://Example.COM/mydb", "postgres://example.com/mydb"));
+        }
+
+        #[test]
+        fn the_default_port_matches_the_same_port_spelled_out() {
+            assert!(same("postgres://example.com/mydb", "postgres://example.com:5432/mydb"));
+            assert!(!same("postgres://example.com/mydb", "postgres://example.com:5433/mydb"));
+        }
+
+        #[test]
+        fn the_schema_selector_is_not_part_of_the_database_identity() {
+            assert!(same(
+                "postgres://example.com/mydb?schema=public",
+                "postgres://example.com/mydb?schema=shadow"
+            ));
+        }
+
+        #[test]
+        fn credentials_are_not_part_of_the_database_identity() {
+            assert!(same(
+                "postgres://alice:secret@example.com/mydb",
+                "postgres://bob:hunter2@example.com/mydb?connection_limit=1"
+            ));
+        }
+
+        #[test]
+        fn different_databases_on_the_same_server_are_distinct() {
+            assert!(!same("postgres://example.com/mydb", "postgres://example.com/shadowdb"));
+        }
+
+        #[test]
+        fn different_hosts_are_distinct() {
+            assert!(!same(
+                "postgres://example.com/mydb",
+                "postgres://other.example.com/mydb"
+            ));
+        }
+
+        #[test]
+        fn prisma_postgres_connection_strings_are_compared_verbatim() {
+            // The `api_key` is what tells the two databases apart, and it is not part of the
+            // comparison, so the two URLs below must not be reported as the same database.
+            assert!(!same(
+                "prisma+postgres://localhost:51213/?api_key=first",
+                "prisma+postgres://localhost:51213/?api_key=second"
+            ));
+            assert!(same(
+                "prisma+postgres://localhost:51213/?api_key=first",
+                "prisma+postgres://localhost:51213/?api_key=first"
+            ));
+        }
+    }
+
+    #[cfg(feature = "mysql")]
+    mod mysql {
+        use super::*;
+
+        fn same(first: &str, second: &str) -> bool {
+            urls_denote_same_database(Flavour::Mysql, first, second)
+        }
+
+        #[test]
+        fn the_default_port_matches_the_same_port_spelled_out() {
+            assert!(same("mysql://Example.com/mydb", "mysql://example.com:3306/mydb"));
+            assert!(!same("mysql://example.com/mydb", "mysql://example.com:3307/mydb"));
+        }
+
+        #[test]
+        fn credentials_are_not_part_of_the_database_identity() {
+            assert!(same(
+                "mysql://alice:secret@example.com/mydb",
+                "mysql://bob:hunter2@example.com/mydb?connection_limit=1"
+            ));
+        }
+
+        #[test]
+        fn different_databases_on_the_same_server_are_distinct() {
+            assert!(!same("mysql://example.com/mydb", "mysql://example.com/shadowdb"));
+        }
+
+        #[test]
+        fn different_hosts_are_distinct() {
+            assert!(!same("mysql://example.com/mydb", "mysql://other.example.com/mydb"));
+        }
+    }
+
+    #[cfg(feature = "mssql")]
+    mod mssql {
+        use super::*;
+
+        fn same(first: &str, second: &str) -> bool {
+            urls_denote_same_database(Flavour::Sqlserver, first, second)
+        }
+
+        #[test]
+        fn the_default_port_matches_the_same_port_spelled_out() {
+            assert!(same(
+                "sqlserver://example.com;database=mydb",
+                "sqlserver://example.com:1433;database=mydb"
+            ));
+            assert!(!same(
+                "sqlserver://example.com;database=mydb",
+                "sqlserver://example.com:1434;database=mydb"
+            ));
+        }
+
+        #[test]
+        fn credentials_and_schema_are_not_part_of_the_database_identity() {
+            assert!(same(
+                "sqlserver://example.com:1433;database=mydb;user=alice;password=secret",
+                "sqlserver://example.com:1433;database=mydb;user=bob;password=hunter2;schema=shadow"
+            ));
+        }
+
+        #[test]
+        fn different_databases_on_the_same_server_are_distinct() {
+            assert!(!same(
+                "sqlserver://example.com:1433;database=mydb",
+                "sqlserver://example.com:1433;database=shadowdb"
+            ));
+        }
+
+        #[test]
+        fn different_hosts_are_distinct() {
+            assert!(!same(
+                "sqlserver://example.com:1433;database=mydb",
+                "sqlserver://other.example.com:1433;database=mydb"
+            ));
+        }
+    }
+
+    #[cfg(feature = "sqlite")]
+    mod sqlite {
+        use super::*;
+
+        fn same(first: &str, second: &str) -> bool {
+            urls_denote_same_database(Flavour::Sqlite, first, second)
+        }
+
+        #[test]
+        fn the_file_scheme_is_not_part_of_the_database_identity() {
+            assert!(same("file:/tmp/prisma/dev.db", "/tmp/prisma/dev.db"));
+            assert!(same("sqlite:/tmp/prisma/dev.db", "file:/tmp/prisma/dev.db"));
+        }
+
+        #[test]
+        fn paths_are_compared_after_normalization() {
+            assert!(same("file:/tmp/prisma/./dev.db", "file:/tmp/prisma/dev.db"));
+        }
+
+        #[test]
+        fn relative_and_absolute_paths_to_the_same_file_are_the_same_database() {
+            let cwd = std::env::current_dir().unwrap();
+            let absolute = cwd.join("dev.db");
+
+            assert!(same("file:dev.db", absolute.to_str().unwrap()));
+        }
+
+        #[test]
+        fn different_files_are_distinct() {
+            assert!(!same("file:/tmp/prisma/dev.db", "file:/tmp/prisma/shadow.db"));
+        }
+
+        #[test]
+        fn anonymous_in_memory_databases_are_never_the_same_database() {
+            assert!(!same(":memory:", ":memory:"));
+            assert!(!same("file::memory:", ":memory:"));
+        }
+    }
+}

--- a/schema-engine/core/src/commands/diff_cli.rs
+++ b/schema-engine/core/src/commands/diff_cli.rs
@@ -2,16 +2,17 @@ use std::sync::Arc;
 
 use crate::{
     DatasourceUrls, SchemaContainerExt,
-    core_error::CoreResult,
-    json_rpc::types::{DiffParams, DiffResult, DiffTarget, UrlContainer},
+    core_error::{CoreError, CoreResult},
+    json_rpc::types::{DiffParams, DiffResult, DiffTarget, MigrationList, UrlContainer},
 };
 use enumflags2::BitFlags;
-use psl::parser_database::ExtensionTypes;
+use psl::{builtin_connectors::BUILTIN_CONNECTORS, datamodel_connector::Flavour, parser_database::ExtensionTypes};
 use schema_connector::{
     ConnectorError, ConnectorHost, DatabaseSchema, ExternalShadowDatabase, Namespaces, SchemaConnector, SchemaDialect,
     SchemaFilter, migrations_directory::Migrations,
 };
 use sql_schema_connector::SqlSchemaConnector;
+use user_facing_errors::schema_engine::ShadowDbSameAsMainDb;
 
 pub async fn diff_cli(
     params: DiffParams,
@@ -20,6 +21,8 @@ pub async fn diff_cli(
     initial_preview_features: BitFlags<psl::PreviewFeature>,
     extension_types: &dyn ExtensionTypes,
 ) -> CoreResult<DiffResult> {
+    validate_shadow_database_is_not_diffed(&params, datasource_urls)?;
+
     // In order to properly handle MultiSchema, we need to make sure the preview feature is
     // correctly set, and we need to grab the namespaces from the Schema, if any.
     // Note that currently, we union all namespaces and preview features. This may not be correct.
@@ -95,6 +98,59 @@ pub async fn diff_cli(
         exit_code,
         stdout: None,
     })
+}
+
+/// Refuses a shadow database that is one of the databases the diff looks at.
+///
+/// A migrations target replays the migration history into the shadow database, which is reset
+/// first. When the shadow database is in fact the datasource's own database, or the database on the
+/// other end of the diff, replaying the history destroys the data that the diff was meant to
+/// describe — and it does so silently, since diffing a database against a copy of the migration
+/// history that was just written into it yields no difference at all.
+///
+/// Resolving a diff target is what opens the connection that does the damage, so the check has to
+/// happen before any target is resolved.
+fn validate_shadow_database_is_not_diffed(params: &DiffParams, datasource_urls: &DatasourceUrls) -> CoreResult<()> {
+    let Some(shadow_database_url) = datasource_urls.shadow_database_url.as_deref() else {
+        return Ok(());
+    };
+
+    let targets = [&params.from, &params.to];
+
+    // Only a migrations target writes to the external shadow database, and its `migration_lock.toml`
+    // is what says how the connection strings are to be interpreted.
+    let Some(flavour) = targets.iter().find_map(|target| match target {
+        DiffTarget::Migrations(migrations) => flavour_from_lock_file(migrations),
+        _ => None,
+    }) else {
+        return Ok(());
+    };
+
+    let diffed_urls = datasource_urls
+        .url
+        .as_deref()
+        .into_iter()
+        .chain(targets.iter().filter_map(|target| match target {
+            DiffTarget::Url(UrlContainer { url }) => Some(url.as_str()),
+            _ => None,
+        }));
+
+    for url in diffed_urls {
+        if sql_schema_connector::urls_denote_same_database(flavour, url, shadow_database_url) {
+            return Err(CoreError::user_facing(ShadowDbSameAsMainDb));
+        }
+    }
+
+    Ok(())
+}
+
+fn flavour_from_lock_file(migrations: &MigrationList) -> Option<Flavour> {
+    let provider = schema_connector::migrations_directory::read_provider_from_lock_file(&migrations.lockfile)?;
+
+    BUILTIN_CONNECTORS
+        .iter()
+        .find(|connector| connector.is_provider(&provider))
+        .map(|connector| connector.flavour())
 }
 
 // Grab the preview features and namespaces. Normally, we can only grab these from Schema files,

--- a/schema-engine/core/src/commands/diff_cli.rs
+++ b/schema-engine/core/src/commands/diff_cli.rs
@@ -290,3 +290,139 @@ async fn json_rpc_diff_target_to_dialect(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::json_rpc::types::{MigrationList, MigrationLockfile, SchemaFilter};
+
+    const MAIN_URL: &str = "postgresql://user:password@localhost:5432/maindb";
+
+    fn migrations_target(provider: &str) -> DiffTarget {
+        DiffTarget::Migrations(MigrationList {
+            base_dir: "/tmp/migrations".to_owned(),
+            lockfile: MigrationLockfile {
+                path: "migration_lock.toml".to_owned(),
+                content: Some(format!("provider = \"{provider}\"")),
+            },
+            shadow_db_init_script: String::new(),
+            migration_directories: Vec::new(),
+        })
+    }
+
+    fn url_target(url: &str) -> DiffTarget {
+        DiffTarget::Url(UrlContainer { url: url.to_owned() })
+    }
+
+    #[track_caller]
+    fn validate(from: DiffTarget, to: DiffTarget, urls: DatasourceUrls) -> CoreResult<()> {
+        let params = DiffParams {
+            from,
+            to,
+            script: false,
+            exit_code: None,
+            filters: SchemaFilter::default(),
+        };
+
+        validate_shadow_database_is_not_diffed(&params, &urls)
+    }
+
+    #[track_caller]
+    fn assert_refused(result: CoreResult<()>) {
+        let err = result.unwrap_err();
+        assert!(
+            err.is_user_facing_error::<ShadowDbSameAsMainDb>(),
+            "expected the shadow database error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_shadow_database_that_is_the_datasource_database_is_refused() {
+        assert_refused(validate(
+            migrations_target("postgresql"),
+            DiffTarget::Empty,
+            DatasourceUrls {
+                url: Some(MAIN_URL.to_owned()),
+                shadow_database_url: Some(MAIN_URL.to_owned()),
+            },
+        ));
+    }
+
+    #[test]
+    fn a_differently_spelled_shadow_database_url_is_refused() {
+        assert_refused(validate(
+            migrations_target("postgresql"),
+            DiffTarget::Empty,
+            DatasourceUrls {
+                url: Some(MAIN_URL.to_owned()),
+                shadow_database_url: Some("postgres://user:password@LOCALHOST/maindb?schema=shadow".to_owned()),
+            },
+        ));
+    }
+
+    #[test]
+    fn a_shadow_database_that_is_a_url_target_is_refused() {
+        assert_refused(validate(
+            url_target(MAIN_URL),
+            migrations_target("postgresql"),
+            DatasourceUrls {
+                url: None,
+                shadow_database_url: Some(MAIN_URL.to_owned()),
+            },
+        ));
+    }
+
+    #[test]
+    fn a_separate_shadow_database_is_allowed() {
+        validate(
+            migrations_target("postgresql"),
+            url_target(MAIN_URL),
+            DatasourceUrls {
+                url: Some(MAIN_URL.to_owned()),
+                shadow_database_url: Some("postgresql://user:password@localhost:5432/shadowdb".to_owned()),
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn without_a_migrations_target_the_shadow_database_url_is_not_checked() {
+        validate(
+            url_target(MAIN_URL),
+            DiffTarget::Empty,
+            DatasourceUrls {
+                url: Some(MAIN_URL.to_owned()),
+                shadow_database_url: Some(MAIN_URL.to_owned()),
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn without_a_shadow_database_url_nothing_is_checked() {
+        validate(
+            migrations_target("postgresql"),
+            DiffTarget::Empty,
+            DatasourceUrls {
+                url: Some(MAIN_URL.to_owned()),
+                shadow_database_url: None,
+            },
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn an_unresolvable_provider_leaves_the_connection_strings_uncompared() {
+        // A migration history whose provider is not a connector we know gives no flavour to compare
+        // the connection strings with. Reporting that is the diff command's own job, further down.
+        validate(
+            migrations_target("not-a-provider"),
+            DiffTarget::Empty,
+            DatasourceUrls {
+                url: Some(MAIN_URL.to_owned()),
+                shadow_database_url: Some("postgres://user:password@LOCALHOST/maindb".to_owned()),
+            },
+        )
+        .unwrap();
+    }
+}

--- a/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
+++ b/schema-engine/sql-migration-tests/src/multi_engine_test_api.rs
@@ -99,6 +99,12 @@ impl TestApi {
         self.args.shadow_database_url()
     }
 
+    /// Creates a second database on the same server as the test database, and returns a connection
+    /// string for it. See [`crate::utils::create_external_shadow_database`].
+    pub fn create_external_shadow_database(&self) -> String {
+        crate::utils::create_external_shadow_database(&self.args)
+    }
+
     /// The ConnectionInfo based on the connection string
     pub fn connection_info(&self) -> ConnectionInfo {
         ConnectionInfo::from_url(self.connection_string()).unwrap()
@@ -220,9 +226,7 @@ impl TestApi {
             }
             ConnectionInfo::Native(NativeConnectionInfo::Mysql(_)) => SqlSchemaConnector::new_mysql(params)?,
             ConnectionInfo::Native(NativeConnectionInfo::Mssql(_)) => SqlSchemaConnector::new_mssql(params)?,
-            ConnectionInfo::Native(NativeConnectionInfo::Sqlite { .. }) => {
-                SqlSchemaConnector::new_sqlite(params).unwrap()
-            }
+            ConnectionInfo::Native(NativeConnectionInfo::Sqlite { .. }) => SqlSchemaConnector::new_sqlite(params)?,
             ConnectionInfo::Native(NativeConnectionInfo::InMemorySqlite { .. }) | ConnectionInfo::External(_) => {
                 unreachable!()
             }

--- a/schema-engine/sql-migration-tests/src/test_api.rs
+++ b/schema-engine/sql-migration-tests/src/test_api.rs
@@ -95,6 +95,12 @@ impl TestApi {
         self.root.shadow_database_connection_string()
     }
 
+    /// Creates a second database on the same server as the test database, and returns a connection
+    /// string for it. See [`crate::utils::create_external_shadow_database`].
+    pub fn create_external_shadow_database(&self) -> String {
+        crate::utils::create_external_shadow_database(self.args())
+    }
+
     pub fn preview_features(&self) -> BitFlags<PreviewFeature> {
         self.root.preview_features()
     }

--- a/schema-engine/sql-migration-tests/src/utils.rs
+++ b/schema-engine/sql-migration-tests/src/utils.rs
@@ -1,8 +1,15 @@
-use std::{error::Error, fmt::Display, io, path::Path};
+use std::{
+    error::Error,
+    fmt::Display,
+    hash::{DefaultHasher, Hash, Hasher},
+    io,
+    path::Path,
+};
 
 use schema_core::json_rpc::types::{
     MigrationDirectory, MigrationFile, MigrationList, MigrationLockfile, SchemaContainer,
 };
+use test_setup::{Tags, TestApiArgs, runtime::run_with_thread_local_runtime as tok};
 
 #[macro_export]
 macro_rules! write_multi_file {
@@ -128,4 +135,45 @@ impl From<io::Error> for ListMigrationsError {
     fn from(err: io::Error) -> Self {
         ListMigrationsError(err)
     }
+}
+
+/// Creates a database on the same server as the test database, and returns a connection string for
+/// it. Commands that replay a migration history need a shadow database that is not the database
+/// they are looking at, and this is the second database on the server that satisfies them.
+pub fn create_external_shadow_database(args: &TestApiArgs) -> String {
+    let name = shadow_database_name(args.test_function_name());
+    let tags = args.tags();
+
+    if tags.contains(Tags::Postgres) {
+        tok(test_setup::postgres::create_postgres_database(
+            args.database_url(),
+            &name,
+        ))
+        .unwrap()
+        .1
+    } else if tags.contains(Tags::Mysql) {
+        tok(test_setup::mysql::create_mysql_database(args.database_url(), &name))
+            .unwrap()
+            .1
+    } else if tags.contains(Tags::Mssql) {
+        tok(test_setup::mssql::init_mssql_database(args.database_url(), &name))
+            .unwrap()
+            .1
+    } else if tags.contains(Tags::Sqlite) {
+        test_setup::sqlite_test_url(&name)
+    } else {
+        panic!("No external shadow database for the database under test.")
+    }
+}
+
+/// Database names are limited to 63 bytes on PostgreSQL and to 64 on MySQL, while test function
+/// names alone can be longer than that, and truncation alone makes the names of tests that share a
+/// long prefix or suffix collide. A hash of the full name keeps them apart.
+fn shadow_database_name(test_function_name: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    test_function_name.hash(&mut hasher);
+    let hash = hasher.finish() as u32;
+    let prefix: String = test_function_name.chars().take(40).collect();
+
+    format!("{prefix}_{hash:x}_shadow")
 }

--- a/schema-engine/sql-migration-tests/tests/migrations/diff.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/diff.rs
@@ -12,6 +12,7 @@ use sql_migration_tests::{
     utils::{list_migrations, to_schema_containers},
 };
 use std::sync::Arc;
+use user_facing_errors::schema_engine::ShadowDbSameAsMainDb;
 
 #[test_connector(tags(Sqlite, Mysql, Postgres, CockroachDb, Mssql))]
 fn from_unique_index_to_without(mut api: TestApi) {
@@ -435,6 +436,123 @@ fn from_empty_to_migrations_folder_without_shadow_db_url_must_error(mut api: Tes
         You must set `datasource.shadowDatabaseUrl` in your `prisma.config.ts` if you want to diff a migrations directory.
     "#]];
     expected_error.assert_eq(&err.to_string());
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+fn from_migrations_with_the_datasource_database_as_shadow_db_must_error(mut api: TestApi) {
+    let migrations_dir = migrations_directory_with_one_migration(&api);
+    let main_url = api.connection_string().to_owned();
+
+    api.raw_cmd("CREATE TABLE precious_data (id INTEGER PRIMARY KEY)");
+
+    // The same database, spelled the way it is configured and spelled differently.
+    let differently_spelled = main_url
+        .replacen("postgresql://", "postgres://", 1)
+        .replace("localhost", "LOCALHOST");
+    assert_ne!(differently_spelled, main_url);
+
+    for shadow_database_url in [main_url.clone(), differently_spelled] {
+        let err = api
+            .diff_with_datasource(
+                &DatasourceUrls {
+                    url: Some(main_url.clone()),
+                    shadow_database_url: Some(shadow_database_url.clone()),
+                },
+                DiffParams {
+                    exit_code: None,
+                    from: DiffTarget::Migrations(list_migrations(migrations_dir.path()).unwrap()),
+                    to: DiffTarget::Empty,
+                    script: false,
+                    filters: SchemaFilter::default(),
+                },
+            )
+            .unwrap_err();
+
+        assert!(
+            err.is_user_facing_error::<ShadowDbSameAsMainDb>(),
+            "shadow database url {shadow_database_url}: {err:?}"
+        );
+    }
+
+    // The migration history is replayed into the shadow database after wiping it, so the diff must
+    // not have run at all.
+    api.assert_schema().assert_has_table("precious_data");
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+fn from_url_to_migrations_with_that_url_as_shadow_db_must_error(mut api: TestApi) {
+    let migrations_dir = migrations_directory_with_one_migration(&api);
+    let main_url = api.connection_string().to_owned();
+
+    api.raw_cmd("CREATE TABLE precious_data (id INTEGER PRIMARY KEY)");
+
+    let err = api
+        .diff_with_datasource(
+            &DatasourceUrls {
+                url: None,
+                shadow_database_url: Some(main_url.clone()),
+            },
+            DiffParams {
+                exit_code: None,
+                from: DiffTarget::Url(UrlContainer { url: main_url }),
+                to: DiffTarget::Migrations(list_migrations(migrations_dir.path()).unwrap()),
+                script: false,
+                filters: SchemaFilter::default(),
+            },
+        )
+        .unwrap_err();
+
+    assert!(err.is_user_facing_error::<ShadowDbSameAsMainDb>(), "{err:?}");
+    api.assert_schema().assert_has_table("precious_data");
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+fn from_migrations_with_a_separate_shadow_db_on_the_same_server_works(mut api: TestApi) {
+    let migrations_dir = migrations_directory_with_one_migration(&api);
+
+    let (result, diff) = diff_result(
+        DatasourceUrls {
+            url: Some(api.connection_string().to_owned()),
+            shadow_database_url: Some(api.create_external_shadow_database()),
+        },
+        DiffParams {
+            exit_code: Some(true),
+            from: DiffTarget::Empty,
+            to: DiffTarget::Migrations(list_migrations(migrations_dir.path()).unwrap()),
+            script: false,
+            filters: SchemaFilter::default(),
+        },
+    );
+
+    assert_eq!(result.exit_code, 2);
+    let expected_diff = expect![[r#"
+
+        [+] Added Schemas
+          - public
+
+        [+] Added tables
+          - cats
+    "#]];
+    expected_diff.assert_eq(&diff);
+}
+
+fn migrations_directory_with_one_migration(api: &TestApi) -> tempfile::TempDir {
+    let migrations_dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        migrations_dir.path().join("migration_lock.toml"),
+        format!("provider = \"{}\"", api.args().provider()),
+    )
+    .unwrap();
+
+    let migration_dir = migrations_dir.path().join("01init");
+    std::fs::create_dir_all(&migration_dir).unwrap();
+    std::fs::write(
+        migration_dir.join("migration.sql"),
+        "CREATE TABLE cats ( id INTEGER PRIMARY KEY );",
+    )
+    .unwrap();
+
+    migrations_dir
 }
 
 #[test_connector(tags(Sqlite))]
@@ -921,7 +1039,7 @@ fn from_migrations_to_schema_datamodel_ignores_manual_partial_indexes_without_pr
     let (result, diff) = diff_result(
         DatasourceUrls {
             url: Some(api.connection_string().to_owned()),
-            shadow_database_url: Some(api.connection_string().to_owned()),
+            shadow_database_url: Some(api.create_external_shadow_database()),
         },
         DiffParams {
             exit_code: Some(true),
@@ -985,7 +1103,7 @@ fn from_schema_datamodel_to_migrations_ignores_manual_partial_indexes_without_pr
     let (result, diff) = diff_result(
         DatasourceUrls {
             url: Some(api.connection_string().to_owned()),
-            shadow_database_url: Some(api.connection_string().to_owned()),
+            shadow_database_url: Some(api.create_external_shadow_database()),
         },
         DiffParams {
             exit_code: Some(true),
@@ -1060,7 +1178,7 @@ fn from_migrations_to_url_ignores_manual_partial_indexes_with_engine_seeded_sche
         Some(initial_datamodel),
         DatasourceUrls {
             url: Some(api.connection_string().to_owned()),
-            shadow_database_url: Some(api.connection_string().to_owned()),
+            shadow_database_url: Some(api.create_external_shadow_database()),
         },
         DiffParams {
             exit_code: Some(true),

--- a/schema-engine/sql-migration-tests/tests/migrations/shadow_database_url_configuration.rs
+++ b/schema-engine/sql-migration-tests/tests/migrations/shadow_database_url_configuration.rs
@@ -2,7 +2,7 @@ use expect_test::expect;
 use quaint::{prelude::Queryable, single::Quaint};
 use sql_migration_tests::multi_engine_test_api::*;
 use test_macros::test_connector;
-use user_facing_errors::UserFacingError;
+use user_facing_errors::{UserFacingError, schema_engine::ShadowDbSameAsMainDb};
 
 // exclude: auth works differently in single-node insecure cockroach
 #[test_connector(tags(Postgres), exclude(CockroachDb))]
@@ -126,10 +126,10 @@ fn shadow_db_url_must_not_match_main_url(api: TestApi) {
                 Some(api.connection_string().to_owned()),
             )
             .err()
-            .unwrap()
-            .to_string();
+            .unwrap();
 
-        assert!(err.contains("The shadow database you configured appears to be the same as the main database. Please specify another shadow database."));
+        assert!(err.is_user_facing_error::<ShadowDbSameAsMainDb>(), "{err:?}");
+        assert!(err.to_string().contains("The shadow database you configured appears to be the same as the main database. Please specify another shadow database."));
     }
 
     // Database name is different -> fine
@@ -182,4 +182,113 @@ fn shadow_db_not_reachable_error_must_have_the_right_connection_info(api: TestAp
         err.unwrap_known().error_code,
         user_facing_errors::common::DatabaseNotReachable::ERROR_CODE
     );
+}
+
+/// A shadow database URL that reaches the main database is refused however it is spelled: what
+/// counts is the database it denotes, not the string it is written as.
+#[track_caller]
+fn assert_shadow_db_url_is_refused(api: &TestApi, shadow_db_url: &str) {
+    let err = api
+        .new_engine_with_connection_strings_or_err(api.connection_string().to_owned(), Some(shadow_db_url.to_owned()))
+        .err()
+        .unwrap();
+
+    assert!(
+        err.is_user_facing_error::<ShadowDbSameAsMainDb>(),
+        "shadow database url {shadow_db_url}: {err:?}"
+    );
+}
+
+#[test_connector(tags(Postgres), exclude(CockroachDb))]
+fn differently_spelled_shadow_db_url_must_not_match_main_url_on_postgres(api: TestApi) {
+    let main_url = api.connection_string();
+
+    let scheme_alias = main_url.replacen("postgresql://", "postgres://", 1);
+    let upper_case_host = main_url.replace("localhost", "LOCALHOST");
+    let other_schema = main_url.replace("schema=public", "schema=shadow");
+    let extra_parameter = format!("{main_url}&connection_limit=1");
+
+    for spelling in [scheme_alias, upper_case_host, other_schema, extra_parameter] {
+        assert_ne!(spelling, main_url);
+        assert_shadow_db_url_is_refused(&api, &spelling);
+    }
+}
+
+#[test_connector(tags(Mysql), exclude(Vitess))]
+fn differently_spelled_shadow_db_url_must_not_match_main_url_on_mysql(api: TestApi) {
+    let main_url = api.connection_string();
+
+    let upper_case_host = main_url.replace("localhost", "LOCALHOST");
+    let extra_parameter = format!("{main_url}?connection_limit=1");
+
+    for spelling in [upper_case_host, extra_parameter] {
+        assert_ne!(spelling, main_url);
+        assert_shadow_db_url_is_refused(&api, &spelling);
+    }
+}
+
+#[test_connector(tags(Mssql))]
+fn differently_spelled_shadow_db_url_must_not_match_main_url_on_mssql(api: TestApi) {
+    let main_url = api.connection_string();
+
+    let upper_case_host = main_url.replace("localhost", "LOCALHOST");
+    let other_schema = format!("{main_url};schema=shadow");
+
+    for spelling in [upper_case_host, other_schema] {
+        assert_ne!(spelling, main_url);
+        assert_shadow_db_url_is_refused(&api, &spelling);
+    }
+}
+
+#[test_connector(tags(Sqlite))]
+fn differently_spelled_shadow_db_path_must_not_match_main_db_path_on_sqlite(api: TestApi) {
+    let main_url = api.connection_string();
+    let file_path = main_url.trim_start_matches("file:");
+    let (directory, file_name) = file_path.rsplit_once('/').unwrap();
+
+    let without_scheme = file_path.to_owned();
+    let redundant_current_directory = format!("file:{directory}/./{file_name}");
+
+    for spelling in [without_scheme, redundant_current_directory] {
+        assert_ne!(spelling, main_url);
+        assert_shadow_db_url_is_refused(&api, &spelling);
+    }
+}
+
+#[test_connector(tags(Sqlite))]
+fn a_relative_shadow_db_path_is_resolved_against_the_working_directory_on_sqlite(api: TestApi) {
+    // Connection strings are compared as they are given, and a relative SQLite path in them is
+    // resolved against the process's working directory. The bare file name of the main database
+    // therefore denotes a different database, unless the main database happens to live in the
+    // working directory.
+    let file_name = api.connection_string().rsplit_once('/').unwrap().1.to_owned();
+    assert!(
+        !std::path::Path::new(&file_name).exists(),
+        "the test database must not live in the working directory for this test to mean anything"
+    );
+
+    api.new_engine_with_connection_strings_or_err(api.connection_string().to_owned(), Some(file_name))
+        .map(drop)
+        .unwrap();
+}
+
+#[test_connector(tags(Postgres, Mysql, Mssql, Sqlite), exclude(CockroachDb, Vitess))]
+fn a_separate_shadow_db_on_the_same_server_is_accepted(api: TestApi) {
+    let migrations_directory = api.create_migrations_directory();
+    let schema = r#"
+        model Cat {
+            id Int @id
+            litterConsumption Int
+        }
+    "#;
+
+    let mut engine = api.new_engine_with_connection_strings(
+        api.connection_string().to_owned(),
+        Some(api.create_external_shadow_database()),
+    );
+
+    engine
+        .create_migration("01init", schema, &migrations_directory)
+        .send_sync()
+        .assert_migration_directories_count(1);
 }


### PR DESCRIPTION
Prisma Migrate commands that replay a migrations directory do so by first resetting a shadow database. Nothing prevented the shadow database URL from denoting the main database itself: `migrate diff --from-migrations` with `shadowDatabaseUrl` equal to the datasource URL dropped the real schema (`DROP SCHEMA … CASCADE` on PostgreSQL) — and because the *from* target resolves before *to*, it then introspected the freshly rebuilt schema and reported an empty diff with exit code 0. This PR makes the engine refuse such configurations before touching any database, with the new user-facing error **P3025**.

## Changes

- **`sql-schema-connector`**: new `same_database` module exporting `urls_denote_same_database(flavour, a, b)` — a flavour-aware comparison built on quaint's URL parsing: host compared case-insensitively, parser-default ports applied, database names compared; the PostgreSQL `?schema=` selector is deliberately ignored (dropping *another* schema of the same database is still data loss); SQLite compares canonicalized file paths; unparseable URLs fall back to exact string equality so the guard can never block a working configuration on a parse quirk. The existing `validate_connection_infos_do_not_match` guard (the `migrate dev` shape) delegates to it — call sites now pass their statically-known flavour — and returns the typed error.
- **`schema-engine-core`**: `diff_cli` runs the guard as its literal first step: when a `Migrations` diff target will use the external shadow database, the shadow URL is compared against the datasource URL and any `DiffTarget::Url` on either side before any dialect or connector is constructed.
- **`user-facing-errors`**: new `P3025` / `ShadowDbSameAsMainDb`; message text unchanged from the previous untyped error.
- **Tests**: an incident repro asserting both the refusal and that a `precious_data` table in the target database survives; per-flavour refusal tests for identity-preserving URL spellings (scheme alias, host case, `?schema=`); same-server-different-database negative controls; no-DB wiring tests for the diff-path guard. A new harness helper provisions a genuinely separate shadow database for tests — notably, three pre-existing tests had configured the database under test as its own shadow database and are repointed here; one previously passed only because both sides of its diff derived from the database the diff had just wiped.

## Why

Two comparison classes are exempt by design: `prisma+postgres://` URLs are compared verbatim (their database identity lives in the `api_key` token, and two distinct local PPg databases share host, port, and path — normalizing would refuse working `prisma dev` setups), and anonymous in-memory SQLite never matches anything (each `:memory:` connection is a private database). Together with DNS aliases, which no static comparison can catch, these are bounded by the follow-up layer: a stacked PR will require an explicitly-provided external shadow database to be *empty* before reset, with explicit consent otherwise.

A note on branch history: the diff-path guard commit briefly broke the three repointed tests — that is, it refused exactly the misconfiguration it exists to refuse. They are fixed within this PR; the branch is green at its tip.

Part of the shadow-db-safety project (Linear: TML-3116); the emptiness-check/consent layer and the CLI consent UX follow in stacked PRs.
