### PR TITLE
fix(qc): don't apply the nested upsert where filter to the parent update

### DIFF
--- a/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
+++ b/query-compiler/core/src/query_graph_builder/write/nested/upsert_nested.rs
@@ -141,7 +141,7 @@ pub fn nested_upsert(
         let update_node = update::update_record_node(
             graph,
             query_schema,
-            filter.clone(),
+            filter,
             child_model.clone(),
             update_input.try_into()?,
             None,
@@ -200,7 +200,9 @@ pub fn nested_upsert(
         } else if parent_relation_field.is_inlined_on_enclosing_model() {
             let parent_model = parent_relation_field.model();
             let parent_model_id = parent_model.shard_aware_primary_identifier();
-            let update_node = utils::update_records_node_placeholder(graph, filter, parent_model.clone());
+            // The upsert `where` filter belongs to the child model, so it must not be applied to the update on the parent table
+            // (it would reference child columns without a join). The parent rows are already pinned by the selectors injected below.
+            let update_node = utils::update_records_node_placeholder(graph, Filter::empty(), parent_model.clone());
 
             // Edge to retrieve the finder
             graph.create_edge(

--- a/query-compiler/query-compiler/tests/data/update-nested-upsert.json
+++ b/query-compiler/query-compiler/tests/data/update-nested-upsert.json
@@ -1,0 +1,21 @@
+{
+  "modelName": "Patient",
+  "action": "updateOne",
+  "query": {
+    "arguments": {
+      "where": { "id": 1 },
+      "data": {
+        "user": {
+          "upsert": {
+            "where": { "email": "user.1@prisma.io" },
+            "create": { "email": "user.1@prisma.io" },
+            "update": { "email": "user.2@prisma.io" }
+          }
+        }
+      }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@update-nested-upsert.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@update-nested-upsert.json.snap
@@ -1,0 +1,61 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/update-nested-upsert.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       userId: Int (userId)
+   }
+   let 0 = unique (query «SELECT "public"."Patient"."id",
+                          "public"."Patient"."userId" FROM "public"."Patient"
+                          WHERE ("public"."Patient"."id" = $1 AND 1=1) LIMIT $2
+                          OFFSET $3»
+                   params [const(BigInt(1)), const(BigInt(1)),
+                           const(BigInt(0))])
+   in let 0$id = mapField id (get 0);
+          0$userId = mapField userId (get 0)
+      in let 1 = unique (query «SELECT "public"."User"."id" FROM "public"."User"
+                                WHERE ("public"."User"."email" = $1 AND
+                                "public"."User"."id" IN [$2,*]) OFFSET $3»
+                         params [const(String("user.1@prisma.io")),
+                                 var(0$userId as Int), const(BigInt(0))])
+         in if (rowCountNeq 0 (get 1))
+            then let 1 = unique (validate (get 1)
+                     [ rowCountNeq 0
+                     ] orRaise "MISSING_RELATED_RECORD");
+                     1$id = mapField id (get 1)
+                 in unique (query «UPDATE "public"."User" SET "email" = $1 WHERE
+                                   ("public"."User"."id" IN [$2,*] AND
+                                   "public"."User"."email" = $3) RETURNING
+                                   "public"."User"."id"»
+                            params [const(String("user.2@prisma.io")),
+                                    var(1$id as Int),
+                                    const(String("user.1@prisma.io"))])
+            else let 3 = unique (query «INSERT INTO "public"."User"
+                                        ("email","role") VALUES
+                                        ($1,CAST($2::text AS "public"."Role"))
+                                        RETURNING "public"."User"."id"»
+                                 params [const(String("user.1@prisma.io")),
+                                         const(String("user"))])
+                 in let 0 = unique (validate (get 0)
+                        [ rowCountNeq 0
+                        ] orRaise "MISSING_RELATED_RECORD");
+                        0$id = mapField id (get 0);
+                        3 = unique (validate (get 3)
+                        [ rowCountNeq 0
+                        ] orRaise "MISSING_RELATED_RECORD");
+                        3$id = mapField id (get 3)
+                    in execute «UPDATE "public"."Patient" SET "userId" = $1
+                                WHERE ("public"."Patient"."id" IN [$2,*] AND
+                                1=1)»
+                       params [var(3$id as Int), var(0$id as Int)];
+      let 0 = unique (validate (get 0)
+          [ rowCountNeq 0
+          ] orRaise "MISSING_RECORD");
+          0$id = mapField id (get 0)
+      in unique (query «SELECT "t0"."id", "t0"."userId" FROM "public"."Patient"
+                        AS "t0" WHERE "t0"."id" = $1 LIMIT $2»
+                 params [var(0$id as Int), const(BigInt(1))])


### PR DESCRIPTION
## Problem

Reported in prisma/prisma#29744.

A nested upsert on a to-one relation that is inlined on the parent fails when the optional `where` filter is provided and the create branch is taken. The generated SQL for the step that connects the newly created child references a child column inside the UPDATE on the parent table:

```sql
UPDATE "public"."Patient" SET "userId" = $1
WHERE ("public"."Patient"."id" IN ($2) AND "public"."User"."email" = $3)
```

The database rejects this with `The column User.email does not exist in the current database`, a cross table reference without a join. The bug only triggers when the `where` argument is passed, which is optional on to-one upserts. Without it the filter is empty and the query is valid, which is why this went mostly unnoticed.

## Root cause

In `nested_upsert`, the update node that writes the foreign key on the parent receives the upsert `where` filter. That filter belongs to the child model, its only role is to select which child to read and update. The equivalent connect step in `nested_connect`, `nested_connect_or_create` and `nested_create` passes `Filter::empty()` to the same placeholder, since the parent rows are already pinned by the selectors injected through the graph edge.

## Fix

Pass `Filter::empty()` for the parent update, matching the sibling builders. A now redundant clone of the filter is also removed since the filter is moved at its last remaining use.

## Tests

* New snapshot test `update-nested-upsert.json` covering the failing shape, a to-one relation inlined on the parent with a `where` filter. Before the fix the snapshot contains the invalid cross table condition shown above, after the fix the parent update is filtered by the selectors only. No other snapshot changed.
* `cargo test -p query-core -p query-compiler -p sql-query-builder` passes.
* `cargo fmt --check` and `cargo clippy -p query-core -p query-compiler --all-targets` with warnings as errors are clean.
* Verified end to end against prisma/prisma v7: with the Wasm compiler built from this branch, the reproduction from the issue (same schema and nested upsert, better-sqlite3 driver adapter) passes, along with the existing upsert functional test suites.
