### PR TITLE
fix(schema-engine): match implicit text casts

### DIFF
--- a/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/schema_differ.rs
+++ b/schema-engine/connectors/sql-schema-connector/src/flavour/postgres/schema_differ.rs
@@ -808,7 +808,7 @@ fn idents_semantically_eq(a: &Ident, b: &Ident) -> bool {
 
 // Compares two expressions that have already been normalized by `StripPgNormalization`.
 fn exprs_semantically_eq(a: &Expr, b: &Expr) -> bool {
-    use sqlparser::ast::CastKind;
+    use sqlparser::ast::{CastKind, DataType};
 
     if a == b {
         return true;
@@ -838,6 +838,29 @@ fn exprs_semantically_eq(a: &Expr, b: &Expr) -> bool {
             },
             Expr::Value(va),
         ) if matches!(expr.as_ref(), Expr::Value(vb) if vb == va) => true,
+
+        // PG normalizes varchar column references with an implicit ::text cast.
+        (
+            inner,
+            Expr::Cast {
+                kind: CastKind::DoubleColon,
+                expr,
+                data_type: DataType::Text,
+                ..
+            },
+        )
+        | (
+            Expr::Cast {
+                kind: CastKind::DoubleColon,
+                expr,
+                data_type: DataType::Text,
+                ..
+            },
+            inner,
+        ) if matches!(
+            expr.as_ref(),
+            Expr::Identifier(_) | Expr::CompoundIdentifier(_)
+        ) => exprs_semantically_eq(inner, expr),
 
         // Unwrap outer :: cast when inner is also a :: cast (PG annotation wrapping user cast).
         (

--- a/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
+++ b/schema-engine/sql-migration-tests/tests/create_migration/create_migration_tests.rs
@@ -398,6 +398,35 @@ fn empty_migrations_should_not_be_created(api: TestApi) {
         .assert_migration_directories_count(1);
 }
 
+#[test_connector(tags(Postgres), exclude(CockroachDb), preview_features("partialIndexes"))]
+fn partial_unique_index_on_varchar_object_predicate_is_not_recreated(mut api: TestApi) {
+    let dm = api.datamodel_with_provider_and_features(
+        r#"
+        model ExternalMappingData {
+            tenantId    String @db.VarChar(255)
+            mappingType String @db.VarChar(255)
+            externalId  String @db.VarChar(4096)
+            caralegalId String @db.VarChar(4096)
+
+            @@id([tenantId, mappingType, externalId, caralegalId])
+            @@unique([tenantId, externalId], map: "ExternalMappingData_userId_tenantId_externalId_key", where: { mappingType: "userId", externalId: { not: "" } })
+        }
+    "#,
+        &[],
+        &["partialIndexes"],
+    );
+
+    let dir = api.create_migrations_directory();
+
+    api.create_migration("initial", &dm, &dir)
+        .send_sync()
+        .assert_migration_directories_count(1);
+
+    api.create_migration("no-op", &dm, &dir)
+        .send_sync()
+        .assert_migration_directories_count(1);
+}
+
 #[test_connector]
 fn migration_name_length_is_validated(api: TestApi) {
     let dm = api.datamodel_with_provider(


### PR DESCRIPTION
## Summary

Fix PostgreSQL partial-index migration drift for `@db.VarChar` fields.

This directly fixes prisma/orm#29386.

PostgreSQL normalizes partial-index predicates by adding `::text` casts
to `VARCHAR` column identifiers and string literals. The schema differ
previously handled the literal cast but not the identifier cast, so
`migrate dev` repeatedly generated a no-op drop/create-index migration.

The predicate comparator now treats an identifier and its implicit
`::text` form as equivalent. Other casts remain significant.

Fixes prisma/prisma#29386

## Test

- Added a PostgreSQL regression test that creates a migration for a
  partial unique index on `VARCHAR` fields, then verifies an unchanged
  schema does not create a second migration.
- Ran:

  ```sh
  cargo test -p sql-migration-tests --test migration_tests -- --nocapture
  ```
  
## AI assistance

AI assistance was used to investigate the PostgreSQL predicate normalization
and draft the regression test. The implementation and test result were
reviewed and verified locally.