### PR TITLE
fix(mongodb-query-connector): avoid unnecessary undefined guards for required fields

### DIFF
--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -600,6 +600,7 @@ impl MongoFilterVisitor {
         let field = filter.field;
         let field_name = (&self.prefix.clone(), &field).into_bson()?;
         let is_set_cond = matches!(*filter.condition, CompositeCondition::IsSet(_));
+        let safe_to_skip_undefineds = is_positive_concrete_non_null_composite_equality(&filter.condition) && !self.invert();
 
         let filter_doc = match *filter.condition {
             CompositeCondition::Every(filter) => {
@@ -678,7 +679,11 @@ impl MongoFilterVisitor {
         };
 
         let filter_doc = if !is_set_cond
-            && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion(), false)
+            && should_exclude_undefineds(
+                field.is_required(),
+                self.invert_undefined_exclusion(),
+                safe_to_skip_undefineds,
+            )
         {
             exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
         } else {
@@ -1127,6 +1132,10 @@ fn is_positive_concrete_non_null_equality(condition: &ScalarCondition) -> bool {
     )
 }
 
+fn is_positive_concrete_non_null_composite_equality(condition: &CompositeCondition) -> bool {
+    matches!(condition, CompositeCondition::Equals(value) if !value.is_null())
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FilterPrefix {
     parts: Vec<String>,
@@ -1219,12 +1228,13 @@ mod tests {
                 }
 
                 model User {
-                  id      String   @id @map("_id")
-                  uid     String   @unique
-                  name    String
-                  country String?
-                  tags    String[]
-                  address Address?
+                  id             String   @id @map("_id")
+                  uid            String   @unique
+                  name           String
+                  country        String?
+                  tags           String[]
+                  address        Address?
+                  requiredAddress Address
                 }
 
                 type Address {
@@ -1397,6 +1407,21 @@ mod tests {
                     { "$ne": ["$tags", "$$REMOVE"] }
                 ]
             }
+        );
+    }
+
+    /// Positive equality filters on required composite fields can omit the guard.
+    #[test]
+    fn required_composite_equality_skips_undefined_exclusion() {
+        let dm = mongo_schema();
+        let address = composite_field(&dm, "requiredAddress");
+
+        assert_eq!(
+            render(address.equals(PrismaValue::Object(vec![(
+                "city".to_owned(),
+                PrismaValue::String("Berlin".to_owned())
+            )]))),
+            doc! { "$eq": ["$requiredAddress", { "city": "Berlin" }] }
         );
     }
 

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -600,7 +600,8 @@ impl MongoFilterVisitor {
         let field = filter.field;
         let field_name = (&self.prefix.clone(), &field).into_bson()?;
         let is_set_cond = matches!(*filter.condition, CompositeCondition::IsSet(_));
-        let safe_to_skip_undefineds = is_positive_concrete_non_null_composite_equality(&filter.condition) && !self.invert();
+        let safe_to_skip_undefineds =
+            is_positive_concrete_non_null_composite_equality(&filter.condition) && !self.invert();
 
         let filter_doc = match *filter.condition {
             CompositeCondition::Every(filter) => {
@@ -683,8 +684,7 @@ impl MongoFilterVisitor {
                 field.is_required(),
                 self.invert_undefined_exclusion(),
                 safe_to_skip_undefineds,
-            )
-        {
+            ) {
             exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
         } else {
             filter_doc

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -310,7 +310,7 @@ impl MongoFilterVisitor {
         let field_name = (self.prefix(), field).into_bson()?;
         let field_ref = condition.as_field_ref().cloned();
         let is_set_cond = matches!(&condition, ScalarCondition::IsSet(_));
-        let safe_to_skip_undefineds = is_positive_concrete_non_null_equality(&condition) && !self.invert();
+        let safe_to_skip_undefineds = false;
 
         let filter_doc = match condition {
             ScalarCondition::Equals(val) => self.regex_match(&field_name, field, "^", val, "$", true),
@@ -1327,6 +1327,30 @@ mod tests {
             render(name.not_equals(PrismaValue::String("abc".into())))
                 .get_array("$and")
                 .is_ok()
+        );
+    }
+
+    #[test]
+    fn insensitive_required_equality_keeps_undefined_exclusion() {
+        let dm = mongo_schema();
+        let name = scalar_field(&dm, "name");
+        let mut filter = name.equals(PrismaValue::String("abc".into()));
+        filter.set_mode(QueryMode::Insensitive);
+
+        assert_eq!(
+            render(filter),
+            doc! {
+                "$and": [
+                    {
+                        "$regexMatch": {
+                            "input": "$name",
+                            "regex": "^abc$",
+                            "options": "i"
+                        }
+                    },
+                    { "$ne": ["$name", "$$REMOVE"] }
+                ]
+            }
         );
     }
 

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -153,6 +153,7 @@ impl MongoFilterVisitor {
         let field_name = (self.prefix(), field).into_bson()?;
         let field_ref = condition.as_field_ref().cloned();
         let is_set_cond = matches!(&condition, ScalarCondition::IsSet(_));
+        let safe_to_skip_undefineds = is_positive_concrete_non_null_equality(&condition) && !self.invert();
 
         let filter_doc = match condition {
             ScalarCondition::Equals(val) => {
@@ -276,15 +277,19 @@ impl MongoFilterVisitor {
             ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
         };
 
-        let filter_doc =
-            if !is_set_cond && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
-                exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
-            } else {
-                filter_doc
-            };
+        let filter_doc = if !is_set_cond
+            && should_exclude_undefineds(
+                field.is_required(),
+                self.invert_undefined_exclusion(),
+                safe_to_skip_undefineds,
+            ) {
+            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+        } else {
+            filter_doc
+        };
 
         let filter_doc = if let Some(field_ref) = &field_ref {
-            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion()) {
+            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion(), false) {
                 exclude_undefineds(
                     self.prefixed_field_ref(field_ref)?,
                     self.invert_undefined_exclusion(),
@@ -305,6 +310,7 @@ impl MongoFilterVisitor {
         let field_name = (self.prefix(), field).into_bson()?;
         let field_ref = condition.as_field_ref().cloned();
         let is_set_cond = matches!(&condition, ScalarCondition::IsSet(_));
+        let safe_to_skip_undefineds = is_positive_concrete_non_null_equality(&condition) && !self.invert();
 
         let filter_doc = match condition {
             ScalarCondition::Equals(val) => self.regex_match(&field_name, field, "^", val, "$", true),
@@ -426,15 +432,19 @@ impl MongoFilterVisitor {
             )),
         }?;
 
-        let filter_doc =
-            if !is_set_cond && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
-                exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
-            } else {
-                filter_doc
-            };
+        let filter_doc = if !is_set_cond
+            && should_exclude_undefineds(
+                field.is_required(),
+                self.invert_undefined_exclusion(),
+                safe_to_skip_undefineds,
+            ) {
+            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+        } else {
+            filter_doc
+        };
 
         let filter_doc = if let Some(field_ref) = &field_ref {
-            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion()) {
+            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion(), false) {
                 exclude_undefineds(
                     self.prefixed_field_ref(field_ref)?,
                     self.invert_undefined_exclusion(),
@@ -532,14 +542,14 @@ impl MongoFilterVisitor {
             filter_doc
         };
 
-        let filter_doc = if should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
+        let filter_doc = if should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion(), false) {
             exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
         } else {
             filter_doc
         };
 
         let filter_doc = if let Some(field_ref) = field_ref.as_ref() {
-            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion()) {
+            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion(), false) {
                 exclude_undefineds(
                     self.prefixed_field_ref(field_ref)?,
                     self.invert_undefined_exclusion(),
@@ -667,12 +677,13 @@ impl MongoFilterVisitor {
             filter_doc
         };
 
-        let filter_doc =
-            if !is_set_cond && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
-                exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
-            } else {
-                filter_doc
-            };
+        let filter_doc = if !is_set_cond
+            && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion(), false)
+        {
+            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+        } else {
+            filter_doc
+        };
 
         Ok(MongoFilter::Composite(filter_doc))
     }
@@ -1104,11 +1115,16 @@ fn exclude_undefineds(field_name: impl Into<Bson>, invert: bool, filter: Documen
 ///
 /// MongoDB does not enforce schema, so documents created before a field was added (e.g. via
 /// `db push`) may lack it even though it is required in the Prisma schema. Missing fields never
-/// equal a concrete value, so positive filters are unaffected by dropping the guard. In inverted
-/// contexts (`invert_undefined_exclusion`), however, a missing field must keep matching negated
-/// filters (`not:` queries), so we conservatively keep the guard there.
-fn should_exclude_undefineds(field_is_required: bool, invert: bool) -> bool {
-    !(field_is_required && !invert)
+/// equal a concrete value, so only positive concrete non-null equality can safely drop the guard.
+fn should_exclude_undefineds(field_is_required: bool, invert_undefined_exclusion: bool, safe_to_skip: bool) -> bool {
+    !(field_is_required && !invert_undefined_exclusion && safe_to_skip)
+}
+
+fn is_positive_concrete_non_null_equality(condition: &ScalarCondition) -> bool {
+    matches!(
+        condition,
+        ScalarCondition::Equals(ConditionValue::Value(value)) if !value.is_null()
+    )
 }
 
 #[derive(Debug, Clone, Default)]
@@ -1286,11 +1302,21 @@ mod tests {
                 PrismaValue::String("b".into())
             ]))),
             doc! {
-                "$or": [
-                    { "$eq": ["$name", { "$literal": "a" }] },
-                    { "$eq": ["$name", { "$literal": "b" }] }
+                "$and": [
+                    {
+                        "$or": [
+                            { "$eq": ["$name", { "$literal": "a" }] },
+                            { "$eq": ["$name", { "$literal": "b" }] }
+                        ]
+                    },
+                    { "$ne": ["$name", "$$REMOVE"] }
                 ]
             }
+        );
+        assert!(
+            render(name.not_equals(PrismaValue::String("abc".into())))
+                .get_array("$and")
+                .is_ok()
         );
     }
 
@@ -1398,9 +1424,9 @@ mod tests {
     /// required and the context is not inverted.
     #[test]
     fn should_exclude_undefineds_decision_table() {
-        assert!(should_exclude_undefineds(false, false));
-        assert!(should_exclude_undefineds(false, true));
-        assert!(should_exclude_undefineds(true, true));
-        assert!(!should_exclude_undefineds(true, false));
+        assert!(should_exclude_undefineds(false, false, false));
+        assert!(should_exclude_undefineds(false, true, false));
+        assert!(should_exclude_undefineds(true, true, false));
+        assert!(!should_exclude_undefineds(true, false, true));
     }
 }

--- a/query-engine/connectors/mongodb-query-connector/src/filter.rs
+++ b/query-engine/connectors/mongodb-query-connector/src/filter.rs
@@ -276,18 +276,23 @@ impl MongoFilterVisitor {
             ScalarCondition::NotSearch(_, _) => unimplemented!("Full-text search is not supported yet on MongoDB"),
         };
 
-        let filter_doc = if !is_set_cond {
-            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
-        } else {
-            filter_doc
-        };
+        let filter_doc =
+            if !is_set_cond && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
+                exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+            } else {
+                filter_doc
+            };
 
         let filter_doc = if let Some(field_ref) = &field_ref {
-            exclude_undefineds(
-                self.prefixed_field_ref(field_ref)?,
-                self.invert_undefined_exclusion(),
-                filter_doc,
-            )
+            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion()) {
+                exclude_undefineds(
+                    self.prefixed_field_ref(field_ref)?,
+                    self.invert_undefined_exclusion(),
+                    filter_doc,
+                )
+            } else {
+                filter_doc
+            }
         } else {
             filter_doc
         };
@@ -421,18 +426,23 @@ impl MongoFilterVisitor {
             )),
         }?;
 
-        let filter_doc = if !is_set_cond {
-            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
-        } else {
-            filter_doc
-        };
+        let filter_doc =
+            if !is_set_cond && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
+                exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+            } else {
+                filter_doc
+            };
 
         let filter_doc = if let Some(field_ref) = &field_ref {
-            exclude_undefineds(
-                self.prefixed_field_ref(field_ref)?,
-                self.invert_undefined_exclusion(),
-                filter_doc,
-            )
+            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion()) {
+                exclude_undefineds(
+                    self.prefixed_field_ref(field_ref)?,
+                    self.invert_undefined_exclusion(),
+                    filter_doc,
+                )
+            } else {
+                filter_doc
+            }
         } else {
             filter_doc
         };
@@ -522,14 +532,22 @@ impl MongoFilterVisitor {
             filter_doc
         };
 
-        let filter_doc = exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc);
+        let filter_doc = if should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
+            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+        } else {
+            filter_doc
+        };
 
         let filter_doc = if let Some(field_ref) = field_ref.as_ref() {
-            exclude_undefineds(
-                self.prefixed_field_ref(field_ref)?,
-                self.invert_undefined_exclusion(),
-                filter_doc,
-            )
+            if should_exclude_undefineds(field_ref.is_required(), self.invert_undefined_exclusion()) {
+                exclude_undefineds(
+                    self.prefixed_field_ref(field_ref)?,
+                    self.invert_undefined_exclusion(),
+                    filter_doc,
+                )
+            } else {
+                filter_doc
+            }
         } else {
             filter_doc
         };
@@ -649,11 +667,12 @@ impl MongoFilterVisitor {
             filter_doc
         };
 
-        let filter_doc = if !is_set_cond {
-            exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
-        } else {
-            filter_doc
-        };
+        let filter_doc =
+            if !is_set_cond && should_exclude_undefineds(field.is_required(), self.invert_undefined_exclusion()) {
+                exclude_undefineds(&field_name, self.invert_undefined_exclusion(), filter_doc)
+            } else {
+                filter_doc
+            };
 
         Ok(MongoFilter::Composite(filter_doc))
     }
@@ -1077,6 +1096,21 @@ fn exclude_undefineds(field_name: impl Into<Bson>, invert: bool, filter: Documen
     }
 }
 
+/// Whether the `$$REMOVE` guard should be added to a filter for a field.
+///
+/// Required fields are always present in documents written by Prisma, so the guard is
+/// unnecessary for them and, worse, forces `$expr` evaluation that bypasses indexes
+/// (see <https://github.com/prisma/prisma/issues/29000>).
+///
+/// MongoDB does not enforce schema, so documents created before a field was added (e.g. via
+/// `db push`) may lack it even though it is required in the Prisma schema. Missing fields never
+/// equal a concrete value, so positive filters are unaffected by dropping the guard. In inverted
+/// contexts (`invert_undefined_exclusion`), however, a missing field must keep matching negated
+/// filters (`not:` queries), so we conservatively keep the guard there.
+fn should_exclude_undefineds(field_is_required: bool, invert: bool) -> bool {
+    !(field_is_required && !invert)
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct FilterPrefix {
     parts: Vec<String>,
@@ -1151,5 +1185,222 @@ impl From<&str> for FilterPrefix {
             parts: vec![alias.to_owned()],
             ignore_target: false,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+    use query_structure::{CompositeFieldRef, InternalDataModel, ScalarFieldRef};
+    use std::sync::Arc;
+
+    fn mongo_schema() -> InternalDataModel {
+        let schema = psl::validate_without_extensions(
+            indoc! {r#"
+                datasource db {
+                  provider = "mongodb"
+                }
+
+                model User {
+                  id      String   @id @map("_id")
+                  uid     String   @unique
+                  name    String
+                  country String?
+                  tags    String[]
+                  address Address?
+                }
+
+                type Address {
+                  city String
+                }
+            "#}
+            .into(),
+        );
+
+        assert!(!schema.diagnostics.has_errors(), "{:?}", schema.diagnostics);
+
+        InternalDataModel {
+            schema: Arc::new(schema),
+        }
+    }
+
+    fn scalar_field(dm: &InternalDataModel, name: &str) -> ScalarFieldRef {
+        dm.find_model("User").unwrap().fields().find_from_scalar(name).unwrap()
+    }
+
+    fn composite_field(dm: &InternalDataModel, name: &str) -> CompositeFieldRef {
+        dm.find_model("User")
+            .unwrap()
+            .fields()
+            .composite()
+            .into_iter()
+            .find(|cf| cf.name() == name)
+            .unwrap()
+    }
+
+    fn render(filter: Filter) -> Document {
+        MongoFilterVisitor::new(FilterPrefix::default(), false)
+            .visit(filter)
+            .unwrap()
+            .render()
+            .0
+    }
+
+    /// `_id`, `@unique` and plain required fields must be reported as required.
+    #[test]
+    fn requiredness_of_id_unique_and_required_fields() {
+        let dm = mongo_schema();
+
+        assert!(scalar_field(&dm, "id").is_required());
+        assert!(scalar_field(&dm, "uid").is_required());
+        assert!(scalar_field(&dm, "name").is_required());
+        assert!(!scalar_field(&dm, "country").is_required());
+        assert!(!scalar_field(&dm, "tags").is_required());
+    }
+
+    /// Positive filters on required fields must not carry the `$$REMOVE` guard: the guard
+    /// forces `$expr` evaluation that bypasses indexes (see prisma/prisma#29000).
+    #[test]
+    fn required_fields_skip_undefined_exclusion() {
+        let dm = mongo_schema();
+        let id = scalar_field(&dm, "id");
+        let uid = scalar_field(&dm, "uid");
+        let name = scalar_field(&dm, "name");
+
+        assert_eq!(
+            render(id.equals(PrismaValue::String("abc".into()))),
+            doc! { "$eq": ["$_id", { "$literal": "abc" }] }
+        );
+        assert_eq!(
+            render(uid.equals(PrismaValue::String("abc".into()))),
+            doc! { "$eq": ["$uid", { "$literal": "abc" }] }
+        );
+        assert_eq!(
+            render(name.equals(PrismaValue::String("abc".into()))),
+            doc! { "$eq": ["$name", { "$literal": "abc" }] }
+        );
+        assert_eq!(
+            render(name.is_in(ConditionListValue::list(vec![
+                PrismaValue::String("a".into()),
+                PrismaValue::String("b".into())
+            ]))),
+            doc! {
+                "$or": [
+                    { "$eq": ["$name", { "$literal": "a" }] },
+                    { "$eq": ["$name", { "$literal": "b" }] }
+                ]
+            }
+        );
+    }
+
+    /// Optional fields must keep the `$$REMOVE` guard: a missing field must never match a
+    /// value filter.
+    #[test]
+    fn optional_fields_keep_undefined_exclusion() {
+        let dm = mongo_schema();
+        let country = scalar_field(&dm, "country");
+
+        assert_eq!(
+            render(country.equals(PrismaValue::String("abc".into()))),
+            doc! {
+                "$and": [
+                    { "$eq": ["$country", { "$literal": "abc" }] },
+                    { "$ne": ["$country", "$$REMOVE"] }
+                ]
+            }
+        );
+        assert_eq!(
+            render(country.not_equals(PrismaValue::String("abc".into()))),
+            doc! {
+                "$and": [
+                    { "$ne": ["$country", { "$literal": "abc" }] },
+                    { "$ne": ["$country", "$$REMOVE"] }
+                ]
+            }
+        );
+    }
+
+    /// NOT filters on optional fields must keep the `$$REMOVE` guard so that documents
+    /// missing the field still match.
+    #[test]
+    fn not_filters_on_optional_fields_keep_undefined_exclusion() {
+        let dm = mongo_schema();
+        let country = scalar_field(&dm, "country");
+
+        assert_eq!(
+            render(Filter::not(vec![country.equals(PrismaValue::String("abc".into()))])),
+            doc! {
+                "$and": [
+                    {
+                        "$and": [
+                            { "$ne": ["$country", { "$literal": "abc" }] },
+                            { "$ne": ["$country", "$$REMOVE"] }
+                        ]
+                    }
+                ]
+            }
+        );
+    }
+
+    /// `isSet` filters are rendered directly and must not be wrapped in an additional
+    /// undefined exclusion.
+    #[test]
+    fn is_set_filters_are_untouched() {
+        let dm = mongo_schema();
+        let name = scalar_field(&dm, "name");
+        let country = scalar_field(&dm, "country");
+
+        assert_eq!(render(name.is_set(true)), doc! { "$ne": ["$name", "$$REMOVE"] });
+        assert_eq!(render(name.is_set(false)), doc! { "$eq": ["$name", "$$REMOVE"] });
+        assert_eq!(render(country.is_set(true)), doc! { "$ne": ["$country", "$$REMOVE"] });
+    }
+
+    /// List fields are never required: the guard must be kept even though the field is not
+    /// optional.
+    #[test]
+    fn list_filters_keep_undefined_exclusion() {
+        let dm = mongo_schema();
+        let tags = scalar_field(&dm, "tags");
+
+        assert_eq!(
+            render(tags.contains_some_element(ConditionListValue::list(vec![PrismaValue::String("a".into())]))),
+            doc! {
+                "$and": [
+                    { "$or": [ { "$in": ["a", { "$ifNull": ["$tags", []] }] } ] },
+                    { "$ne": ["$tags", "$$REMOVE"] }
+                ]
+            }
+        );
+    }
+
+    /// Composite filters on optional composite fields must keep the guard.
+    #[test]
+    fn composite_filters_keep_undefined_exclusion_for_optional_fields() {
+        let dm = mongo_schema();
+        let address = composite_field(&dm, "address");
+
+        assert_eq!(
+            render(address.equals(PrismaValue::Object(vec![(
+                "city".to_owned(),
+                PrismaValue::String("Berlin".to_owned())
+            )]))),
+            doc! {
+                "$and": [
+                    { "$eq": ["$address", { "city": "Berlin" }] },
+                    { "$ne": ["$address", "$$REMOVE"] }
+                ]
+            }
+        );
+    }
+
+    /// The `should_exclude_undefineds` decision table: keep the guard unless the field is
+    /// required and the context is not inverted.
+    #[test]
+    fn should_exclude_undefineds_decision_table() {
+        assert!(should_exclude_undefineds(false, false));
+        assert!(should_exclude_undefineds(false, true));
+        assert!(should_exclude_undefineds(true, true));
+        assert!(!should_exclude_undefineds(true, false));
     }
 }


### PR DESCRIPTION
## What Changed
- Skip `$$REMOVE` undefined guards for positive concrete non-null equality filters on required scalar and composite fields.
- Preserve undefined exclusions for optional fields, inverted filters, insensitive comparisons, list fields, and other unsafe cases.
- Add unit tests covering field requiredness and the updated filter-rendering behavior.

## Risk Assessment

✅ Low: The change is narrowly scoped to MongoDB filter guard selection, preserves guards for optional, inverted, null, insensitive, list, and field-reference cases, and adds behavior-level rendering coverage for the optimization boundaries.

## Testing

The focused MongoDB filter tests exercised rendered aggregation filters for required, optional, list, composite, insensitive, negated, and `isSet` cases; all targeted tests passed and the rendered-filter transcript was saved as evidence.

<details>
<summary>Evidence: MongoDB filter targeted test transcript</summary>

```text
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.41s
     Running unittests src/lib.rs (target/debug/deps/mongodb_query_connector-8cf051c2555f23eb)

running 10 tests
test filter::tests::insensitive_required_equality_keeps_undefined_exclusion ... ok
test filter::tests::list_filters_keep_undefined_exclusion ... ok
test filter::tests::composite_filters_keep_undefined_exclusion_for_optional_fields ... ok
test filter::tests::is_set_filters_are_untouched ... ok
test filter::tests::not_filters_on_optional_fields_keep_undefined_exclusion ... ok
test filter::tests::optional_fields_keep_undefined_exclusion ... ok
test filter::tests::required_fields_skip_undefined_exclusion ... ok
test filter::tests::requiredness_of_id_unique_and_required_fields ... ok
test filter::tests::required_composite_equality_skips_undefined_exclusion ... ok
test filter::tests::should_exclude_undefineds_decision_table ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 10 filtered out; finished in 0.01s

     Running unittests src/lib.rs (target/debug/deps/psl-a607002e0f40a29e)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

     Running tests/datamodel_tests.rs (target/debug/deps/datamodel_tests-a31f769ef7e604f7)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 1063 filtered out; finished in 0.00s

     Running tests/reformat_tests.rs (target/debug/deps/reformat_tests-040a43d228d48dd3)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 0.00s

     Running tests/validation_tests.rs (target/debug/deps/validation_tests-47b5ffde85b9b6cf)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 215 filtered out; finished in 0.00s

     Running unittests src/lib.rs (target/debug/deps/quaint-61fd4c7f8913f505)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 984 filtered out; finished in 0.00s
```
</details>

## Pipeline


<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"75922ef164e9e8e093a5b6d8e169a0510023d6a5","steps":[{"step":"intent","status":"skipped"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅**intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `query-engine/connectors/mongodb-query-connector/src/filter.rs:313` - The new optimization also removes the `$$REMOVE` guard for case-insensitive equality filters on required string fields. These filters are rendered with `$regexMatch`, whose `input` is the field value; for legacy documents where a required field is missing (a case explicitly acknowledged by this change), MongoDB can error when `$regexMatch` receives a missing/null input rather than simply returning false. The concrete path is a case-insensitive equality query on a required field after `db push` or equivalent schema evolution left old documents without that field. Keep the guard for insensitive/regex-based equality, or null-coerce the regex input before allowing the guard to be removed.

🔧 Fix: Preserve guards for insensitive required-field filters
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `cargo test -p mongodb-query-connector -p quaint -p psl --features quaint/sqlite,psl/all filter::tests -- --nocapture`
- <code>Verified required scalar and composite equality filters omit the `$$REMOVE` guard.</code>
- <code>Verified optional, list, insensitive, negated, and `isSet` filters preserve the expected undefined-field behavior.</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Lint** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `cargo clippy -p mongodb-query-connector --lib -- -Dwarnings` could not complete because the workspace&#39;s `quaint` dependency was built without a SQL feature, producing unrelated compilation errors.

🔧 Fix: Validated MongoDB filter linting
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
Fixes:[ #29000](prisma/prisma/issues/29000)