### PR TITLE
fix(qc): never use a partial unique index as an ON CONFLICT target

### DIFF
--- a/query-compiler/core/src/query_ast/upsert.rs
+++ b/query-compiler/core/src/query_ast/upsert.rs
@@ -13,11 +13,12 @@ pub struct NativeUpsert {
 }
 
 impl NativeUpsert {
-    /// `conflict_target` is the non-empty column list the statement arbitrates on,
-    /// as chosen by [`conflict_target`]. It is taken rather than recomputed here so
-    /// that the check deciding this query is buildable and the columns it emits
-    /// cannot drift apart: an empty list renders as `ON CONFLICT ()`, which is a
-    /// syntax error rather than a planning failure.
+    /// `conflict_target` is the non-empty column list the statement arbitrates on:
+    /// the columns of the very constraint the `where` clause named, as resolved by
+    /// the query graph builder. It is taken rather than recomputed here so that the
+    /// check deciding this query is buildable and the columns it emits cannot drift
+    /// apart; an empty list renders as `ON CONFLICT ()`, a syntax error rather than
+    /// a planning failure.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
@@ -84,43 +85,4 @@ impl NativeUpsert {
     pub fn record_filter(&self) -> &RecordFilter {
         &self.record_filter
     }
-}
-
-/// The columns an `INSERT ... ON CONFLICT` can name as its conflict target for
-/// `filter`, or `None` when the model carries no constraint the database could
-/// infer from them.
-///
-/// Partial (`WHERE`-filtered) unique indexes are never candidates. Inferring one
-/// requires repeating its predicate in the statement, which the generated SQL
-/// does not carry, so PostgreSQL rejects it with 42P10 ("there is no unique or
-/// exclusion constraint matching the ON CONFLICT specification") on every call,
-/// whatever the data. `None` therefore means "the connector-native upsert is not
-/// usable here"; callers fall back to the read-then-write graph, which handles
-/// those models correctly.
-pub fn conflict_target(model: &Model, filter: &Filter) -> Option<Vec<ScalarFieldRef>> {
-    let scalars = filter.scalars();
-
-    let unique_index = model
-        .unique_indexes()
-        .filter(|index| !index.is_partial())
-        .find(|index| {
-            index
-                .fields()
-                .all(|f| scalars.contains(&ScalarFieldRef::from((model.dm.clone(), f))))
-        });
-
-    if let Some(index) = unique_index {
-        return Some(
-            index
-                .fields()
-                .map(|f| ScalarFieldRef::from((model.dm.clone(), f)))
-                .collect(),
-        );
-    }
-
-    // The primary key, which is never partial. This also covers the single-field
-    // case that used to fall through to `Filter::unique_scalars`, whose notion of
-    // uniqueness counts partial indexes too.
-    let ids: Vec<ScalarFieldRef> = model.fields().id_fields()?.collect();
-    ids.iter().all(|f| scalars.contains(f)).then_some(ids)
 }

--- a/query-compiler/core/src/query_ast/upsert.rs
+++ b/query-compiler/core/src/query_ast/upsert.rs
@@ -7,17 +7,25 @@ pub struct NativeUpsert {
     record_filter: RecordFilter,
     create: WriteArgs,
     update: WriteArgs,
+    conflict_target: Vec<ScalarFieldRef>,
     pub selected_fields: FieldSelection,
     pub selection_order: Vec<String>,
 }
 
 impl NativeUpsert {
+    /// `conflict_target` is the non-empty column list the statement arbitrates on,
+    /// as chosen by [`conflict_target`]. It is taken rather than recomputed here so
+    /// that the check deciding this query is buildable and the columns it emits
+    /// cannot drift apart: an empty list renders as `ON CONFLICT ()`, which is a
+    /// syntax error rather than a planning failure.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: String,
         model: Model,
         record_filter: RecordFilter,
         create: WriteArgs,
         update: WriteArgs,
+        conflict_target: Vec<ScalarFieldRef>,
         selected_fields: FieldSelection,
         selection_order: Vec<String>,
     ) -> Self {
@@ -27,6 +35,7 @@ impl NativeUpsert {
             record_filter,
             create,
             update,
+            conflict_target,
             selected_fields,
             selection_order,
         }
@@ -56,29 +65,8 @@ impl NativeUpsert {
         &mut self.create
     }
 
-    pub fn unique_constraints(&self) -> Vec<ScalarFieldRef> {
-        let compound_indexes = self.model.unique_indexes();
-        let scalars = self.record_filter.filter.scalars();
-        let unique_index = compound_indexes.into_iter().find(|index| {
-            index
-                .fields()
-                .all(|f| scalars.contains(&ScalarFieldRef::from((self.model.dm.clone(), f))))
-        });
-
-        if let Some(index) = unique_index {
-            return index
-                .fields()
-                .map(|f| ScalarFieldRef::from((self.model.dm.clone(), f)))
-                .collect();
-        }
-
-        if let Some(ids) = self.model.fields().compound_id()
-            && ids.clone().all(|f| scalars.contains(&f))
-        {
-            return ids.collect();
-        }
-
-        self.record_filter.filter.unique_scalars()
+    pub fn conflict_target(&self) -> &[ScalarFieldRef] {
+        &self.conflict_target
     }
 
     pub fn filter(&self) -> &Filter {
@@ -96,4 +84,43 @@ impl NativeUpsert {
     pub fn record_filter(&self) -> &RecordFilter {
         &self.record_filter
     }
+}
+
+/// The columns an `INSERT ... ON CONFLICT` can name as its conflict target for
+/// `filter`, or `None` when the model carries no constraint the database could
+/// infer from them.
+///
+/// Partial (`WHERE`-filtered) unique indexes are never candidates. Inferring one
+/// requires repeating its predicate in the statement, which the generated SQL
+/// does not carry, so PostgreSQL rejects it with 42P10 ("there is no unique or
+/// exclusion constraint matching the ON CONFLICT specification") on every call,
+/// whatever the data. `None` therefore means "the connector-native upsert is not
+/// usable here"; callers fall back to the read-then-write graph, which handles
+/// those models correctly.
+pub fn conflict_target(model: &Model, filter: &Filter) -> Option<Vec<ScalarFieldRef>> {
+    let scalars = filter.scalars();
+
+    let unique_index = model
+        .unique_indexes()
+        .filter(|index| !index.is_partial())
+        .find(|index| {
+            index
+                .fields()
+                .all(|f| scalars.contains(&ScalarFieldRef::from((model.dm.clone(), f))))
+        });
+
+    if let Some(index) = unique_index {
+        return Some(
+            index
+                .fields()
+                .map(|f| ScalarFieldRef::from((model.dm.clone(), f)))
+                .collect(),
+        );
+    }
+
+    // The primary key, which is never partial. This also covers the single-field
+    // case that used to fall through to `Filter::unique_scalars`, whose notion of
+    // uniqueness counts partial indexes too.
+    let ids: Vec<ScalarFieldRef> = model.fields().id_fields()?.collect();
+    ids.iter().all(|f| scalars.contains(f)).then_some(ids)
 }

--- a/query-compiler/core/src/query_ast/write.rs
+++ b/query-compiler/core/src/query_ast/write.rs
@@ -138,6 +138,7 @@ impl WriteQuery {
         record_filter: RecordFilter,
         create: WriteArgs,
         update: WriteArgs,
+        conflict_target: Vec<ScalarFieldRef>,
         read: RecordQuery,
     ) -> crate::Query {
         crate::Query::Write(WriteQuery::Upsert(NativeUpsert::new(
@@ -146,6 +147,7 @@ impl WriteQuery {
             record_filter,
             create,
             update,
+            conflict_target,
             read.selected_fields,
             read.selection_order,
         )))

--- a/query-compiler/core/src/query_graph_builder/extractors/mod.rs
+++ b/query-compiler/core/src/query_graph_builder/extractors/mod.rs
@@ -6,6 +6,6 @@ mod utils;
 pub(crate) use filters::*;
 pub(crate) use query_arguments::*;
 pub(crate) use rel_aggregations::*;
-pub(crate) use utils::resolve_compound_field;
+pub(crate) use utils::{resolve_compound_field, resolve_compound_id};
 
 use crate::query_document::*;

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -5,8 +5,8 @@ use crate::{
     query_ast::*,
     query_graph::{Flow, QueryGraph, QueryGraphDependency},
 };
-use query_structure::Model;
-use schema::QuerySchema;
+use query_structure::{Model, ScalarFieldRef};
+use schema::{QuerySchema, compound_index_field_name};
 
 /// Handles a top-level upsert
 ///
@@ -70,14 +70,16 @@ pub(crate) fn upsert_record(
         query_schema,
     );
 
+    // The native upsert must additionally arbitrate on a constraint the database
+    // can infer, and it has to be the very one the `where` clause named — see
+    // `conflict_target`.
+    let conflict_columns = can_use_native_upsert
+        .then(|| unique_selector(&where_argument, &model))
+        .flatten()
+        .and_then(|selector| conflict_target(&model, selector));
+
     let filter = extract_unique_filter(where_argument, &model)?;
     let read_query = read::find_unique(field.clone(), model.clone(), query_schema)?;
-
-    // The native upsert additionally needs a conflict target the database can
-    // infer from the `where` filter, which a partial unique index cannot supply.
-    let conflict_columns = can_use_native_upsert
-        .then(|| conflict_target(&model, &filter))
-        .flatten();
 
     if let Some(conflict_columns) = conflict_columns
         && let ReadQuery::RecordQuery(read) = read_query
@@ -199,9 +201,8 @@ pub(crate) fn upsert_record(
 // 3. There is only 1 unique field in the where clause
 // 4. The unique field defined in where clause has the same value as defined in the create arguments
 //
-// The caller checks one further condition that needs the extracted filter rather
-// than the raw arguments: the model must have a conflict target the database can
-// infer. See `conflict_target`.
+// The caller checks one further condition: the unique named in the where clause
+// must be usable as an `ON CONFLICT` target. See `conflict_target`.
 fn can_use_connector_native_upsert<'a>(
     model: &Model,
     where_field: &ParsedInputMap<'a>,
@@ -240,6 +241,74 @@ fn can_use_connector_native_upsert<'a>(
         && !has_nested_selects
         && where_values_same_as_create
         && !query_schema.relation_mode().is_prisma()
+}
+
+/// The single `where` key that names a unique constraint.
+///
+/// `can_use_connector_native_upsert` separately requires that there be exactly
+/// one; the remaining keys are non-unique filters that narrow the update.
+fn unique_selector<'a>(where_field: &'a ParsedInputMap<'_>, model: &Model) -> Option<&'a str> {
+    where_field
+        .iter()
+        .map(|(field_name, _)| field_name.as_ref())
+        .find(|field_name| is_unique_field(field_name, model))
+}
+
+/// The columns an `INSERT ... ON CONFLICT` can arbitrate on for the unique that
+/// `where` names, or `None` when that unique cannot be a conflict target.
+///
+/// The arbiter has to be the constraint the `where` clause actually named, not
+/// merely one the filter happens to cover. Picking a narrower unique makes the
+/// statement conflict on rows the `where` clause does not select: with a
+/// `@@unique([email, status])` selector and a total `@unique` on `email` alone,
+/// `ON CONFLICT ("email")` collides with a row holding a different `status`,
+/// whose `DO UPDATE ... WHERE` then matches nothing, so the upsert quietly
+/// returns no row instead of creating one or reporting the unique violation.
+///
+/// Partial (`WHERE`-filtered) uniques are never usable either. Inferring one
+/// requires repeating its predicate in the statement, which the generated SQL
+/// does not carry, so PostgreSQL rejects it with 42P10 ("there is no unique or
+/// exclusion constraint matching the ON CONFLICT specification") on every call,
+/// whatever the data.
+///
+/// `None` means the connector-native upsert is not usable, and the caller falls
+/// back to the read-then-write graph, which handles both cases correctly.
+fn conflict_target(model: &Model, selector: &str) -> Option<Vec<ScalarFieldRef>> {
+    // A compound selector names the primary key, which is never partial...
+    if let Some(primary_key) = resolve_compound_id(selector, model) {
+        return Some(primary_key);
+    }
+
+    // ...or exactly one `@@unique` index.
+    if let Some(index) = model
+        .unique_indexes()
+        .filter(|index| index.fields().len() > 1)
+        .find(|index| compound_index_field_name(*index) == selector)
+    {
+        return (!index.is_partial()).then(|| {
+            index
+                .fields()
+                .map(|f| ScalarFieldRef::from((model.dm.clone(), f)))
+                .collect()
+        });
+    }
+
+    // A single-column selector is usable when the primary key or a non-partial
+    // unique index covers exactly that column.
+    let field = model.fields().find_from_scalar(selector).ok()?;
+    let is_single_column_id = model.fields().id_fields().is_some_and(|ids| {
+        let ids: Vec<_> = ids.collect();
+        ids.len() == 1 && ids[0] == field
+    });
+    let has_total_unique = model.unique_indexes().filter(|index| !index.is_partial()).any(|index| {
+        let mut fields = index.fields();
+        fields.len() == 1
+            && fields
+                .next()
+                .is_some_and(|f| ScalarFieldRef::from((model.dm.clone(), f)) == field)
+    });
+
+    (is_single_column_id || has_total_unique).then(|| vec![field])
 }
 
 fn is_unique_field(field_name: &str, model: &Model) -> bool {

--- a/query-compiler/core/src/query_graph_builder/write/upsert.rs
+++ b/query-compiler/core/src/query_graph_builder/write/upsert.rs
@@ -73,7 +73,15 @@ pub(crate) fn upsert_record(
     let filter = extract_unique_filter(where_argument, &model)?;
     let read_query = read::find_unique(field.clone(), model.clone(), query_schema)?;
 
-    if can_use_native_upsert && let ReadQuery::RecordQuery(read) = read_query {
+    // The native upsert additionally needs a conflict target the database can
+    // infer from the `where` filter, which a partial unique index cannot supply.
+    let conflict_columns = can_use_native_upsert
+        .then(|| conflict_target(&model, &filter))
+        .flatten();
+
+    if let Some(conflict_columns) = conflict_columns
+        && let ReadQuery::RecordQuery(read) = read_query
+    {
         let mut create_write_args = WriteArgsParser::from(&model, create_argument)?.args;
         let mut update_write_args = WriteArgsParser::from(&model, update_argument)?.args;
 
@@ -86,6 +94,7 @@ pub(crate) fn upsert_record(
             filter.into(),
             create_write_args,
             update_write_args,
+            conflict_columns,
             read,
         ));
 
@@ -189,6 +198,10 @@ pub(crate) fn upsert_record(
 // 2. The create and update arguments do not have any nested queries
 // 3. There is only 1 unique field in the where clause
 // 4. The unique field defined in where clause has the same value as defined in the create arguments
+//
+// The caller checks one further condition that needs the extracted filter rather
+// than the raw arguments: the model must have a conflict target the database can
+// infer. See `conflict_target`.
 fn can_use_connector_native_upsert<'a>(
     model: &Model,
     where_field: &ParsedInputMap<'a>,

--- a/query-compiler/query-compiler/src/translate/query/write.rs
+++ b/query-compiler/query-compiler/src/translate/query/write.rs
@@ -262,7 +262,7 @@ pub(crate) fn translate_write_query(query: WriteQuery, builder: &dyn QueryBuilde
                     upsert.create().clone(),
                     upsert.update().clone(),
                     upsert.selected_fields(),
-                    &upsert.unique_constraints(),
+                    upsert.conflict_target(),
                 )
                 .map_err(TranslateError::QueryBuildFailure)?;
             Expression::Unique(Box::new(Expression::Query(query)))

--- a/query-compiler/query-compiler/tests/data/schema.prisma
+++ b/query-compiler/query-compiler/tests/data/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider        = "prisma-client"
-  previewFeatures = ["relationJoins"]
+  previewFeatures = ["relationJoins", "partialIndexes"]
 }
 
 datasource db {
@@ -96,4 +96,26 @@ model NotificationSettings {
   emailMarketing Boolean @default(true)
   smsMarketing   Boolean @default(true)
   user           User    @relation(fields: [userId], references: [id], onDelete: Cascade, onUpdate: NoAction)
+}
+
+/// A partial unique index is not a usable `ON CONFLICT` target, so an upsert on
+/// this model must arbitrate on `@@unique([email, status])` even though the
+/// partial one covers a subset of the same columns and is declared first.
+model PartialUnique {
+  id     Int    @id @default(autoincrement())
+  email  String
+  status String
+  name   String
+
+  @@unique([email], map: "partial_unique_active_email", where: raw("status = 'active'"))
+  @@unique([email, status])
+}
+
+/// The only unique on `email` is partial, so an upsert keyed on it has no
+/// conflict target at all and must fall back to the read-then-write plan.
+model PartialUniqueOnly {
+  id     Int    @id @default(autoincrement())
+  email  String @unique(map: "partial_unique_only_email", where: raw("status = 'active'"))
+  status String
+  name   String
 }

--- a/query-compiler/query-compiler/tests/data/schema.prisma
+++ b/query-compiler/query-compiler/tests/data/schema.prisma
@@ -119,3 +119,12 @@ model PartialUniqueOnly {
   status String
   name   String
 }
+
+model PartialSelectorOverlap {
+  id     Int    @id @default(autoincrement())
+  email  String @unique
+  status String
+  name   String
+
+  @@unique([email, status], map: "partial_email_status", where: raw("status = 'active'"))
+}

--- a/query-compiler/query-compiler/tests/data/upsert-partial-selector-overlap.json
+++ b/query-compiler/query-compiler/tests/data/upsert-partial-selector-overlap.json
@@ -1,0 +1,15 @@
+{
+  "modelName": "PartialSelectorOverlap",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email_status": { "email": "user@example.com", "status": "active" } },
+      "update": { "name": "updated" },
+      "create": { "email": "user@example.com", "status": "active", "name": "created" }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/upsert-partial-unique-only.json
+++ b/query-compiler/query-compiler/tests/data/upsert-partial-unique-only.json
@@ -1,0 +1,15 @@
+{
+  "modelName": "PartialUniqueOnly",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email": "user@example.com" },
+      "update": { "name": "updated" },
+      "create": { "email": "user@example.com", "status": "active", "name": "created" }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/data/upsert-partial-unique.json
+++ b/query-compiler/query-compiler/tests/data/upsert-partial-unique.json
@@ -1,0 +1,15 @@
+{
+  "modelName": "PartialUnique",
+  "action": "upsertOne",
+  "query": {
+    "arguments": {
+      "relationLoadStrategy": "query",
+      "where": { "email_status": { "email": "user@example.com", "status": "active" } },
+      "update": { "name": "updated" },
+      "create": { "email": "user@example.com", "status": "active", "name": "created" }
+    },
+    "selection": {
+      "$scalars": true
+    }
+  }
+}

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-partial-selector-overlap.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-partial-selector-overlap.json.snap
@@ -1,0 +1,82 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-partial-selector-overlap.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       status: String (status)
+       name: String (name)
+   }
+   let 0 = query «SELECT "public"."PartialSelectorOverlap"."id" FROM
+                  "public"."PartialSelectorOverlap" WHERE
+                  (("public"."PartialSelectorOverlap"."email" = $1 AND
+                  "public"."PartialSelectorOverlap"."status" = $2) AND 1=1)
+                  OFFSET $3»
+           params [const(String("user@example.com")), const(String("active")),
+                   const(BigInt(0))]
+   in let 5 = if (rowCountNeq 0 (get 0))
+          then let 0 = unique (get 0);
+                   0$id = mapField id (get 0)
+               in let 2 = unique (query «UPDATE
+                                         "public"."PartialSelectorOverlap" SET
+                                         "name" = $1 WHERE
+                                         ("public"."PartialSelectorOverlap"."id"
+                                         IN [$2,*] AND
+                                         (("public"."PartialSelectorOverlap"."email"
+                                         = $3 AND
+                                         "public"."PartialSelectorOverlap"."status"
+                                         = $4) AND 1=1)) RETURNING
+                                         "public"."PartialSelectorOverlap"."id",
+                                         "public"."PartialSelectorOverlap"."email",
+                                         "public"."PartialSelectorOverlap"."status",
+                                         "public"."PartialSelectorOverlap"."name"»
+                                  params [const(String("updated")),
+                                          var(0$id as Int),
+                                          const(String("user@example.com")),
+                                          const(String("active"))])
+                  in let 4 = let 2 = unique (validate (get 2)
+                                 [ rowCountNeq 0
+                                 ] orRaise "MISSING_RECORD");
+                                 2$id = mapField id (get 2)
+                         in unique (query «SELECT
+                                           "public"."PartialSelectorOverlap"."id",
+                                           "public"."PartialSelectorOverlap"."email",
+                                           "public"."PartialSelectorOverlap"."status",
+                                           "public"."PartialSelectorOverlap"."name"
+                                           FROM
+                                           "public"."PartialSelectorOverlap"
+                                           WHERE
+                                           "public"."PartialSelectorOverlap"."id"
+                                           = $1 LIMIT $2 OFFSET $3»
+                                    params [var(2$id as Int), const(BigInt(1)),
+                                            const(BigInt(0))])
+                     in getFirstNonEmpty4
+          else let 1 = unique (query «INSERT INTO
+                                      "public"."PartialSelectorOverlap"
+                                      ("email","status","name") VALUES
+                                      ($1,$2,$3) RETURNING
+                                      "public"."PartialSelectorOverlap"."id"»
+                               params [const(String("user@example.com")),
+                                       const(String("active")),
+                                       const(String("created"))])
+               in let 3 = let 1 = unique (validate (get 1)
+                              [ rowCountNeq 0
+                              ] orRaise "MISSING_RECORD");
+                              1$id = mapField id (get 1)
+                      in unique (query «SELECT
+                                        "public"."PartialSelectorOverlap"."id",
+                                        "public"."PartialSelectorOverlap"."email",
+                                        "public"."PartialSelectorOverlap"."status",
+                                        "public"."PartialSelectorOverlap"."name"
+                                        FROM "public"."PartialSelectorOverlap"
+                                        WHERE
+                                        "public"."PartialSelectorOverlap"."id" =
+                                        $1 LIMIT $2 OFFSET $3»
+                                 params [var(1$id as Int), const(BigInt(1)),
+                                         const(BigInt(0))])
+                  in getFirstNonEmpty3
+      in getFirstNonEmpty5

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-partial-unique-only.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-partial-unique-only.json.snap
@@ -1,0 +1,72 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-partial-unique-only.json
+snapshot_kind: text
+---
+transaction
+   dataMap {
+       id: Int (id)
+       email: String (email)
+       status: String (status)
+       name: String (name)
+   }
+   let 0 = query «SELECT "public"."PartialUniqueOnly"."id" FROM
+                  "public"."PartialUniqueOnly" WHERE
+                  ("public"."PartialUniqueOnly"."email" = $1 AND 1=1) OFFSET $2»
+           params [const(String("user@example.com")), const(BigInt(0))]
+   in let 5 = if (rowCountNeq 0 (get 0))
+          then let 0 = unique (get 0);
+                   0$id = mapField id (get 0)
+               in let 2 = unique (query «UPDATE "public"."PartialUniqueOnly" SET
+                                         "name" = $1 WHERE
+                                         ("public"."PartialUniqueOnly"."id" IN
+                                         [$2,*] AND
+                                         ("public"."PartialUniqueOnly"."email" =
+                                         $3 AND 1=1)) RETURNING
+                                         "public"."PartialUniqueOnly"."id",
+                                         "public"."PartialUniqueOnly"."email",
+                                         "public"."PartialUniqueOnly"."status",
+                                         "public"."PartialUniqueOnly"."name"»
+                                  params [const(String("updated")),
+                                          var(0$id as Int),
+                                          const(String("user@example.com"))])
+                  in let 4 = let 2 = unique (validate (get 2)
+                                 [ rowCountNeq 0
+                                 ] orRaise "MISSING_RECORD");
+                                 2$id = mapField id (get 2)
+                         in unique (query «SELECT
+                                           "public"."PartialUniqueOnly"."id",
+                                           "public"."PartialUniqueOnly"."email",
+                                           "public"."PartialUniqueOnly"."status",
+                                           "public"."PartialUniqueOnly"."name"
+                                           FROM "public"."PartialUniqueOnly"
+                                           WHERE
+                                           "public"."PartialUniqueOnly"."id" =
+                                           $1 LIMIT $2 OFFSET $3»
+                                    params [var(2$id as Int), const(BigInt(1)),
+                                            const(BigInt(0))])
+                     in getFirstNonEmpty4
+          else let 1 = unique (query «INSERT INTO "public"."PartialUniqueOnly"
+                                      ("email","status","name") VALUES
+                                      ($1,$2,$3) RETURNING
+                                      "public"."PartialUniqueOnly"."id"»
+                               params [const(String("user@example.com")),
+                                       const(String("active")),
+                                       const(String("created"))])
+               in let 3 = let 1 = unique (validate (get 1)
+                              [ rowCountNeq 0
+                              ] orRaise "MISSING_RECORD");
+                              1$id = mapField id (get 1)
+                      in unique (query «SELECT
+                                        "public"."PartialUniqueOnly"."id",
+                                        "public"."PartialUniqueOnly"."email",
+                                        "public"."PartialUniqueOnly"."status",
+                                        "public"."PartialUniqueOnly"."name" FROM
+                                        "public"."PartialUniqueOnly" WHERE
+                                        "public"."PartialUniqueOnly"."id" = $1
+                                        LIMIT $2 OFFSET $3»
+                                 params [var(1$id as Int), const(BigInt(1)),
+                                         const(BigInt(0))])
+                  in getFirstNonEmpty3
+      in getFirstNonEmpty5

--- a/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-partial-unique.json.snap
+++ b/query-compiler/query-compiler/tests/snapshots/queries__queries@upsert-partial-unique.json.snap
@@ -1,0 +1,22 @@
+---
+source: query-compiler/query-compiler/tests/queries.rs
+expression: pretty
+input_file: query-compiler/query-compiler/tests/data/upsert-partial-unique.json
+snapshot_kind: text
+---
+dataMap {
+    id: Int (id)
+    email: String (email)
+    status: String (status)
+    name: String (name)
+}
+unique (query «INSERT INTO "public"."PartialUnique" ("email","status","name")
+               VALUES ($1,$2,$3) ON CONFLICT ("email","status") DO UPDATE SET
+               "name" = $4 WHERE (("public"."PartialUnique"."email" = $5 AND
+               "public"."PartialUnique"."status" = $6) AND 1=1) RETURNING
+               "public"."PartialUnique"."id", "public"."PartialUnique"."email",
+               "public"."PartialUnique"."status",
+               "public"."PartialUnique"."name"»
+        params [const(String("user@example.com")), const(String("active")),
+                const(String("created")), const(String("updated")),
+                const(String("user@example.com")), const(String("active"))])

--- a/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
+++ b/query-engine/connector-test-kit-rs/query-engine-tests/tests/new/native_upsert.rs
@@ -363,6 +363,123 @@ mod native_upsert {
         Ok(())
     }
 
+    pub fn partial_and_total_unique() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              id     Int    @id
+              email  String
+              status String
+              name   String
+
+              @@unique([email], map: "partial_email", where: raw("status = 'active'"))
+              @@unique([email, status], map: "email_status")
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // The conflict target must be the total unique the `where` clause names, even
+    // when a partial unique covers a subset of the same columns and is declared
+    // first. A partial index cannot be inferred from a bare column list, so
+    // picking it makes the database reject every call (Postgres: 42P10).
+    #[connector_test(schema(partial_and_total_unique), capabilities(NativeUpsert, PartialIndex))]
+    async fn should_upsert_on_total_unique_over_partial(mut runner: Runner) -> TestResult<()> {
+        let upsert = r#"
+          mutation {
+            upsertOneTestModel(
+              where: {email_status: {
+                email: "hello@example.com",
+                status: "active"
+              }},
+              create: {
+                id: 1,
+                email: "hello@example.com",
+                status: "active",
+                name: "hello",
+              },
+              update: {
+                name: "hello-updated",
+              }
+            ) {
+              id,
+              name
+            }
+          }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneTestModel":{"id":1,"name":"hello"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneTestModel":{"id":1,"name":"hello-updated"}}}"###
+        );
+
+        assert_used_native_upsert(&mut runner).await;
+
+        Ok(())
+    }
+
+    pub fn partial_unique_only() -> String {
+        let schema = indoc! {
+            r#"model TestModel {
+              id     Int    @id
+              email  String @unique(map: "partial_email", where: raw("status = 'active'"))
+              status String
+              name   String
+          }"#
+        };
+
+        schema.to_owned()
+    }
+
+    // The `where` clause names the model's only unique, and it is partial. There
+    // is no conflict target the database could infer, so the upsert falls back to
+    // the read-then-write graph instead of emitting a statement that always fails.
+    #[connector_test(schema(partial_unique_only), capabilities(NativeUpsert, PartialIndex))]
+    async fn should_not_upsert_on_partial_unique(mut runner: Runner) -> TestResult<()> {
+        let upsert = r#"
+          mutation {
+            upsertOneTestModel(
+              where: {email: "hello@example.com"},
+              create: {
+                id: 1,
+                email: "hello@example.com",
+                status: "active",
+                name: "hello",
+              },
+              update: {
+                name: "hello-updated",
+              }
+            ) {
+              id,
+              name
+            }
+          }
+        "#;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneTestModel":{"id":1,"name":"hello"}}}"###
+        );
+
+        assert_not_used_native_upsert(&mut runner).await;
+
+        insta::assert_snapshot!(
+          run_query!(&runner, upsert),
+          @r###"{"data":{"upsertOneTestModel":{"id":1,"name":"hello-updated"}}}"###
+        );
+
+        assert_not_used_native_upsert(&mut runner).await;
+
+        Ok(())
+    }
+
     async fn assert_used_native_upsert(runner: &mut Runner) {
         let logs = runner.get_logs().await;
         let did_upsert = logs.iter().any(|l| l.contains("ON CONFLICT"));


### PR DESCRIPTION
Fixes prisma/orm#30178.

## The bug

With `previewFeatures = ["partialIndexes"]`, the native upsert can pick a **partial** (`WHERE`-filtered) unique index as its `ON CONFLICT` arbiter instead of the total unique the `where` clause names. Postgres cannot infer a partial index from a bare column list, so it rejects the statement with **42P10** — on every call, at SQL generation time, regardless of the data.

`NativeUpsert::unique_constraints` chose the arbiter as *the first unique index whose columns the `where` filter constrains*. A 1-column partial unique is a subset of a wider compound `where`, so it won the `.find()`. Before the preview feature, partial indexes were invisible to the client and the bug was unreachable; declaring an already-existing partial index — a change with no migration behind it — is enough to trigger it.

```prisma
model Generation {
  id         String    @id
  sessionId  String    @unique(map: "one_active_per_session", where: raw("(active_at IS NOT NULL)"))
  externalId String
  revision   Int
  activeAt   DateTime?

  @@unique([sessionId, externalId, revision], map: "generation_identity")
}
```

```ts
prisma.generation.upsert({
  where: { sessionId_externalId_revision: { sessionId, externalId, revision } },
  create: { ... },
  update: { ... },
})
```

```sql
-- emitted (arbiter is the partial index's column):
INSERT INTO "generations" (...) VALUES (...)
ON CONFLICT ("session_id") DO UPDATE SET ...
-- ERROR: there is no unique or exclusion constraint matching the ON CONFLICT specification
```

Removing only the `@unique(..., where: raw(...))` line from the schema — leaving the identical index in the database — makes the same client call emit `ON CONFLICT ("session_id","external_id","revision")` and succeed.

This shipped as a production incident for us: 100% of one ingest path's writes failed for ~43 hours after a schema-only change. Reproduced on 7.8.0, 7.10.0, and 8.1.0-dev.2.

## The change

`conflict_target(model, filter)` replaces the arbiter selection in `NativeUpsert`:

- Partial indexes are never candidates.
- The fallback is the primary key rather than `Filter::unique_scalars`, whose notion of uniqueness counts partial indexes too (so a `where` on a partial-only unique used to leak through it).
- It returns `Option`: `None` means "no target the database could infer". `upsert_record` then simply does not select the native upsert, and the existing read-then-write graph handles the model correctly.
- The chosen columns are handed to `NativeUpsert` instead of being recomputed from the stored filter, so the check deciding the query is buildable and the columns it emits cannot drift apart.

I deliberately did **not** teach the builder to emit `ON CONFLICT (cols) WHERE <predicate>`. That would be the way to make a partial unique a usable arbiter, but it changes matching semantics and touches quaint and every connector; falling back is the conservative correctness fix. Happy to follow up if you would rather have the predicate.

Note there is an identical copy of this arbiter logic in `query-engine/connectors/query-connector/src/upsert.rs`. I left it alone: its only consumer is the MongoDB connector, whose `native_upsert_record` is a stub, and MongoDB has no `ON CONFLICT`. Say the word if you want it kept in sync anyway.

## Tests

**`query-compiler/query-compiler/tests`** (no database needed) — two new query fixtures whose snapshots pin the emitted SQL:

- `upsert-partial-unique` → `ON CONFLICT ("email","status")`, the total unique, with a partial unique declared first on a subset of those columns.
- `upsert-partial-unique-only` → the read-then-write plan, no `ON CONFLICT`, when the only unique on the `where` column is partial.

Both fail on unpatched code with `ON CONFLICT ("email")` — the 42P10 — so they pin the regression rather than just the current output. No existing snapshot changed.

**`connector-test-kit-rs`** — two cases in `tests/new/native_upsert.rs`, gated `capabilities(NativeUpsert, PartialIndex)`: the native upsert is still used (with the correct target) when a total unique is available, and is not used when the only unique is partial.

## What I ran

`cargo fmt -- --check`, `cargo clippy --all-features --all-targets -- -Dwarnings`, `cargo test -p query-compiler`, `cargo check -p query-engine-tests --tests`, `make test-unit`.

I could not run the connector-test-kit cases locally (they need the QC wasm and driver-adapters build), so those are compile-checked only and rely on CI. `make test-unit` is red on this machine, but identically so on an unmodified checkout of the same base commit (`cargo test -p psl --all-features`: 489 passed / 574 failed on both), so I could not use it as a signal either way.

