### PR TITLE
fix(driver-adapters): drop D1 tables children-first in test reset

### DIFF
--- a/libs/driver-adapters/executor/src/driver-adapters-manager/d1.ts
+++ b/libs/driver-adapters/executor/src/driver-adapters-manager/d1.ts
@@ -86,6 +86,9 @@ async function migrateDiff(D1_DATABASE: D1Database, migrationScript: string) {
   await runBatch(D1_DATABASE, preparedStatements)
 }
 
+// Rows returned by `PRAGMA foreign_key_list`; `table` is the referenced parent.
+const D1ForeignKeys = S.array(S.struct({ table: S.string }))
+
 async function migrateReset(D1_DATABASE: D1Database) {
   let { results: rawTables } = (await D1_DATABASE.prepare(
     `PRAGMA main.table_list;`,
@@ -116,13 +119,68 @@ async function migrateReset(D1_DATABASE: D1Database) {
     )
   }
 
+  // Map each table to the tables its foreign keys reference (its parents).
+  // Self-references don't constrain the drop order.
+  const parentsOf = new Map<string, Set<string>>()
+  for (const table of tables) {
+    if (table.type !== 'table') {
+      continue
+    }
+    const { results: rawForeignKeys } = (await D1_DATABASE.prepare(
+      `PRAGMA foreign_key_list("${table.name}");`,
+    ).run()) as D1Result
+    const foreignKeys = S.decodeUnknownSync(D1ForeignKeys, {
+      onExcessProperty: 'preserve',
+    })(rawForeignKeys)
+    parentsOf.set(
+      table.name,
+      new Set(
+        foreignKeys.map((fk) => fk.table).filter((name) => name !== table.name),
+      ),
+    )
+  }
+
+  // Drop a table only after every table referencing it is gone: in a batch, a
+  // child's DROP no longer compiles once its FK parent is dropped
+  // (`no such table: main.<parent>`, wrangler >= 4.126), and
+  // `defer_foreign_keys` doesn't help because it defers enforcement, not name
+  // resolution. Views are never FK parents, so they drop right away. Tables in
+  // a reference cycle can't be ordered and keep their original order.
+  const remaining = new Set(tables.map((table) => table.name))
+  const ordered = [] as typeof tables
+  let progress = true
+  while (remaining.size > 0 && progress) {
+    progress = false
+    for (const table of tables) {
+      if (!remaining.has(table.name)) {
+        continue
+      }
+      const isReferenced = tables.some(
+        (other) =>
+          other.name !== table.name &&
+          remaining.has(other.name) &&
+          parentsOf.get(other.name)?.has(table.name),
+      )
+      if (!isReferenced) {
+        ordered.push(table)
+        remaining.delete(table.name)
+        progress = true
+      }
+    }
+  }
+  for (const table of tables) {
+    if (remaining.has(table.name)) {
+      ordered.push(table)
+    }
+  }
+
   const batch = [] as string[]
 
   // Allow violating foreign key constraints on the batch transaction.
   // The foreign key constraints are automatically re-enabled at the end of the transaction, regardless of it succeeding.
   batch.push(`PRAGMA defer_foreign_keys = ${1};`)
 
-  for (const table of tables) {
+  for (const table of ordered) {
     if (table.type === 'view') {
       batch.push(`DROP VIEW IF EXISTS "${table.name}";`)
     } else {


### PR DESCRIPTION
## Symptom

Every `d1` job in the QC workflow fails on every PR since 2026-08-25. All four shards die in test setup with `D1_ERROR: no such table: main.Category`, raised from `migrateReset` in the driver-adapters executor before any test logic runs.

## Root cause

- wrangler 4.126.0 (released 2026-08-25) changed local D1 behavior: in a batch, `DROP TABLE` on a table whose FK parent was dropped earlier in the same batch now fails with `no such table: main.<parent>`. `PRAGMA defer_foreign_keys` does not help — it defers enforcement, not name resolution.
- Bisected with a standalone repro: 4.125.0 good, 4.126.0 bad. The failing CI jobs installed 4.127.1 (also bad); the last green run (Aug 3) used 4.118.0 (good).
- `migrateReset` drops tables in `PRAGMA table_list` order, which can place a parent (e.g. `Category`) before a child that references it (e.g. `_CategoryToPost`). Every test's setup then fails.

## Fix

Order the drops so a table is dropped only after every table that references it is gone:

- Read each table's FK parents with `PRAGMA foreign_key_list`, ignoring self-references.
- Repeatedly emit entities that no still-remaining table references (views are never FK parents, so they emit immediately).
- Append any leftovers (reference cycles) in their original order as a fallback.

Everything else stays as is: the `sqlite_sequence` delete, the `defer_foreign_keys` pragma, `DROP VIEW` vs `DROP TABLE`, `IF EXISTS`, and the batch execution. The fix was validated in a standalone repro with the exact migration script from CI, under both wrangler 4.127.1 (fails before, passes after) and 4.118.0 (still passes).

## How this broke with no code changes

The executor has no lockfile and declares `"wrangler": "^4.4.0"`, so every CI run installs the newest wrangler 4.x. Pinning wrangler (or adding a lockfile) was considered and is left to the maintainers; this PR only fixes the drop order.

## Verification

The executor has no test harness; the `d1` CI jobs on this PR are the verification.